### PR TITLE
Hotfix for no loaded wallets

### DIFF
--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -262,6 +262,10 @@ impl BitcoinNode {
     }
 
     pub async fn list_wallets(&self) -> Result<Vec<String>, anyhow::Error> {
-        self.call::<Vec<String>>("listwallets", vec![]).await
+        let res = self.call::<Vec<String>>("listwallets", vec![]).await;
+        match res {
+            Ok(wallets) => Ok(wallets),
+            Err(_) => Ok(vec![]),
+        }
     }
 }

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -174,7 +174,7 @@ impl BitcoinService {
             .expect("Failed to list loaded wallets");
 
         if wallets.is_empty() {
-            panic!("No loaded wallet found!");
+            tracing::warn!("No loaded wallet found!");
         }
 
         Self {


### PR DESCRIPTION
# Description
If there's no loaded wallets for the sequencer, an error comes up so it can be handled later.