### PR TITLE
Check system tx method hashes in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -182,6 +182,14 @@ jobs:
             exit 1
           fi
 
+  sys_tx_keccak:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+      - name: Check system tx against artifacts ABI
+        run: python crates/evm/src/evm/system_contracts/test/check_sys_hashes.py
+
   check_no_std:
     runs-on: ubicloud-standard-4
     if: github.event.pull_request.draft == false

--- a/crates/evm/src/evm/system_contracts/test/check_sys_hashes.py
+++ b/crates/evm/src/evm/system_contracts/test/check_sys_hashes.py
@@ -24,14 +24,18 @@ sys_contracts = {
     }
 }
 
+# for every contract
 for contract, exp in sys_contracts.items():
+    # open the ABI/artifact file
     with open(artifact_dir + f"{contract}.sol/{contract}.json") as f:
         abi = json.load(f)
         ids = abi["methodIdentifiers"]
 
+        # check that every expected method is present in the ABI
         for id in exp:
             assert id in ids, f"'{id}' not found in {contract} ABI"
 
+        # check that every method in the ABI has the expected keccak hash
         for id, hash in ids.items():
             for exp_id, exp_hash in exp.items():
                 if id.startswith(exp_id):

--- a/crates/evm/src/evm/system_contracts/test/check_sys_hashes.py
+++ b/crates/evm/src/evm/system_contracts/test/check_sys_hashes.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+import os
+import json
+
+# If this script fails:
+# - update crates/evm/src/evm/system_contracts/mod.rs accordingly
+
+test_script_dir = os.path.dirname(os.path.realpath(__file__))
+artifact_dir = test_script_dir + "/../out/"
+
+
+def assert_hash(contract, id, hash, expected_hash):
+    msg = f"{contract}::{id} must have hash '{expected_hash}', but '{hash}' is set instead."
+    assert hash == expected_hash, msg
+
+
+sys_contracts = {
+    "BitcoinLightClient": {
+        "initializeBlockNumber(uint256)": "1f578333",
+        "setBlockInfo(bytes32,bytes32)": "0e27bc11",
+        "getBlockHash(uint256)": "ee82ac5e",
+        "getWitnessRootByNumber(uint256)": "61b207e2",
+    }
+}
+
+for contract, exp in sys_contracts.items():
+    with open(artifact_dir + f"{contract}.sol/{contract}.json") as f:
+        abi = json.load(f)
+        ids = abi["methodIdentifiers"]
+
+        for id in exp:
+            assert id in ids, f"'{id}' not found in {contract} ABI"
+
+        for id, hash in ids.items():
+            for exp_id, exp_hash in exp.items():
+                if id.startswith(exp_id):
+                    assert_hash(contract, id, hash, exp_hash)


### PR DESCRIPTION
# Description
We access sys tx methods by their hashes like that:

```
    /// Return input data to query the block hash by block number mapping
    pub fn get_block_hash(block_number: u64) -> Bytes {
        let mut func_selector: Vec<u8> = vec![0xee, 0x82, 0xac, 0x5e]; // getBlockHash(uint256) ee82ac5e
```

This PR adds a CI check that 'getBlockHash(uint256)' has hash 'ee82ac5e' in compiled ABI.

## Testing

In CI