### PR TITLE
Okko/hive ci

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    needs: prepare
+    needs: [docker, prepare]
     name: run
     runs-on: ubicloud-standard-4
     permissions:


### PR DESCRIPTION
# Description
Makes the Hive test runner job dependent on both docker build and hive build.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to #230 