### PR TITLE
Add `eth_get_block_transaction_count_by_number`

### DIFF
--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -945,6 +945,22 @@ impl<C: sov_modules_api::Context> Evm<C> {
         }
     }
 
+    /// Handler for: `eth_getBlockTransactionCountByNumber`
+    #[rpc_method(name = "eth_getBlockTransactionCountByNumber")]
+    pub fn eth_get_block_transaction_count_by_number(
+        &self,
+        block_number: Option<BlockNumberOrTag>,
+        working_set: &mut WorkingSet<C>,
+    ) -> RpcResult<Option<reth_primitives::U256>> {
+        info!("evm module: eth_getBlockTransactionCountByNumber");
+        // Get the number of transactions in a block given block number
+        let block = self.get_block_by_number(block_number, None, working_set)?;
+        match block {
+            Some(block) => Ok(Some(U256::from(block.transactions.len()))),
+            None => Ok(None),
+        }
+    }
+
     /// Inner gas estimator
     pub(crate) fn estimate_gas_with_env(
         &self,

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -949,12 +949,12 @@ impl<C: sov_modules_api::Context> Evm<C> {
     #[rpc_method(name = "eth_getBlockTransactionCountByNumber")]
     pub fn eth_get_block_transaction_count_by_number(
         &self,
-        block_number: Option<BlockNumberOrTag>,
+        block_number: BlockNumberOrTag,
         working_set: &mut WorkingSet<C>,
     ) -> RpcResult<Option<reth_primitives::U256>> {
         info!("evm module: eth_getBlockTransactionCountByNumber");
         // Get the number of transactions in a block given block number
-        let block = self.get_block_by_number(block_number, None, working_set)?;
+        let block = self.get_block_by_number(Some(block_number), None, working_set)?;
         match block {
             Some(block) => Ok(Some(U256::from(block.transactions.len()))),
             None => Ok(None),

--- a/crates/evm/src/tests/queries/basic_queries.rs
+++ b/crates/evm/src/tests/queries/basic_queries.rs
@@ -239,18 +239,29 @@ fn get_block_transaction_count_by_hash_test() {
 fn get_block_transaction_count_by_number_test() {
     let (evm, mut working_set, _) = init_evm();
 
-    let result =
-        evm.eth_get_block_transaction_count_by_number(Some(BlockNumberOrTag::Number(5)), &mut working_set);
+    let result = evm.eth_get_block_transaction_count_by_number(
+        Some(BlockNumberOrTag::Number(5)),
+        &mut working_set,
+    );
     // Non-existent block number should return None
     assert_eq!(result, Ok(None));
 
-    let result = evm.eth_get_block_transaction_count_by_number(Some(BlockNumberOrTag::Number(1)), &mut working_set);
+    let result = evm.eth_get_block_transaction_count_by_number(
+        Some(BlockNumberOrTag::Number(1)),
+        &mut working_set,
+    );
     assert_eq!(result, Ok(Some(U256::from(3))));
 
-    let result = evm.eth_get_block_transaction_count_by_number(Some(BlockNumberOrTag::Number(2)), &mut working_set);
+    let result = evm.eth_get_block_transaction_count_by_number(
+        Some(BlockNumberOrTag::Number(2)),
+        &mut working_set,
+    );
     assert_eq!(result, Ok(Some(U256::from(4))));
 
-    let result = evm.eth_get_block_transaction_count_by_number(Some(BlockNumberOrTag::Number(2)), &mut working_set);
+    let result = evm.eth_get_block_transaction_count_by_number(
+        Some(BlockNumberOrTag::Number(2)),
+        &mut working_set,
+    );
     assert_eq!(result, Ok(Some(U256::from(2))));
 }
 

--- a/crates/evm/src/tests/queries/basic_queries.rs
+++ b/crates/evm/src/tests/queries/basic_queries.rs
@@ -240,26 +240,26 @@ fn get_block_transaction_count_by_number_test() {
     let (evm, mut working_set, _) = init_evm();
 
     let result = evm.eth_get_block_transaction_count_by_number(
-        Some(BlockNumberOrTag::Number(5)),
+        BlockNumberOrTag::Number(5),
         &mut working_set,
     );
     // Non-existent block number should return None
     assert_eq!(result, Ok(None));
 
     let result = evm.eth_get_block_transaction_count_by_number(
-        Some(BlockNumberOrTag::Number(1)),
+        BlockNumberOrTag::Number(1),
         &mut working_set,
     );
     assert_eq!(result, Ok(Some(U256::from(3))));
 
     let result = evm.eth_get_block_transaction_count_by_number(
-        Some(BlockNumberOrTag::Number(2)),
+        BlockNumberOrTag::Number(2),
         &mut working_set,
     );
     assert_eq!(result, Ok(Some(U256::from(4))));
 
     let result = evm.eth_get_block_transaction_count_by_number(
-        Some(BlockNumberOrTag::Number(2)),
+        BlockNumberOrTag::Number(2),
         &mut working_set,
     );
     assert_eq!(result, Ok(Some(U256::from(2))));

--- a/crates/evm/src/tests/queries/basic_queries.rs
+++ b/crates/evm/src/tests/queries/basic_queries.rs
@@ -239,29 +239,21 @@ fn get_block_transaction_count_by_hash_test() {
 fn get_block_transaction_count_by_number_test() {
     let (evm, mut working_set, _) = init_evm();
 
-    let result = evm.eth_get_block_transaction_count_by_number(
-        BlockNumberOrTag::Number(5),
-        &mut working_set,
-    );
+    let result = evm
+        .eth_get_block_transaction_count_by_number(BlockNumberOrTag::Number(5), &mut working_set);
     // Non-existent block number should return None
     assert_eq!(result, Ok(None));
 
-    let result = evm.eth_get_block_transaction_count_by_number(
-        BlockNumberOrTag::Number(1),
-        &mut working_set,
-    );
+    let result = evm
+        .eth_get_block_transaction_count_by_number(BlockNumberOrTag::Number(1), &mut working_set);
     assert_eq!(result, Ok(Some(U256::from(3))));
 
-    let result = evm.eth_get_block_transaction_count_by_number(
-        BlockNumberOrTag::Number(2),
-        &mut working_set,
-    );
+    let result = evm
+        .eth_get_block_transaction_count_by_number(BlockNumberOrTag::Number(2), &mut working_set);
     assert_eq!(result, Ok(Some(U256::from(4))));
 
-    let result = evm.eth_get_block_transaction_count_by_number(
-        BlockNumberOrTag::Number(2),
-        &mut working_set,
-    );
+    let result = evm
+        .eth_get_block_transaction_count_by_number(BlockNumberOrTag::Number(2), &mut working_set);
     assert_eq!(result, Ok(Some(U256::from(2))));
 }
 

--- a/crates/evm/src/tests/queries/basic_queries.rs
+++ b/crates/evm/src/tests/queries/basic_queries.rs
@@ -236,6 +236,25 @@ fn get_block_transaction_count_by_hash_test() {
 }
 
 #[test]
+fn get_block_transaction_count_by_number_test() {
+    let (evm, mut working_set, _) = init_evm();
+
+    let result =
+        evm.eth_get_block_transaction_count_by_number(Some(BlockNumberOrTag::Number(5)), &mut working_set);
+    // Non-existent block number should return None
+    assert_eq!(result, Ok(None));
+
+    let result = evm.eth_get_block_transaction_count_by_number(Some(BlockNumberOrTag::Number(1)), &mut working_set);
+    assert_eq!(result, Ok(Some(U256::from(3))));
+
+    let result = evm.eth_get_block_transaction_count_by_number(Some(BlockNumberOrTag::Number(2)), &mut working_set);
+    assert_eq!(result, Ok(Some(U256::from(4))));
+
+    let result = evm.eth_get_block_transaction_count_by_number(Some(BlockNumberOrTag::Number(2)), &mut working_set);
+    assert_eq!(result, Ok(Some(U256::from(2))));
+}
+
+#[test]
 fn call_test() {
     let (evm, mut working_set, signer) = init_evm();
 

--- a/crates/evm/src/tests/queries/basic_queries.rs
+++ b/crates/evm/src/tests/queries/basic_queries.rs
@@ -253,7 +253,7 @@ fn get_block_transaction_count_by_number_test() {
     assert_eq!(result, Ok(Some(U256::from(4))));
 
     let result = evm
-        .eth_get_block_transaction_count_by_number(BlockNumberOrTag::Number(2), &mut working_set);
+        .eth_get_block_transaction_count_by_number(BlockNumberOrTag::Number(3), &mut working_set);
     assert_eq!(result, Ok(Some(U256::from(2))));
 }
 


### PR DESCRIPTION
# Description
Adds [eth_getBlockTransactionCountByNumber](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblocktransactioncountbynumber) as an RPC method.

## Testing
Added a unit test.
