### PR TITLE
Docs: Fix incorrect toml paths in run.md.

### DIFF
--- a/docs/run.md
+++ b/docs/run.md
@@ -16,23 +16,23 @@ Run on a local da layer, sharable between nodes that run on your computer.
 
 Run sequencer on Mock DA:
 ```sh
-./target/debug/citrea --da-layer mock --rollup-config-path citrea/rollup/configs/mock/sequencer_rollup_config.toml --sequencer-config-path citrea/rollup/configs/mock/sequencer_config.toml --genesis-paths citrea/test-data/genesis/demo-tests/mock
+./target/debug/citrea --da-layer mock --rollup-config-path bin/citrea/configs/mock/sequencer_rollup_config.toml --sequencer-config-path bin/citrea/configs/mock/sequencer_config.toml --genesis-paths bin/test-data/genesis/demo-tests/mock
 ```
 
 Sequencer RPC is accessible at `127.0.0.1:12345`
 
 _Optional_: Run full node on Mock DA:
 ```sh
-./target/debug/citrea --rollup-config-path citrea/rollup/configs/mock/rollup_config.toml --genesis-paths citrea/test-data/genesis/demo-tests/mock 
+./target/debug/citrea --rollup-config-path bin/citrea/configs/mock/sequencer_rollup_config.toml --genesis-paths bin/test-data/genesis/demo-tests/mock
 ```
 
 Full node RPC is accessible at `127.0.0.1:12346`
 
-To publish blocks on Mock DA, run these on two seperate terminals:
+To publish blocks on Mock DA, run these two on seperate terminals:
 ```sh
- ./citrea/rollup/publish_block.sh
+./bin/citrea/publish_block.sh
 
- ./citrea/rollup/publish_da_block.sh
+./bin/citrea/publish_da_block.sh
 ```
 
 ### Run on Bitcoin Regtest
@@ -56,7 +56,7 @@ Mine blocks so that the wallet has BTC:
 bitcoin-cli -regtest -generate 201
 ```
 
-Edit `bin/citrea/configs/bitcoin-regtest/sequencer_rollup_config.toml` and `bin/citrea/configs/bitcoin-regtest/sequencer_rollup_config.toml` files and put in your rpc url, username and password:
+Edit `bin/citrea/configs/bitcoin-regtest/sequencer_rollup_config.toml` and `bin/citrea/configs/bitcoin-regtest/sequencer_config.toml` files and put in your rpc url, username and password:
 
 ```toml
 [da]
@@ -70,7 +70,7 @@ node_password = ""
 
 Run sequencer:
 ```sh
-./target/debug/citrea --da-layer bitcoin --rollup-config-path citrea/rollup/configs/bitcoin-regtest/sequencer_rollup_config.toml --sequencer-config-path citrea/rollup/configs/bitcoin-regtest/sequencer_config.toml --genesis-paths citrea/test-data/genesis/demo-tests/bitcoin-regtest
+./target/debug/citrea --da-layer bitcoin --rollup-config-path bin/citrea/configs/bitcoin-regtest/sequencer_rollup_config.toml --sequencer-config-path bin/citrea/configs/bitcoin-regtest/sequencer_config.toml --genesis-paths bin/test-data/genesis/demo-tests/bitcoin-regtest
 ```
 
 Sequencer RPC is accessible at `127.0.0.1:12345`
@@ -79,14 +79,14 @@ _Optional_: Run full node
 
 Run full node:
 ```sh
-./target/debug/citrea --da-layer bitcoin --rollup-config-path citrea/rollup/configs/bitcoin-regtest/rollup_config.toml --genesis-paths citrea/test-data/genesis/demo-tests/bitcoin-regtest
+./target/debug/citrea --da-layer bitcoin --rollup-config-path bin/citrea/configs/bitcoin-regtest/rollup_config.toml --genesis-paths bin/test-data/genesis/demo-tests/bitcoin-regtest
 ```
 
 Full node RPC is accessible at `127.0.0.1:12346`
 
 To publish blocks on Bitcoin Regtest, run this and keep the terminal open:
 ```sh
- ./citrea/rollup/publish_block.sh
+./bin/citrea/publish_block.sh
 ```
 
 To delete sequencer or full nodes databases run:


### PR DESCRIPTION
# Description
Documentation has incorrect paths for toml files.

## Testing
Run commands on a new environment.
