### PR TITLE
Unused dependencies check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,6 +97,38 @@ jobs:
             exit 1
           fi
 
+  udeps:
+    name: udeps
+    runs-on: ubicloud-standard-16
+    timeout-minutes: 60
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rui314/setup-mold@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "23.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+      - name: Install Rust
+        run: rustup show && rustup install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu # Nightly is needed for our configuration of cargo fmt
+      - name: Install cargo-risczero
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-risczero@0.19
+      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
+        run: cargo risczero install --version v2024-04-22.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run udeps
+        run: SKIP_GUEST_BUILD=1 cargo +nightly udeps
+
   deny:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -127,7 +127,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run udeps
-        run: SKIP_GUEST_BUILD=1 cargo +nightly udeps
+        run: SKIP_GUEST_BUILD=1 cargo +nightly udeps --workspace --all-features
 
   deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -132,7 +132,7 @@ jobs:
         uses: aig787/cargo-udeps-action@v1
         with:
           version: 'latest'
-          args: '--workspace --all-features'
+          args: '--workspace --all-features --all-targets'
 
   deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -127,6 +127,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run cargo-udeps
+        env:
+          RUSTFLAGS: -A warnings
         uses: aig787/cargo-udeps-action@v1
         with:
           version: 'latest'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -126,8 +126,11 @@ jobs:
         run: cargo risczero install --version v2024-04-22.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run udeps
-        run: SKIP_GUEST_BUILD=1 cargo +nightly udeps --workspace --all-features
+      - name: Run cargo-udeps
+        uses: aig787/cargo-udeps-action@v1
+        with:
+          version: 'latest'
+          args: '--workspace --all-features'
 
   deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -99,7 +99,7 @@ jobs:
 
   udeps:
     name: udeps
-    runs-on: ubicloud-standard-16
+    runs-on: ubicloud-standard-4
     timeout-minutes: 60
     if: github.event.pull_request.draft == false
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,7 +1591,6 @@ dependencies = [
  "humantime",
  "jsonrpsee",
  "log",
- "prometheus 0.11.0",
  "proptest",
  "regex",
  "reqwest 0.12.3",
@@ -6105,21 +6104,6 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8425533e7122f0c3cc7a37e6244b16ad3a2cc32ae7ac6276e2a75da0d9c200d"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "parking_lot 0.11.2",
- "protobuf",
- "regex",
- "thiserror",
-]
-
-[[package]]
-name = "prometheus"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
@@ -6259,12 +6243,6 @@ checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
  "prost 0.12.3",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf-src"
@@ -9263,7 +9241,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "once_cell",
- "prometheus 0.13.3",
+ "prometheus",
  "proptest",
  "proptest-derive 0.3.0",
  "rocksdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9073,6 +9073,7 @@ dependencies = [
  "serde_json",
  "sov-modules-api",
  "sov-modules-core",
+ "sov-state",
  "syn 1.0.109",
  "trybuild",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,12 +475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,7 +1579,6 @@ dependencies = [
  "citrea-stf",
  "clap",
  "const-rollup-config",
- "criterion",
  "ethereum-rpc",
  "ethereum-types",
  "ethers",
@@ -1598,8 +1591,6 @@ dependencies = [
  "humantime",
  "jsonrpsee",
  "log",
- "log4rs",
- "prettytable-rs",
  "prometheus 0.11.0",
  "proptest",
  "regex",
@@ -1626,12 +1617,9 @@ dependencies = [
  "sov-modules-stf-blueprint",
  "sov-prover-storage-manager",
  "sov-risc0-adapter",
- "sov-rng-da-service",
  "sov-rollup-interface",
- "sov-sequencer",
  "sov-state",
  "sov-stf-runner",
- "sov-zk-cycle-macros",
  "tempfile",
  "tendermint",
  "tokio",
@@ -1649,7 +1637,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "bytes",
- "citrea-evm",
  "clap",
  "ethereum-types",
  "ethers",
@@ -1691,7 +1678,6 @@ name = "citrea-sequencer"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "bitcoin-da",
  "borsh",
  "chrono",
  "citrea-evm",
@@ -1745,7 +1731,6 @@ dependencies = [
  "serde_json",
  "soft-confirmation-rule-enforcer",
  "sov-accounts",
- "sov-mock-da",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rollup-interface",
@@ -2098,27 +2083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ctr"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,7 +2304,6 @@ dependencies = [
  "borsh",
  "citrea-evm",
  "clap",
- "demo-stf",
  "hex",
  "jsonrpsee",
  "rand 0.8.5",
@@ -2363,7 +2326,6 @@ dependencies = [
  "sov-prover-storage-manager",
  "sov-rollup-interface",
  "sov-sequencer-registry",
- "sov-soft-confirmations-kernel",
  "sov-state",
  "sov-stf-runner",
  "sov-value-setter",
@@ -2452,12 +2414,6 @@ dependencies = [
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "destructure_traitobject"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
 name = "digest"
@@ -2733,12 +2689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,7 +2857,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "citrea-evm",
- "citrea-stf",
  "ethers",
  "jsonrpsee",
  "proptest",
@@ -2919,10 +2868,8 @@ dependencies = [
  "sequencer-client",
  "serde",
  "serde_json",
- "sov-accounts",
  "sov-modules-api",
  "sov-rollup-interface",
- "sov-stf-runner",
  "tokio",
  "tracing",
 ]
@@ -4373,9 +4320,6 @@ dependencies = [
  "jsonrpsee",
  "serde",
  "sov-chain-state",
- "sov-data-generators",
- "sov-mock-da",
- "sov-mock-zkvm",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-prover-storage-manager",
@@ -5074,43 +5018,6 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "log-mdc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
-
-[[package]]
-name = "log4rs"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6"
-dependencies = [
- "anyhow",
- "arc-swap",
- "chrono",
- "derivative",
- "fnv",
- "humantime",
- "libc",
- "log",
- "log-mdc",
- "once_cell",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "serde",
- "serde-value",
- "serde_json",
- "serde_yaml",
- "thiserror",
- "thread-id",
- "typemap-ors",
- "winapi",
-]
 
 [[package]]
 name = "lru"
@@ -5683,15 +5590,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6118,20 +6016,6 @@ checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2 1.0.79",
  "syn 2.0.55",
-]
-
-[[package]]
-name = "prettytable-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
-dependencies = [
- "csv",
- "encode_unicode",
- "is-terminal",
- "lazy_static",
- "term",
- "unicode-width",
 ]
 
 [[package]]
@@ -8523,7 +8407,6 @@ name = "sequencer-client"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "citrea-evm",
  "ethers",
  "hex",
  "jsonrpsee",
@@ -8543,16 +8426,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
 ]
 
 [[package]]
@@ -8661,19 +8534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.2.6",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha-1"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8754,11 +8614,8 @@ dependencies = [
 name = "shared-backup-db"
 version = "0.3.0"
 dependencies = [
- "hex",
- "lazy_static",
  "postgres",
  "serde",
- "shared-backup-db",
  "tokio",
  "tokio-postgres",
 ]
@@ -8951,7 +8808,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-accounts",
  "sov-modules-api",
  "sov-prover-storage-manager",
  "sov-state",
@@ -8969,7 +8825,6 @@ dependencies = [
  "jmt",
  "serde",
  "serde_json",
- "sov-attester-incentives",
  "sov-bank",
  "sov-chain-state",
  "sov-mock-da",
@@ -9037,9 +8892,6 @@ dependencies = [
  "jsonrpsee",
  "serde",
  "serde_json",
- "sov-chain-state",
- "sov-data-generators",
- "sov-mock-da",
  "sov-modules-api",
  "sov-prover-storage-manager",
  "sov-state",
@@ -9097,7 +8949,6 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "sov-mock-da",
- "sov-prover-storage-manager",
  "sov-rollup-interface",
  "sov-schema-db",
  "tempfile",
@@ -9137,7 +8988,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-mock-da",
  "sov-rollup-interface",
  "tokio",
  "tokio-stream",
@@ -9159,7 +9009,6 @@ dependencies = [
 name = "sov-module-schemas"
 version = "0.3.0"
 dependencies = [
- "citrea-evm",
  "sov-accounts",
  "sov-bank",
  "sov-mock-da",
@@ -9188,13 +9037,10 @@ dependencies = [
  "proptest",
  "proptest-derive 0.3.0",
  "rand 0.8.5",
- "risc0-zkvm",
- "risc0-zkvm-platform",
  "schemars",
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-bank",
  "sov-db",
  "sov-mock-da",
  "sov-modules-api",
@@ -9240,21 +9086,12 @@ name = "sov-modules-macros"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
- "clap",
  "jsonrpsee",
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "schemars",
  "serde",
  "serde_json",
- "sov-bank",
- "sov-modules-api",
- "sov-modules-core",
- "sov-modules-macros",
- "sov-state",
  "syn 1.0.109",
- "tempfile",
  "trybuild",
 ]
 
@@ -9278,7 +9115,6 @@ dependencies = [
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rollup-interface",
- "sov-sequencer",
  "sov-state",
  "sov-stf-runner",
  "tokio",
@@ -9318,7 +9154,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sov-data-generators",
  "sov-modules-api",
  "sov-modules-macros",
  "sov-nft-module",
@@ -9343,7 +9178,6 @@ dependencies = [
  "sov-mock-da",
  "sov-mock-zkvm",
  "sov-modules-api",
- "sov-prover-incentives",
  "sov-prover-storage-manager",
  "sov-state",
  "tempfile",
@@ -9543,7 +9377,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sov-accounts",
  "sov-bank",
  "sov-db",
  "sov-mock-da",
@@ -9552,7 +9385,6 @@ dependencies = [
  "sov-modules-stf-blueprint",
  "sov-prover-storage-manager",
  "sov-rollup-interface",
- "sov-sequencer",
  "sov-sequencer-registry",
  "sov-state",
  "sov-stf-runner",
@@ -9561,7 +9393,6 @@ dependencies = [
  "tokio",
  "toml 0.8.2",
  "tracing",
- "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -9578,7 +9409,6 @@ dependencies = [
  "sov-modules-api",
  "sov-prover-storage-manager",
  "sov-state",
- "sov-value-setter",
  "tempfile",
  "thiserror",
 ]
@@ -9605,14 +9435,8 @@ dependencies = [
 name = "sov-zk-cycle-macros"
 version = "0.3.0"
 dependencies = [
- "anyhow",
- "borsh",
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "risc0-zkvm",
- "risc0-zkvm-platform",
- "sov-zk-cycle-macros",
- "sov-zk-cycle-utils",
  "syn 1.0.109",
  "trybuild",
 ]
@@ -9986,16 +9810,6 @@ dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
  "syn 2.0.55",
-]
-
-[[package]]
-name = "thread-id"
-version = "4.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -10560,15 +10374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap-ors"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
-dependencies = [
- "unsafe-any-ors",
-]
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10657,12 +10462,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10683,21 +10482,6 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-any-ors"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
-dependencies = [
- "destructure_traitobject",
-]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9064,11 +9064,15 @@ name = "sov-modules-macros"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "borsh",
+ "clap",
  "jsonrpsee",
  "proc-macro2 1.0.79",
  "quote 1.0.35",
  "serde",
  "serde_json",
+ "sov-modules-api",
+ "sov-modules-core",
  "syn 1.0.109",
  "trybuild",
 ]
@@ -9415,6 +9419,9 @@ version = "0.3.0"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
+ "risc0-zkvm",
+ "risc0-zkvm-platform",
+ "sov-zk-cycle-macros",
  "syn 1.0.109",
  "trybuild",
 ]

--- a/bin/citrea/Cargo.toml
+++ b/bin/citrea/Cargo.toml
@@ -102,7 +102,6 @@ revm = { workspace = true }
 
 rustc_version_runtime = { workspace = true }
 tendermint = "0.32"
-prometheus = "0.11.0"
 log = "0.4"
 regex = "1.10"
 

--- a/bin/citrea/Cargo.toml
+++ b/bin/citrea/Cargo.toml
@@ -55,7 +55,6 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 soft-confirmation-rule-enforcer = { path = "../../crates/soft-confirmation-rule-enforcer" }
 sov-db = { path = "../../crates/sovereign-sdk/full-node/db/sov-db" }
 ethereum-rpc = { path = "../../crates/ethereum-rpc" }
-sov-sequencer = { path = "../../crates/sovereign-sdk/full-node/sov-sequencer" }
 sequencer-client = { path = "../../crates/sequencer-client" }
 citrea-sequencer = { path = "../../crates/sequencer" }
 sov-risc0-adapter = { path = "../../crates/sovereign-sdk/adapters/risc0", features = [
@@ -68,7 +67,6 @@ clap = { workspace = true }
 secp256k1 = { workspace = true }
 
 [dev-dependencies]
-sov-rng-da-service = { path = "../../crates/sovereign-sdk/utils/rng-da-service" }
 sov-rollup-interface = { path = "../../crates/sovereign-sdk/rollup-interface", features = [
     "fuzzing",
 ] }
@@ -77,7 +75,6 @@ sov-prover-storage-manager = { path = "../../crates/sovereign-sdk/full-node/sov-
 ] }
 sov-mock-da = { path = "../../crates/sovereign-sdk/adapters/mock-da" }
 citrea-evm = { path = "../../crates/evm", features = ["smart_contracts"] }
-sov-zk-cycle-macros = { path = "../../crates/sovereign-sdk/utils/zk-cycle-macros" }
 shared-backup-db = { path = "../../crates/shared-backup-db", features = [
     "test-utils",
 ] }
@@ -106,10 +103,7 @@ revm = { workspace = true }
 rustc_version_runtime = { workspace = true }
 tendermint = "0.32"
 prometheus = "0.11.0"
-prettytable-rs = "^0.10"
-criterion = "0.5.1"
 log = "0.4"
-log4rs = "1.0"
 regex = "1.10"
 
 [features]
@@ -119,7 +113,6 @@ default = [
 bench = [
     "hex",
     "sov-risc0-adapter/bench",
-    "sov-zk-cycle-macros/bench",
     "risc0/bench",
 ]
 

--- a/bin/citrea/provers/risc0/guest-mock/Cargo.lock
+++ b/bin/citrea/provers/risc0/guest-mock/Cargo.lock
@@ -2781,6 +2781,7 @@ name = "sov-modules-macros"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "borsh",
  "proc-macro2",
  "quote",
  "serde_json",

--- a/bin/citrea/provers/risc0/guest-mock/Cargo.lock
+++ b/bin/citrea/provers/risc0/guest-mock/Cargo.lock
@@ -784,7 +784,6 @@ dependencies = [
  "serde",
  "soft-confirmation-rule-enforcer",
  "sov-accounts",
- "sov-mock-da",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rollup-interface",
@@ -2750,8 +2749,6 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "jmt",
- "risc0-zkvm",
- "risc0-zkvm-platform",
  "serde",
  "sha2",
  "sov-modules-core",
@@ -2784,12 +2781,9 @@ name = "sov-modules-macros"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
  "proc-macro2",
  "quote",
- "schemars",
  "serde_json",
- "sov-modules-core",
  "syn 1.0.109",
 ]
 
@@ -2896,8 +2890,6 @@ dependencies = [
 name = "sov-zk-cycle-macros"
 version = "0.3.0"
 dependencies = [
- "anyhow",
- "borsh",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/crates/citrea-stf/Cargo.toml
+++ b/crates/citrea-stf/Cargo.toml
@@ -28,7 +28,6 @@ secp256k1 = { workspace = true }
 
 sov-stf-runner = { path = "../sovereign-sdk/full-node/sov-stf-runner" }
 sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface" }
-sov-mock-da = { path = "../sovereign-sdk/adapters/mock-da" }
 sov-modules-stf-blueprint = { path = "../sovereign-sdk/module-system/sov-modules-stf-blueprint" }
 sov-accounts = { path = "../sovereign-sdk/module-system/module-implementations/sov-accounts" }
 sov-state = { path = "../sovereign-sdk/module-system/sov-state" }
@@ -56,7 +55,6 @@ native = [
     "sov-accounts/native",
     "sov-modules-api/native",
     "sov-rollup-interface/native",
-    "sov-mock-da/native",
     "sov-modules-stf-blueprint/native",
     "soft-confirmation-rule-enforcer/native",
     "citrea-evm/native",

--- a/crates/ethereum-rpc/Cargo.toml
+++ b/crates/ethereum-rpc/Cargo.toml
@@ -13,7 +13,6 @@ resolver = "2"
 
 [dependencies]
 citrea-evm = { path = "../evm" }
-sov-stf-runner = { path = "../sovereign-sdk/full-node/sov-stf-runner" }
 sequencer-client = { path = "../sequencer-client" }
 anyhow = { workspace = true }
 tracing = { workspace = true }
@@ -36,9 +35,7 @@ sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface", features = 
     "native",
 ] }
 
-citrea-stf = { path = "../citrea-stf", features = ["native"] }
 sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api" }
-sov-accounts = { path = "../sovereign-sdk/module-system/module-implementations/sov-accounts" }
 
 [dev-dependencies]
 tokio = { workspace = true }
@@ -48,4 +45,4 @@ proptest = { workspace = true }
 [features]
 default = ["local"]
 local = []
-native = ["citrea-stf/native", "citrea-evm/native"]
+native = ["citrea-evm/native"]

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -48,12 +48,10 @@ reth-interfaces = { workspace = true, optional = true }
 reth-rpc-types = { workspace = true, optional = true }
 reth-rpc-types-compat = { workspace = true, optional = true }
 reth-revm = { workspace = true, optional = true }
-reth-rpc = { workspace = true, optional = true }
 secp256k1 = { workspace = true, optional = true }
 itertools = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
-citrea-evm = { path = ".", features = ["native", "smart_contracts"] }
 revm = { workspace = true, features = [
     "optional_block_gas_limit",
     "optional_eip3607",
@@ -69,6 +67,7 @@ lazy_static = "1.4.0"
 walkdir = "2.3.3"
 reth-db = { workspace = true }
 reth-provider = { workspace = true }
+reth-rpc = { workspace = true }
 reth-stages = { workspace = true }
 rayon = { workspace = true }
 
@@ -79,7 +78,6 @@ native = [
     "sov-state/native",
     "sov-modules-api/native",
 
-    "reth-rpc",
     "reth-interfaces",
     "reth-rpc-types",
     "reth-rpc-types-compat",

--- a/crates/sequencer-client/Cargo.toml
+++ b/crates/sequencer-client/Cargo.toml
@@ -21,7 +21,6 @@ jsonrpsee = { workspace = true, features = ["http-client"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true }
-citrea-evm = { path = "../evm" }
 
 ethers = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -13,7 +13,6 @@ resolver = "2"
 
 [dependencies]
 anyhow = { workspace = true }
-bitcoin-da = { path = "../bitcoin-da" }
 borsh = { workspace = true }
 chrono = { workspace = true }
 digest = { workspace = true }

--- a/crates/shared-backup-db/Cargo.toml
+++ b/crates/shared-backup-db/Cargo.toml
@@ -15,12 +15,9 @@ resolver = "2"
 postgres = "0.19.7"
 tokio-postgres = "0.7.10"
 serde = { workspace = true }
-hex = { workspace = true }
 tokio = { workspace = true }
-lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
-shared-backup-db = { path = ".", features = ["test-utils"] }
 
 [features]
 default = []

--- a/crates/sovereign-sdk/adapters/mock-da/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/mock-da/Cargo.toml
@@ -30,7 +30,6 @@ tracing = { workspace = true }
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
 
 [dev-dependencies]
-sov-mock-da = { path = ".", features = ["native"] }
 futures = { workspace = true }
 
 [features]

--- a/crates/sovereign-sdk/examples/demo-stf/Cargo.toml
+++ b/crates/sovereign-sdk/examples/demo-stf/Cargo.toml
@@ -29,14 +29,11 @@ secp256k1 = { workspace = true }
 
 sov-stf-runner = { path = "../../../sovereign-sdk/full-node/sov-stf-runner" }
 sov-rollup-interface = { path = "../../../sovereign-sdk/rollup-interface" }
-sov-cli = { path = "../../../sovereign-sdk/module-system/sov-cli", optional = true }
 sov-sequencer-registry = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-sequencer-registry" }
 sov-blob-storage = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-blob-storage" }
 sov-bank = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-bank" }
 sov-nft-module = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-nft-module" }
-sov-soft-confirmations-kernel = { path = "../../../sovereign-sdk/module-system/sov-soft-confirmations-kernel" }
 
-sov-mock-da = { path = "../../../sovereign-sdk/adapters/mock-da" }
 sov-chain-state = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-chain-state" }
 sov-modules-stf-blueprint = { path = "../../../sovereign-sdk/module-system/sov-modules-stf-blueprint" }
 sov-value-setter = { path = "../../../sovereign-sdk/module-system/module-implementations/examples/sov-value-setter" }
@@ -48,10 +45,11 @@ soft-confirmation-rule-enforcer = { path = "../../../soft-confirmation-rule-enfo
 
 
 [dev-dependencies]
-demo-stf = { path = ".", features = ["native"] }
 tempfile = { workspace = true }
 rand = { workspace = true }
+sov-cli = { path = "../../../sovereign-sdk/module-system/sov-cli" }
 sov-data-generators = { path = "../../../sovereign-sdk/module-system/utils/sov-data-generators" }
+sov-mock-da = { path = "../../../sovereign-sdk/adapters/mock-da" }
 sov-mock-zkvm = { path = "../../../sovereign-sdk/adapters/mock-zkvm" }
 sov-prover-storage-manager = { path = "../../../sovereign-sdk/full-node/sov-prover-storage-manager", features = [
     "test-utils",
@@ -65,7 +63,6 @@ native = [
     "sov-stf-runner/native",
     "sov-bank/native",
     "sov-nft-module/native",
-    "sov-cli",
     "sov-accounts/native",
     "sov-sequencer-registry/native",
     "sov-blob-storage/native",
@@ -73,9 +70,7 @@ native = [
     "sov-value-setter/native",
     "sov-modules-api/native",
     "sov-rollup-interface/native",
-    "sov-mock-da/native",
     "sov-modules-stf-blueprint/native",
-    "sov-soft-confirmations-kernel/native",
     "clap",
     "serde",
     "serde_json",

--- a/crates/sovereign-sdk/full-node/db/sov-db/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/db/sov-db/Cargo.toml
@@ -36,7 +36,6 @@ tokio = { workspace = true }
 [dev-dependencies]
 sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
 tempfile = { workspace = true }
-sov-prover-storage-manager = { path = "../../sov-prover-storage-manager" }
 criterion = "0.5.1"
 rand = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/Cargo.toml
@@ -50,11 +50,6 @@ sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-bluepr
     "native",
 ] }
 
-sov-accounts = { path = "../../module-system/module-implementations/sov-accounts", features = [
-    "native",
-] }
-sov-sequencer = { path = "../sov-sequencer" }
-
 sov-state = { path = "../../module-system/sov-state", features = ["native"] }
 sov-modules-api = { path = "../../module-system/sov-modules-api", features = [
     "native",
@@ -67,7 +62,6 @@ sov-prover-storage-manager = { path = "../sov-prover-storage-manager", features 
     "test-utils",
 ] }
 
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 
 [features]

--- a/crates/sovereign-sdk/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 
 
 [dev-dependencies]
-sov-value-setter = { path = ".", features = ["native"] }
 tempfile = { workspace = true }
 sov-modules-api = { path = "../../../sov-modules-api", features = ["native"] }
 sov-prover-storage-manager = { path = "../../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }

--- a/crates/sovereign-sdk/module-system/module-implementations/integration-tests/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/integration-tests/Cargo.toml
@@ -21,11 +21,8 @@ jsonrpsee = { workspace = true }
 sov-modules-api = { path = "../../sov-modules-api", features = ["native"] }
 sov-state = { path = "../../sov-state", features = ["native"] }
 
-sov-mock-zkvm = { path = "../../../adapters/mock-zkvm" }
 sov-schema-db = { path = "../../../full-node/db/sov-schema-db" }
-sov-data-generators = { path = "../../utils/sov-data-generators" }
 sov-rollup-interface = { path = "../../../rollup-interface", features = ["native"] }
-sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
 sov-modules-stf-blueprint = { path = "../../sov-modules-stf-blueprint", features = ["native"] }
 
 sov-chain-state = { path = "../sov-chain-state", features = ["native"] }

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-accounts/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-accounts/Cargo.toml
@@ -29,7 +29,6 @@ sov-state = { path = "../../sov-state", version = "0.3" }
 
 
 [dev-dependencies]
-sov-accounts = { path = ".", features = ["native"] }
 tempfile = { workspace = true }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
 

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-attester-incentives/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-attester-incentives/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 
 [dev-dependencies]
 tempfile = { workspace = true }
-sov-attester-incentives = { path = ".", features = ["native"] }
 sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
 sov-mock-zkvm = { path = "../../../adapters/mock-zkvm" }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-chain-state/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-chain-state/Cargo.toml
@@ -23,9 +23,6 @@ sov-state = { path = "../../sov-state", version = "0.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-sov-data-generators = { path = "../../utils/sov-data-generators" }
-sov-chain-state = { path = ".", features = ["native"] }
-sov-mock-da = { path = "../../../adapters/mock-da" }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
 
 

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-nft-module/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-nft-module/Cargo.toml
@@ -33,7 +33,6 @@ tracing = { workspace = true, optional = true }
 [dev-dependencies]
 sov-nft-module = { version = "*", features = ["native"], path = "." }
 tempfile = { workspace = true }
-sov-data-generators = { path = "../../utils/sov-data-generators" }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = [
     "test-utils",
 ] }

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-prover-incentives/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-prover-incentives/Cargo.toml
@@ -13,7 +13,6 @@ resolver = "2"
 
 [dev-dependencies]
 tempfile = { workspace = true }
-sov-prover-incentives = { features = ["native"], path = "." }
 sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
 sov-mock-zkvm = { path = "../../../adapters/mock-zkvm" }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.3", features = ["native"] }

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
@@ -53,3 +53,6 @@ native = [
     "sov-bank/native",
 ]
 serde = []
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["risc0-zkvm", "risc0-zkvm-platform", "sov-zk-cycle-macros", "sov-zk-cycle-utils"]

--- a/crates/sovereign-sdk/module-system/module-schemas/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-schemas/Cargo.toml
@@ -30,7 +30,6 @@ sov-prover-incentives = { path = "../module-implementations/sov-prover-incentive
 sov-sequencer-registry = { path = "../module-implementations/sov-sequencer-registry", features = [
     "native",
 ] }
-citrea-evm = { path = "../../../evm" }
 sov-value-setter = { path = "../module-implementations/examples/sov-value-setter", features = [
     "native",
 ] }

--- a/crates/sovereign-sdk/module-system/sov-modules-api/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/Cargo.toml
@@ -40,21 +40,12 @@ ed25519-dalek = { version = "=2.0.0", default-features = false, features = [
 ] }
 rand = { workspace = true, optional = true }
 
-# sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.3", optional = true }
-risc0-zkvm = { workspace = true, default-features = false, features = [
-    "std",
-], optional = true }
-risc0-zkvm-platform = { workspace = true, optional = true }
-
 [dev-dependencies]
 bincode = { workspace = true }
 tempfile = { workspace = true }
 sov-modules-api = { path = ".", features = ["native"] }
 sov-modules-core = { path = "../sov-modules-core", features = ["mocks"] }
 sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
-sov-bank = { path = "../module-implementations/sov-bank", features = [
-    "native",
-] }
 sov-db = { path = "../../full-node/db/sov-db" }
 sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = [
     "test-utils",
@@ -69,11 +60,7 @@ arbitrary = [
     "proptest/default",
     "sov-state/arbitrary",
 ]
-bench = [
-    # "sov-zk-cycle-macros", 
-    "risc0-zkvm",
-    "risc0-zkvm-platform",
-]
+bench = []
 default = ["macros"]
 native = [
     "serde_json",

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
@@ -27,10 +27,11 @@ trybuild = "1.0"
 
 sov-modules-api = { path = "../sov-modules-api", features = [ "native" ] }
 sov-modules-core = { path = "../sov-modules-core" }
+sov-state = { path = "../sov-state" }
 
 [dependencies]
 anyhow = { workspace = true }
-borsh = { workspace = true, optional = true }
+borsh = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"], optional = true }
 proc-macro2 = "1.0"
 quote = "1.0"
@@ -42,9 +43,9 @@ syn = { version = "1.0", features = ["full"] }
 anyhow = { workspace = true }
 
 [features]
-default = ["borsh"]
+default = []
 native = ["jsonrpsee"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["borsh"]
-development = ["clap", "sov-modules-core", "sov-modules-api"]
+development = ["clap", "sov-modules-core", "sov-modules-api", "sov-state"]

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
@@ -20,27 +20,17 @@ name = "tests"
 path = "tests/all_tests.rs"
 
 [dev-dependencies]
-clap = { workspace = true }
 jsonrpsee = { workspace = true, features = ["macros", "http-client", "server"] }
 serde = { workspace = true }
-tempfile = { workspace = true }
 trybuild = "1.0"
-
-sov-modules-api = { path = "../sov-modules-api" }
-sov-state = { path = "../sov-state" }
-sov-bank = { path = "../module-implementations/sov-bank", features = ["native"] }
-sov-modules-macros = { path = ".", features = ["native"] }
 
 [dependencies]
 anyhow = { workspace = true }
-borsh = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"], optional = true }
 proc-macro2 = "1.0"
 quote = "1.0"
-schemars = { workspace = true }
 serde_json = { workspace = true }
 syn = { version = "1.0", features = ["full"] }
-sov-modules-core = { path = "../sov-modules-core" }
 
 
 [build-dependencies]

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
@@ -20,12 +20,17 @@ name = "tests"
 path = "tests/all_tests.rs"
 
 [dev-dependencies]
+clap = { workspace = true }
 jsonrpsee = { workspace = true, features = ["macros", "http-client", "server"] }
 serde = { workspace = true }
 trybuild = "1.0"
 
+sov-modules-api = { path = "../sov-modules-api", features = [ "native" ] }
+sov-modules-core = { path = "../sov-modules-core" }
+
 [dependencies]
 anyhow = { workspace = true }
+borsh = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"], optional = true }
 proc-macro2 = "1.0"
 quote = "1.0"
@@ -37,5 +42,9 @@ syn = { version = "1.0", features = ["full"] }
 anyhow = { workspace = true }
 
 [features]
-default = []
+default = ["borsh"]
 native = ["jsonrpsee"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["borsh"]
+development = ["clap", "sov-modules-core", "sov-modules-api"]

--- a/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/Cargo.toml
@@ -33,7 +33,6 @@ sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-bluepr
 ], version = "0.3" }
 sov-db = { path = "../../full-node/db/sov-db", version = "0.3" }
 
-sov-sequencer = { path = "../../full-node/sov-sequencer" }
 sov-ledger-rpc = { path = "../../full-node/sov-ledger-rpc", features = [
     "server",
 ] }

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/Cargo.toml
@@ -35,3 +35,6 @@ sov-blob-storage = { path = "../module-implementations/sov-blob-storage" }
 bench = ["sov-zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]
 default = []
 native = ["sov-state/native", "sov-modules-api/native", "jsonrpsee", "sov-chain-state/native", "sov-blob-storage/native"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["risc0-zkvm", "risc0-zkvm-platform", "sov-zk-cycle-macros", "sov-zk-cycle-utils"]

--- a/crates/sovereign-sdk/module-system/sov-soft-confirmations-kernel/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-soft-confirmations-kernel/Cargo.toml
@@ -19,7 +19,7 @@ sov-blob-storage = { path = "../module-implementations/sov-blob-storage" }
 sov-chain-state = { path = "../module-implementations/sov-chain-state" }
 
 [features]
-default = []
+default = ["native"]
 native = [
 	"sov-state/native",
 	"sov-modules-api/native",

--- a/crates/sovereign-sdk/module-system/sov-state/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-state/Cargo.toml
@@ -46,3 +46,6 @@ arbitrary = [
 bench = ["sov-zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]
 default = []
 native = ["sov-db"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["risc0-zkvm", "risc0-zkvm-platform", "sov-zk-cycle-macros"]

--- a/crates/sovereign-sdk/utils/zk-cycle-macros/Cargo.toml
+++ b/crates/sovereign-sdk/utils/zk-cycle-macros/Cargo.toml
@@ -20,18 +20,12 @@ name = "tests"
 path = "tests/all_tests.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-borsh = { workspace = true }
 
 [dev-dependencies]
 trybuild = "1.0"
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros" }
-sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils" }
-risc0-zkvm = { workspace = true, default-features = false, features = ["std"] }
-risc0-zkvm-platform = { workspace = true }
 
 [features]
 bench = []

--- a/crates/sovereign-sdk/utils/zk-cycle-macros/Cargo.toml
+++ b/crates/sovereign-sdk/utils/zk-cycle-macros/Cargo.toml
@@ -26,6 +26,12 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 trybuild = "1.0"
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros" }
+risc0-zkvm = { workspace = true, default-features = false, features = ["std"] }
+risc0-zkvm-platform = { workspace = true }
 
 [features]
 bench = []
+
+[package.metadata.cargo-udeps.ignore]
+development = ["risc0-zkvm", "risc0-zkvm-platform", "sov-zk-cycle-macros"]


### PR DESCRIPTION
# Description

`cargo-udeps` makes sure we don't leave in unused dependencies. Might report some false positives, we therefore add some ignores into our `Cargo.toml` files because we know for a fact that a specific dependency is used which `udeps` does not see.

https://github.com/est31/cargo-udeps