### PR TITLE
Increase timeouts of Hive CI jobs

### DIFF
--- a/.github/workflows/docker_hive.yml
+++ b/.github/workflows/docker_hive.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   docker:
-    timeout-minutes: 60
+    timeout-minutes: 120
     name: Build and publish Docker image
     runs-on: ubicloud-standard-16
     steps:

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -50,13 +50,13 @@ jobs:
           path: ./artifacts
 
   test:
-    timeout-minutes: 15
+    timeout-minutes: 120
     strategy:
       fail-fast: false
 
     needs: prepare
     name: run
-    runs-on: ubicloud-standard-4
+    runs-on: ubicloud-standard-8
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
# Description
Increases the timeout of the Hive tests and Docker builds, and runs the Hive tests on a more powerful machines.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to #230 