### PR TITLE
Impl. web3_ rpc endpoints

### DIFF
--- a/examples/demo-rollup/tests/evm/test_client.rs
+++ b/examples/demo-rollup/tests/evm/test_client.rs
@@ -283,6 +283,20 @@ impl<T: TestContract> TestClient<T> {
             .unwrap()
     }
 
+    pub(crate) async fn web3_client_version(&self) -> String {
+        self.http_client
+            .request("web3_clientVersion", rpc_params![])
+            .await
+            .unwrap()
+    }
+
+    pub(crate) async fn web3_sha3(&self, bytes: String) -> String {
+        self.http_client
+            .request("web3_sha3", rpc_params![bytes])
+            .await
+            .unwrap()
+    }
+
     pub(crate) async fn eth_accounts(&self) -> Vec<Address> {
         self.http_client
             .request("eth_accounts", rpc_params![])


### PR DESCRIPTION
# Description
Implements web3_clientVersion and web3_sha3 as described by [Ethereum JSON RPC docs](https://ethereum.org/en/developers/docs/apis/json-rpc/#web3_clientversion)

## Linked Issues
Closes #72 

## Testing
Added web3 tests in evm integration tests, not the best place but it was where i could test it.

