### PR TITLE
Bump rustc version

### DIFF
--- a/bin/citrea/tests/evm/mod.rs
+++ b/bin/citrea/tests/evm/mod.rs
@@ -53,7 +53,7 @@ async fn web3_rpc_tests() -> Result<(), anyhow::Error> {
 
     assert_eq!(
         test_client.web3_client_version().await,
-        format!("citrea/{}/{}/rust-1.77.1", tag, arch)
+        format!("citrea/{}/{}/rust-1.77.2", tag, arch)
     );
     assert_eq!(
         test_client


### PR DESCRIPTION
# Description

A new version of rustc is released.

See error: https://github.com/chainwayxyz/citrea/actions/runs/8653017088/job/23732699699#step:11:1759