### PR TITLE
Add sequencer mempool_conf

### DIFF
--- a/bin/citrea/configs/bitcoin-regtest/sequencer_config.toml
+++ b/bin/citrea/configs/bitcoin-regtest/sequencer_config.toml
@@ -1,1 +1,6 @@
 min_soft_confirmations_per_commitment = 1000
+[mempool_conf]
+pending_tx_limit = 100000
+queue_tx_limit = 100000
+base_fee_limit = 100000
+max_account_slots = 16

--- a/bin/citrea/configs/mock-dockerized/sequencer_config.toml
+++ b/bin/citrea/configs/mock-dockerized/sequencer_config.toml
@@ -1,6 +1,6 @@
 min_soft_confirmations_per_commitment = 10
 [mempool_conf]
-pending_tx_limit = 10000000
+pending_tx_limit = 100000
 queue_tx_limit = 100000
 base_fee_limit = 100000
 max_account_slots = 16

--- a/bin/citrea/configs/mock-dockerized/sequencer_config.toml
+++ b/bin/citrea/configs/mock-dockerized/sequencer_config.toml
@@ -1,1 +1,6 @@
 min_soft_confirmations_per_commitment = 10
+[mempool_conf]
+pending_tx_limit = 10000000
+queue_tx_limit = 100000
+base_fee_limit = 100000
+max_account_slots = 16

--- a/bin/citrea/configs/mock/sequencer_config.toml
+++ b/bin/citrea/configs/mock/sequencer_config.toml
@@ -1,6 +1,6 @@
 min_soft_confirmations_per_commitment = 10
 [mempool_conf]
-pending_tx_limit = 10000000
+pending_tx_limit = 100000
 queue_tx_limit = 100000
 base_fee_limit = 100000
 max_account_slots = 16

--- a/bin/citrea/configs/mock/sequencer_config.toml
+++ b/bin/citrea/configs/mock/sequencer_config.toml
@@ -1,1 +1,6 @@
 min_soft_confirmations_per_commitment = 10
+[mempool_conf]
+pending_tx_limit = 10000000
+queue_tx_limit = 100000
+base_fee_limit = 100000
+max_account_slots = 16

--- a/bin/citrea/configs/mocknet/sequencer_config.toml
+++ b/bin/citrea/configs/mocknet/sequencer_config.toml
@@ -1,1 +1,6 @@
 min_soft_confirmations_per_commitment = 1000
+[mempool_conf]
+pending_tx_limit = 100000
+queue_tx_limit = 100000
+base_fee_limit = 100000
+max_account_slots = 16

--- a/bin/citrea/tests/test_helpers.rs
+++ b/bin/citrea/tests/test_helpers.rs
@@ -83,6 +83,7 @@ pub async fn start_rollup(
 
     let sequencer_config = SequencerConfig {
         min_soft_confirmations_per_commitment,
+        mempool_conf: Default::default(),
     };
 
     let mock_demo_rollup = MockDemoRollup {};

--- a/crates/sequencer/src/config.rs
+++ b/crates/sequencer/src/config.rs
@@ -5,6 +5,32 @@ use serde::Deserialize;
 pub struct SequencerConfig {
     /// Min. soft confirmaitons for sequencer to commit
     pub min_soft_confirmations_per_commitment: u64,
+    /// Sequencer specific mempool config
+    pub mempool_conf: SequencerMempoolConfig,
+}
+
+/// Mempool Config for the sequencer
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SequencerMempoolConfig {
+    /// Max number of transactions in the pending sub-pool
+    pub pending_tx_limit: u64,
+    /// Max number of transactions in the queued sub-pool
+    pub queue_tx_limit: u64,
+    /// Max number of transactions in the base-fee sub-pool
+    pub base_fee_limit: u64,
+    /// Max number of executable transaction slots guaranteed per account
+    pub max_account_slots: u64,
+}
+
+impl Default for SequencerMempoolConfig {
+    fn default() -> Self {
+        Self {
+            pending_tx_limit: 100000,
+            queue_tx_limit: 100000,
+            base_fee_limit: 100000,
+            max_account_slots: 16,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -26,6 +52,11 @@ mod tests {
     fn test_correct_config_sequencer() {
         let config = r#"
             min_soft_confirmations_per_commitment = 123
+            [mempool_conf]
+            pending_tx_limit = 100000
+            queue_tx_limit = 100000
+            base_fee_limit = 100000
+            max_account_slots = 16
         "#;
 
         let config_file = create_config_from(config);
@@ -34,6 +65,12 @@ mod tests {
 
         let expected = SequencerConfig {
             min_soft_confirmations_per_commitment: 123,
+            mempool_conf: SequencerMempoolConfig {
+                pending_tx_limit: 100000,
+                queue_tx_limit: 100000,
+                base_fee_limit: 100000,
+                max_account_slots: 16,
+            },
         };
         assert_eq!(config, expected);
     }

--- a/crates/sequencer/src/config.rs
+++ b/crates/sequencer/src/config.rs
@@ -10,6 +10,7 @@ pub struct SequencerConfig {
 }
 
 /// Mempool Config for the sequencer
+/// Read: https://github.com/ledgerwatch/erigon/wiki/Transaction-Pool-Design
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct SequencerMempoolConfig {
     /// Max number of transactions in the pending sub-pool

--- a/crates/sequencer/src/mempool.rs
+++ b/crates/sequencer/src/mempool.rs
@@ -1,16 +1,17 @@
 use std::sync::Arc;
 
 use citrea_evm::SYSTEM_SIGNER;
-use reth_primitives::{BaseFeeParamsKind, Chain, ChainSpec, TxHash};
+use reth_primitives::{Chain, ChainSpecBuilder, Genesis, TxHash};
 use reth_tasks::TokioTaskExecutor;
 use reth_transaction_pool::blobstore::NoopBlobStore;
 use reth_transaction_pool::error::PoolError;
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, CoinbaseTipOrdering, EthPooledTransaction,
-    EthTransactionValidator, Pool, PoolResult, TransactionPool, TransactionValidationTaskExecutor,
-    ValidPoolTransaction,
+    EthTransactionValidator, Pool, PoolConfig, PoolResult, SubPoolLimit, TransactionPool,
+    TransactionValidationTaskExecutor, ValidPoolTransaction, TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
 };
 
+use crate::config::SequencerMempoolConfig;
 pub use crate::db_provider::DbProvider;
 
 type CitreaMempoolImpl<C> = Pool<
@@ -24,16 +25,56 @@ type Transaction<C> = <CitreaMempoolImpl<C> as TransactionPool>::Transaction;
 pub(crate) struct CitreaMempool<C: sov_modules_api::Context>(CitreaMempoolImpl<C>);
 
 impl<C: sov_modules_api::Context> CitreaMempool<C> {
-    pub(crate) fn new(client: DbProvider<C>) -> Self {
+    pub(crate) fn new(client: DbProvider<C>, mempool_conf: SequencerMempoolConfig) -> Self {
         let blob_store = NoopBlobStore::default();
-        let genesis_hash = client.genesis_block().unwrap().unwrap().header.hash;
+        let genesis_block = client.genesis_block().unwrap().unwrap();
         let evm_config = client.cfg();
-        let chain_spec = ChainSpec {
-            chain: Chain::from_id(evm_config.chain_id),
-            genesis_hash,
-            base_fee_params: BaseFeeParamsKind::Constant(evm_config.base_fee_params),
-            ..Default::default()
+
+        let chain_spec = ChainSpecBuilder::default()
+            .chain(Chain::from_id(evm_config.chain_id))
+            .shanghai_activated()
+            .genesis(
+                Genesis::default()
+                    .with_nonce(genesis_block.header.nonce.unwrap().into())
+                    .with_timestamp(genesis_block.header.timestamp.saturating_to())
+                    .with_extra_data(genesis_block.header.extra_data)
+                    .with_gas_limit(genesis_block.header.gas_limit.saturating_to())
+                    .with_difficulty(genesis_block.header.difficulty)
+                    .with_mix_hash(genesis_block.header.mix_hash.unwrap())
+                    .with_coinbase(genesis_block.header.miner)
+                    .with_base_fee(Some(
+                        genesis_block
+                            .header
+                            .base_fee_per_gas
+                            .unwrap()
+                            .saturating_to(),
+                    )),
+            )
+            .build();
+
+        // Default 10x'ed from standard limits
+        let pool_config = Default::default();
+        let pool_config = PoolConfig {
+            pending_limit: SubPoolLimit {
+                max_txs: mempool_conf.pending_tx_limit as usize,
+                max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT * 10 * 1024 * 1024,
+            },
+            basefee_limit: SubPoolLimit {
+                max_txs: mempool_conf.base_fee_limit as usize,
+                max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT * 10 * 1024 * 1024,
+            },
+            queued_limit: SubPoolLimit {
+                max_txs: mempool_conf.queue_tx_limit as usize,
+                max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT * 10 * 1024 * 1024,
+            },
+            blob_limit: SubPoolLimit {
+                max_txs: 0,
+                max_size: 0,
+            },
+            max_account_slots: mempool_conf.max_account_slots as usize,
+            ..pool_config
         };
+
         Self(Pool::eth_pool(
             TransactionValidationTaskExecutor::eth(
                 client,
@@ -42,7 +83,7 @@ impl<C: sov_modules_api::Context> CitreaMempool<C> {
                 TokioTaskExecutor::default(),
             ),
             blob_store,
-            Default::default(),
+            pool_config,
         ))
     }
 

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -117,7 +117,7 @@ where
         // used as client of reth's mempool
         let db_provider = DbProvider::new(storage.clone());
 
-        let pool = CitreaMempool::new(db_provider.clone());
+        let pool = CitreaMempool::new(db_provider.clone(), config.mempool_conf.clone());
 
         Ok(Self {
             da_service,


### PR DESCRIPTION
# Description
The sequencer is the standalone block producer (as of now), and full nodes do not involve in this. Therefore, the machine can carry a bit more load in the mempool(s). This PR introduces configurable limits for this.

Must read:
https://github.com/ledgerwatch/erigon/wiki/Transaction-Pool-Design

https://github.com/paradigmxyz/reth/blob/027f920eb43f4d17c2eae9939dbfcc4d36cd2ce5/book/cli/reth/node.md?plain=1#L321

