### PR TITLE
Use dprint to format TOML files

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -90,6 +90,8 @@ jobs:
         run: cargo risczero install --version v2024-04-22.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check TOML
+        uses: dprint/check@v2.2
       - name: Run lint
         run: |
           if ! SKIP_GUEST_BUILD=1 make lint ; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,61 +1,61 @@
 [workspace]
 resolver = "2"
 members = [
-    # Citrea
-    "bin/citrea",
-    "crates/bitcoin-da",
-    "crates/evm",
-    "crates/sequencer",
-    "crates/sequencer-client",
-    "crates/soft-confirmation-rule-enforcer",
-    "crates/ethereum-rpc",
-    # Sovereign sdk
-    "crates/sovereign-sdk/rollup-interface",
-    "crates/sovereign-sdk/adapters/risc0",
-    "crates/sovereign-sdk/adapters/mock-da",
-    "crates/sovereign-sdk/adapters/mock-zkvm",
-    # Examples
-    "crates/sovereign-sdk/examples/const-rollup-config",
-    "crates/sovereign-sdk/examples/demo-simple-stf",
-    "crates/sovereign-sdk/examples/simple-nft-module",
-    "crates/sovereign-sdk/examples/demo-stf",
-    # Full Node
-    "crates/sovereign-sdk/full-node/db/sov-db",
-    "crates/sovereign-sdk/full-node/sov-sequencer",
-    "crates/sovereign-sdk/full-node/sov-ledger-rpc",
-    "crates/sovereign-sdk/full-node/sov-stf-runner",
-    "crates/sovereign-sdk/full-node/sov-prover-storage-manager",
-    # Utils
-    "crates/sovereign-sdk/utils/zk-cycle-macros",
-    "crates/sovereign-sdk/utils/zk-cycle-utils",
-    "crates/sovereign-sdk/utils/bashtestmd",
-    "crates/sovereign-sdk/utils/rng-da-service",
-    # Module System
-    "crates/sovereign-sdk/module-system/sov-cli",
-    "crates/sovereign-sdk/module-system/sov-modules-stf-blueprint",
-    "crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint",
-    "crates/sovereign-sdk/module-system/sov-modules-macros",
-    "crates/sovereign-sdk/module-system/sov-modules-core",
-    "crates/sovereign-sdk/module-system/sov-soft-confirmations-kernel",
-    "crates/sovereign-sdk/module-system/sov-state",
-    "crates/sovereign-sdk/module-system/sov-modules-api",
-    "crates/sovereign-sdk/module-system/module-schemas",
-    "crates/sovereign-sdk/module-system/utils/sov-data-generators",
-    "crates/sovereign-sdk/module-system/module-implementations/sov-accounts",
-    "crates/sovereign-sdk/module-system/module-implementations/sov-bank",
-    "crates/sovereign-sdk/module-system/module-implementations/sov-nft-module",
-    "crates/sovereign-sdk/module-system/module-implementations/sov-chain-state",
-    "crates/sovereign-sdk/module-system/module-implementations/sov-blob-storage",
-    "crates/sovereign-sdk/module-system/module-implementations/sov-prover-incentives",
-    "crates/sovereign-sdk/module-system/module-implementations/sov-attester-incentives",
-    "crates/sovereign-sdk/module-system/module-implementations/sov-sequencer-registry",
-    "crates/sovereign-sdk/module-system/module-implementations/module-template",
-    "crates/sovereign-sdk/module-system/module-implementations/examples/sov-value-setter",
-    "crates/sovereign-sdk/module-system/module-implementations/examples/sov-vec-setter",
-    "crates/sovereign-sdk/module-system/module-implementations/examples/sov-accessory-state",
-    "crates/sovereign-sdk/module-system/module-implementations/integration-tests",
-    # Offchain
-    "crates/shared-backup-db",
+  # Citrea
+  "bin/citrea",
+  "crates/bitcoin-da",
+  "crates/evm",
+  "crates/sequencer",
+  "crates/sequencer-client",
+  "crates/soft-confirmation-rule-enforcer",
+  "crates/ethereum-rpc",
+  # Sovereign sdk
+  "crates/sovereign-sdk/rollup-interface",
+  "crates/sovereign-sdk/adapters/risc0",
+  "crates/sovereign-sdk/adapters/mock-da",
+  "crates/sovereign-sdk/adapters/mock-zkvm",
+  # Examples
+  "crates/sovereign-sdk/examples/const-rollup-config",
+  "crates/sovereign-sdk/examples/demo-simple-stf",
+  "crates/sovereign-sdk/examples/simple-nft-module",
+  "crates/sovereign-sdk/examples/demo-stf",
+  # Full Node
+  "crates/sovereign-sdk/full-node/db/sov-db",
+  "crates/sovereign-sdk/full-node/sov-sequencer",
+  "crates/sovereign-sdk/full-node/sov-ledger-rpc",
+  "crates/sovereign-sdk/full-node/sov-stf-runner",
+  "crates/sovereign-sdk/full-node/sov-prover-storage-manager",
+  # Utils
+  "crates/sovereign-sdk/utils/zk-cycle-macros",
+  "crates/sovereign-sdk/utils/zk-cycle-utils",
+  "crates/sovereign-sdk/utils/bashtestmd",
+  "crates/sovereign-sdk/utils/rng-da-service",
+  # Module System
+  "crates/sovereign-sdk/module-system/sov-cli",
+  "crates/sovereign-sdk/module-system/sov-modules-stf-blueprint",
+  "crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint",
+  "crates/sovereign-sdk/module-system/sov-modules-macros",
+  "crates/sovereign-sdk/module-system/sov-modules-core",
+  "crates/sovereign-sdk/module-system/sov-soft-confirmations-kernel",
+  "crates/sovereign-sdk/module-system/sov-state",
+  "crates/sovereign-sdk/module-system/sov-modules-api",
+  "crates/sovereign-sdk/module-system/module-schemas",
+  "crates/sovereign-sdk/module-system/utils/sov-data-generators",
+  "crates/sovereign-sdk/module-system/module-implementations/sov-accounts",
+  "crates/sovereign-sdk/module-system/module-implementations/sov-bank",
+  "crates/sovereign-sdk/module-system/module-implementations/sov-nft-module",
+  "crates/sovereign-sdk/module-system/module-implementations/sov-chain-state",
+  "crates/sovereign-sdk/module-system/module-implementations/sov-blob-storage",
+  "crates/sovereign-sdk/module-system/module-implementations/sov-prover-incentives",
+  "crates/sovereign-sdk/module-system/module-implementations/sov-attester-incentives",
+  "crates/sovereign-sdk/module-system/module-implementations/sov-sequencer-registry",
+  "crates/sovereign-sdk/module-system/module-implementations/module-template",
+  "crates/sovereign-sdk/module-system/module-implementations/examples/sov-value-setter",
+  "crates/sovereign-sdk/module-system/module-implementations/examples/sov-vec-setter",
+  "crates/sovereign-sdk/module-system/module-implementations/examples/sov-accessory-state",
+  "crates/sovereign-sdk/module-system/module-implementations/integration-tests",
+  # Offchain
+  "crates/shared-backup-db",
 ]
 
 [workspace.package]
@@ -88,29 +88,17 @@ digest = { version = "0.10.6", default-features = false, features = ["alloc"] }
 rs_merkle = "1.4.2"
 futures = "0.3"
 pin-project = { version = "1.1.3" }
-hex = { version = "0.4.3", default-features = false, features = [
-    "alloc",
-    "serde",
-] }
-once_cell = { version = "1.19.0", default-features = false, features = [
-    "alloc",
-] }
+hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
+once_cell = { version = "1.19.0", default-features = false, features = ["alloc"] }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.3.1", default-features = false, features = ["alloc"] }
 proptest-derive = "0.3.0"
 rand = "0.8"
 rayon = "1.8.0"
 rustc_version_runtime = { version = "0.3.0", default-features = false }
-reqwest = { version = "0.12", features = [
-    "rustls-tls",
-    "json",
-    "http2",
-], default-features = false }
+reqwest = { version = "0.12", features = ["rustls-tls", "json", "http2"], default-features = false }
 rocksdb = { version = "0.21.0", features = ["lz4"] }
-serde = { version = "1.0.192", default-features = false, features = [
-    "alloc",
-    "derive",
-] }
+serde = { version = "1.0.192", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10.6", default-features = false }
 thiserror = "1.0.50"
@@ -161,10 +149,7 @@ alloy-trie = { version = "=0.3.0", default-features = false }
 alloy-primitives = "0.6.4"
 alloy-sol-types = "0.6.4"
 
-secp256k1 = { version = "0.27.0", default-features = false, features = [
-    "global-context",
-    "recovery",
-] }
+secp256k1 = { version = "0.27.0", default-features = false, features = ["global-context", "recovery"] }
 
 [patch.'https://github.com/eigerco/celestia-node-rs.git']
 # Uncomment to apply local changes

--- a/bin/citrea/Cargo.toml
+++ b/bin/citrea/Cargo.toml
@@ -1,126 +1,105 @@
 [package]
 name = "citrea"
 version = { workspace = true }
-edition = { workspace = true }
 authors = { workspace = true }
-license = { workspace = true }
+default-run = "citrea"
+edition = { workspace = true }
 homepage = "sovereign.xyz"
+license = { workspace = true }
 publish = false
 resolver = "2"
-default-run = "citrea"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # non-optional dependencies
 bitcoin-da = { path = "../../crates/bitcoin-da", features = ["native"] }
-sov-mock-da = { path = "../../crates/sovereign-sdk/adapters/mock-da", features = [
-    "native",
-] }
 const-rollup-config = { path = "../../crates/sovereign-sdk/examples/const-rollup-config" }
-sov-stf-runner = { path = "../../crates/sovereign-sdk/full-node/sov-stf-runner", features = [
-    "native",
-] }
-sov-rollup-interface = { path = "../../crates/sovereign-sdk/rollup-interface", features = [
-    "native",
-] }
+sov-mock-da = { path = "../../crates/sovereign-sdk/adapters/mock-da", features = ["native"] }
 sov-prover-storage-manager = { path = "../../crates/sovereign-sdk/full-node/sov-prover-storage-manager" }
+sov-rollup-interface = { path = "../../crates/sovereign-sdk/rollup-interface", features = ["native"] }
+sov-stf-runner = { path = "../../crates/sovereign-sdk/full-node/sov-stf-runner", features = ["native"] }
 
-sov-modules-rollup-blueprint = { path = "../../crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint" }
-sov-modules-stf-blueprint = { path = "../../crates/sovereign-sdk/module-system/sov-modules-stf-blueprint", features = [
-    "native",
-] }
-sov-modules-api = { path = "../../crates/sovereign-sdk/module-system/sov-modules-api", features = [
-    "native",
-] }
-citrea-stf = { path = "../../crates/citrea-stf", features = ["native"] }
-sov-ledger-rpc = { path = "../../crates/sovereign-sdk/full-node/sov-ledger-rpc", features = [
-    "server",
-] }
-risc0 = { path = "./provers/risc0" }
-borsh = { workspace = true, features = ["bytes"] }
-async-trait = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
+borsh = { workspace = true, features = ["bytes"] }
+citrea-stf = { path = "../../crates/citrea-stf", features = ["native"] }
+hex = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
+reth-primitives = { workspace = true }
+reth-rpc-types = { workspace = true }
+reth-transaction-pool = { workspace = true }
+risc0 = { path = "./provers/risc0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tracing = { workspace = true }
-hex = { workspace = true, optional = true }
+sov-ledger-rpc = { path = "../../crates/sovereign-sdk/full-node/sov-ledger-rpc", features = ["server"] }
+sov-modules-api = { path = "../../crates/sovereign-sdk/module-system/sov-modules-api", features = ["native"] }
+sov-modules-rollup-blueprint = { path = "../../crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint" }
+sov-modules-stf-blueprint = { path = "../../crates/sovereign-sdk/module-system/sov-modules-stf-blueprint", features = ["native"] }
 tokio = { workspace = true }
-reth-primitives = { workspace = true }
-reth-transaction-pool = { workspace = true }
-reth-rpc-types = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
+citrea-sequencer = { path = "../../crates/sequencer" }
+clap = { workspace = true }
+ethereum-rpc = { path = "../../crates/ethereum-rpc" }
+secp256k1 = { workspace = true }
+sequencer-client = { path = "../../crates/sequencer-client" }
 soft-confirmation-rule-enforcer = { path = "../../crates/soft-confirmation-rule-enforcer" }
 sov-db = { path = "../../crates/sovereign-sdk/full-node/db/sov-db" }
-ethereum-rpc = { path = "../../crates/ethereum-rpc" }
+sov-risc0-adapter = { path = "../../crates/sovereign-sdk/adapters/risc0", features = ["native"] }
 sov-sequencer = { path = "../../crates/sovereign-sdk/full-node/sov-sequencer" }
-sequencer-client = { path = "../../crates/sequencer-client" }
-citrea-sequencer = { path = "../../crates/sequencer" }
-sov-risc0-adapter = { path = "../../crates/sovereign-sdk/adapters/risc0", features = [
-    "native",
-] }
-sov-state = { path = "../../crates/sovereign-sdk/module-system/sov-state", features = [
-    "native",
-] }
-clap = { workspace = true }
-secp256k1 = { workspace = true }
+sov-state = { path = "../../crates/sovereign-sdk/module-system/sov-state", features = ["native"] }
 
 [dev-dependencies]
-sov-rng-da-service = { path = "../../crates/sovereign-sdk/utils/rng-da-service" }
-sov-rollup-interface = { path = "../../crates/sovereign-sdk/rollup-interface", features = [
-    "fuzzing",
-] }
-sov-prover-storage-manager = { path = "../../crates/sovereign-sdk/full-node/sov-prover-storage-manager", features = [
-    "test-utils",
-] }
-sov-mock-da = { path = "../../crates/sovereign-sdk/adapters/mock-da" }
 citrea-evm = { path = "../../crates/evm", features = ["smart_contracts"] }
+shared-backup-db = { path = "../../crates/shared-backup-db", features = ["test-utils"] }
+sov-mock-da = { path = "../../crates/sovereign-sdk/adapters/mock-da" }
+sov-prover-storage-manager = { path = "../../crates/sovereign-sdk/full-node/sov-prover-storage-manager", features = ["test-utils"] }
+sov-rng-da-service = { path = "../../crates/sovereign-sdk/utils/rng-da-service" }
+sov-rollup-interface = { path = "../../crates/sovereign-sdk/rollup-interface", features = ["fuzzing"] }
 sov-zk-cycle-macros = { path = "../../crates/sovereign-sdk/utils/zk-cycle-macros" }
-shared-backup-db = { path = "../../crates/shared-backup-db", features = [
-    "test-utils",
-] }
 
-humantime = "2.1"
-rs_merkle = { workspace = true }
-borsh = { workspace = true }
 bincode = { workspace = true }
-sha2 = { workspace = true }
+borsh = { workspace = true }
 hex = { workspace = true }
-serde_json = { workspace = true }
-tempfile = { workspace = true }
+humantime = "2.1"
 proptest = { workspace = true }
 reqwest = { workspace = true }
+rs_merkle = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true }
 
 ethereum-types = { workspace = true }
-ethers-core = { workspace = true }
+ethers = { workspace = true }
 ethers-contract = { workspace = true }
+ethers-core = { workspace = true }
 ethers-middleware = { workspace = true }
 ethers-providers = { workspace = true }
 ethers-signers = { workspace = true }
-ethers = { workspace = true }
 revm = { workspace = true }
 
-rustc_version_runtime = { workspace = true }
-tendermint = "0.32"
-prometheus = "0.11.0"
-prettytable-rs = "^0.10"
 criterion = "0.5.1"
 log = "0.4"
 log4rs = "1.0"
+prettytable-rs = "^0.10"
+prometheus = "0.11.0"
 regex = "1.10"
+rustc_version_runtime = { workspace = true }
+tendermint = "0.32"
 
 [features]
 default = [
+
 ] # Deviate from convention by making the "native" feature active by default. This aligns with how this package is meant to be used (as a binary first, library second).
 
 bench = [
-    "hex",
-    "sov-risc0-adapter/bench",
-    "sov-zk-cycle-macros/bench",
-    "risc0/bench",
+  "hex",
+  "sov-risc0-adapter/bench",
+  "sov-zk-cycle-macros/bench",
+  "risc0/bench",
 ]
 
 [[bin]]

--- a/bin/citrea/configs/bitcoin-regtest/rollup_config.toml
+++ b/bin/citrea/configs/bitcoin-regtest/rollup_config.toml
@@ -9,7 +9,7 @@ prover_da_pub_key = ""
 node_url = ""
 # fill here
 node_username = ""
-# fill here                                       
+# fill here
 node_password = ""
 network = "regtest"
 address = "bcrt1q02g8qhycr0v8cnflt86kksfe2sqhm486fdkx4l"

--- a/bin/citrea/configs/bitcoin-regtest/sequencer_rollup_config.toml
+++ b/bin/citrea/configs/bitcoin-regtest/sequencer_rollup_config.toml
@@ -9,7 +9,7 @@ prover_da_pub_key = ""
 node_url = ""
 # fill here
 node_username = ""
-# fill here                                       
+# fill here
 node_password = ""
 network = "regtest"
 address = "bcrt1q02g8qhycr0v8cnflt86kksfe2sqhm486fdkx4l"

--- a/bin/citrea/provers/risc0/Cargo.toml
+++ b/bin/citrea/provers/risc0/Cargo.toml
@@ -2,9 +2,9 @@
 name = "risc0"
 version = "0.3.0"
 edition = "2021"
-resolver = "2"
 license = "MIT OR Apache-2.0"
 publish = false
+resolver = "2"
 
 [build-dependencies]
 risc0-build = { workspace = true }

--- a/bin/citrea/provers/risc0/guest-mock/Cargo.toml
+++ b/bin/citrea/provers/risc0/guest-mock/Cargo.toml
@@ -7,19 +7,19 @@ resolver = "2"
 [workspace]
 
 [dependencies]
+# forcing cargo for this version or else chooses 0.3.1 and there is some dependency conflicts
+alloy-trie = { version = "=0.3.0", default-features = false }
 anyhow = "1.0.68"
+citrea-stf = { path = "../../../../../crates/citrea-stf" }
+# forcing cargo for this version or else chooses 3.1.1 and there is some dependency conflicts
+revm-primitives = { version = "=3.1.0", default-features = false }
 risc0-zkvm = { version = "0.20", default-features = false, features = ["std"] }
 risc0-zkvm-platform = "0.20"
 sov-mock-da = { path = "../../../../../crates/sovereign-sdk/adapters/mock-da" }
-citrea-stf = { path = "../../../../../crates/citrea-stf" }
-sov-risc0-adapter = { path = "../../../../../crates/sovereign-sdk/adapters/risc0" }
 sov-modules-api = { path = "../../../../../crates/sovereign-sdk/module-system/sov-modules-api" }
-sov-state = { path = "../../../../../crates/sovereign-sdk/module-system/sov-state" }
 sov-modules-stf-blueprint = { path = "../../../../../crates/sovereign-sdk/module-system/sov-modules-stf-blueprint" }
-# forcing cargo for this version or else chooses 3.1.1 and there is some dependency conflicts
-revm-primitives = { version = "=3.1.0", default-features = false }
-# forcing cargo for this version or else chooses 0.3.1 and there is some dependency conflicts
-alloy-trie = { version = "=0.3.0", default-features = false }
+sov-risc0-adapter = { path = "../../../../../crates/sovereign-sdk/adapters/risc0" }
+sov-state = { path = "../../../../../crates/sovereign-sdk/module-system/sov-state" }
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
@@ -43,7 +43,7 @@ opt-level = 3
 
 [features]
 bench = [
-    "sov-modules-api/bench",
-    "sov-state/bench",
-    "sov-modules-stf-blueprint/bench",
+  "sov-modules-api/bench",
+  "sov-state/bench",
+  "sov-modules-stf-blueprint/bench",
 ]

--- a/crates/bitcoin-da/Cargo.toml
+++ b/crates/bitcoin-da/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "bitcoin-da"
 version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
 authors = ["Chainway <info@chainway.xyz>"]
+edition = "2021"
 homepage = "https://www.chainway.xyz"
+license = "MIT OR Apache-2.0"
 publish = false
 repository = "https://github.com/chainway/bitcoin-da"
 rust-version = "1.66"
@@ -16,29 +16,28 @@ sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface" }
 
 tokio = { workspace = true, features = ["full"], optional = true }
 
-reqwest = { workspace = true, optional = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 base64 = "0.13.1"
+borsh = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 pin-project = { workspace = true, optional = true, features = [] }
-tracing = { workspace = true }
 rand = { workspace = true }
+reqwest = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
-async-trait = { workspace = true }
-borsh = { workspace = true }
-anyhow = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 bitcoin = { version = "0.31.1", features = ["serde", "rand"] }
 brotli = "3.3.4"
 futures.workspace = true
 
-
 [features]
 default = []
 native = [
-    "dep:tokio",
-    "dep:reqwest",
-    "dep:pin-project",
-    "sov-rollup-interface/native",
+  "dep:tokio",
+  "dep:reqwest",
+  "dep:pin-project",
+  "sov-rollup-interface/native",
 ]

--- a/crates/citrea-stf/Cargo.toml
+++ b/crates/citrea-stf/Cargo.toml
@@ -1,42 +1,38 @@
 [package]
 name = "citrea-stf"
 version = { workspace = true }
-edition = { workspace = true }
-resolver = "2"
 authors = { workspace = true }
-license = { workspace = true }
+edition = { workspace = true }
 homepage = "sovereign.xyz"
+license = { workspace = true }
 publish = false
+resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
-jsonrpsee = { workspace = true, features = [
-    "http-client",
-    "server",
-], optional = true }
 # will be needed after we update the storage system
 # tokio = { workspace = true, features = ["sync"], optional = true }
 hex = { workspace = true }
-tracing = { workspace = true }
+jsonrpsee = { workspace = true, features = ["http-client", "server"], optional = true }
 secp256k1 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true, optional = true }
+tracing = { workspace = true }
 
-sov-stf-runner = { path = "../sovereign-sdk/full-node/sov-stf-runner" }
-sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface" }
-sov-mock-da = { path = "../sovereign-sdk/adapters/mock-da" }
-sov-modules-stf-blueprint = { path = "../sovereign-sdk/module-system/sov-modules-stf-blueprint" }
 sov-accounts = { path = "../sovereign-sdk/module-system/module-implementations/sov-accounts" }
-sov-state = { path = "../sovereign-sdk/module-system/sov-state" }
+sov-mock-da = { path = "../sovereign-sdk/adapters/mock-da" }
 sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api" }
+sov-modules-stf-blueprint = { path = "../sovereign-sdk/module-system/sov-modules-stf-blueprint" }
+sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface" }
+sov-state = { path = "../sovereign-sdk/module-system/sov-state" }
+sov-stf-runner = { path = "../sovereign-sdk/full-node/sov-stf-runner" }
 
 citrea-evm = { path = "../evm" }
 soft-confirmation-rule-enforcer = { path = "../soft-confirmation-rule-enforcer" }
-
 
 [dev-dependencies]
 # citrea-stf = { path = ".", features = ["native"] }
@@ -48,26 +44,25 @@ soft-confirmation-rule-enforcer = { path = "../soft-confirmation-rule-enforcer" 
 #     "test-utils",
 # ] }
 
-
 [features]
 default = []
 native = [
-    "sov-stf-runner/native",
-    "sov-accounts/native",
-    "sov-modules-api/native",
-    "sov-rollup-interface/native",
-    "sov-mock-da/native",
-    "sov-modules-stf-blueprint/native",
-    "soft-confirmation-rule-enforcer/native",
-    "citrea-evm/native",
-    "clap",
-    "serde",
-    "serde_json",
-    "jsonrpsee",
-    # "tokio",
+  "sov-stf-runner/native",
+  "sov-accounts/native",
+  "sov-modules-api/native",
+  "sov-rollup-interface/native",
+  "sov-mock-da/native",
+  "sov-modules-stf-blueprint/native",
+  "soft-confirmation-rule-enforcer/native",
+  "citrea-evm/native",
+  "clap",
+  "serde",
+  "serde_json",
+  "jsonrpsee",
+  # "tokio",
 ]
 serde = [
-    "sov-accounts/serde",
-    "citrea-evm/serde",
-    "soft-confirmation-rule-enforcer/serde",
+  "sov-accounts/serde",
+  "citrea-evm/serde",
+  "soft-confirmation-rule-enforcer/serde",
 ]

--- a/crates/ethereum-rpc/Cargo.toml
+++ b/crates/ethereum-rpc/Cargo.toml
@@ -7,18 +7,18 @@ license = { workspace = true }
 repository = { workspace = true }
 
 version = { workspace = true }
-readme = "README.md"
 publish = false
+readme = "README.md"
 resolver = "2"
 
 [dependencies]
-citrea-evm = { path = "../evm" }
-sov-stf-runner = { path = "../sovereign-sdk/full-node/sov-stf-runner" }
-sequencer-client = { path = "../sequencer-client" }
 anyhow = { workspace = true }
-tracing = { workspace = true }
+citrea-evm = { path = "../evm" }
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 rustc_version_runtime = { workspace = true }
+sequencer-client = { path = "../sequencer-client" }
+sov-stf-runner = { path = "../sovereign-sdk/full-node/sov-stf-runner" }
+tracing = { workspace = true }
 
 borsh = { workspace = true }
 serde = { workspace = true }
@@ -29,21 +29,18 @@ reth-rpc-types = { workspace = true }
 reth-rpc-types-compat = { workspace = true }
 
 ethers = { workspace = true }
-tokio = { workspace = true }
 schnellru = "0.2.1"
+tokio = { workspace = true }
 
-sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface", features = [
-    "native",
-] }
+sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface", features = ["native"] }
 
 citrea-stf = { path = "../citrea-stf", features = ["native"] }
-sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api" }
 sov-accounts = { path = "../sovereign-sdk/module-system/module-implementations/sov-accounts" }
+sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api" }
 
 [dev-dependencies]
-tokio = { workspace = true }
 proptest = { workspace = true }
-
+tokio = { workspace = true }
 
 [features]
 default = ["local"]

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -1,109 +1,97 @@
 [package]
 name = "citrea-evm"
-description = "EVM Module of Citrea"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "EVM Module of Citrea"
 
 version = { workspace = true }
-readme = "README.md"
 publish = false
+readme = "README.md"
 
 [dependencies]
 sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api", version = "0.3" }
-sov-state = { path = "../sovereign-sdk/module-system/sov-state", version = "0.3" }
 sov-prover-storage-manager = { path = "../sovereign-sdk/full-node/sov-prover-storage-manager", optional = true }
+sov-state = { path = "../sovereign-sdk/module-system/sov-state", version = "0.3" }
 
 anyhow = { workspace = true }
-thiserror = { workspace = true }
-schemars = { workspace = true, optional = true }
+borsh = { workspace = true, features = ["rc"] }
 clap = { workspace = true, optional = true }
+hex = { workspace = true }
+jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
-borsh = { workspace = true, features = ["rc"] }
-hex = { workspace = true }
-jsonrpsee = { workspace = true, features = [
-    "macros",
-    "client-core",
-    "server",
-], optional = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 
-
 ethereum-types = { workspace = true, optional = true }
-ethers-core = { workspace = true, optional = true }
+ethers = { workspace = true, optional = true }
 ethers-contract = { workspace = true, optional = true }
+ethers-core = { workspace = true, optional = true }
 ethers-middleware = { workspace = true, optional = true }
 ethers-signers = { workspace = true, optional = true }
-ethers = { workspace = true, optional = true }
 
 alloy-primitives = { workspace = true, features = ["rand", "rlp", "serde"] }
-alloy-sol-types = { workspace = true, optional = true }
 alloy-rlp = { workspace = true, optional = true }
-revm = { workspace = true }
-reth-primitives = { workspace = true, default-features = false }
+alloy-sol-types = { workspace = true, optional = true }
+itertools = { version = "0.11.0", optional = true }
 reth-interfaces = { workspace = true, optional = true }
-reth-rpc-types = { workspace = true, optional = true }
-reth-rpc-types-compat = { workspace = true, optional = true }
+reth-primitives = { workspace = true, default-features = false }
 reth-revm = { workspace = true, optional = true }
 reth-rpc = { workspace = true, optional = true }
+reth-rpc-types = { workspace = true, optional = true }
+reth-rpc-types-compat = { workspace = true, optional = true }
+revm = { workspace = true }
 secp256k1 = { workspace = true, optional = true }
-itertools = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
-citrea-evm = { path = ".", features = ["native", "smart_contracts"] }
-revm = { workspace = true, features = [
-    "optional_block_gas_limit",
-    "optional_eip3607",
-    "optional_no_base_fee",
-] }
-tempfile = { workspace = true }
 bytes = { workspace = true }
-rand = { workspace = true }
-sov-prover-storage-manager = { path = "../sovereign-sdk/full-node/sov-prover-storage-manager", features = [
-    "test-utils",
-] }
+citrea-evm = { path = ".", features = ["native", "smart_contracts"] }
 lazy_static = "1.4.0"
-walkdir = "2.3.3"
+rand = { workspace = true }
+rayon = { workspace = true }
 reth-db = { workspace = true }
 reth-provider = { workspace = true }
 reth-stages = { workspace = true }
-rayon = { workspace = true }
-
+revm = { workspace = true, features = ["optional_block_gas_limit", "optional_eip3607", "optional_no_base_fee"] }
+sov-prover-storage-manager = { path = "../sovereign-sdk/full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
+walkdir = "2.3.3"
 
 [features]
 default = []
 native = [
-    "sov-state/native",
-    "sov-modules-api/native",
+  "sov-state/native",
+  "sov-modules-api/native",
 
-    "reth-rpc",
-    "reth-interfaces",
-    "reth-rpc-types",
-    "reth-rpc-types-compat",
-    "reth-revm",
+  "reth-rpc",
+  "reth-interfaces",
+  "reth-rpc-types",
+  "reth-rpc-types-compat",
+  "reth-revm",
 
-    "alloy-sol-types",
-    "alloy-rlp",
+  "alloy-sol-types",
+  "alloy-rlp",
 
-    "jsonrpsee",
-    "schemars",
-    "clap",
-    "itertools",
-    "serde_json",
-    "secp256k1",
+  "jsonrpsee",
+  "schemars",
+  "clap",
+  "itertools",
+  "serde_json",
+  "secp256k1",
 ]
 serde = []
 smart_contracts = [
-    "native",
+  "native",
 
-    "ethereum-types",
-    "ethers-core",
-    "ethers-contract",
-    "ethers-signers",
-    "ethers",
+  "ethereum-types",
+  "ethers-core",
+  "ethers-contract",
+  "ethers-signers",
+  "ethers",
 
-    "serde_json",
+  "serde_json",
 ]

--- a/crates/sequencer-client/Cargo.toml
+++ b/crates/sequencer-client/Cargo.toml
@@ -7,31 +7,30 @@ license = { workspace = true }
 repository = { workspace = true }
 
 version = { workspace = true }
-readme = "README.md"
 publish = false
+readme = "README.md"
 resolver = "2"
 
 [dependencies]
 sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface" }
 
 anyhow = { workspace = true }
-tracing = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client"] }
+tracing = { workspace = true }
 
+citrea-evm = { path = "../evm" }
+hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-hex = { workspace = true }
-citrea-evm = { path = "../evm" }
 
 ethers = { workspace = true }
 tokio = { workspace = true }
 
-reth-rpc-types = { workspace = true }
 reth-primitives = { workspace = true }
+reth-rpc-types = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
-
 
 [features]
 default = []

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -7,8 +7,8 @@ license = { workspace = true }
 repository = { workspace = true }
 
 version = { workspace = true }
-readme = "README.md"
 publish = false
+readme = "README.md"
 resolver = "2"
 
 [dependencies]
@@ -24,45 +24,43 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 
-reth-primitives = { workspace = true }
-reth-rpc-types = { workspace = true }
-reth-transaction-pool = { workspace = true }
-reth-provider = { workspace = true }
-reth-tasks = { workspace = true }
-reth-interfaces = { workspace = true }
 reth-db = { workspace = true }
-reth-trie = { workspace = true }
-reth-rpc-types-compat = { workspace = true }
+reth-interfaces = { workspace = true }
+reth-primitives = { workspace = true }
+reth-provider = { workspace = true }
 reth-rpc = { workspace = true }
+reth-rpc-types = { workspace = true }
+reth-rpc-types-compat = { workspace = true }
+reth-tasks = { workspace = true }
+reth-transaction-pool = { workspace = true }
+reth-trie = { workspace = true }
 
 revm = { workspace = true }
 
 ethers = { workspace = true }
-tokio = { workspace = true }
 schnellru = "0.2.1"
+tokio = { workspace = true }
 
-sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface", features = [
-    "native",
-] }
 citrea-evm = { path = "../evm" }
 sov-db = { path = "../sovereign-sdk/full-node/db/sov-db", version = "0.3" }
+sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface", features = ["native"] }
 
 sov-stf-runner = { path = "../sovereign-sdk/full-node/sov-stf-runner" }
 
 sov-modules-stf-blueprint = { path = "../sovereign-sdk/module-system/sov-modules-stf-blueprint" }
 
 citrea-stf = { path = "../citrea-stf", features = ["native"] }
-sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api" }
-sov-accounts = { path = "../sovereign-sdk/module-system/module-implementations/sov-accounts" }
-sov-state = { path = "../sovereign-sdk/module-system/sov-state" }
-sov-mock-da = { path = "../sovereign-sdk/adapters/mock-da" }
 hex = { workspace = true }
+sov-accounts = { path = "../sovereign-sdk/module-system/module-implementations/sov-accounts" }
+sov-mock-da = { path = "../sovereign-sdk/adapters/mock-da" }
+sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api" }
+sov-state = { path = "../sovereign-sdk/module-system/sov-state" }
 
 shared-backup-db = { path = "../shared-backup-db" }
 
 [dev-dependencies]
-tokio = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true }
 
 [features]
 default = []

--- a/crates/shared-backup-db/Cargo.toml
+++ b/crates/shared-backup-db/Cargo.toml
@@ -7,17 +7,17 @@ license = { workspace = true }
 repository = { workspace = true }
 
 version = { workspace = true }
-readme = "README.md"
 publish = false
+readme = "README.md"
 resolver = "2"
 
 [dependencies]
-postgres = "0.19.7"
-tokio-postgres = "0.7.10"
-serde = { workspace = true }
 hex = { workspace = true }
-tokio = { workspace = true }
 lazy_static = { version = "1.4.0", optional = true }
+postgres = "0.19.7"
+serde = { workspace = true }
+tokio = { workspace = true }
+tokio-postgres = "0.7.10"
 
 [dev-dependencies]
 shared-backup-db = { path = ".", features = ["test-utils"] }

--- a/crates/soft-confirmation-rule-enforcer/Cargo.toml
+++ b/crates/soft-confirmation-rule-enforcer/Cargo.toml
@@ -7,35 +7,26 @@ license = { workspace = true }
 repository = { workspace = true }
 
 version = { workspace = true }
-readme = "README.md"
 publish = false
+readme = "README.md"
 resolver = "2"
 
 [dependencies]
 sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api", version = "0.3" }
-sov-state = { path = "../sovereign-sdk/module-system/sov-state", version = "0.3" }
 sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface" }
+sov-state = { path = "../sovereign-sdk/module-system/sov-state", version = "0.3" }
 
-borsh = { workspace = true }
-serde = { workspace = true }
 anyhow = { workspace = true }
-jsonrpsee = { workspace = true, features = [
-    "macros",
-    "client-core",
-    "server",
-], optional = true }
+borsh = { workspace = true }
+jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
+serde = { workspace = true }
 
 [dev-dependencies]
-sov-mock-da = { path = "../sovereign-sdk/adapters/mock-da", features = [
-    "native",
-] }
-sov-prover-storage-manager = { path = "../sovereign-sdk/full-node/sov-prover-storage-manager", features = [
-    "test-utils",
-] }
 chrono = { workspace = true, default-features = true }
-tempfile = { workspace = true }
 lazy_static = "1.4.0"
-
+sov-mock-da = { path = "../sovereign-sdk/adapters/mock-da", features = ["native"] }
+sov-prover-storage-manager = { path = "../sovereign-sdk/full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/crates/sovereign-sdk/adapters/avail/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/avail/Cargo.toml
@@ -1,58 +1,52 @@
 [package]
 name = "sov-avail-adapter"
 version.workspace = true
-edition.workspace = true
-license.workspace = true
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
+license.workspace = true
 publish.workspace = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+avail-subxt = { git = "https://github.com/availproject/avail.git", tag = "v1.6.3", features = ["std"], optional = true }
 borsh = { workspace = true, features = ["bytes"] }
-sov-rollup-interface = { path = "../../rollup-interface" }
 bytes = { version = "1.2.1", features = ["serde"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"], optional = true }
 primitive-types = { version = "0.12.2", features = ["serde"] }
+sov-rollup-interface = { path = "../../rollup-interface" }
 sp-core-hashing = "14.0.0"
 subxt = { version = "0.29", optional = true }
-avail-subxt = { git = "https://github.com/availproject/avail.git", tag = "v1.6.3", features = [
-    "std",
-], optional = true }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
-    "derive",
-    "full",
-    "bit-vec",
-], optional = true }
 
 # Convenience
-tokio = { workspace = true, optional = true }
-futures = { workspace = true, optional = true }
-pin-project = { workspace = true, optional = true }
-tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.17", features = ["fmt"] }
-async-trait = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true, optional = true }
+hex = { workspace = true }
+pin-project = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-reqwest = { workspace = true, optional = true }
-thiserror = { workspace = true }
-sp-keyring = { version = "24", optional = true }
 sp-core = { version = "21", optional = true }
-hex = { workspace = true }
+sp-keyring = { version = "24", optional = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, optional = true }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3.17", features = ["fmt"] }
 
 [features]
 default = ["native"]
 native = [
-    "dep:tokio",
-    "dep:codec",
-    "dep:reqwest",
-    "dep:avail-subxt",
-    "dep:subxt",
-    "dep:futures",
-    "dep:pin-project",
-    "dep:sp-keyring",
-    "dep:sp-core",
-    "sov-rollup-interface/native",
+  "dep:tokio",
+  "dep:codec",
+  "dep:reqwest",
+  "dep:avail-subxt",
+  "dep:subxt",
+  "dep:futures",
+  "dep:pin-project",
+  "dep:sp-keyring",
+  "dep:sp-core",
+  "sov-rollup-interface/native",
 ]

--- a/crates/sovereign-sdk/adapters/celestia/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/celestia/Cargo.toml
@@ -8,44 +8,38 @@ publish = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-borsh = { workspace = true, features = ["bytes"] }
 bech32 = { workspace = true, default-features = true }
+borsh = { workspace = true, features = ["bytes"] }
 prost = "0.12"
 # I keep this commented as a reminder to opportunity to optimze this crate for non native compilation
-#tendermint = { version = "0.32", default-features = false, features = ["std"] }
+# tendermint = { version = "0.32", default-features = false, features = ["std"] }
 
 celestia-proto = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "66b7c6c" }
 celestia-rpc = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "66b7c6c", default-features = false, optional = true }
 celestia-types = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "66b7c6c", default-features = false }
+nmt-rs = { git = "https://github.com/Sovereign-Labs/nmt-rs.git", rev = "d821332", features = ["serde", "borsh"] }
 tendermint = { git = "https://github.com/eigerco/celestia-tendermint-rs.git", rev = "ef58b85", default-features = false }
 tendermint-proto = { git = "https://github.com/eigerco/celestia-tendermint-rs.git", rev = "ef58b85" }
-nmt-rs = { git = "https://github.com/Sovereign-Labs/nmt-rs.git", rev = "d821332", features = [
-    "serde",
-    "borsh",
-] }
 
 # Convenience
-async-trait = { workspace = true }
 anyhow = { workspace = true }
-sha2 = { workspace = true }
+async-trait = { workspace = true }
 base64 = "0.21.5"
+futures = { workspace = true, optional = true }
 hex = { workspace = true, features = ["serde"] }
 jsonrpsee = { workspace = true, features = ["http-client"], optional = true }
+pin-project = { workspace = true, optional = true }
+risc0-zkvm = { workspace = true, default-features = false, features = ["std"], optional = true }
+risc0-zkvm-platform = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true }
-futures = { workspace = true, optional = true }
-pin-project = { workspace = true, optional = true }
-thiserror = { workspace = true }
-tracing = { workspace = true }
+sha2 = { workspace = true }
 sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.3", optional = true }
-risc0-zkvm = { workspace = true, default-features = false, features = [
-    "std",
-], optional = true }
-risc0-zkvm-platform = { workspace = true, optional = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, optional = true }
+tracing = { workspace = true }
 
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
-
 
 [dev-dependencies]
 postcard = { version = "1", features = ["use-std"] }
@@ -56,14 +50,14 @@ wiremock = "0.5"
 [features]
 default = ["native"]
 native = [
-    "dep:tokio",
-    "dep:futures",
-    "dep:pin-project",
-    "dep:jsonrpsee",
-    "dep:serde_json",
-    "dep:celestia-rpc",
-    "tendermint/default",
-    "sov-rollup-interface/native",
+  "dep:tokio",
+  "dep:futures",
+  "dep:pin-project",
+  "dep:jsonrpsee",
+  "dep:serde_json",
+  "dep:celestia-rpc",
+  "tendermint/default",
+  "sov-rollup-interface/native",
 ]
 risc0 = ["dep:risc0-zkvm", "dep:risc0-zkvm-platform"]
 bench = ["sov-zk-cycle-macros/bench", "risc0"]

--- a/crates/sovereign-sdk/adapters/mock-da/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/mock-da/Cargo.toml
@@ -1,47 +1,47 @@
 [package]
 name = "sov-mock-da"
-description = "Mock implementation of Data Availability layer for testing purposes"
 version.workspace = true
-edition.workspace = true
-license.workspace = true
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
-repository.workspace = true
-readme = "README.md"
+license.workspace = true
 publish = true
+readme = "README.md"
+repository.workspace = true
+description = "Mock implementation of Data Availability layer for testing purposes"
 
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 borsh = { workspace = true, features = ["bytes"] }
 bytes = { workspace = true, features = ["serde"] }
-serde = { workspace = true }
+futures = { workspace = true, optional = true }
 hex = { workspace = true }
 lazy_static = { version = "1.4.0", optional = true }
-sha2 = { workspace = true }
-tokio = { workspace = true, optional = true }
-futures = { workspace = true, optional = true }
-tokio-stream = { version = "0.1.14", features = ["full"], optional = true }
 pin-project = { workspace = true, optional = true }
 rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
+serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
+sha2 = { workspace = true }
+tokio = { workspace = true, optional = true }
+tokio-stream = { version = "0.1.14", features = ["full"], optional = true }
 tracing = { workspace = true }
 
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
 
 [dev-dependencies]
-sov-mock-da = { path = ".", features = ["native"] }
 futures = { workspace = true }
+sov-mock-da = { path = ".", features = ["native"] }
 
 [features]
 default = []
 native = [
-    "dep:rusqlite",
-    "dep:serde_json",
-    "dep:tokio",
-    "dep:lazy_static",
-    "dep:tokio-stream",
-    "dep:futures",
-    "dep:pin-project",
-    "sov-rollup-interface/native",
+  "dep:rusqlite",
+  "dep:serde_json",
+  "dep:tokio",
+  "dep:lazy_static",
+  "dep:tokio-stream",
+  "dep:futures",
+  "dep:pin-project",
+  "sov-rollup-interface/native",
 ]

--- a/crates/sovereign-sdk/adapters/mock-zkvm/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/mock-zkvm/Cargo.toml
@@ -1,21 +1,20 @@
 [package]
 name = "sov-mock-zkvm"
-description = "Mock zkVM implementation"
 version.workspace = true
-edition.workspace = true
-license.workspace = true
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
-repository.workspace = true
+license.workspace = true
 publish = true
-
+repository.workspace = true
+description = "Mock zkVM implementation"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = { workspace = true }
-borsh = { workspace = true }
 bincode = { workspace = true }
+borsh = { workspace = true }
 serde = { workspace = true }
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
 

--- a/crates/sovereign-sdk/adapters/risc0/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/risc0/Cargo.toml
@@ -1,34 +1,34 @@
 [package]
 name = "sov-risc0-adapter"
+version = { workspace = true }
 authors = { workspace = true }
-description = "An adapter allowing Risc0 to be used with the Sovereign SDK"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-repository = { workspace = true }
-version = { workspace = true }
 readme = "README.md"
+repository = { workspace = true }
+description = "An adapter allowing Risc0 to be used with the Sovereign SDK"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = { workspace = true }
 bincode = { workspace = true }
-risc0-zkvm = { workspace = true, default-features = false, features = ["std"] }
-risc0-zkvm-platform = { workspace = true }
-risc0-zkp = { workspace = true, optional = true }
-risc0-circuit-rv32im = { workspace = true, optional = true }
-serde = { workspace = true }
 bytemuck = "1.13.1"
 once_cell = { version = "1.19.0", optional = true }
 parking_lot = { version = "0.12.1", optional = true }
-sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", version = "0.3" }
+risc0-circuit-rv32im = { workspace = true, optional = true }
+risc0-zkp = { workspace = true, optional = true }
+risc0-zkvm = { workspace = true, default-features = false, features = ["std"] }
+risc0-zkvm-platform = { workspace = true }
+serde = { workspace = true }
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", version = "0.3" }
 
 [features]
 default = []
 native = ["risc0-zkvm/prove", "dep:risc0-zkp", "dep:risc0-circuit-rv32im"]
-bench = ["once_cell", "parking_lot","native","sov-zk-cycle-utils/native"]
+bench = ["once_cell", "parking_lot", "native", "sov-zk-cycle-utils/native"]
 
 [[test]]
 name = "native"

--- a/crates/sovereign-sdk/adapters/solana/da_client/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/solana/da_client/Cargo.toml
@@ -6,24 +6,24 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anchor-lang = "0.28.0"
 anchor-client = "0.28.0"
-solana-sdk = "1.16"
+anchor-lang = "0.28.0"
+anyhow = "1.0.75"
+backoff = { version = "0.4.0", features = ["tokio"] }
+blake3 = "1.3.3"
+blockroot = { path = "../solana_da_programs/programs/blockroot", features = ["no-entrypoint"] }
 bs58 = "0.5.0"
 clap = { workspace = true }
-blockroot = {path = "../solana_da_programs/programs/blockroot", features = ["no-entrypoint"]}
-solana-runtime = "1.16"
-solana-rpc-client = "1.16"
-anyhow = "1.0.75"
-rand = "0.8.5"
-hex = "0.4.3"
-blake3 = "1.3.3"
-futures = "0.3.24"
 env_logger = "0.10.0"
-backoff = { version = "0.4.0", features = ["tokio"] }
-tokio = { version = "1.32.0", features = ["rt-multi-thread", "macros", "time"] }
+futures = "0.3.24"
+hex = "0.4.3"
 log = { version = "0.4.14", features = ["std"] }
-yellowstone-grpc-proto = { git = "https://github.com/rpcpool/yellowstone-grpc.git", package = "yellowstone-grpc-proto", rev = "v1.9.0+solana.1.16.15" }
+rand = "0.8.5"
+solana-rpc-client = "1.16"
+solana-runtime = "1.16"
+solana-sdk = "1.16"
+tokio = { version = "1.32.0", features = ["rt-multi-thread", "macros", "time"] }
 yellowstone-grpc-client = { git = "https://github.com/rpcpool/yellowstone-grpc.git", package = "yellowstone-grpc-client", rev = "v1.9.0+solana.1.16.15" }
+yellowstone-grpc-proto = { git = "https://github.com/rpcpool/yellowstone-grpc.git", package = "yellowstone-grpc-proto", rev = "v1.9.0+solana.1.16.15" }
 
 [workspace]

--- a/crates/sovereign-sdk/adapters/solana/solana_da_programs/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/solana/solana_da_programs/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "programs/*"
+  "programs/*",
 ]
 
 [profile.release]

--- a/crates/sovereign-sdk/adapters/solana/solana_da_programs/programs/blockroot/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/solana/solana_da_programs/programs/blockroot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "blockroot"
 version = "0.3.0"
-description = "Created with Anchor"
 edition = "2021"
+description = "Created with Anchor"
 
 [lib]
 crate-type = ["cdylib", "lib"]
@@ -16,4 +16,4 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = {version = "0.28.0", features = ["init-if-needed"]}
+anchor-lang = { version = "0.28.0", features = ["init-if-needed"] }

--- a/crates/sovereign-sdk/examples/const-rollup-config/Cargo.toml
+++ b/crates/sovereign-sdk/examples/const-rollup-config/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "const-rollup-config"
 version = { workspace = true }
-edition = { workspace = true }
 authors = { workspace = true }
-license = { workspace = true }
+edition = { workspace = true }
 homepage = "sovereign.xyz"
+license = { workspace = true }
 publish = false

--- a/crates/sovereign-sdk/examples/demo-simple-stf/Cargo.toml
+++ b/crates/sovereign-sdk/examples/demo-simple-stf/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "demo-simple-stf"
 version = { workspace = true }
-edition = { workspace = true }
-resolver = "2"
 authors = { workspace = true }
-license = { workspace = true }
+edition = { workspace = true }
 homepage = "sovereign.xyz"
+license = { workspace = true }
 publish = false
+resolver = "2"
 
 [dependencies]
 anyhow = { workspace = true }
+hex = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
-hex = { workspace = true }
 
 sov-rollup-interface = { path = "../../rollup-interface" }
 

--- a/crates/sovereign-sdk/examples/demo-stf/Cargo.toml
+++ b/crates/sovereign-sdk/examples/demo-stf/Cargo.toml
@@ -1,95 +1,88 @@
 [package]
 name = "demo-stf"
 version = { workspace = true }
-edition = { workspace = true }
-resolver = "2"
 authors = { workspace = true }
-license = { workspace = true }
+edition = { workspace = true }
 homepage = "sovereign.xyz"
+license = { workspace = true }
 publish = false
+resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
-toml = { workspace = true, optional = true }
-jsonrpsee = { workspace = true, features = [
-    "http-client",
-    "server",
-], optional = true }
-tokio = { workspace = true, optional = true }
 hex = { workspace = true }
-tracing = { workspace = true }
+jsonrpsee = { workspace = true, features = ["http-client", "server"], optional = true }
 reth-primitives = { workspace = true }
 secp256k1 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+toml = { workspace = true, optional = true }
+tracing = { workspace = true }
 
-sov-stf-runner = { path = "../../../sovereign-sdk/full-node/sov-stf-runner" }
-sov-rollup-interface = { path = "../../../sovereign-sdk/rollup-interface" }
-sov-cli = { path = "../../../sovereign-sdk/module-system/sov-cli", optional = true }
-sov-sequencer-registry = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-sequencer-registry" }
-sov-blob-storage = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-blob-storage" }
 sov-bank = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-bank" }
+sov-blob-storage = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-blob-storage" }
+sov-cli = { path = "../../../sovereign-sdk/module-system/sov-cli", optional = true }
 sov-nft-module = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-nft-module" }
+sov-rollup-interface = { path = "../../../sovereign-sdk/rollup-interface" }
+sov-sequencer-registry = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-sequencer-registry" }
 sov-soft-confirmations-kernel = { path = "../../../sovereign-sdk/module-system/sov-soft-confirmations-kernel" }
+sov-stf-runner = { path = "../../../sovereign-sdk/full-node/sov-stf-runner" }
 
-sov-mock-da = { path = "../../../sovereign-sdk/adapters/mock-da" }
-sov-chain-state = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-chain-state" }
-sov-modules-stf-blueprint = { path = "../../../sovereign-sdk/module-system/sov-modules-stf-blueprint" }
-sov-value-setter = { path = "../../../sovereign-sdk/module-system/module-implementations/examples/sov-value-setter" }
-sov-accounts = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-accounts" }
-sov-state = { path = "../../../sovereign-sdk/module-system/sov-state" }
-sov-modules-api = { path = "../../../sovereign-sdk/module-system/sov-modules-api" }
 citrea-evm = { path = "../../../evm" }
 soft-confirmation-rule-enforcer = { path = "../../../soft-confirmation-rule-enforcer" }
-
+sov-accounts = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-accounts" }
+sov-chain-state = { path = "../../../sovereign-sdk/module-system/module-implementations/sov-chain-state" }
+sov-mock-da = { path = "../../../sovereign-sdk/adapters/mock-da" }
+sov-modules-api = { path = "../../../sovereign-sdk/module-system/sov-modules-api" }
+sov-modules-stf-blueprint = { path = "../../../sovereign-sdk/module-system/sov-modules-stf-blueprint" }
+sov-state = { path = "../../../sovereign-sdk/module-system/sov-state" }
+sov-value-setter = { path = "../../../sovereign-sdk/module-system/module-implementations/examples/sov-value-setter" }
 
 [dev-dependencies]
 demo-stf = { path = ".", features = ["native"] }
-tempfile = { workspace = true }
 rand = { workspace = true }
 sov-data-generators = { path = "../../../sovereign-sdk/module-system/utils/sov-data-generators" }
 sov-mock-zkvm = { path = "../../../sovereign-sdk/adapters/mock-zkvm" }
-sov-prover-storage-manager = { path = "../../../sovereign-sdk/full-node/sov-prover-storage-manager", features = [
-    "test-utils",
-] }
-
+sov-prover-storage-manager = { path = "../../../sovereign-sdk/full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [features]
 default = []
 offchain = ["sov-nft-module/offchain"]
 native = [
-    "sov-stf-runner/native",
-    "sov-bank/native",
-    "sov-nft-module/native",
-    "sov-cli",
-    "sov-accounts/native",
-    "sov-sequencer-registry/native",
-    "sov-blob-storage/native",
-    "sov-chain-state/native",
-    "sov-value-setter/native",
-    "sov-modules-api/native",
-    "sov-rollup-interface/native",
-    "sov-mock-da/native",
-    "sov-modules-stf-blueprint/native",
-    "sov-soft-confirmations-kernel/native",
-    "clap",
-    "serde",
-    "serde_json",
-    "jsonrpsee",
-    "tokio",
-    "toml",
+  "sov-stf-runner/native",
+  "sov-bank/native",
+  "sov-nft-module/native",
+  "sov-cli",
+  "sov-accounts/native",
+  "sov-sequencer-registry/native",
+  "sov-blob-storage/native",
+  "sov-chain-state/native",
+  "sov-value-setter/native",
+  "sov-modules-api/native",
+  "sov-rollup-interface/native",
+  "sov-mock-da/native",
+  "sov-modules-stf-blueprint/native",
+  "sov-soft-confirmations-kernel/native",
+  "clap",
+  "serde",
+  "serde_json",
+  "jsonrpsee",
+  "tokio",
+  "toml",
 ]
 serde = [
-    "sov-bank/serde",
-    "sov-sequencer-registry/serde",
-    "sov-blob-storage/serde",
-    "sov-value-setter/serde",
-    "sov-accounts/serde",
-    "sov-nft-module/serde",
-    "citrea-evm/serde",
-    "soft-confirmation-rule-enforcer/serde",
+  "sov-bank/serde",
+  "sov-sequencer-registry/serde",
+  "sov-blob-storage/serde",
+  "sov-value-setter/serde",
+  "sov-accounts/serde",
+  "sov-nft-module/serde",
+  "citrea-evm/serde",
+  "soft-confirmation-rule-enforcer/serde",
 ]

--- a/crates/sovereign-sdk/examples/simple-nft-module/Cargo.toml
+++ b/crates/sovereign-sdk/examples/simple-nft-module/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "simple-nft-module"
 version = { workspace = true }
-edition = { workspace = true }
 authors = { workspace = true }
-license = { workspace = true }
+edition = { workspace = true }
 homepage = "sovereign.xyz"
+license = { workspace = true }
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -18,16 +18,15 @@ sov-modules-api = { path = "../../module-system/sov-modules-api" }
 sov-state = { path = "../../module-system/sov-state" }
 
 clap = { workspace = true, optional = true }
+jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 schemars = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 
 [dev-dependencies]
-sov-rollup-interface = { path = "../../rollup-interface" }
-tempfile = { workspace = true }
 simple-nft-module = { version = "*", features = ["native"], path = "." }
 sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
-
+sov-rollup-interface = { path = "../../rollup-interface" }
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/crates/sovereign-sdk/full-node/db/sov-db/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/db/sov-db/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sov-db"
-description = "A high-level DB interface for the Sovereign SDK"
-license = "Apache-2.0" # This license is inherited from Aptos 
-edition = { workspace = true }
 authors = { workspace = true }
+edition = { workspace = true }
 homepage = { workspace = true }
+license = "Apache-2.0" # This license is inherited from Aptos
 repository = { workspace = true }
+description = "A high-level DB interface for the Sovereign SDK"
 
 version = { workspace = true }
 readme = "README.md"
@@ -16,38 +16,36 @@ resolver = "2"
 [dependencies]
 # Maintained by sovereign labs
 jmt = { workspace = true }
-sov-schema-db = { path = "../sov-schema-db", version = "0.3" }
 sov-rollup-interface = { path = "../../../rollup-interface", version = "0.3", features = ["native"] }
+sov-schema-db = { path = "../sov-schema-db", version = "0.3" }
 
 # External
 anyhow = { workspace = true, default-features = true }
 arbitrary = { workspace = true, optional = true }
-byteorder = { workspace = true, default-features = true }
+bincode = { workspace = true }
 borsh = { workspace = true, default-features = true, features = ["bytes", "rc"] }
+byteorder = { workspace = true, default-features = true }
 proptest = { workspace = true, optional = true, default-features = true }
 proptest-derive = { workspace = true, optional = true }
+rocksdb = { workspace = true }
 serde = { workspace = true, default-features = true, features = ["rc"] }
 tempfile = { workspace = true, optional = true }
-rocksdb = { workspace = true }
-bincode = { workspace = true }
 tokio = { workspace = true }
 
-
 [dev-dependencies]
-sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
-tempfile = { workspace = true }
-sov-prover-storage-manager = { path = "../../sov-prover-storage-manager" }
 criterion = "0.5.1"
 rand = { workspace = true }
 sha2 = { workspace = true }
-
+sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
+sov-prover-storage-manager = { path = "../../sov-prover-storage-manager" }
+tempfile = { workspace = true }
 
 [features]
 arbitrary = [
-    "dep:arbitrary",
-    "dep:proptest",
-    "dep:proptest-derive",
-    "dep:tempfile",
+  "dep:arbitrary",
+  "dep:proptest",
+  "dep:proptest-derive",
+  "dep:tempfile",
 ]
 
 [[bench]]

--- a/crates/sovereign-sdk/full-node/db/sov-schema-db/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/db/sov-schema-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sov-schema-db"
+license = "Apache-2.0" # This license is inherited from Aptos
 description = "A low level interface transforming RocksDB into a type-oriented data store"
-license = "Apache-2.0"                                                                     # This license is inherited from Aptos 
 
 # Workspace inherited keys
 version = { workspace = true }
@@ -21,13 +21,13 @@ prometheus = { workspace = true }
 proptest = { workspace = true, optional = true, default-features = true }
 proptest-derive = { workspace = true, optional = true }
 rocksdb = { workspace = true }
-tracing = { workspace = true, default-features = true }
 thiserror = { workspace = true }
+tracing = { workspace = true, default-features = true }
 
 [dev-dependencies]
 byteorder = { workspace = true, default-features = true }
-tempfile = { workspace = true }
 sov-schema-db = { path = ".", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/crates/sovereign-sdk/full-node/sov-ledger-rpc/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/sov-ledger-rpc/Cargo.toml
@@ -4,31 +4,31 @@ authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-description = "JSON-RPC server and client implementations for Sovereign SDK rollups"
 repository = { workspace = true }
+description = "JSON-RPC server and client implementations for Sovereign SDK rollups"
 
 version = { workspace = true }
-resolver = "2"
 publish = true
+resolver = "2"
 
 [dependencies]
 # Common dependencies
-jsonrpsee = { workspace = true }
-serde = "1"
-sov-rollup-interface = { path = "../../rollup-interface", features = ["native"], version = "0.3" }
 # Client dependencies
 # (None)
 # Server dependencies
 anyhow = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
+jsonrpsee = { workspace = true }
+serde = "1"
 sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["native"], optional = true, version = "0.3" }
+sov-rollup-interface = { path = "../../rollup-interface", features = ["native"], version = "0.3" }
 
 [dev-dependencies]
-tempfile = "3"
 serde_json = "1"
 sov-db = { path = "../../full-node/db/sov-db" }
-tokio = { workspace = true, features = ["full"] }
 sov-ledger-rpc = { path = ".", features = ["client", "server"] }
+tempfile = "3"
+tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = ["client", "server"]

--- a/crates/sovereign-sdk/full-node/sov-prover-storage-manager/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/sov-prover-storage-manager/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sov-prover-storage-manager"
-description = "Hierarchical storage manager for prover storage"
-license = { workspace = true }
-edition = { workspace = true }
 authors = { workspace = true }
+edition = { workspace = true }
 homepage = { workspace = true }
+license = { workspace = true }
 repository = { workspace = true }
+description = "Hierarchical storage manager for prover storage"
 
 version = { workspace = true }
 readme = "README.md"
@@ -13,19 +13,19 @@ resolver = "2"
 
 [dependencies]
 anyhow = { workspace = true }
-sov-rollup-interface = { path = "../../rollup-interface" }
 sov-db = { path = "../db/sov-db" }
+sov-rollup-interface = { path = "../../rollup-interface" }
 sov-schema-db = { path = "../db/sov-schema-db" }
 sov-state = { path = "../../module-system/sov-state", features = ["native"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
-sov-schema-db = { path = "../db/sov-schema-db", features = ["test-utils"] }
-tempfile = { workspace = true }
 criterion = "0.5.1"
 rand = { workspace = true }
 sha2 = { workspace = true }
+sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
+sov-schema-db = { path = "../db/sov-schema-db", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "single_thread_storage_bench"

--- a/crates/sovereign-sdk/full-node/sov-sequencer/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/sov-sequencer/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "sov-sequencer"
 authors = { workspace = true }
-description = "A simple implementation of a sequencer for Sovereign SDK rollups"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A simple implementation of a sequencer for Sovereign SDK rollups"
 
 version = { workspace = true }
 readme = "README.md"
 resolver = "2"
-
 
 [dependencies]
 anyhow = { workspace = true }
@@ -18,20 +17,19 @@ borsh = { workspace = true }
 hex = { workspace = true }
 jsonrpsee = { workspace = true, features = ["client", "server"] }
 serde = { workspace = true, features = ["derive"] }
-tracing = { workspace = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
 sov-modules-api = { path = "../../module-system/sov-modules-api", version = "0.3", features = ["native"] }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
 sov-state = { path = "../../module-system/sov-state", version = "0.3" }
-
+tracing = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
-rand = { workspace = true }
-tokio = { workspace = true }
 async-trait = { workspace = true }
-sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter", features = ["native"] }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3", features = ["native"] }
+rand = { workspace = true }
+sov-db = { path = "../db/sov-db" }
 sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
 sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.3", features = ["native"] }
 sov-schema-db = { path = "../db/sov-schema-db" }
-sov-db = { path = "../db/sov-db" }
+sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter", features = ["native"] }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/Cargo.toml
@@ -1,89 +1,73 @@
 [package]
 name = "sov-stf-runner"
+version = { workspace = true }
 authors = { workspace = true }
-description = "Runs Sovereign SDK rollups and their verifiers"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-repository = { workspace = true }
-version = { workspace = true }
 readme = "README.md"
+repository = { workspace = true }
 resolver = "2"
+description = "Runs Sovereign SDK rollups and their verifiers"
 
 [dependencies]
 anyhow = { workspace = true }
-num_cpus = { workspace = true }
-thiserror = { workspace = true, optional = true }
-borsh = { workspace = true }
-serde_json = { workspace = true }
-serde = { workspace = true }
-toml = { workspace = true, optional = true }
-rs_merkle = { workspace = true }
-jsonrpsee = { workspace = true, features = [
-    "http-client",
-    "server",
-], optional = true }
-tokio = { workspace = true, optional = true }
-hex = { workspace = true }
-tracing = { workspace = true, optional = true }
-futures = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
+borsh = { workspace = true }
+futures = { workspace = true, optional = true }
+hex = { workspace = true }
+jsonrpsee = { workspace = true, features = ["http-client", "server"], optional = true }
+num_cpus = { workspace = true }
 rayon = { workspace = true, optional = true }
-sov-db = { path = "../db/sov-db", version = "0.3", optional = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
-sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-blueprint" }
+rs_merkle = { workspace = true }
 sequencer-client = { path = "../../../sequencer-client", optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sov-db = { path = "../db/sov-db", version = "0.3", optional = true }
+sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-blueprint" }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+thiserror = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+toml = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
 sov-modules-api = { path = "../../module-system/sov-modules-api", version = "0.3" }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 sha2 = { workspace = true }
+tempfile = { workspace = true }
 
-sov-sequencer-registry = { path = "../../module-system/module-implementations/sov-sequencer-registry", features = [
-    "native",
-] }
-sov-bank = { path = "../../module-system/module-implementations/sov-bank", features = [
-    "native",
-] }
-sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-blueprint", features = [
-    "native",
-] }
+sov-bank = { path = "../../module-system/module-implementations/sov-bank", features = ["native"] }
+sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-blueprint", features = ["native"] }
+sov-sequencer-registry = { path = "../../module-system/module-implementations/sov-sequencer-registry", features = ["native"] }
 
-sov-accounts = { path = "../../module-system/module-implementations/sov-accounts", features = [
-    "native",
-] }
+sov-accounts = { path = "../../module-system/module-implementations/sov-accounts", features = ["native"] }
 sov-sequencer = { path = "../sov-sequencer" }
 
+sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["native"] }
 sov-state = { path = "../../module-system/sov-state", features = ["native"] }
-sov-modules-api = { path = "../../module-system/sov-modules-api", features = [
-    "native",
-] }
 sov-stf-runner = { path = ".", features = ["mock"] }
 
 sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
 sov-mock-zkvm = { path = "../../adapters/mock-zkvm" }
-sov-prover-storage-manager = { path = "../sov-prover-storage-manager", features = [
-    "test-utils",
-] }
+sov-prover-storage-manager = { path = "../sov-prover-storage-manager", features = ["test-utils"] }
 
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-
 
 [features]
 default = []
 mock = ["native"]
 native = [
-    "sov-db",
-    "sequencer-client",
-    "sov-modules-api/native",
-    "sov-modules-stf-blueprint/native",
-    "jsonrpsee",
-    "toml",
-    "tokio",
-    "tracing",
-    "futures",
-    "async-trait",
-    "rayon",
-    "thiserror",
+  "sov-db",
+  "sequencer-client",
+  "sov-modules-api/native",
+  "sov-modules-stf-blueprint/native",
+  "jsonrpsee",
+  "toml",
+  "tokio",
+  "tracing",
+  "futures",
+  "async-trait",
+  "rayon",
+  "thiserror",
 ]

--- a/crates/sovereign-sdk/fuzz/Cargo.toml
+++ b/crates/sovereign-sdk/fuzz/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "sovereign-sdk-fuzz"
 version = "0.3.0"
-publish = false
 edition = "2021"
+publish = false
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
+rand = "0.8"
 serde_json = "1"
 tempfile = "3"
-rand = "0.8"
 
 # Sovereign-maintained dependencies.
-sov-celestia-adapter = { path = "../adapters/celestia", features = ["native"] }
-sov-modules-api = { path = "../module-system/sov-modules-api", features = ["arbitrary", "native"] }
 sov-accounts = { path = "../module-system/module-implementations/sov-accounts", features = ["arbitrary", "native"] }
 sov-bank = { path = "../module-system/module-implementations/sov-bank", features = ["native"] }
-sov-state = { path = "../module-system/sov-state" }
+sov-celestia-adapter = { path = "../adapters/celestia", features = ["native"] }
+sov-modules-api = { path = "../module-system/sov-modules-api", features = ["arbitrary", "native"] }
 sov-prover-storage-manager = { path = "../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+sov-state = { path = "../module-system/sov-state" }
 
 # Prevent this from interfering with workspaces.
 [workspace]

--- a/crates/sovereign-sdk/module-system/module-implementations/examples/sov-accessory-state/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/examples/sov-accessory-state/Cargo.toml
@@ -7,20 +7,20 @@ license = { workspace = true }
 repository = { workspace = true }
 
 version = { workspace = true }
-readme = "README.md"
 publish = false
+readme = "README.md"
 resolver = "2"
 
 [dependencies]
+borsh = { workspace = true, features = ["rc"] }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
+serde = { workspace = true, optional = true }
 sov-modules-api = { path = "../../../sov-modules-api" }
 sov-state = { path = "../../../sov-state" }
-serde = { workspace = true, optional = true }
-borsh = { workspace = true, features = ["rc"] }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 sov-prover-storage-manager = { path = "../../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/crates/sovereign-sdk/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
@@ -1,36 +1,34 @@
 [package]
 name = "sov-value-setter"
-description = "A Sovereign SDK example module for setting/reading value from state"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A Sovereign SDK example module for setting/reading value from state"
 
 version = { workspace = true }
+publish = false
 readme = "README.md"
 resolver = "2"
-publish = false
-
 
 [dev-dependencies]
-sov-value-setter = { path = ".", features = ["native"] }
-tempfile = { workspace = true }
 sov-modules-api = { path = "../../../sov-modules-api", features = ["native"] }
 sov-prover-storage-manager = { path = "../../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
-
+sov-value-setter = { path = ".", features = ["native"] }
+tempfile = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-sov-modules-api = { path = "../../../sov-modules-api" }
-sov-state = { path = "../../../sov-state" }
+borsh = { workspace = true, features = ["rc"] }
+clap = { workspace = true, optional = true }
+jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
+sov-modules-api = { path = "../../../sov-modules-api" }
+sov-state = { path = "../../../sov-state" }
 thiserror = { workspace = true }
-borsh = { workspace = true, features = ["rc"] }
-jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
-clap = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/crates/sovereign-sdk/module-system/module-implementations/examples/sov-vec-setter/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/examples/sov-vec-setter/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
 name = "sov-vec-setter"
-description = "A Sovereign SDK example module for setting/reading vectors from state"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A Sovereign SDK example module for setting/reading vectors from state"
 
 version = { workspace = true }
+publish = false
 readme = "README.md"
 resolver = "2"
-publish = false
 
 [dev-dependencies]
-tempfile = { workspace = true }
 sov-modules-api = { path = "../../../sov-modules-api", features = ["native", "macros"] }
 sov-prover-storage-manager = { path = "../../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-sov-modules-api = { path = "../../../sov-modules-api", default-features = false, features = ["macros"] }
-sov-state = { path = "../../../sov-state", default-features = false }
+borsh = { workspace = true, features = ["rc"] }
+clap = { workspace = true, optional = true }
+jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
+sov-modules-api = { path = "../../../sov-modules-api", default-features = false, features = ["macros"] }
+sov-state = { path = "../../../sov-state", default-features = false }
 thiserror = { workspace = true }
-borsh = { workspace = true, features = ["rc"] }
-jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
-clap = { workspace = true, optional = true }
 
 [features]
 default = ["native"]

--- a/crates/sovereign-sdk/module-system/module-implementations/integration-tests/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/integration-tests/Cargo.toml
@@ -7,27 +7,27 @@ license = { workspace = true }
 repository = { workspace = true }
 
 version = { workspace = true }
-readme = "README.md"
 publish = false
+readme = "README.md"
 resolver = "2"
 
 [dev-dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
-tempfile = { workspace = true }
-serde = { workspace = true }
 jsonrpsee = { workspace = true }
+serde = { workspace = true }
+tempfile = { workspace = true }
 
 sov-modules-api = { path = "../../sov-modules-api", features = ["native"] }
 sov-state = { path = "../../sov-state", features = ["native"] }
 
-sov-mock-zkvm = { path = "../../../adapters/mock-zkvm" }
-sov-schema-db = { path = "../../../full-node/db/sov-schema-db" }
 sov-data-generators = { path = "../../utils/sov-data-generators" }
-sov-rollup-interface = { path = "../../../rollup-interface", features = ["native"] }
 sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
+sov-mock-zkvm = { path = "../../../adapters/mock-zkvm" }
 sov-modules-stf-blueprint = { path = "../../sov-modules-stf-blueprint", features = ["native"] }
+sov-rollup-interface = { path = "../../../rollup-interface", features = ["native"] }
+sov-schema-db = { path = "../../../full-node/db/sov-schema-db" }
 
 sov-chain-state = { path = "../sov-chain-state", features = ["native"] }
-sov-value-setter = { path = "../examples/sov-value-setter", features = ["native"] }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+sov-value-setter = { path = "../examples/sov-value-setter", features = ["native"] }

--- a/crates/sovereign-sdk/module-system/module-implementations/module-template/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/module-template/Cargo.toml
@@ -7,8 +7,8 @@ license = { workspace = true }
 repository = { workspace = true }
 
 version = { workspace = true }
-readme = "README.md"
 publish = false
+readme = "README.md"
 resolver = "2"
 
 [dependencies]
@@ -26,17 +26,16 @@ sov-bank = { path = "../sov-bank" }
 sov-modules-api = { path = "../../sov-modules-api" }
 sov-state = { path = "../../sov-state" }
 
-
 [dev-dependencies]
-tempfile = { workspace = true }
 module-template = { path = ".", version = "*", features = ["native"] }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [features]
 default = []
 arbitrary = [
-    "dep:arbitrary",
-    "dep:proptest",
-    "dep:proptest-derive"
+  "dep:arbitrary",
+  "dep:proptest",
+  "dep:proptest-derive",
 ]
 native = ["serde_json", "schemars", "sov-modules-api/native"]

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-accounts/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-accounts/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sov-accounts"
-description = "A Sovereign SDK module for managing rollup state using accounts"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A Sovereign SDK module for managing rollup state using accounts"
 
 version = { workspace = true }
 readme = "README.md"
@@ -15,33 +15,32 @@ resolver = "2"
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
 borsh = { workspace = true, features = ["rc"] }
+clap = { workspace = true, optional = true }
+jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
-clap = { workspace = true, optional = true }
-jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 
 sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
 sov-state = { path = "../../sov-state", version = "0.3" }
 
-
 [dev-dependencies]
 sov-accounts = { path = ".", features = ["native"] }
-tempfile = { workspace = true }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [features]
 default = []
 arbitrary = [
-    "dep:arbitrary",
-    "dep:proptest",
-    "dep:proptest-derive",
-    "sov-state/arbitrary",
-    "sov-modules-api/arbitrary",
-    "sov-state/arbitrary"
+  "dep:arbitrary",
+  "dep:proptest",
+  "dep:proptest-derive",
+  "sov-state/arbitrary",
+  "sov-modules-api/arbitrary",
+  "sov-state/arbitrary",
 ]
 native = ["serde", "serde_json", "jsonrpsee", "schemars", "clap", "sov-state/native", "sov-modules-api/native"]
 serde = []

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-attester-incentives/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-attester-incentives/Cargo.toml
@@ -1,49 +1,47 @@
 [package]
 name = "sov-attester-incentives"
-description = "A Sovereign SDK module for incentivizing provers"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A Sovereign SDK module for incentivizing provers"
 
 version = { workspace = true }
+publish = false
 readme = "README.md"
 resolver = "2"
-publish = false
 
 [dev-dependencies]
-tempfile = { workspace = true }
 sov-attester-incentives = { path = ".", features = ["native"] }
 sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
 sov-mock-zkvm = { path = "../../../adapters/mock-zkvm" }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
 sov-modules-core = { path = "../../sov-modules-core", version = "0.3", features = ["mocks"] }
-sov-rollup-interface = { path = "../../../rollup-interface", version = "0.3" }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
-
+sov-rollup-interface = { path = "../../../rollup-interface", version = "0.3" }
+tempfile = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bcs = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
-bcs =  { workspace = true }
 jmt = { workspace = true }
-thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 sov-bank = { path = "../sov-bank", version = "0.3" }
 sov-chain-state = { path = "../sov-chain-state", version = "0.3" }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
 sov-state = { path = "../../sov-state", version = "0.3" }
 
-
 [features]
 default = []
 native = [
-    "serde_json",
-    "sov-modules-api/native",
-    "sov-bank/native",
-    "sov-chain-state/native",
-    "sov-state/native",
+  "serde_json",
+  "sov-modules-api/native",
+  "sov-bank/native",
+  "sov-chain-state/native",
+  "sov-state/native",
 ]

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sov-bank"
-description = "A Sovereign SDK managing fungible tokens"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A Sovereign SDK managing fungible tokens"
 
 version = { workspace = true }
 readme = "README.md"
@@ -24,15 +24,14 @@ thiserror = { workspace = true }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
 sov-state = { path = "../../sov-state", version = "0.3" }
 
-
 [dev-dependencies]
 sov-bank = { path = ".", features = ["native", "test-utils"] }
-tempfile = { workspace = true }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [features]
 default = []
-native = ["serde", "serde_json", "jsonrpsee", "clap", "schemars", "sov-state/native", "sov-modules-api/native", ]
+native = ["serde", "serde_json", "jsonrpsee", "clap", "schemars", "sov-state/native", "sov-modules-api/native"]
 cli = ["native"]
 serde = []
 test-utils = []

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-blob-storage/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-blob-storage/Cargo.toml
@@ -1,45 +1,52 @@
 [package]
 name = "sov-blob-storage"
-description = "A Sovereign SDK module for holding blobs from Data Availability Layer"
+version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-repository = { workspace = true }
-version = { workspace = true }
 readme = "README.md"
+repository = { workspace = true }
+description = "A Sovereign SDK module for holding blobs from Data Availability Layer"
 
 resolver = "2"
 
-
 [dependencies]
 anyhow = { workspace = true }
-borsh = { workspace = true }
 bincode = { workspace = true }
-tracing = { workspace = true }
+borsh = { workspace = true }
 hex = { workspace = true }
+tracing = { workspace = true }
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
-sov-state = { path = "../../sov-state", version = "0.3" }
-sov-sequencer-registry = { path = "../sov-sequencer-registry", version = "0.3" }
 sov-chain-state = { path = "../sov-chain-state", version = "0.3" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
+sov-sequencer-registry = { path = "../sov-sequencer-registry", version = "0.3" }
+sov-state = { path = "../../sov-state", version = "0.3" }
 
+clap = { workspace = true, optional = true }
+jsonrpsee = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-jsonrpsee = { workspace = true, optional = true }
-clap = { workspace = true, optional = true }
-
 
 [dev-dependencies]
-tempfile = { workspace = true }
 jmt = { workspace = true }
+sov-bank = { path = "../sov-bank" }
 sov-blob-storage = { path = ".", features = ["native"] }
 sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
-sov-bank = { path = "../sov-bank" }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [features]
 default = []
-native = ["jsonrpsee", "schemars", "serde", "serde_json", "sov-modules-api/native", "sov-state/native", "sov-sequencer-registry/native", "clap"]
+native = [
+  "jsonrpsee",
+  "schemars",
+  "serde",
+  "serde_json",
+  "sov-modules-api/native",
+  "sov-state/native",
+  "sov-sequencer-registry/native",
+  "clap",
+]
 serde = ["dep:serde"]

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-chain-state/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-chain-state/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sov-chain-state"
 authors = { workspace = true }
-description = "A Sovereign SDK module for storing a rollup's historical state"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A Sovereign SDK module for storing a rollup's historical state"
 
 version = { workspace = true }
 readme = "README.md"
@@ -14,20 +14,19 @@ resolver = "2"
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
+jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
-jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 
 sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
 sov-state = { path = "../../sov-state", version = "0.3" }
 
 [dev-dependencies]
-tempfile = { workspace = true }
-sov-data-generators = { path = "../../utils/sov-data-generators" }
 sov-chain-state = { path = ".", features = ["native"] }
+sov-data-generators = { path = "../../utils/sov-data-generators" }
 sov-mock-da = { path = "../../../adapters/mock-da" }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
-
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-nft-module/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-nft-module/Cargo.toml
@@ -1,26 +1,22 @@
 [package]
 name = "sov-nft-module"
-description = "A Sovereign SDK module for managing non-fungible tokens"
 version = { workspace = true }
-edition = { workspace = true }
 authors = { workspace = true }
-license = { workspace = true }
+edition = { workspace = true }
 homepage = "sovereign.xyz"
+license = { workspace = true }
 publish = false
+description = "A Sovereign SDK module for managing non-fungible tokens"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
-serde = { workspace = true }
+jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 schemars = { workspace = true, optional = true }
+serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
-jsonrpsee = { workspace = true, features = [
-    "macros",
-    "client-core",
-    "server",
-], optional = true }
 
 sov-modules-api = { path = "../../sov-modules-api" }
 sov-modules-macros = { path = "../../sov-modules-macros" }
@@ -31,24 +27,21 @@ tokio = { version = "1.35.0", features = ["full"], optional = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
-sov-nft-module = { version = "*", features = ["native"], path = "." }
-tempfile = { workspace = true }
 sov-data-generators = { path = "../../utils/sov-data-generators" }
-sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = [
-    "test-utils",
-] }
-
+sov-nft-module = { version = "*", features = ["native"], path = "." }
+sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [features]
 default = []
 offchain = ["postgres", "tokio", "tracing"]
 native = [
-    "serde",
-    "serde_json",
-    "jsonrpsee",
-    "schemars",
-    "sov-state/native",
-    "sov-modules-api/native",
+  "serde",
+  "serde_json",
+  "jsonrpsee",
+  "schemars",
+  "sov-state/native",
+  "sov-modules-api/native",
 ]
 serde = []
 test = ["native"]

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-prover-incentives/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-prover-incentives/Cargo.toml
@@ -1,29 +1,28 @@
 [package]
 name = "sov-prover-incentives"
-description = "A Sovereign SDK module for incentivizing provers"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A Sovereign SDK module for incentivizing provers"
 
 version = { workspace = true }
 readme = "README.md"
 resolver = "2"
 
 [dev-dependencies]
-tempfile = { workspace = true }
-sov-prover-incentives = { features = ["native"], path = "." }
 sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
 sov-mock-zkvm = { path = "../../../adapters/mock-zkvm" }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.3", features = ["native"] }
+sov-prover-incentives = { features = ["native"], path = "." }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
-
+tempfile = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-borsh = { workspace = true, features = ["rc"] }
 bincode = { workspace = true }
+borsh = { workspace = true, features = ["rc"] }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
@@ -31,7 +30,6 @@ serde_json = { workspace = true, optional = true }
 sov-bank = { path = "../sov-bank", version = "0.3" }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
 sov-state = { path = "../../sov-state", version = "0.3" }
-
 
 [features]
 default = []

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sov-sequencer-registry"
-description = "A Sovereign SDK module for registering rollup sequencers"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A Sovereign SDK module for registering rollup sequencers"
 
 version = { workspace = true }
 readme = "README.md"
@@ -15,41 +15,41 @@ resolver = "2"
 [dependencies]
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
+borsh = { workspace = true, features = ["rc"] }
 clap = { workspace = true, optional = true }
+jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
-sov-bank = { path = "../sov-bank", version = "0.3" }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
-sov-state = { path = "../../sov-state", version = "0.3" }
+risc0-zkvm = { workspace = true, default-features = false, features = ["std"], optional = true }
+risc0-zkvm-platform = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
-borsh = { workspace = true, features = ["rc"] }
-jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
+sov-bank = { path = "../sov-bank", version = "0.3" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
+sov-state = { path = "../../sov-state", version = "0.3" }
 sov-zk-cycle-macros = { path = "../../../utils/zk-cycle-macros", version = "0.3", optional = true }
-risc0-zkvm = { workspace = true, default-features = false, features = ["std"], optional = true }
-risc0-zkvm-platform = { workspace = true, optional = true }
 sov-zk-cycle-utils = { path = "../../../utils/zk-cycle-utils", version = "0.3", optional = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
-sov-sequencer-registry = { path = ".", features = ["native"] }
 sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+sov-sequencer-registry = { path = ".", features = ["native"] }
+tempfile = { workspace = true }
 
 [features]
 bench = ["sov-zk-cycle-macros/bench", "risc0-zkvm", "risc0-zkvm-platform", "sov-zk-cycle-utils"]
 default = []
 arbitrary = ["dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
 native = [
-    "serde",
-    "serde_json",
-    "jsonrpsee",
-    "schemars",
-    "clap",
-    "sov-state/native",
-    "sov-modules-api/native",
-    # This:
-    "sov-bank/native",
+  "serde",
+  "serde_json",
+  "jsonrpsee",
+  "schemars",
+  "clap",
+  "sov-state/native",
+  "sov-modules-api/native",
+  # This:
+  "sov-bank/native",
 ]
 serde = []

--- a/crates/sovereign-sdk/module-system/module-schemas/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-schemas/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sov-module-schemas"
-description = "A dummy crate that stores as files the JSON Schemas for all Sovereign modules"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A dummy crate that stores as files the JSON Schemas for all Sovereign modules"
 
 version = { workspace = true }
+publish = false
 readme = "README.md"
 resolver = "2"
-publish = false
 
 [build-dependencies]
 sov-modules-api = { path = "../sov-modules-api" }
@@ -18,19 +18,9 @@ sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
 sov-mock-zkvm = { path = "../../adapters/mock-zkvm" }
 
 # Modules
-sov-accounts = { path = "../module-implementations/sov-accounts", features = [
-    "native",
-] }
-sov-bank = { path = "../module-implementations/sov-bank", features = [
-    "native",
-] }
-sov-prover-incentives = { path = "../module-implementations/sov-prover-incentives", features = [
-    "native",
-] }
-sov-sequencer-registry = { path = "../module-implementations/sov-sequencer-registry", features = [
-    "native",
-] }
+sov-accounts = { path = "../module-implementations/sov-accounts", features = ["native"] }
+sov-bank = { path = "../module-implementations/sov-bank", features = ["native"] }
+sov-prover-incentives = { path = "../module-implementations/sov-prover-incentives", features = ["native"] }
+sov-sequencer-registry = { path = "../module-implementations/sov-sequencer-registry", features = ["native"] }
 citrea-evm = { path = "../../../evm" }
-sov-value-setter = { path = "../module-implementations/examples/sov-value-setter", features = [
-    "native",
-] }
+sov-value-setter = { path = "../module-implementations/examples/sov-value-setter", features = ["native"] }

--- a/crates/sovereign-sdk/module-system/sov-cli/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-cli/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sov-cli"
 version.workspace = true
-edition.workspace = true
-license.workspace = true
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
+license.workspace = true
 publish.workspace = true
 repository.workspace = true
 
@@ -14,26 +14,19 @@ repository.workspace = true
 name = "sov_cli"
 path = "src/lib.rs"
 
-
 [dependencies]
-sov-modules-api = { path = "../sov-modules-api", version = "0.3", features = [
-    "native",
-] }
-sov-bank = { path = "../module-implementations/sov-bank", version = "0.3", features = [
-    "native",
-] }
-sov-accounts = { path = "../module-implementations/sov-accounts", version = "0.3", features = [
-    "native",
-] }
-directories = "5.0.1"
 anyhow = { workspace = true }
-hex = { workspace = true, features = ["serde"] }
 borsh = { workspace = true }
+directories = "5.0.1"
+hex = { workspace = true, features = ["serde"] }
+jsonrpsee = { workspace = true, features = ["client"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-jsonrpsee = { workspace = true, features = ["client"] }
+sov-accounts = { path = "../module-implementations/sov-accounts", version = "0.3", features = ["native"] }
+sov-bank = { path = "../module-implementations/sov-bank", version = "0.3", features = ["native"] }
+sov-modules-api = { path = "../sov-modules-api", version = "0.3", features = ["native"] }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 demo-stf = { path = "../../examples/demo-stf", features = ["native"] }
 sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
+tempfile = { workspace = true }

--- a/crates/sovereign-sdk/module-system/sov-modules-api/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/Cargo.toml
@@ -1,94 +1,85 @@
 [package]
 name = "sov-modules-api"
-description = "Defines the interface of the Sovereign SDK module system"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "Defines the interface of the Sovereign SDK module system"
 
 version = { workspace = true }
 readme = "README.md"
 resolver = "2"
 
 [dependencies]
-jsonrpsee = { workspace = true, optional = true }
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
-sov-state = { path = "../sov-state", version = "0.3" }
-sov-modules-core = { path = "../sov-modules-core", version = "0.3" }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
-sov-modules-macros = { path = "../sov-modules-macros", version = "0.3", optional = true }
-sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", optional = true }
-serde = { workspace = true }
+bech32 = { workspace = true }
 borsh = { workspace = true }
+clap = { workspace = true, optional = true }
+derive_more = { workspace = true, default-features = true }
+hex = { workspace = true }
+jmt = { workspace = true }
+jsonrpsee = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
-thiserror = { workspace = true }
-sha2 = { workspace = true }
-bech32 = { workspace = true }
-derive_more = { workspace = true, default-features = true }
-jmt = { workspace = true }
-serde_json = { workspace = true, optional = true }
-hex = { workspace = true }
-clap = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true, features = [] }
+serde = { workspace = true }
+serde_json = { workspace = true, optional = true }
+sha2 = { workspace = true }
+sov-modules-core = { path = "../sov-modules-core", version = "0.3" }
+sov-modules-macros = { path = "../sov-modules-macros", version = "0.3", optional = true }
+sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", optional = true }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+sov-state = { path = "../sov-state", version = "0.3" }
+thiserror = { workspace = true }
 
 # The risc0 patch only applies to version 2.0.0 exactly.
-ed25519-dalek = { version = "=2.0.0", default-features = false, features = [
-    "serde",
-] }
+ed25519-dalek = { version = "=2.0.0", default-features = false, features = ["serde"] }
 rand = { workspace = true, optional = true }
 
 # sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.3", optional = true }
-risc0-zkvm = { workspace = true, default-features = false, features = [
-    "std",
-], optional = true }
+risc0-zkvm = { workspace = true, default-features = false, features = ["std"], optional = true }
 risc0-zkvm-platform = { workspace = true, optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
-tempfile = { workspace = true }
+sov-bank = { path = "../module-implementations/sov-bank", features = ["native"] }
+sov-db = { path = "../../full-node/db/sov-db" }
+sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
 sov-modules-api = { path = ".", features = ["native"] }
 sov-modules-core = { path = "../sov-modules-core", features = ["mocks"] }
-sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
-sov-bank = { path = "../module-implementations/sov-bank", features = [
-    "native",
-] }
-sov-db = { path = "../../full-node/db/sov-db" }
-sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = [
-    "test-utils",
-] }
-
+sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+tempfile = { workspace = true }
 
 [features]
 arbitrary = [
-    "dep:arbitrary",
-    "dep:proptest",
-    "dep:proptest-derive",
-    "proptest/default",
-    "sov-state/arbitrary",
+  "dep:arbitrary",
+  "dep:proptest",
+  "dep:proptest-derive",
+  "proptest/default",
+  "sov-state/arbitrary",
 ]
 bench = [
-    # "sov-zk-cycle-macros", 
-    "risc0-zkvm",
-    "risc0-zkvm-platform",
+  # "sov-zk-cycle-macros",
+  "risc0-zkvm",
+  "risc0-zkvm-platform",
 ]
 default = ["macros"]
 native = [
-    "serde_json",
-    "rand",
-    "schemars",
-    "serde",
-    "ed25519-dalek/default",
-    "ed25519-dalek/rand_core",
-    "clap",
-    "jsonrpsee",
-    "macros",
-    "sov-modules-core/native",
-    "sov-modules-macros/native",
-    "sov-state/native",
-    "sov-prover-storage-manager",
+  "serde_json",
+  "rand",
+  "schemars",
+  "serde",
+  "ed25519-dalek/default",
+  "ed25519-dalek/rand_core",
+  "clap",
+  "jsonrpsee",
+  "macros",
+  "sov-modules-core/native",
+  "sov-modules-macros/native",
+  "sov-state/native",
+  "sov-prover-storage-manager",
 ]
 macros = ["sov-modules-macros"]
 serde = ["sov-modules-core/serde"]

--- a/crates/sovereign-sdk/module-system/sov-modules-core/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "sov-modules-core"
-description = "Defines the core components of the Sovereign SDK module system"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "Defines the core components of the Sovereign SDK module system"
 
 version = { workspace = true }
 readme = "README.md"
 resolver = "2"
-
 
 [dependencies]
 anyhow = { workspace = true }
@@ -30,44 +29,40 @@ thiserror = { workspace = true, optional = true }
 
 sov-rollup-interface = { path = "../../rollup-interface", default-features = false }
 
-
 [dev-dependencies]
 proptest = { workspace = true }
 serde_json = { workspace = true }
-tempfile = { workspace = true }
-sov-state = { path = "../sov-state", features = ["native"] }
-sov-modules-api = { path = "../sov-modules-api", features = ["native"] }
 sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
+sov-modules-api = { path = "../sov-modules-api", features = ["native"] }
 sov-modules-core = { path = ".", features = ["mocks"] }
-sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = [
-    "test-utils",
-] }
-
+sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+sov-state = { path = "../sov-state", features = ["native"] }
+tempfile = { workspace = true }
 
 [features]
 default = ["std"]
 arbitrary = [
-    "dep:arbitrary",
-    "dep:proptest",
-    "dep:proptest-derive",
-    "proptest/default",
-    "std",
+  "dep:arbitrary",
+  "dep:proptest",
+  "dep:proptest-derive",
+  "proptest/default",
+  "std",
 ]
 native = []
 std = [
-    "anyhow/default",
-    "bech32/default",
-    "borsh/default",
-    "derive_more/default",
-    "digest/default",
-    "hex/default",
-    "jmt",
-    "schemars",
-    "serde/default",
-    "sha2/default",
-    "sov-rollup-interface/default",
-    "sync",
-    "thiserror",
+  "anyhow/default",
+  "bech32/default",
+  "borsh/default",
+  "derive_more/default",
+  "digest/default",
+  "hex/default",
+  "jmt",
+  "schemars",
+  "serde/default",
+  "sha2/default",
+  "sov-rollup-interface/default",
+  "sync",
+  "thiserror",
 ]
 serde = []
 sync = ["borsh/rc", "serde/rc"]

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sov-modules-macros"
-description = "Macros for use with the Sovereign SDK module system"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "Macros for use with the Sovereign SDK module system"
 
 version = { workspace = true }
+autotests = false
 readme = "README.md"
 resolver = "2"
-autotests = false
 
 [lib]
 proc-macro = true
@@ -26,10 +26,10 @@ serde = { workspace = true }
 tempfile = { workspace = true }
 trybuild = "1.0"
 
-sov-modules-api = { path = "../sov-modules-api" }
-sov-state = { path = "../sov-state" }
 sov-bank = { path = "../module-implementations/sov-bank", features = ["native"] }
+sov-modules-api = { path = "../sov-modules-api" }
 sov-modules-macros = { path = ".", features = ["native"] }
+sov-state = { path = "../sov-state" }
 
 [dependencies]
 anyhow = { workspace = true }
@@ -39,9 +39,8 @@ proc-macro2 = "1.0"
 quote = "1.0"
 schemars = { workspace = true }
 serde_json = { workspace = true }
-syn = { version = "1.0", features = ["full"] }
 sov-modules-core = { path = "../sov-modules-core" }
-
+syn = { version = "1.0", features = ["full"] }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/Cargo.toml
@@ -1,48 +1,37 @@
 [package]
 name = "sov-modules-rollup-blueprint"
-description = "This crate contains abstractions needed to create a new rollup"
+version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-repository = { workspace = true }
-version = { workspace = true }
-readme = "README.md"
-resolver = "2"
 publish = true
+readme = "README.md"
+repository = { workspace = true }
+resolver = "2"
+description = "This crate contains abstractions needed to create a new rollup"
 
 [dependencies]
-sov-rollup-interface = { path = "../../rollup-interface", features = [
-    "native",
-], version = "0.3" }
-sov-stf-runner = { path = "../../full-node/sov-stf-runner", features = [
-    "native",
-], version = "0.3" }
-citrea-sequencer = { path = "../../../sequencer", features = [
-], version = "0.3" }
+citrea-sequencer = { path = "../../../sequencer", features = [], version = "0.3" }
 const-rollup-config = { path = "../../examples/const-rollup-config" }
-sov-state = { path = "../sov-state", version = "0.3" }
 sequencer-client = { path = "../../../sequencer-client" }
-sov-modules-api = { path = "../../module-system/sov-modules-api", features = [
-    "native",
-], version = "0.3" }
 sov-cli = { path = "../../module-system/sov-cli" }
+sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["native"], version = "0.3" }
+sov-rollup-interface = { path = "../../rollup-interface", features = ["native"], version = "0.3" }
+sov-state = { path = "../sov-state", version = "0.3" }
+sov-stf-runner = { path = "../../full-node/sov-stf-runner", features = ["native"], version = "0.3" }
 
-sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-blueprint", features = [
-    "native",
-], version = "0.3" }
 sov-db = { path = "../../full-node/db/sov-db", version = "0.3" }
+sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-blueprint", features = ["native"], version = "0.3" }
 
+sov-ledger-rpc = { path = "../../full-node/sov-ledger-rpc", features = ["server"] }
 sov-sequencer = { path = "../../full-node/sov-sequencer" }
-sov-ledger-rpc = { path = "../../full-node/sov-ledger-rpc", features = [
-    "server",
-] }
 
-hex = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
+borsh = { workspace = true }
+hex = { workspace = true }
+jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-async-trait = { workspace = true }
-jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 tokio = { workspace = true }
-borsh = { workspace = true }

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sov-modules-stf-blueprint"
-description = "Defines a generic state transition function for use with the Sovereign SDK module system"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "Defines a generic state transition function for use with the Sovereign SDK module system"
 
 version = { workspace = true }
 readme = "README.md"
@@ -13,25 +13,31 @@ resolver = "2"
 
 [dependencies]
 anyhow = { workspace = true }
-thiserror = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-tracing = { workspace = true }
-jmt = { workspace = true }
 hex = { workspace = true }
+jmt = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+tracing = { workspace = true }
 
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
-sov-state = { path = "../sov-state", version = "0.3" }
-sov-modules-api = { path = "../sov-modules-api", version = "0.3" }
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.3", optional = true }
-sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", version = "0.3", optional = true }
+jsonrpsee = { workspace = true, features = ["server"], optional = true }
 risc0-zkvm = { workspace = true, default-features = false, features = ["std"], optional = true }
 risc0-zkvm-platform = { workspace = true, optional = true }
-jsonrpsee = { workspace = true, features = ["server"], optional = true }
-sov-chain-state = { path = "../module-implementations/sov-chain-state" }
 sov-blob-storage = { path = "../module-implementations/sov-blob-storage" }
+sov-chain-state = { path = "../module-implementations/sov-chain-state" }
+sov-modules-api = { path = "../sov-modules-api", version = "0.3" }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+sov-state = { path = "../sov-state", version = "0.3" }
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.3", optional = true }
+sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", version = "0.3", optional = true }
 
 [features]
 bench = ["sov-zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]
 default = []
-native = ["sov-state/native", "sov-modules-api/native", "jsonrpsee", "sov-chain-state/native", "sov-blob-storage/native"]
+native = [
+  "sov-state/native",
+  "sov-modules-api/native",
+  "jsonrpsee",
+  "sov-chain-state/native",
+  "sov-blob-storage/native",
+]

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/clippy.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/clippy.toml
@@ -1,1 +1,1 @@
-type-complexity-threshold  = 300
+type-complexity-threshold = 300

--- a/crates/sovereign-sdk/module-system/sov-soft-confirmations-kernel/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-soft-confirmations-kernel/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sov-soft-confirmations-kernel"
 version.workspace = true
-edition.workspace = true
-license.workspace = true
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
+license.workspace = true
 publish.workspace = true
 repository.workspace = true
 
@@ -13,16 +13,16 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 
-sov-state = { path = "../sov-state", version = "0.3" }
-sov-modules-api = { path = "../sov-modules-api", version = "0.3" }
 sov-blob-storage = { path = "../module-implementations/sov-blob-storage" }
 sov-chain-state = { path = "../module-implementations/sov-chain-state" }
+sov-modules-api = { path = "../sov-modules-api", version = "0.3" }
+sov-state = { path = "../sov-state", version = "0.3" }
 
 [features]
 default = []
 native = [
-	"sov-state/native",
-	"sov-modules-api/native",
-	"sov-chain-state/native",
-	"sov-blob-storage/native",
+  "sov-state/native",
+  "sov-modules-api/native",
+  "sov-chain-state/native",
+  "sov-blob-storage/native",
 ]

--- a/crates/sovereign-sdk/module-system/sov-state/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-state/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sov-state"
-description = "Defines traits and types for state storage in the Sovereign SDK module system"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "Defines traits and types for state storage in the Sovereign SDK module system"
 
 version = { workspace = true }
 readme = "README.md"
@@ -14,34 +14,34 @@ resolver = "2"
 [dependencies]
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
-borsh = { workspace = true, features = ["rc", "bytes"] }
 bcs = { workspace = true }
+borsh = { workspace = true, features = ["rc", "bytes"] }
+hex = { workspace = true }
+jmt = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
-thiserror = { workspace = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
-sov-modules-core = { path = "../sov-modules-core", version = "0.3" }
-sov-db = { path = "../../full-node/db/sov-db", version = "0.3", optional = true }
-jmt = { workspace = true }
-hex = { workspace = true }
 sha2 = { workspace = true }
+sov-db = { path = "../../full-node/db/sov-db", version = "0.3", optional = true }
+sov-modules-core = { path = "../sov-modules-core", version = "0.3" }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+thiserror = { workspace = true }
 
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.3", optional = true }
 risc0-zkvm = { workspace = true, default-features = false, features = ["std"], optional = true }
 risc0-zkvm-platform = { workspace = true, optional = true }
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.3", optional = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 proptest = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 arbitrary = [
-    "dep:arbitrary",
-    "dep:proptest",
-    "dep:proptest-derive",
-    "sov-modules-core/arbitrary",
+  "dep:arbitrary",
+  "dep:proptest",
+  "dep:proptest-derive",
+  "sov-modules-core/arbitrary",
 ]
 bench = ["sov-zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]
 default = []

--- a/crates/sovereign-sdk/module-system/utils/sov-data-generators/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/utils/sov-data-generators/Cargo.toml
@@ -1,24 +1,23 @@
 [package]
 name = "sov-data-generators"
-description = "A set of generator utils used to automatically produce and serialize transaction data"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "A set of generator utils used to automatically produce and serialize transaction data"
 
 version = { workspace = true }
-resolver = "2"
 publish = false
-
+resolver = "2"
 
 [dependencies]
+sov-bank = { path = "../../module-implementations/sov-bank", features = ["native"] }
+sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
 sov-modules-api = { path = "../../sov-modules-api", features = ["native"] }
 sov-modules-stf-blueprint = { path = "../../sov-modules-stf-blueprint", features = ["native"] }
-sov-value-setter = { path = "../../module-implementations/examples/sov-value-setter", features = ["native"] }
-sov-bank = { path = "../../module-implementations/sov-bank", features = ["native"] }
 sov-state = { path = "../../sov-state" }
-sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
+sov-value-setter = { path = "../../module-implementations/examples/sov-value-setter", features = ["native"] }
 
 borsh = { workspace = true }
 

--- a/crates/sovereign-sdk/rollup-interface/Cargo.toml
+++ b/crates/sovereign-sdk/rollup-interface/Cargo.toml
@@ -1,19 +1,18 @@
 [package]
 name = "sov-rollup-interface"
-description = "Defines interfaces for building rollups with the Sovereign SDK"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "Defines interfaces for building rollups with the Sovereign SDK"
 
 version = { workspace = true }
+exclude = [
+  "specs/assets/*",
+]
 readme = "README.md"
 resolver = "2"
-exclude = [
-    "specs/assets/*",
-]
-
 
 [dependencies]
 anyhow = { workspace = true }
@@ -21,11 +20,11 @@ async-trait = { workspace = true }
 borsh = { workspace = true }
 bytes = { workspace = true, optional = true, default-features = true }
 digest = { workspace = true }
+futures = { workspace = true, optional = true }
 hex = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
-futures = { workspace = true, optional = true }
 # TODO: Remove tokio when https://github.com/Sovereign-Labs/sovereign-sdk/issues/1161 is resolved
 tokio = { workspace = true, optional = true }
 
@@ -33,25 +32,24 @@ tokio = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-
 [dev-dependencies]
-serde_json = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = ["std"]
 native = ["std", "tokio", "futures"]
 fuzzing = ["proptest", "proptest-derive", "sha2", "std"]
 std = [
-    "anyhow/default",
-    "borsh/default",
-    "borsh/bytes",
-    "bytes",
-    "digest/default",
-    "hex/default",
-    "proptest?/default",
-    "serde/default",
-    "sha2?/default",
-    "thiserror"
+  "anyhow/default",
+  "borsh/default",
+  "borsh/bytes",
+  "bytes",
+  "digest/default",
+  "hex/default",
+  "proptest?/default",
+  "serde/default",
+  "sha2?/default",
+  "thiserror",
 ]

--- a/crates/sovereign-sdk/utils/bashtestmd/Cargo.toml
+++ b/crates/sovereign-sdk/utils/bashtestmd/Cargo.toml
@@ -7,9 +7,9 @@ license = { workspace = true }
 repository = { workspace = true }
 
 version = { workspace = true }
-resolver = "2"
-publish = false
 autotests = false
+publish = false
+resolver = "2"
 
 [dependencies]
 clap = { workspace = true }

--- a/crates/sovereign-sdk/utils/rng-da-service/Cargo.toml
+++ b/crates/sovereign-sdk/utils/rng-da-service/Cargo.toml
@@ -7,27 +7,21 @@ license = { workspace = true }
 repository = { workspace = true }
 
 version = { workspace = true }
-resolver = "2"
 publish = false
+resolver = "2"
 
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-tokio = { workspace = true }
-futures = { workspace = true }
 # Sovereign dependencies
-demo-stf = { path = "../../../sovereign-sdk/examples/demo-stf", features = [
-    "native",
-] }
+demo-stf = { path = "../../../sovereign-sdk/examples/demo-stf", features = ["native"] }
+futures = { workspace = true }
+serde = { workspace = true }
 sov-bank = { path = "../../module-system/module-implementations/sov-bank" }
-sov-modules-api = { path = "../../module-system/sov-modules-api", features = [
-    "native",
-] }
-sov-rollup-interface = { path = "../../rollup-interface", features = [
-    "native",
-] }
 sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
+sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["native"] }
+sov-rollup-interface = { path = "../../rollup-interface", features = ["native"] }
+tokio = { workspace = true }
 
 hex = { workspace = true }

--- a/crates/sovereign-sdk/utils/zk-cycle-macros/Cargo.toml
+++ b/crates/sovereign-sdk/utils/zk-cycle-macros/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sov-zk-cycle-macros"
-description = "cycle counting utils"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "cycle counting utils"
 
 version = { workspace = true }
+autotests = false
 readme = "README.md"
 resolver = "2"
-autotests = false
 
 [lib]
 proc-macro = true
@@ -21,17 +21,17 @@ path = "tests/all_tests.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-syn = { version = "1.0", features = ["full"] }
-quote = "1.0"
-proc-macro2 = "1.0"
 borsh = { workspace = true }
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-trybuild = "1.0"
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros" }
-sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils" }
 risc0-zkvm = { workspace = true, default-features = false, features = ["std"] }
 risc0-zkvm-platform = { workspace = true }
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros" }
+sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils" }
+trybuild = "1.0"
 
 [features]
 bench = []

--- a/crates/sovereign-sdk/utils/zk-cycle-utils/Cargo.toml
+++ b/crates/sovereign-sdk/utils/zk-cycle-utils/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "sov-zk-cycle-utils"
 authors = { workspace = true }
-description = "Utilities for counting risc0 cycles consumed by Sovereign SDK functions"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = "Utilities for counting risc0 cycles consumed by Sovereign SDK functions"
 
 version = { workspace = true }
+autotests = false
 readme = "README.md"
 resolver = "2"
-autotests = false
 
 [dependencies]
+bytes = "1.5.0"
 risc0-zkvm = { workspace = true, default-features = false, features = ['std'] }
 risc0-zkvm-platform = { workspace = true }
-bytes = "1.5.0"
 
 [features]
 default = []

--- a/crates/sovereign-sdk/utils/zk-cycle-utils/tracer/Cargo.toml
+++ b/crates/sovereign-sdk/utils/zk-cycle-utils/tracer/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 [workspace]
 
 [dependencies]
-rustc-demangle = "0.1.18"
-goblin = "0.2"
 capstone = "0.11.0"
-regex = "1.5.4"
-prettytable-rs = "^0.10"
-textwrap = "0.16.0"
-indicatif = "0.17.6"
 clap = { workspace = true }
+goblin = "0.2"
+indicatif = "0.17.6"
+prettytable-rs = "^0.10"
+regex = "1.5.4"
+rustc-demangle = "0.1.18"
+textwrap = "0.16.0"

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,5 @@
 [licenses]
-
-# TODO: figure this out after refactoring 
+# TODO: figure this out after refactoring
 
 allow = [
   "Apache-2.0",

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,5 @@
+{
+  "includes": ["**/*.{toml}"],
+  "excludes": ["**/target", "crates/evm/src/evm/system_contracts"],
+  "plugins": ["https://plugins.dprint.dev/toml-0.5.3.wasm"]
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
-components = [ "rustfmt", "rust-src", "clippy" ]
+components = ["rustfmt", "rust-src", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
# Description

https://dprint.dev/install/

dprint maintains proper formatting for all `Cargo.toml` files. Very useful for maintaining consistency IMO.

Merge if you agree with this change.
