### PR TITLE
Refactor: simplify EthBatchBuilder::add_messages

### DIFF
--- a/full-node/sov-ethereum/src/batch_builder.rs
+++ b/full-node/sov-ethereum/src/batch_builder.rs
@@ -27,8 +27,6 @@ impl<C: sov_modules_api::Context> EthBatchBuilder<C> {
 
     /// Adds `messages` to the mempool.
     pub fn add_messages(&mut self, messages: Vec<Vec<u8>>) {
-        for message in messages {
-            self.mempool.push_back(message);
-        }
+        self.mempool.extend(messages);
     }
 }


### PR DESCRIPTION
# Description

It's a refactoring with a miiiinor perf improvement given the fact that a vec of msgs is a trusted len iter and VecDeque utilizes this knowledge:

```
    default fn spec_extend(&mut self, iter: I) {
        // This is the case for a TrustedLen iterator.
        let (low, high) = iter.size_hint();
        if let Some(additional) = high {
            debug_assert_eq!(
                low,
                additional,
                "TrustedLen iterator's size hint is not exact: {:?}",
                (low, high)
            );
            self.reserve(additional);
```

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
