### PR TITLE
Esad/detect l1 fee fail txs

### DIFF
--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -1864,7 +1864,7 @@ async fn sequencer_crash_and_replace_full_node() -> Result<(), anyhow::Error> {
 async fn transaction_failing_on_l1_is_removed_from_mempool() -> Result<(), anyhow::Error> {
     citrea::initialize_logging();
 
-    let (seq_test_client, full_node_test_client, seq_task, full_node_task, addr) =
+    let (seq_test_client, full_node_test_client, seq_task, full_node_task, _) =
         initialize_test(Default::default()).await;
 
     let random_wallet = LocalWallet::new(&mut thread_rng()).with_chain_id(seq_test_client.chain_id);

--- a/crates/evm/src/call.rs
+++ b/crates/evm/src/call.rs
@@ -222,6 +222,12 @@ impl<C: sov_modules_api::Context> Evm<C> {
                         continue;
                     }
                     EVMError::Custom(msg) => {
+                        #[cfg(feature = "native")]
+                        if !msg.starts_with("Gas used") {
+                            // only custom error not related to l1 fees is Gas used exceeds block gas limit
+                            self.l1_fee_failed_txs
+                                .push(&evm_tx_recovered.hash(), &mut working_set.accessory_state());
+                        }
                         // This is a custom error - we need to log it but no need to shutdown the system as of now.
                         tracing::error!("evm: Custom error: {:?}", msg);
                         continue;

--- a/crates/evm/src/call.rs
+++ b/crates/evm/src/call.rs
@@ -224,6 +224,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                     EVMError::Custom(msg) => {
                         #[cfg(feature = "native")]
                         if !msg.starts_with("Gas used") {
+                            tracing::error!("native native");
                             // only custom error not related to l1 fees is Gas used exceeds block gas limit
                             self.l1_fee_failed_txs
                                 .push(&evm_tx_recovered.hash(), &mut working_set.accessory_state());

--- a/crates/evm/src/call.rs
+++ b/crates/evm/src/call.rs
@@ -224,8 +224,8 @@ impl<C: sov_modules_api::Context> Evm<C> {
                     EVMError::Custom(msg) => {
                         #[cfg(feature = "native")]
                         if !msg.starts_with("Gas used") {
-                            tracing::error!("native native");
-                            // only custom error not related to l1 fees is Gas used exceeds block gas limit
+                            // not really good way to seperate these transactions but it's the best we can do for now
+                            // TODO: replace this branching with a better one.
                             self.l1_fee_failed_txs
                                 .push(&evm_tx_recovered.hash(), &mut working_set.accessory_state());
                         }

--- a/crates/evm/src/hooks.rs
+++ b/crates/evm/src/hooks.rs
@@ -293,5 +293,7 @@ where
             accessory_working_set,
         );
         self.pending_head.delete(accessory_working_set);
+
+        self.l1_fee_failed_txs.clear(accessory_working_set);
     }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -171,9 +171,9 @@ impl<C: sov_modules_api::Context> Evm<C> {
     }
 
     /// Returns transaction hashes that failed to pay the L1 fee.
-    pub fn get_l1_fee_failed_txs<'a>(
+    pub fn get_l1_fee_failed_txs(
         &self,
-        accessory_working_set: &'a mut AccessoryWorkingSet<C>,
+        accessory_working_set: &mut AccessoryWorkingSet<C>,
     ) -> Vec<TxHash> {
         self.l1_fee_failed_txs.iter(accessory_working_set).collect()
     }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -33,10 +33,10 @@ mod tests;
 
 use evm::db::EvmDb;
 use evm::DbAccount;
-use reth_primitives::{Address, B256};
+use reth_primitives::{Address, TxHash, B256};
 pub use revm::primitives::SpecId;
 use revm::primitives::U256;
-use sov_modules_api::{Error, ModuleInfo, WorkingSet};
+use sov_modules_api::{AccessoryWorkingSet, Error, ModuleInfo, StateVecAccessor, WorkingSet};
 use sov_state::codec::BcsCodec;
 
 use crate::evm::primitive_types::{
@@ -100,6 +100,12 @@ pub struct Evm<C: sov_modules_api::Context> {
     #[state]
     pub(crate) l1_fee_rate: sov_modules_api::StateValue<u64, BcsCodec>,
 
+    /// Transaction's hash that failed to pay the L1 fee.
+    /// Used to prevent DOS attacks.
+    /// The vector is cleared in `finalize_hook`.
+    #[state]
+    pub(crate) l1_fee_failed_txs: sov_modules_api::AccessoryStateVec<TxHash, BcsCodec>,
+
     /// Used only by the RPC: This represents the head of the chain and is set in two distinct stages:
     /// 1. `end_slot_hook`: the pending head is populated with data from pending_transactions.
     /// 2. `finalize_hook` the `root_hash` is populated.
@@ -162,5 +168,13 @@ impl<C: sov_modules_api::Context> Evm<C> {
             self.latest_block_hashes.clone(),
             working_set,
         )
+    }
+
+    /// Returns transaction hashes that failed to pay the L1 fee.
+    pub fn get_l1_fee_failed_txs<'a>(
+        &self,
+        accessory_working_set: &'a mut AccessoryWorkingSet<C>,
+    ) -> Vec<TxHash> {
+        self.l1_fee_failed_txs.iter(accessory_working_set).collect()
     }
 }

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -708,7 +708,7 @@ where
                                     .insert_sequencer_commitment(
                                         l1_start_height as u32,
                                         l1_end_height as u32,
-                                        tx_id.into().to_vec(),
+                                        Into::<[u8; 32]>::into(tx_id).to_vec(),
                                         commitment.l1_start_block_hash.to_vec(),
                                         commitment.l1_end_block_hash.to_vec(),
                                         l2_range.start().0 as u32,

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -296,9 +296,14 @@ where
 
                 // before finalize we can get tx hashes that failed due to L1 fees.
                 let evm = Evm::<C>::default();
-                let mut working_set = WorkingSet::<C>::new(self.storage.clone());
+
+                // nasty hack to access state
+                let mut intermediary_working_set = checkpoint.to_revertable();
+
                 let l1_fee_failed_txs =
-                    evm.get_l1_fee_failed_txs(&mut working_set.accessory_state());
+                    evm.get_l1_fee_failed_txs(&mut intermediary_working_set.accessory_state());
+
+                let checkpoint = intermediary_working_set.checkpoint();
 
                 // Finalize soft confirmation
                 let slot_result = self.stf.finalize_soft_batch(


### PR DESCRIPTION
# Description
If a transaction fails due to L1 fee, we don't want to rerun it, or we try that every block which is DOS. So we remove them from the mempool after its first execution.

no merge yet. waiting on some confirmations on writing to accessory state in sov-module calls. 

## Linked Issues
#477 
