### PR TITLE
Use cargo metadata instead of git to fetch version

### DIFF
--- a/bin/citrea/tests/evm/mod.rs
+++ b/bin/citrea/tests/evm/mod.rs
@@ -6,6 +6,7 @@ use citrea_evm::smart_contracts::{
     HiveContract, LogsContract, SimpleStorageContract, TestContract,
 };
 use citrea_stf::genesis_config::GenesisPaths;
+use ethereum_rpc::VERSION;
 use ethers_core::abi::Address;
 use ethers_core::types::{BlockId, Bytes, U256};
 use ethers_signers::{LocalWallet, Signer};
@@ -46,14 +47,13 @@ async fn web3_rpc_tests() -> Result<(), anyhow::Error> {
 
     let test_client = make_test_client(port).await;
 
-    let tag = ethereum_rpc::get_latest_git_tag().unwrap_or_else(|_| "unknown".to_string());
     let arch = std::env::consts::ARCH;
 
     assert_eq!(
         test_client.web3_client_version().await,
         format!(
             "citrea/{}/{}/rust-{}",
-            tag,
+            VERSION,
             arch,
             rustc_version_runtime::version()
         )

--- a/bin/citrea/tests/evm/mod.rs
+++ b/bin/citrea/tests/evm/mod.rs
@@ -6,11 +6,11 @@ use citrea_evm::smart_contracts::{
     HiveContract, LogsContract, SimpleStorageContract, TestContract,
 };
 use citrea_stf::genesis_config::GenesisPaths;
-use ethereum_rpc::VERSION;
 use ethers_core::abi::Address;
 use ethers_core::types::{BlockId, Bytes, U256};
 use ethers_signers::{LocalWallet, Signer};
 use reth_primitives::BlockNumberOrTag;
+use sov_rollup_interface::CITREA_VERSION;
 
 // use sov_demo_rollup::initialize_logging;
 use crate::test_client::TestClient;
@@ -53,7 +53,7 @@ async fn web3_rpc_tests() -> Result<(), anyhow::Error> {
         test_client.web3_client_version().await,
         format!(
             "citrea/{}/{}/rust-{}",
-            VERSION,
+            CITREA_VERSION,
             arch,
             rustc_version_runtime::version()
         )

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -31,6 +31,7 @@ use sov_rollup_interface::services::da::DaService;
 use tracing::{info, instrument};
 
 const MAX_TRACE_BLOCK: u32 = 1000;
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Clone)]
 pub struct EthRpcConfig {
@@ -101,15 +102,7 @@ impl<C: sov_modules_api::Context, Da: DaService> Ethereum<C, Da> {
         let arch = std::env::consts::ARCH;
         let rustc_v = version();
 
-        let git_latest_tag = match get_latest_git_tag() {
-            Ok(tag) => tag,
-            Err(e) => {
-                info!("Failed to get latest git tag: {}", e);
-                "unknown".to_string()
-            }
-        };
-
-        let current_version = format!("{}/{}/{}/rust-{}", rollup, git_latest_tag, arch, rustc_v);
+        let current_version = format!("{}/{}/{}/rust-{}", rollup, VERSION, arch, rustc_v);
 
         let trace_cache = Mutex::new(LruMap::new(ByLength::new(MAX_TRACE_BLOCK)));
 
@@ -120,7 +113,7 @@ impl<C: sov_modules_api::Context, Da: DaService> Ethereum<C, Da> {
             eth_signer,
             storage,
             sequencer_client,
-            web3_client_version: current_version,
+            web3_client_version: VERSION.to_owned(),
             trace_cache,
         }
     }

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -113,7 +113,7 @@ impl<C: sov_modules_api::Context, Da: DaService> Ethereum<C, Da> {
             eth_signer,
             storage,
             sequencer_client,
-            web3_client_version: VERSION.to_owned(),
+            web3_client_version: current_version,
             trace_cache,
         }
     }

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -31,7 +31,7 @@ use sov_rollup_interface::services::da::DaService;
 use tracing::{info, instrument};
 
 const MAX_TRACE_BLOCK: u32 = 1000;
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Clone)]
 pub struct EthRpcConfig {

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -28,10 +28,10 @@ use serde_json::json;
 use sov_modules_api::utils::to_jsonrpsee_error_object;
 use sov_modules_api::WorkingSet;
 use sov_rollup_interface::services::da::DaService;
+use sov_rollup_interface::CITREA_VERSION;
 use tracing::{info, instrument};
 
 const MAX_TRACE_BLOCK: u32 = 1000;
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Clone)]
 pub struct EthRpcConfig {
@@ -102,7 +102,7 @@ impl<C: sov_modules_api::Context, Da: DaService> Ethereum<C, Da> {
         let arch = std::env::consts::ARCH;
         let rustc_v = version();
 
-        let current_version = format!("{}/{}/{}/rust-{}", rollup, VERSION, arch, rustc_v);
+        let current_version = format!("{}/{}/{}/rust-{}", rollup, CITREA_VERSION, arch, rustc_v);
 
         let trace_cache = Mutex::new(LruMap::new(ByLength::new(MAX_TRACE_BLOCK)));
 

--- a/crates/sovereign-sdk/rollup-interface/src/lib.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/lib.rs
@@ -8,6 +8,9 @@
 
 extern crate alloc;
 
+/// The current version of Citrea.
+///
+/// Mostly used for web3_clientVersion RPC calls and might be used for other purposes.
 pub const CITREA_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 mod state_machine;

--- a/crates/sovereign-sdk/rollup-interface/src/lib.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/lib.rs
@@ -8,6 +8,8 @@
 
 extern crate alloc;
 
+pub const CITREA_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 mod state_machine;
 pub use state_machine::*;
 


### PR DESCRIPTION
# Description
Fetches the package version from cargo metadata instead of using git.

## Linked Issues
- Fixes #576 

