### PR TITLE
Add L1 block hash to query response

### DIFF
--- a/crates/evm/src/evm/primitive_types.rs
+++ b/crates/evm/src/evm/primitive_types.rs
@@ -94,7 +94,7 @@ impl Block {
         SealedBlock {
             header: self.header.seal_slow(),
             l1_fee_rate: self.l1_fee_rate,
-            last_l1_hash: self.last_l1_hash,
+            l1_hash: self.l1_hash,
             transactions: self.transactions,
         }
     }
@@ -113,8 +113,8 @@ pub(crate) struct SealedBlock {
     /// L1 fee rate.
     pub(crate) l1_fee_rate: u64,
 
-    /// Last L1 hash.
-    pub(crate) last_l1_hash: B256,
+    /// The hash of L1 block that the L2 block corresponds to.  
+    pub(crate) l1_hash: B256,
 
     /// Transactions in this block.
     pub(crate) transactions: Range<u64>,

--- a/crates/evm/src/evm/primitive_types.rs
+++ b/crates/evm/src/evm/primitive_types.rs
@@ -82,8 +82,8 @@ pub(crate) struct Block {
     /// L1 fee rate.
     pub(crate) l1_fee_rate: u64,
 
-    /// Last L1 hash.
-    pub(crate) last_l1_hash: B256,
+    /// The hash of L1 block this L2 block is bound to.
+    pub(crate) l1_hash: B256,
 
     /// Transactions in this block.
     pub(crate) transactions: Range<u64>,

--- a/crates/evm/src/evm/primitive_types.rs
+++ b/crates/evm/src/evm/primitive_types.rs
@@ -82,7 +82,7 @@ pub(crate) struct Block {
     /// L1 fee rate.
     pub(crate) l1_fee_rate: u64,
 
-    /// The hash of L1 block this L2 block is bound to.
+    /// The hash of L1 block that the L2 block corresponds to.  
     pub(crate) l1_hash: B256,
 
     /// Transactions in this block.

--- a/crates/evm/src/evm/primitive_types.rs
+++ b/crates/evm/src/evm/primitive_types.rs
@@ -82,6 +82,9 @@ pub(crate) struct Block {
     /// L1 fee rate.
     pub(crate) l1_fee_rate: u64,
 
+    /// Last L1 hash.
+    pub(crate) last_l1_hash: B256,
+
     /// Transactions in this block.
     pub(crate) transactions: Range<u64>,
 }
@@ -91,6 +94,7 @@ impl Block {
         SealedBlock {
             header: self.header.seal_slow(),
             l1_fee_rate: self.l1_fee_rate,
+            last_l1_hash: self.last_l1_hash,
             transactions: self.transactions,
         }
     }
@@ -108,6 +112,9 @@ pub(crate) struct SealedBlock {
 
     /// L1 fee rate.
     pub(crate) l1_fee_rate: u64,
+
+    /// Last L1 hash.
+    pub(crate) last_l1_hash: B256,
 
     /// Transactions in this block.
     pub(crate) transactions: Range<u64>,

--- a/crates/evm/src/genesis.rs
+++ b/crates/evm/src/genesis.rs
@@ -175,7 +175,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             header,
             l1_fee_rate: 0,
             // TODO: Check this for genesis hash - is it completely fine?
-            last_l1_hash: B256::default(),
+            l1_hash: B256::default(),
             transactions: 0u64..0u64,
         };
 

--- a/crates/evm/src/genesis.rs
+++ b/crates/evm/src/genesis.rs
@@ -174,6 +174,8 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let block = Block {
             header,
             l1_fee_rate: 0,
+            // TODO: Check this for genesis hash - is it completely fine?
+            last_l1_hash: B256::default(),
             transactions: 0u64..0u64,
         };
 

--- a/crates/evm/src/hooks.rs
+++ b/crates/evm/src/hooks.rs
@@ -113,6 +113,11 @@ where
             .get(working_set)
             .expect("L1 fee rate must be set");
 
+        let last_l1_hash = self
+            .last_l1_hash
+            .get(working_set)
+            .expect("Last L1 hash must be set");
+
         let parent_block = self
             .head
             .get(working_set)
@@ -182,6 +187,7 @@ where
         let block = Block {
             header,
             l1_fee_rate,
+            last_l1_hash,
             transactions: start_tx_index..start_tx_index + pending_transactions.len() as u64,
         };
 

--- a/crates/evm/src/hooks.rs
+++ b/crates/evm/src/hooks.rs
@@ -44,8 +44,8 @@ where
 
         // populate system events
         let mut system_events = vec![];
-        if let Some(last_l1_hash) = self.last_l1_hash.get(working_set) {
-            if last_l1_hash != da_slot_hash {
+        if let Some(l1_hash) = self.last_l1_hash.get(working_set) {
+            if l1_hash != da_slot_hash {
                 // That's a new L1 block
                 system_events.push(SystemEvent::L1BlockHashSetBlockInfo(
                     da_slot_hash,
@@ -113,7 +113,7 @@ where
             .get(working_set)
             .expect("L1 fee rate must be set");
 
-        let last_l1_hash = self
+        let l1_hash = self
             .last_l1_hash
             .get(working_set)
             .expect("Last L1 hash must be set");
@@ -187,7 +187,7 @@ where
         let block = Block {
             header,
             l1_fee_rate,
-            last_l1_hash,
+            l1_hash,
             transactions: start_tx_index..start_tx_index + pending_transactions.len() as u64,
         };
 

--- a/crates/evm/src/hooks.rs
+++ b/crates/evm/src/hooks.rs
@@ -44,8 +44,8 @@ where
 
         // populate system events
         let mut system_events = vec![];
-        if let Some(l1_hash) = self.last_l1_hash.get(working_set) {
-            if l1_hash != da_slot_hash {
+        if let Some(last_l1_hash) = self.last_l1_hash.get(working_set) {
+            if last_l1_hash != da_slot_hash {
                 // That's a new L1 block
                 system_events.push(SystemEvent::L1BlockHashSetBlockInfo(
                     da_slot_hash,

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -179,8 +179,8 @@ impl<C: sov_modules_api::Context> Evm<C> {
                     serde_json::json!(sealed_block.l1_fee_rate),
                 ),
                 (
-                    "last_l1_hash".to_string(),
-                    serde_json::json!(sealed_block.last_l1_hash),
+                    "l1_hash".to_string(),
+                    serde_json::json!(sealed_block.l1_hash),
                 ),
             ])),
         };

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1,4 +1,5 @@
 use std::array::TryFromSliceError;
+use std::collections::BTreeMap;
 use std::ops::{Range, RangeInclusive};
 
 use alloy_primitives::Uint;
@@ -106,16 +107,16 @@ impl<C: sov_modules_api::Context> Evm<C> {
     ) -> RpcResult<Option<reth_rpc_types::RichBlock>> {
         info!("evm module: eth_getBlockByNumber");
 
-        let block = match self.get_sealed_block_by_number(block_number, working_set) {
-            Some(block) => block,
+        let sealed_block = match self.get_sealed_block_by_number(block_number, working_set) {
+            Some(sealed_block) => sealed_block,
             None => return Ok(None), // if block doesn't exist return null
         };
 
         // Build rpc header response
-        let mut header = from_primitive_with_hash(block.header.clone());
+        let mut header = from_primitive_with_hash(sealed_block.header.clone());
         header.total_difficulty = Some(header.difficulty);
         // Collect transactions with ids from db
-        let transactions: Vec<TransactionSignedAndRecovered> = block
+        let transactions: Vec<TransactionSignedAndRecovered> = sealed_block
             .transactions
             .clone()
             .map(|id| {
@@ -126,7 +127,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .collect();
 
         let block = Block {
-            header: block.header.header().clone(),
+            header: sealed_block.header.header().clone(),
             body: transactions
                 .iter()
                 .map(|tx| tx.signed_transaction.clone())
@@ -172,7 +173,16 @@ impl<C: sov_modules_api::Context> Evm<C> {
             uncles: Default::default(),
             transactions,
             withdrawals: Default::default(),
-            other: Default::default(),
+            other: OtherFields::new(BTreeMap::<String, _>::from([
+                (
+                    "l1_fee_rate".to_string(),
+                    serde_json::json!(sealed_block.l1_fee_rate),
+                ),
+                (
+                    "last_l1_hash".to_string(),
+                    serde_json::json!(sealed_block.last_l1_hash),
+                ),
+            ])),
         };
 
         Ok(Some(block.into()))

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -175,11 +175,11 @@ impl<C: sov_modules_api::Context> Evm<C> {
             withdrawals: Default::default(),
             other: OtherFields::new(BTreeMap::<String, _>::from([
                 (
-                    "l1_fee_rate".to_string(),
+                    "l1FeeRate".to_string(),
                     serde_json::json!(sealed_block.l1_fee_rate),
                 ),
                 (
-                    "l1_hash".to_string(),
+                    "l1Hash".to_string(),
                     serde_json::json!(sealed_block.l1_hash),
                 ),
             ])),

--- a/crates/evm/src/tests/genesis_tests.rs
+++ b/crates/evm/src/tests/genesis_tests.rs
@@ -229,7 +229,7 @@ fn genesis_block() {
                 *GENESIS_HASH
             ),
             l1_fee_rate: 0,
-            last_l1_hash: B256::default(),
+            l1_hash: B256::default(),
             transactions: (0u64..0u64),
         }
     );

--- a/crates/evm/src/tests/genesis_tests.rs
+++ b/crates/evm/src/tests/genesis_tests.rs
@@ -60,10 +60,10 @@ lazy_static! {
     };
 
     pub(crate) static ref GENESIS_HASH: B256 = B256::from(hex!(
-        "5aa8e649f234ae2128a8eb8536f557fafd7b6a46f12cba8d89a73eb74ee0f0e3"
+        "21d33ac980d24d19397167ce9b4e9fb072d7942f22c2451e8d49c9b1c3bc1ff1"
     ));
     pub(crate) static ref GENESIS_STATE_ROOT: B256 = B256::from(hex!(
-        "62dcfcbbc789410f13b8ec77a27fa8fc1c804c5cedbf2c2498b886b7c5a2f35b"
+        "cf60bd2197418b787dc8a3e1befea15f15546bc60a12075fe06da5ee9a284e95"
     ));
     pub(crate) static ref GENESIS_DA_TXS_COMMITMENT: B256 = B256::from(hex!(
         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
@@ -229,6 +229,7 @@ fn genesis_block() {
                 *GENESIS_HASH
             ),
             l1_fee_rate: 0,
+            last_l1_hash: B256::default(),
             transactions: (0u64..0u64),
         }
     );

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -87,7 +87,7 @@ fn end_soft_confirmation_hook_sets_head() {
         Block {
             header: Header {
                 parent_hash: B256::from(hex!(
-                    "fc47267bb1f23e28564d539ad13370a335660149b44ca2b76c1787563781f69a"
+                    "42636769d88c0357ce9ed99fb4a6ee53ced60b0ae0abb18f00ade7033009060e"
                 )),
 
                 ommers_hash: EMPTY_OMMER_ROOT_HASH,
@@ -115,6 +115,7 @@ fn end_soft_confirmation_hook_sets_head() {
                 parent_beacon_block_root: None,
             },
             l1_fee_rate: 0,
+            last_l1_hash: B256::from(DA_ROOT_HASH.0),
             transactions: 0..2
         }
     );
@@ -301,10 +302,11 @@ fn finalize_hook_creates_final_block() {
                     parent_beacon_block_root: None,
                 },
                 B256::from(hex!(
-                    "d47d66976036582aa26c9039e38de00d1b47886efbfc75d84e68d611e13c1c09"
+                    "5d2e1acc0a8cd7b4d543f1043b24fbb97ec769a789825afb57172fa5f1c74d98"
                 ))
             ),
             l1_fee_rate: 0,
+            last_l1_hash: B256::from(DA_ROOT_HASH.0),
             transactions: 0..2
         }
     );

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -115,7 +115,7 @@ fn end_soft_confirmation_hook_sets_head() {
                 parent_beacon_block_root: None,
             },
             l1_fee_rate: 0,
-            last_l1_hash: B256::from(DA_ROOT_HASH.0),
+            l1_hash: B256::from(DA_ROOT_HASH.0),
             transactions: 0..2
         }
     );
@@ -306,7 +306,7 @@ fn finalize_hook_creates_final_block() {
                 ))
             ),
             l1_fee_rate: 0,
-            last_l1_hash: B256::from(DA_ROOT_HASH.0),
+            l1_hash: B256::from(DA_ROOT_HASH.0),
             transactions: 0..2
         }
     );

--- a/crates/evm/src/tests/queries/basic_queries.rs
+++ b/crates/evm/src/tests/queries/basic_queries.rs
@@ -411,7 +411,7 @@ fn check_against_third_block(block: &Rich<Block>) {
     );
 
     inner_block.other.insert(
-        "last_l1_hash".to_string(),
+        "l1_hash".to_string(),
         serde_json::Value::String(
             "0x0808080808080808080808080808080808080808080808080808080808080808".to_string(),
         ),

--- a/crates/evm/src/tests/queries/basic_queries.rs
+++ b/crates/evm/src/tests/queries/basic_queries.rs
@@ -406,12 +406,12 @@ fn check_against_third_block(block: &Rich<Block>) {
     })).unwrap();
 
     inner_block.other.insert(
-        "l1_fee_rate".to_string(),
+        "l1FeeRate".to_string(),
         serde_json::Value::Number(serde_json::Number::from(1)),
     );
 
     inner_block.other.insert(
-        "l1_hash".to_string(),
+        "l1Hash".to_string(),
         serde_json::Value::String(
             "0x0808080808080808080808080808080808080808080808080808080808080808".to_string(),
         ),

--- a/crates/evm/src/tests/queries/basic_queries.rs
+++ b/crates/evm/src/tests/queries/basic_queries.rs
@@ -376,7 +376,7 @@ fn call_test() {
 
 fn check_against_third_block(block: &Rich<Block>) {
     // details = false
-    let inner_block = serde_json::from_value::<Block>(json!({
+    let mut inner_block = serde_json::from_value::<Block>(json!({
         "hash": "0x2d7962c316685635252886d6801a553139e94e3b7d2b678f8c9d974a54e24ab9",
         "parentHash": "0x97dcd6347f726d864f7b4e2f279f535f0e050bdba9da89e9b2cc744897565432",
         "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
@@ -402,8 +402,20 @@ fn check_against_third_block(block: &Rich<Block>) {
             "0x17fa953338b32b30795ccb62f050f1c9bcdd48f4793fb2d6d34290b444841271",
             "0xd7e5b2bce65678b5e1a4430b1320b18a258fd5412e20bd5734f446124a9894e6"
         ],
-        "size": "0x54b"
+        "size": "0x54b",
     })).unwrap();
+
+    inner_block.other.insert(
+        "l1_fee_rate".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(1)),
+    );
+
+    inner_block.other.insert(
+        "last_l1_hash".to_string(),
+        serde_json::Value::String(
+            "0x0808080808080808080808080808080808080808080808080808080808080808".to_string(),
+        ),
+    );
 
     let rich_block: Rich<Block> = Rich {
         inner: inner_block,

--- a/crates/evm/src/tests/tx_tests.rs
+++ b/crates/evm/src/tests/tx_tests.rs
@@ -130,6 +130,7 @@ fn prepare_call_block_env() {
     let block = Block {
         header: Default::default(),
         l1_fee_rate: Default::default(),
+        last_l1_hash: Default::default(),
         transactions: Default::default(),
     };
 

--- a/crates/evm/src/tests/tx_tests.rs
+++ b/crates/evm/src/tests/tx_tests.rs
@@ -130,7 +130,7 @@ fn prepare_call_block_env() {
     let block = Block {
         header: Default::default(),
         l1_fee_rate: Default::default(),
-        last_l1_hash: Default::default(),
+        l1_hash: Default::default(),
         transactions: Default::default(),
     };
 


### PR DESCRIPTION
# Description
eth_getBlockByNumber now returns both l1_fee_rate and l1_block_hash.

Closes #300. 