### PR TITLE
Add docker dependency to Hive test job in Hive CI

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    needs: prepare
+    needs: [docker, prepare]
     name: run
     runs-on: ubicloud-standard-4
     permissions:


### PR DESCRIPTION
# Description
Makes the Hive test job dependent on docker build.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to #230 
