### PR TITLE
remove ethers dependency on system txs

### DIFF
--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -1342,7 +1342,6 @@ async fn test_reopen_prover() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn test_system_transactons() -> Result<(), anyhow::Error> {
     // citrea::initialize_logging();
-    let l1_blockhash_contract = L1BlockHashList::default();
 
     let system_contract_address =
         Address::from_str("0x3100000000000000000000000000000000000001").unwrap();
@@ -1434,7 +1433,7 @@ async fn test_system_transactons() -> Result<(), anyhow::Error> {
         let hash_on_chain: String = full_node_test_client
             .contract_call(
                 system_contract_address,
-                l1_blockhash_contract.get_block_hash(i),
+                ethers::types::Bytes::from(L1BlockHashList::get_block_hash(i).to_vec()),
                 None,
             )
             .await

--- a/crates/evm/src/evm/system_contracts/mod.rs
+++ b/crates/evm/src/evm/system_contracts/mod.rs
@@ -1,61 +1,49 @@
-use alloy_primitives::{address, Address};
-use ethers_contract::BaseContract;
-use ethers_core::abi::Abi;
-use ethers_core::types::Bytes;
-
-fn make_contract_from_abi(abi_json: &str) -> BaseContract {
-    let j: serde_json::Value = serde_json::from_str(abi_json).unwrap();
-    let abi = &j.as_object().unwrap()["abi"];
-    let abi: Abi = serde_json::from_value(abi.to_owned()).unwrap();
-    BaseContract::from(abi)
-}
+use alloy_primitives::{address, Address, Bytes, U256};
 
 /// L1BlockHashList wrapper.
-pub struct L1BlockHashList {
-    base_contract: BaseContract,
-}
-
-impl Default for L1BlockHashList {
-    fn default() -> Self {
-        let base_contract = make_contract_from_abi(include_str!(
-            "./out/L1BlockHashList.sol/L1BlockHashList.json"
-        ));
-        Self { base_contract }
-    }
-}
+pub struct L1BlockHashList {}
 
 impl L1BlockHashList {
     pub(crate) fn address() -> Address {
         address!("3100000000000000000000000000000000000001")
     }
 
-    pub(crate) fn init(&self, block_number: u64) -> Bytes {
-        let args = ethereum_types::U256::from(block_number);
-        self.base_contract
-            .encode("initializeBlockNumber", args)
-            .expect("ABI for system contract should be correct")
+    pub(crate) fn init(block_number: u64) -> Bytes {
+        let mut func_selector: Vec<u8> = vec![0x1f, 0x57, 0x83, 0x33]; // initializeBlockNumber(u256) 1f578333
+
+        let block_number = U256::from(block_number);
+        func_selector.extend_from_slice(&block_number.to_be_bytes::<32>());
+
+        Bytes::from(func_selector)
     }
 
-    pub(crate) fn set_block_info(&self, block_hash: [u8; 32], txs_commitments: [u8; 32]) -> Bytes {
-        let args = (block_hash, txs_commitments);
-        self.base_contract
-            .encode("setBlockInfo", args)
-            .expect("ABI for system contract should be correct")
+    pub(crate) fn set_block_info(block_hash: [u8; 32], txs_commitments: [u8; 32]) -> Bytes {
+        let mut func_selector = vec![0x0e, 0x27, 0xbc, 0x11]; // setBlockInfo(bytes32, bytes32) 0e27bc11
+
+        func_selector.extend_from_slice(&block_hash);
+        func_selector.extend_from_slice(&txs_commitments);
+
+        Bytes::from(func_selector)
     }
 
     /// Return input data to query the block hash by block number mapping
-    pub fn get_block_hash(&self, block_number: u64) -> Bytes {
-        let args = ethereum_types::U256::from(block_number);
-        self.base_contract
-            .encode("getBlockHash", args)
-            .expect("ABI for system contract should be correct")
+    pub fn get_block_hash(block_number: u64) -> Bytes {
+        let mut func_selector: Vec<u8> = vec![0xee, 0x82, 0xac, 0x5e]; // getBlockHash(uint256) ee82ac5e
+
+        let block_number = U256::from(block_number);
+        println!("block_number: {:?}", block_number);
+        func_selector.extend_from_slice(&block_number.to_be_bytes::<32>());
+
+        Bytes::from(func_selector)
     }
 
     #[allow(dead_code)]
-    pub(crate) fn get_witness_root_by_number(&self, block_number: u64) -> Bytes {
-        let args = ethereum_types::U256::from(block_number);
-        self.base_contract
-            .encode("getWitnessRootByNumber", args)
-            .expect("ABI for system contract should be correct")
+    pub(crate) fn get_witness_root_by_number(block_number: u64) -> Bytes {
+        let mut func_selector: Vec<u8> = vec![0x61, 0xb2, 0x07, 0xe2]; // getWitnessRootByNumber(uint256) 61b207e2
+
+        let block_number = U256::from(block_number);
+        func_selector.extend_from_slice(&block_number.to_be_bytes::<32>());
+
+        Bytes::from(func_selector)
     }
 }

--- a/crates/evm/src/evm/system_events.rs
+++ b/crates/evm/src/evm/system_events.rs
@@ -1,6 +1,6 @@
 use reth_primitives::{
-    address, Address, Bytes as RethBytes, Signature, Transaction, TransactionKind,
-    TransactionSigned, TransactionSignedEcRecovered, TransactionSignedNoHash, TxEip1559, U256,
+    address, Address, Signature, Transaction, TransactionKind, TransactionSigned,
+    TransactionSignedEcRecovered, TransactionSignedNoHash, TxEip1559, U256,
 };
 
 use super::system_contracts::L1BlockHashList;
@@ -24,11 +24,10 @@ pub(crate) enum SystemEvent {
 }
 
 fn system_event_to_transaction(event: SystemEvent, nonce: u64, chain_id: u64) -> Transaction {
-    let sys_block_hash = L1BlockHashList::default();
     let body: TxEip1559 = match event {
         SystemEvent::L1BlockHashInitialize(block_number) => TxEip1559 {
             to: TransactionKind::Call(L1BlockHashList::address()),
-            input: RethBytes::from(sys_block_hash.init(block_number).to_vec()),
+            input: L1BlockHashList::init(block_number),
             nonce,
             chain_id,
             value: U256::ZERO,
@@ -38,11 +37,7 @@ fn system_event_to_transaction(event: SystemEvent, nonce: u64, chain_id: u64) ->
         },
         SystemEvent::L1BlockHashSetBlockInfo(block_hash, txs_commitments) => TxEip1559 {
             to: TransactionKind::Call(L1BlockHashList::address()),
-            input: RethBytes::from(
-                sys_block_hash
-                    .set_block_info(block_hash, txs_commitments)
-                    .to_vec(),
-            ),
+            input: L1BlockHashList::set_block_info(block_hash, txs_commitments),
             nonce,
             chain_id,
             value: U256::ZERO,

--- a/crates/evm/src/tests/sys_tx_tests.rs
+++ b/crates/evm/src/tests/sys_tx_tests.rs
@@ -24,8 +24,6 @@ fn test_sys_l1blockhashlist() {
     let (mut config, dev_signer, _) =
         get_evm_config_starting_base_fee(U256::from_str("1000000").unwrap(), None, 1);
 
-    let l1_block_hash_list = L1BlockHashList::default();
-
     config.data.push(AccountData::new(
         L1BlockHashList::address(),
         U256::ZERO,
@@ -86,7 +84,7 @@ fn test_sys_l1blockhashlist() {
         .get_call(
             TransactionRequest {
                 to: Some(L1BlockHashList::address()),
-                input: TransactionInput::new(l1_block_hash_list.get_block_hash(1).to_vec().into()),
+                input: TransactionInput::new(L1BlockHashList::get_block_hash(1)),
                 ..Default::default()
             },
             None,
@@ -100,12 +98,7 @@ fn test_sys_l1blockhashlist() {
         .get_call(
             TransactionRequest {
                 to: Some(L1BlockHashList::address()),
-                input: TransactionInput::new(
-                    l1_block_hash_list
-                        .get_witness_root_by_number(1)
-                        .to_vec()
-                        .into(),
-                ),
+                input: TransactionInput::new(L1BlockHashList::get_witness_root_by_number(1)),
                 ..Default::default()
             },
             None,
@@ -205,7 +198,7 @@ fn test_sys_l1blockhashlist() {
         .get_call(
             TransactionRequest {
                 to: Some(L1BlockHashList::address()),
-                input: TransactionInput::new(l1_block_hash_list.get_block_hash(2).to_vec().into()),
+                input: TransactionInput::new(L1BlockHashList::get_block_hash(2)),
                 ..Default::default()
             },
             None,
@@ -219,12 +212,7 @@ fn test_sys_l1blockhashlist() {
         .get_call(
             TransactionRequest {
                 to: Some(L1BlockHashList::address()),
-                input: TransactionInput::new(
-                    l1_block_hash_list
-                        .get_witness_root_by_number(2)
-                        .to_vec()
-                        .into(),
-                ),
+                input: TransactionInput::new(L1BlockHashList::get_witness_root_by_number(2)),
                 ..Default::default()
             },
             None,


### PR DESCRIPTION
# Description
Removes dependency on ethers in system transactions module. This is helpful for batch proving

This is a part of https://github.com/chainwayxyz/citrea/issues/329