### PR TITLE
Split Hive CI to docker and hive test workflows

### DIFF
--- a/.github/workflows/docker_hive.yml
+++ b/.github/workflows/docker_hive.yml
@@ -1,0 +1,40 @@
+# Makes a Docker build to be used in Hive tests.
+
+name: Docker for Hive
+
+on:
+  workflow_dispatch:
+  schedule:
+    # every day
+    - cron: "13 21 * * *" # 21:13 UTC
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Except in `nightly` and `stable` branches! Any cancelled job will cause the
+  # CI run to fail, and we want to keep a clean history for major branches.
+  cancel-in-progress: ${{ (github.ref != 'refs/heads/nightly') && (github.ref != 'refs/heads/stable') }}
+
+jobs:
+  docker:
+    timeout-minutes: 60
+    name: Build and publish Docker image
+    runs-on: ubicloud-standard-16
+    steps:
+      - uses: actions/checkout@v4
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v3.2.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          file: ./hive/Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/citrea:latest

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -1,12 +1,13 @@
 # Runs `ethereum/hive` tests.
 
-name: hive
+name: Hive
 
 on:
   workflow_dispatch:
-  schedule:
-    # every day
-    - cron: "13 21 * * *" # 21:13 UTC
+  workflow_run:
+    workflows: ["Docker for Hive"]
+    types:
+      - completed
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,27 +19,6 @@ concurrency:
   cancel-in-progress: ${{ (github.ref != 'refs/heads/nightly') && (github.ref != 'refs/heads/stable') }}
 
 jobs:
-  docker:
-    timeout-minutes: 60
-    name: Build and publish Docker image
-    runs-on: ubicloud-standard-16
-    steps:
-      - uses: actions/checkout@v4
-      - name: Docker Setup Buildx
-        uses: docker/setup-buildx-action@v3.2.0
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v5.3.0
-        with:
-          context: .
-          file: ./hive/Dockerfile
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/citrea:latest
-  
   prepare:
     timeout-minutes: 45
     runs-on: ubicloud-standard-4


### PR DESCRIPTION
# Description
Splits the Hive CI into two parts so as all Hive test runs shouldn't require a fresh docker build. In this configuration, a Docker build is taken every day and if the build is completed successfully Hive tests are run, the Hive tests can be triggered manually as well.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to #230