### PR TITLE
Fix genesis roots mismatch

### DIFF
--- a/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
@@ -174,7 +174,7 @@ pub trait RollupBlueprint: Sized + Send + Sync {
 
         let native_stf = StfBlueprint::new();
 
-        let genesis_root = prover_storage.get_root_hash(0);
+        let genesis_root = prover_storage.get_root_hash(1);
 
         let init_variant = match prev_root {
             Some(root_hash) => InitVariant::Initialized(root_hash),
@@ -271,7 +271,7 @@ pub trait RollupBlueprint: Sized + Send + Sync {
 
         let native_stf = StfBlueprint::new();
 
-        let genesis_root = prover_storage.get_root_hash(0);
+        let genesis_root = prover_storage.get_root_hash(1);
 
         let init_variant = match prev_root {
             Some(root_hash) => InitVariant::Initialized(root_hash),


### PR DESCRIPTION
# Description

When starting a sequencer node from genesis, the following happens:

1. `prover_storage` is created from an empty state leading to having a root hash of `5350415253455f4d45524b4c455f504c414345484f4c4445525f484153485f5f` which is calculated by the JellyMerkleTree from the empty state. Calling `prover_storage.get_root_hash(0)` where `0` is the version of the state we want returns that hash.
2. The chain is initialized in `stf::init_chain` where the newly initialized state is committed at JMT version 1.
3. Restart the node, the chain is NOT initialized again because  `prover_storage.get_root_hash(0)` would return the previously mentioned root hash so we pass `InitVariant::Initialized(root_hash)` to the sequencer where `root_hash` is the previously mentioned root hash.

This ignores the fact that the chain init state has been done and committed at JMT version 1. Which is the version that we should be passing to the `prover_storage.get_root_hash` to get the actually committed state root hash.

After the fix, what would happen is:
1. Start the node with an empty state. The call to `get_root_hash` should error because no root hash would be found for state version 1.
2. `stf::init_chain` is called and the state is initialized properly.
3. The state has the correct root hash.
4. Restarting the node, the `prover_storage.get_root_hash(1)` should get the actually committed state root hash, passing `InitVariant::Initialized(root_hash)` with that correct root hash.

As for the second problem where the balances are returned as 0 before producing any block, i have not been able to reproduce this issue. To me, it seems like the balances are initialized properly.

## Linked Issues
- Fixes #287 

## Testing
Not yet.

## Docs
Not yet.
