### PR TITLE
Esad/enhance u256 to u64 conversion

### DIFF
--- a/crates/ethereum-rpc/src/gas_price/cache.rs
+++ b/crates/ethereum-rpc/src/gas_price/cache.rs
@@ -6,8 +6,6 @@ use reth_rpc_types::{Block, BlockTransactions, Rich, TransactionReceipt};
 use schnellru::{ByLength, LruMap};
 use sov_modules_api::WorkingSet;
 
-use super::gas_oracle::convert_u256_to_u64;
-
 /// Cache for gas oracle
 pub struct BlockCache<C: sov_modules_api::Context> {
     // Assuming number_to_hash and cache are always in sync
@@ -36,7 +34,7 @@ impl<C: sov_modules_api::Context> BlockCache<C> {
         let mut number_to_hash = self.number_to_hash.lock().unwrap();
         if let Some(block) = cache.get(&block_hash) {
             // Even though block is in cache, ask number_to_hash to keep it in sync
-            let number = convert_u256_to_u64(block.header.number.unwrap_or_default());
+            let number: u64 = block.header.number.unwrap_or_default().saturating_to();
             number_to_hash.get(&number);
             return Ok(Some(block.clone()));
         }
@@ -49,7 +47,7 @@ impl<C: sov_modules_api::Context> BlockCache<C> {
 
         // Add block to cache if it exists
         if let Some(block) = &block {
-            let number = convert_u256_to_u64(block.header.number.unwrap_or_default());
+            let number: u64 = block.header.number.unwrap_or_default().saturating_to();
 
             number_to_hash.insert(number, block_hash);
             cache.insert(block_hash, block.clone());
@@ -83,7 +81,7 @@ impl<C: sov_modules_api::Context> BlockCache<C> {
 
         // Add block to cache if it exists
         if let Some(block) = &block {
-            let number = convert_u256_to_u64(block.header.number.unwrap_or_default());
+            let number: u64 = block.header.number.unwrap_or_default().saturating_to();
             let hash = block.header.hash.unwrap_or_default();
 
             number_to_hash.insert(number, hash);

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1,4 +1,3 @@
-use std::array::TryFromSliceError;
 use std::collections::BTreeMap;
 use std::ops::{Range, RangeInclusive};
 
@@ -900,7 +899,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         // if the provided gas limit is less than computed cap, use that
         let gas_limit = std::cmp::min(U256::from(tx_env.gas_limit), highest_gas_limit);
-        tx_env.gas_limit = convert_u256_to_u64(gas_limit).unwrap();
+        tx_env.gas_limit = gas_limit.saturating_to();
 
         let evm_db = self.get_db(working_set);
 
@@ -1652,12 +1651,6 @@ fn map_out_of_gas_err<C: sov_modules_api::Context>(
         },
         Err(err) => EthApiError::from(err),
     }
-}
-
-fn convert_u256_to_u64(u256: reth_primitives::U256) -> Result<u64, TryFromSliceError> {
-    let bytes: [u8; 32] = u256.to_be_bytes();
-    let bytes: [u8; 8] = bytes[24..].try_into()?;
-    Ok(u64::from_be_bytes(bytes))
 }
 
 /// Updates the highest and lowest gas limits for binary search

--- a/crates/sovereign-sdk/full-node/sov-ledger-rpc/src/server.rs
+++ b/crates/sovereign-sdk/full-node/sov-ledger-rpc/src/server.rs
@@ -43,7 +43,7 @@ where
 {
     let mut rpc = RpcModule::new(ledger);
 
-    rpc.register_method("ledger_getHead", move |params, ledger| {
+    rpc.register_async_method("ledger_getHead", |params, ledger| async move {
         let mut params = params.sequence();
         let query_mode = params.optional_next()?.unwrap_or(QueryMode::Compact);
         ledger
@@ -52,50 +52,51 @@ where
     })?;
 
     // Primary getters.
-    rpc.register_method("ledger_getSlots", move |params, ledger| {
+    rpc.register_async_method("ledger_getSlots", |params, ledger| async move {
         let args: QueryArgs<Vec<SlotIdentifier>> = extract_query_args(params)?;
         ledger
             .get_slots::<B, Tx>(&args.0, args.1)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getBatches", move |params, ledger| {
+    rpc.register_async_method("ledger_getBatches", |params, ledger| async move {
         let args: QueryArgs<Vec<BatchIdentifier>> = extract_query_args(params)?;
         ledger
             .get_batches::<B, Tx>(&args.0, args.1)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getTransactions", move |params, ledger| {
+    rpc.register_async_method("ledger_getTransactions", |params, ledger| async move {
         let args: QueryArgs<Vec<TxIdentifier>> = extract_query_args(params)?;
         ledger
             .get_transactions::<Tx>(&args.0, args.1)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getEvents", move |params, db| {
+    rpc.register_async_method("ledger_getEvents", |params, ledger| async move {
         let ids: Vec<EventIdentifier> = params.parse().or_else(|_| params.one())?;
-        db.get_events(&ids)
+        ledger
+            .get_events(&ids)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
 
     // By-hash getters.
-    rpc.register_method("ledger_getSlotByHash", move |params, ledger| {
+    rpc.register_async_method("ledger_getSlotByHash", |params, ledger| async move {
         let args: QueryArgs<HexHash> = extract_query_args(params)?;
         ledger
             .get_slot_by_hash::<B, Tx>(&args.0 .0, args.1)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getSoftBatchByHash", move |params, ledger| {
+    rpc.register_async_method("ledger_getSoftBatchByHash", |params, ledger| async move {
         let args: QueryArgs<HexHash> = extract_query_args(params)?;
         ledger
             .get_soft_batch_by_hash::<Tx>(&args.0 .0)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getBatchByHash", move |params, ledger| {
+    rpc.register_async_method("ledger_getBatchByHash", |params, ledger| async move {
         let args: QueryArgs<HexHash> = extract_query_args(params)?;
         ledger
             .get_batch_by_hash::<B, Tx>(&args.0 .0, args.1)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getTransactionByHash", move |params, ledger| {
+    rpc.register_async_method("ledger_getTransactionByHash", |params, ledger| async move {
         let args: QueryArgs<HexHash> = extract_query_args(params)?;
         ledger
             .get_tx_by_hash::<Tx>(&args.0 .0, args.1)
@@ -103,31 +104,34 @@ where
     })?;
 
     // By-number getters.
-    rpc.register_method("ledger_getSlotByNumber", move |params, ledger| {
+    rpc.register_async_method("ledger_getSlotByNumber", |params, ledger| async move {
         let args: QueryArgs<u64> = extract_query_args(params)?;
         ledger
             .get_slot_by_number::<B, Tx>(args.0, args.1)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getSoftBatchByNumber", move |params, ledger| {
+    rpc.register_async_method("ledger_getSoftBatchByNumber", |params, ledger| async move {
         let args: QueryArgs<u64> = extract_query_args(params)?;
         ledger
             .get_soft_batch_by_number::<Tx>(args.0)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getBatchByNumber", move |params, ledger| {
+    rpc.register_async_method("ledger_getBatchByNumber", |params, ledger| async move {
         let args: QueryArgs<u64> = extract_query_args(params)?;
         ledger
             .get_batch_by_number::<B, Tx>(args.0, args.1)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getTransactionByNumber", move |params, ledger| {
-        let args: QueryArgs<u64> = extract_query_args(params)?;
-        ledger
-            .get_tx_by_number::<Tx>(args.0, args.1)
-            .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
-    })?;
-    rpc.register_method("ledger_getEventByNumber", move |params, ledger| {
+    rpc.register_async_method(
+        "ledger_getTransactionByNumber",
+        |params, ledger| async move {
+            let args: QueryArgs<u64> = extract_query_args(params)?;
+            ledger
+                .get_tx_by_number::<Tx>(args.0, args.1)
+                .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
+        },
+    )?;
+    rpc.register_async_method("ledger_getEventByNumber", |params, ledger| async move {
         let args: u64 = params.one()?;
         ledger
             .get_event_by_number(args)
@@ -135,36 +139,39 @@ where
     })?;
 
     // Range getters.
-    rpc.register_method("ledger_getSlotsRange", move |params, ledger| {
+    rpc.register_async_method("ledger_getSlotsRange", |params, ledger| async move {
         let args: RangeArgs = params.parse()?;
         ledger
             .get_slots_range::<B, Tx>(args.0, args.1, args.2)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getBatchesRange", move |params, ledger| {
+    rpc.register_async_method("ledger_getBatchesRange", |params, ledger| async move {
         let args: RangeArgs = params.parse()?;
         ledger
             .get_batches_range::<B, Tx>(args.0, args.1, args.2)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getSoftBatchRange", move |params, ledger| {
+    rpc.register_async_method("ledger_getSoftBatchRange", |params, ledger| async move {
         let args: (u64, u64) = params.parse()?;
         ledger
             .get_soft_batches_range(args.0, args.1)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getTransactionsRange", move |params, ledger| {
+    rpc.register_async_method("ledger_getTransactionsRange", |params, ledger| async move {
         let args: RangeArgs = params.parse()?;
         ledger
             .get_transactions_range::<Tx>(args.0, args.1, args.2)
             .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
     })?;
-    rpc.register_method("ledger_getSoftConfirmationStatus", move |params, ledger| {
-        let args: QueryArgs<u64> = extract_query_args(params)?;
-        ledger
-            .get_soft_confirmation_status(args.0)
-            .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
-    })?;
+    rpc.register_async_method(
+        "ledger_getSoftConfirmationStatus",
+        |params, ledger| async move {
+            let args: QueryArgs<u64> = extract_query_args(params)?;
+            ledger
+                .get_soft_confirmation_status(args.0)
+                .map_err(|e| to_jsonrpsee_error_object(LEDGER_RPC_ERROR, e))
+        },
+    )?;
 
     rpc.register_subscription(
         "ledger_subscribeSlots",

--- a/crates/sovereign-sdk/fuzz/Cargo.lock
+++ b/crates/sovereign-sdk/fuzz/Cargo.lock
@@ -3014,9 +3014,7 @@ dependencies = [
  "jsonrpsee",
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "schemars",
  "serde_json",
- "sov-modules-core",
  "syn 1.0.109",
 ]
 


### PR DESCRIPTION
# Description
Removes `convert_u256_to_u64` function, because alloy's `U256` has `saturating_to()`
Also the old function did `wrapping_to`, which didn't really make sense.
## Linked Issues
Closes #210 
