### PR TITLE
Recover Tx in sendRawTransaction

### DIFF
--- a/full-node/chainway-sequencer/src/lib.rs
+++ b/full-node/chainway-sequencer/src/lib.rs
@@ -1,5 +1,6 @@
 pub use sov_evm::DevSigner;
 mod mempool;
+mod utils;
 
 use std::borrow::BorrowMut;
 use std::marker::PhantomData;
@@ -9,13 +10,13 @@ use std::time::Duration;
 
 use borsh::ser::BorshSerialize;
 use demo_stf::runtime::Runtime;
-use ethers::types::{Bytes, H256};
+use ethers::types::H256;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::lock::Mutex;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::RpcModule;
 use mempool::Mempool;
-use reth_primitives::TransactionSignedNoHash as RethTransactionSignedNoHash;
+use reth_primitives::Bytes;
 use sov_accounts::Accounts;
 use sov_accounts::Response::{AccountEmpty, AccountExists};
 use sov_evm::{CallMessage, RlpEvmTransaction};
@@ -25,6 +26,8 @@ use sov_modules_rollup_blueprint::{Rollup, RollupBlueprint};
 use sov_modules_stf_blueprint::{Batch, RawTx};
 use sov_rollup_interface::services::da::DaService;
 use tracing::info;
+
+use crate::utils::recover_raw_transaction;
 
 pub struct RpcContext {
     pub mempool: Arc<Mutex<Mempool>>,
@@ -153,14 +156,19 @@ impl<C: sov_modules_api::Context, Da: DaService, S: RollupBlueprint> ChainwaySeq
             info!("Sequencer: eth_sendRawTransaction");
             let data: Bytes = parameters.one().unwrap();
 
-            let raw_evm_tx = RlpEvmTransaction { rlp: data.to_vec() };
+            // Only check if the signature is valid for now
+            let recovered = recover_raw_transaction(data.clone())?;
 
-            let hash = get_tx_hash(&raw_evm_tx).unwrap();
+            // TODO: make mempool conversions once it is implemented
+            // Follow the example of eth_sendRawTransaction in reth
+            // https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/api/transactions.rs#L505
+
+            let raw_evm_tx = RlpEvmTransaction { rlp: data.to_vec() };
 
             // Mempool had to be arc mutex to mutate chainway sequencer
             ctx.mempool.lock().await.pool.push_back(raw_evm_tx);
 
-            Ok::<H256, ErrorObjectOwned>(hash)
+            Ok::<H256, ErrorObjectOwned>((*recovered.hash()).into())
         })?;
         rpc.register_async_method("eth_publishBatch", |_parameters, ctx| async move {
             info!("Sequencer: eth_publishBatch");
@@ -170,12 +178,4 @@ impl<C: sov_modules_api::Context, Da: DaService, S: RollupBlueprint> ChainwaySeq
         self.rollup.rpc_methods.merge(rpc).unwrap();
         Ok(())
     }
-}
-
-fn get_tx_hash(raw_tx: &RlpEvmTransaction) -> Result<H256, jsonrpsee::core::Error> {
-    let signed_transaction: RethTransactionSignedNoHash = raw_tx.clone().try_into()?;
-
-    let tx_hash = signed_transaction.hash();
-
-    Ok(H256::from(tx_hash))
 }

--- a/full-node/chainway-sequencer/src/utils.rs
+++ b/full-node/chainway-sequencer/src/utils.rs
@@ -1,0 +1,22 @@
+//! Commonly used code snippets
+
+use reth_primitives::{Bytes, PooledTransactionsElement, PooledTransactionsElementEcRecovered};
+use sov_evm::{EthApiError, EthResult};
+
+/// Recovers a [PooledTransactionsElementEcRecovered] from an enveloped encoded byte stream.
+///
+/// See [PooledTransactionsElement::decode_enveloped]
+pub(crate) fn recover_raw_transaction(
+    data: Bytes,
+) -> EthResult<PooledTransactionsElementEcRecovered> {
+    if data.is_empty() {
+        return Err(EthApiError::EmptyRawTransactionData);
+    }
+
+    let transaction = PooledTransactionsElement::decode_enveloped(data)
+        .map_err(|_| EthApiError::FailedToDecodeSignedTransaction)?;
+
+    transaction
+        .try_into_ecrecovered()
+        .or(Err(EthApiError::InvalidTransactionSignature))
+}


### PR DESCRIPTION
# Description
This logic checks the encoding format and recovers the signer. As long as encoding is correct there is no incorrect signer, it always recovers some address. The rest of the logic must be handled in block building and mempool. This PR leaves the mempool part as TODO.

## Linked Issues
- Fixes #15 