### PR TITLE
Don't wait on Sequencer::send_transaction

### DIFF
--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -458,14 +458,12 @@ where
 
                         // submit commitment
                         self.da_service
-                            .send_transaction(
+                            .send_tx_no_wait(
                                 DaData::SequencerCommitment(commitment)
                                     .try_to_vec()
-                                    .unwrap()
-                                    .as_slice(),
+                                    .unwrap(),
                             )
-                            .await
-                            .expect("Sequencer: Failed to send commitment");
+                            .await;
 
                         self.ledger_db
                             .set_last_sequencer_commitment_l1_height(SlotNumber(


### PR DESCRIPTION
# Description
Send tx in a tokio thread. That's actually not ideal, because it can block some io in tokio if the number of tokio threads = number of async sendings. This impl can be improved ofc.

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/303

## Testing
`make test`