### PR TITLE
Refactor mempool tests to reuse fn initialize_test to create node instance

### DIFF
--- a/examples/demo-rollup/tests/test_client/mod.rs
+++ b/examples/demo-rollup/tests/test_client/mod.rs
@@ -27,6 +27,7 @@ pub struct TestClient {
     client: SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
     http_client: HttpClient,
     current_nonce: AtomicU64,
+    pub(crate) rpc_addr: std::net::SocketAddr,
 }
 
 impl TestClient {
@@ -51,6 +52,7 @@ impl TestClient {
             client,
             http_client,
             current_nonce: AtomicU64::new(0),
+            rpc_addr,
         };
         client.sync_nonce().await;
         client


### PR DESCRIPTION
# Description

There was a lot of repeated code like:

```
let seq_task = tokio::spawn(async {
        start_rollup(
            seq_port_tx,
            GenesisPaths::from_dir("../test-data/genesis/integration-tests"),
            BasicKernelGenesisPaths {
                chain_state: "../test-data/genesis/integration-tests/chain_state.json".into(),
            },
            RollupProverConfig::Execute,
            NodeMode::SequencerNode,
            None,
            DEFAULT_MIN_SOFT_CONFIRMATIONS_PER_COMMITMENT,
        )
        .await;
    });
```

I refactored it.
