### PR TITLE
release 0.4.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bashtestmd"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "clap",
  "indoc",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "citrea"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-evm"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-risc0-bonsai-adapter"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-sequencer"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "alloy-rlp",
  "anyhow",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-stf"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1903,7 +1903,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-rollup-config"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 
 [[package]]
 name = "constant_time_eq"
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "demo-simple-stf"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "demo-stf"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-rpc"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4368,7 +4368,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "module-template"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -7688,7 +7688,7 @@ dependencies = [
 
 [[package]]
 name = "risc0"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "risc0-build",
 ]
@@ -7971,7 +7971,7 @@ dependencies = [
 
 [[package]]
 name = "rollup-constants"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 
 [[package]]
 name = "route-recognizer"
@@ -8471,7 +8471,7 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "sequencer-client"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "ethers",
@@ -8679,7 +8679,7 @@ dependencies = [
 
 [[package]]
 name = "shared-backup-db"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "deadpool-postgres",
  "postgres-types",
@@ -8721,7 +8721,7 @@ dependencies = [
 
 [[package]]
 name = "simple-nft-module"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8803,7 +8803,7 @@ dependencies = [
 
 [[package]]
 name = "soft-confirmation-rule-enforcer"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8851,7 +8851,7 @@ dependencies = [
 
 [[package]]
 name = "sov-accessory-state"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "borsh",
  "jsonrpsee",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "sov-accounts"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -8885,7 +8885,7 @@ dependencies = [
 
 [[package]]
 name = "sov-bank"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8904,7 +8904,7 @@ dependencies = [
 
 [[package]]
 name = "sov-cli"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8923,7 +8923,7 @@ dependencies = [
 
 [[package]]
 name = "sov-data-generators"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "borsh",
  "proptest",
@@ -8937,7 +8937,7 @@ dependencies = [
 
 [[package]]
 name = "sov-db"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -8962,7 +8962,7 @@ dependencies = [
 
 [[package]]
 name = "sov-ledger-rpc"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -8979,7 +8979,7 @@ dependencies = [
 
 [[package]]
 name = "sov-mock-da"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9001,7 +9001,7 @@ dependencies = [
 
 [[package]]
 name = "sov-mock-zkvm"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9012,7 +9012,7 @@ dependencies = [
 
 [[package]]
 name = "sov-module-schemas"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "sov-accounts",
  "sov-bank",
@@ -9026,7 +9026,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-api"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -9060,7 +9060,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-core"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -9088,7 +9088,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-macros"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -9107,7 +9107,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-rollup-blueprint"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9131,7 +9131,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-stf-blueprint"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -9153,7 +9153,7 @@ dependencies = [
 
 [[package]]
 name = "sov-nft-module"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -9174,7 +9174,7 @@ dependencies = [
 
 [[package]]
 name = "sov-prover-incentives"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9193,7 +9193,7 @@ dependencies = [
 
 [[package]]
 name = "sov-prover-storage-manager"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9210,7 +9210,7 @@ dependencies = [
 
 [[package]]
 name = "sov-risc0-adapter"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9228,7 +9228,7 @@ dependencies = [
 
 [[package]]
 name = "sov-rng-da-service"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9246,7 +9246,7 @@ dependencies = [
 
 [[package]]
 name = "sov-rollup-interface"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9266,7 +9266,7 @@ dependencies = [
 
 [[package]]
 name = "sov-schema-db"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -9283,7 +9283,7 @@ dependencies = [
 
 [[package]]
 name = "sov-sequencer"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9307,7 +9307,7 @@ dependencies = [
 
 [[package]]
 name = "sov-sequencer-registry"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -9334,7 +9334,7 @@ dependencies = [
 
 [[package]]
 name = "sov-state"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -9359,7 +9359,7 @@ dependencies = [
 
 [[package]]
 name = "sov-stf-runner"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9393,7 +9393,7 @@ dependencies = [
 
 [[package]]
 name = "sov-value-setter"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -9411,7 +9411,7 @@ dependencies = [
 
 [[package]]
 name = "sov-vec-setter"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -9429,7 +9429,7 @@ dependencies = [
 
 [[package]]
 name = "sov-zk-cycle-macros"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
@@ -9442,7 +9442,7 @@ dependencies = [
 
 [[package]]
 name = "sov-zk-cycle-utils"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "bytes",
  "risc0-zkvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0-rc.1"
 edition = "2021"
 license = "GPL-3.0"
 authors = ["Chainway Labs <info@chainway.xyz>"]
@@ -92,7 +92,7 @@ hex = { version = "0.4.3", default-features = false, features = [
     "alloc",
     "serde",
 ] }
-log-panics = { version = "2", features = ["with-backtrace"]}
+log-panics = { version = "2", features = ["with-backtrace"] }
 once_cell = { version = "1.19.0", default-features = false, features = [
     "alloc",
 ] }

--- a/bin/citrea/provers/risc0/Cargo.toml
+++ b/bin/citrea/provers/risc0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc0"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 edition = "2021"
 resolver = "2"
 license = "MIT OR Apache-2.0"

--- a/bin/citrea/provers/risc0/build.rs
+++ b/bin/citrea/provers/risc0/build.rs
@@ -13,8 +13,8 @@ fn main() {
         let elf = r#"
             pub const BITCOIN_DA_ELF: &[u8] = &[];
             pub const MOCK_DA_ELF: &[u8] = &[];
-            pub const BITCOIN_DA_ID: [u32; 8] = [0;8];
-            pub const MOCK_DA_ID: [u32; 8] = [0;8];
+            pub const BITCOIN_DA_ID: [u32; 8] = [1852392876, 267005174, 1499487651, 3449263495, 171724239, 2872987482, 1693303230, 1704831148];
+            pub const MOCK_DA_ID: [u32; 8] = [2194593138, 561805477, 1426744713, 3604074109, 1275509937, 1729051969, 72044789, 2546174080];
         "#;
 
         std::fs::write(methods_path, elf).expect("Failed to write mock rollup elf");

--- a/bin/citrea/provers/risc0/guest-bitcoin/Cargo.lock
+++ b/bin/citrea/provers/risc0/guest-bitcoin/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-evm"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-stf"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "rollup-constants"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 
 [[package]]
 name = "rrs-lib"
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "soft-confirmation-rule-enforcer"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "sov-accounts"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-api"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-core"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-macros"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-stf-blueprint"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "sov-risc0-adapter"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "sov-rollup-interface"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "sov-state"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "sov-stf-runner"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "sov-zk-cycle-macros"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bin/citrea/provers/risc0/guest-mock/Cargo.lock
+++ b/bin/citrea/provers/risc0/guest-mock/Cargo.lock
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-evm"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-stf"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "soft-confirmation-rule-enforcer"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "sov-accounts"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "sov-mock-da"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-api"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-core"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-macros"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-stf-blueprint"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "sov-risc0-adapter"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "sov-rollup-interface"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "sov-state"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "sov-stf-runner"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "sov-zk-cycle-macros"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/ethereum-rpc/Cargo.toml
+++ b/crates/ethereum-rpc/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 resolver = "2"
 
 [dependencies]
-citrea-evm = { path = "../evm" }
+citrea-evm = { path = "../evm", features = ["native"] }
 sequencer-client = { path = "../sequencer-client" }
 anyhow = { workspace = true }
 tracing = { workspace = true }
@@ -46,4 +46,3 @@ proptest = { workspace = true }
 [features]
 default = ["local"]
 local = []
-native = ["citrea-evm/native"]

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 publish = false
 
 [dependencies]
-sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api", version = "0.3", default-features = false, features = [
+sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api", default-features = false, features = [
     "macros",
 ] }
-sov-state = { path = "../sovereign-sdk/module-system/sov-state", version = "0.3" }
+sov-state = { path = "../sovereign-sdk/module-system/sov-state" }
 sov-prover-storage-manager = { path = "../sovereign-sdk/full-node/sov-prover-storage-manager", optional = true }
 
 anyhow = { workspace = true }

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -46,7 +46,7 @@ sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface", features = 
     "native",
 ] }
 citrea-evm = { path = "../evm", features = ["native"] }
-sov-db = { path = "../sovereign-sdk/full-node/db/sov-db", version = "0.3" }
+sov-db = { path = "../sovereign-sdk/full-node/db/sov-db" }
 
 sov-stf-runner = { path = "../sovereign-sdk/full-node/sov-stf-runner" }
 

--- a/crates/soft-confirmation-rule-enforcer/Cargo.toml
+++ b/crates/soft-confirmation-rule-enforcer/Cargo.toml
@@ -12,10 +12,10 @@ publish = false
 resolver = "2"
 
 [dependencies]
-sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api", version = "0.3", default-features = false, features = [
+sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api", default-features = false, features = [
     "macros",
 ] }
-sov-state = { path = "../sovereign-sdk/module-system/sov-state", version = "0.3" }
+sov-state = { path = "../sovereign-sdk/module-system/sov-state" }
 sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface" }
 
 borsh = { workspace = true }

--- a/crates/sovereign-sdk/adapters/celestia/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/celestia/Cargo.toml
@@ -38,13 +38,13 @@ futures = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.3", optional = true }
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
 risc0-zkvm = { workspace = true, default-features = false, features = [
     "std",
 ], optional = true }
 risc0-zkvm-platform = { workspace = true, optional = true }
 
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+sov-rollup-interface = { path = "../../rollup-interface" }
 
 
 [dev-dependencies]

--- a/crates/sovereign-sdk/adapters/mock-da/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/mock-da/Cargo.toml
@@ -27,7 +27,7 @@ rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
 serde_json = { workspace = true, optional = true }
 tracing = { workspace = true }
 
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+sov-rollup-interface = { path = "../../rollup-interface" }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/crates/sovereign-sdk/adapters/mock-zkvm/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/mock-zkvm/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = { workspace = true }
 borsh = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+sov-rollup-interface = { path = "../../rollup-interface" }
 
 [features]
 default = []

--- a/crates/sovereign-sdk/adapters/risc0-bonsai/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/risc0-bonsai/Cargo.toml
@@ -22,7 +22,7 @@ serde = { workspace = true }
 bytemuck = "1.13.1"
 once_cell = { version = "1.19.0", optional = true }
 parking_lot = { version = "0.12.1", optional = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+sov-rollup-interface = { path = "../../rollup-interface" }
 tracing = { workspace = true }
 bonsai-sdk = "0.7.0"
 hex = { workspace = true }

--- a/crates/sovereign-sdk/adapters/risc0/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/risc0/Cargo.toml
@@ -22,8 +22,8 @@ serde = { workspace = true }
 bytemuck = "1.13.1"
 once_cell = { version = "1.19.0", optional = true }
 parking_lot = { version = "0.12.1", optional = true }
-sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", version = "0.3", optional = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", optional = true }
+sov-rollup-interface = { path = "../../rollup-interface" }
 
 [features]
 default = []

--- a/crates/sovereign-sdk/adapters/solana/da_client/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/solana/da_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "da_client"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,9 @@ anchor-client = "0.28.0"
 solana-sdk = "1.16"
 bs58 = "0.5.0"
 clap = { workspace = true }
-blockroot = {path = "../solana_da_programs/programs/blockroot", features = ["no-entrypoint"]}
+blockroot = { path = "../solana_da_programs/programs/blockroot", features = [
+    "no-entrypoint",
+] }
 solana-runtime = "1.16"
 solana-rpc-client = "1.16"
 anyhow = "1.0.75"

--- a/crates/sovereign-sdk/adapters/solana/solana_da_programs/programs/blockroot/Cargo.toml
+++ b/crates/sovereign-sdk/adapters/solana/solana_da_programs/programs/blockroot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockroot"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 description = "Created with Anchor"
 edition = "2021"
 
@@ -16,4 +16,4 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = {version = "0.28.0", features = ["init-if-needed"]}
+anchor-lang = { version = "0.28.0", features = ["init-if-needed"] }

--- a/crates/sovereign-sdk/examples/simple-nft-module/Cargo.toml
+++ b/crates/sovereign-sdk/examples/simple-nft-module/Cargo.toml
@@ -20,16 +20,29 @@ sov-state = { path = "../../module-system/sov-state" }
 clap = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
+jsonrpsee = { workspace = true, features = [
+    "macros",
+    "client-core",
+    "server",
+], optional = true }
 
 [dev-dependencies]
 sov-rollup-interface = { path = "../../rollup-interface" }
 tempfile = { workspace = true }
-simple-nft-module = { version = "*", features = ["native"], path = "." }
-sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+simple-nft-module = { features = ["native"], path = "." }
+sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = [
+    "test-utils",
+] }
 
 
 [features]
 default = []
-native = ["sov-state/native", "sov-modules-api/native", "jsonrpsee", "schemars", "serde_json", "clap"]
+native = [
+    "sov-state/native",
+    "sov-modules-api/native",
+    "jsonrpsee",
+    "schemars",
+    "serde_json",
+    "clap",
+]
 test = ["native"]

--- a/crates/sovereign-sdk/full-node/db/sov-db/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/db/sov-db/Cargo.toml
@@ -16,8 +16,8 @@ resolver = "2"
 [dependencies]
 # Maintained by sovereign labs
 jmt = { workspace = true }
-sov-schema-db = { path = "../sov-schema-db", version = "0.3" }
-sov-rollup-interface = { path = "../../../rollup-interface", version = "0.3", features = [
+sov-schema-db = { path = "../sov-schema-db" }
+sov-rollup-interface = { path = "../../../rollup-interface", features = [
     "native",
 ] }
 

--- a/crates/sovereign-sdk/full-node/sov-ledger-rpc/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/sov-ledger-rpc/Cargo.toml
@@ -15,13 +15,17 @@ publish = true
 # Common dependencies
 jsonrpsee = { workspace = true }
 serde = "1"
-sov-rollup-interface = { path = "../../rollup-interface", features = ["native"], version = "0.3" }
+sov-rollup-interface = { path = "../../rollup-interface", features = [
+    "native",
+] }
 # Client dependencies
 # (None)
 # Server dependencies
 anyhow = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
-sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["native"], optional = true, version = "0.3" }
+sov-modules-api = { path = "../../module-system/sov-modules-api", features = [
+    "native",
+], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/sovereign-sdk/full-node/sov-sequencer/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/sov-sequencer/Cargo.toml
@@ -19,9 +19,11 @@ hex = { workspace = true }
 jsonrpsee = { workspace = true, features = ["client", "server"] }
 serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
-sov-modules-api = { path = "../../module-system/sov-modules-api", version = "0.3", features = ["native"] }
-sov-state = { path = "../../module-system/sov-state", version = "0.3" }
+sov-rollup-interface = { path = "../../rollup-interface" }
+sov-modules-api = { path = "../../module-system/sov-modules-api", features = [
+    "native",
+] }
+sov-state = { path = "../../module-system/sov-state" }
 
 
 [dev-dependencies]
@@ -29,9 +31,15 @@ tempfile = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
-sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter", features = ["native"] }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3", features = ["native"] }
+sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter", features = [
+    "native",
+] }
+sov-rollup-interface = { path = "../../rollup-interface", features = [
+    "native",
+] }
 sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
-sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", features = [
+    "test-utils",
+] }
 sov-schema-db = { path = "../db/sov-schema-db" }
 sov-db = { path = "../db/sov-db" }

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/Cargo.toml
@@ -29,12 +29,12 @@ tracing = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
-sov-db = { path = "../db/sov-db", version = "0.3", optional = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+sov-db = { path = "../db/sov-db", optional = true }
+sov-rollup-interface = { path = "../../rollup-interface" }
 sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-blueprint" }
 sequencer-client = { path = "../../../sequencer-client", optional = true }
 
-sov-modules-api = { path = "../../module-system/sov-modules-api", version = "0.3", default-features = false }
+sov-modules-api = { path = "../../module-system/sov-modules-api", default-features = false }
 
 shared-backup-db = { path = "../../../shared-backup-db", optional = true }
 

--- a/crates/sovereign-sdk/fuzz/Cargo.toml
+++ b/crates/sovereign-sdk/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sovereign-sdk-fuzz"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 publish = false
 edition = "2021"
 

--- a/crates/sovereign-sdk/module-system/module-implementations/module-template/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/module-template/Cargo.toml
@@ -29,14 +29,12 @@ sov-state = { path = "../../sov-state" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-module-template = { path = ".", version = "*", features = ["native"] }
-sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+module-template = { path = ".", features = ["native"] }
+sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = [
+    "test-utils",
+] }
 
 [features]
 default = []
-arbitrary = [
-    "dep:arbitrary",
-    "dep:proptest",
-    "dep:proptest-derive"
-]
+arbitrary = ["dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
 native = ["serde_json", "schemars", "sov-modules-api/native"]

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-accounts/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-accounts/Cargo.toml
@@ -28,10 +28,10 @@ jsonrpsee = { workspace = true, features = [
     "server",
 ], optional = true }
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.3", default-features = false, features = [
+sov-modules-api = { path = "../../sov-modules-api", default-features = false, features = [
     "macros",
 ] }
-sov-state = { path = "../../sov-state", version = "0.3" }
+sov-state = { path = "../../sov-state" }
 
 
 [dev-dependencies]

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/Cargo.toml
@@ -15,24 +15,38 @@ resolver = "2"
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 clap = { workspace = true, optional = true }
-jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
+jsonrpsee = { workspace = true, features = [
+    "macros",
+    "client-core",
+    "server",
+], optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.3", default-features = false }
-sov-state = { path = "../../sov-state", version = "0.3" }
+sov-modules-api = { path = "../../sov-modules-api", default-features = false }
+sov-state = { path = "../../sov-state" }
 
 
 [dev-dependencies]
 sov-bank = { path = ".", features = ["native", "test-utils"] }
 tempfile = { workspace = true }
-sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = [
+    "test-utils",
+] }
 
 [features]
 default = []
-native = ["serde", "serde_json", "jsonrpsee", "clap", "schemars", "sov-state/native", "sov-modules-api/native", ]
+native = [
+    "serde",
+    "serde_json",
+    "jsonrpsee",
+    "clap",
+    "schemars",
+    "sov-state/native",
+    "sov-modules-api/native",
+]
 cli = ["native"]
 serde = []
 test-utils = []

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-nft-module/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-nft-module/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1.35.0", features = ["full"], optional = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
-sov-nft-module = { version = "*", features = ["native"], path = "." }
+sov-nft-module = { features = ["native"], path = "." }
 tempfile = { workspace = true }
 sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = [
     "test-utils",

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-prover-incentives/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-prover-incentives/Cargo.toml
@@ -15,8 +15,10 @@ resolver = "2"
 tempfile = { workspace = true }
 sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
 sov-mock-zkvm = { path = "../../../adapters/mock-zkvm" }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.3", features = ["native"] }
-sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+sov-modules-api = { path = "../../sov-modules-api", features = ["native"] }
+sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = [
+    "test-utils",
+] }
 
 
 [dependencies]
@@ -27,11 +29,16 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 
-sov-bank = { path = "../sov-bank", version = "0.3" }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.3" }
-sov-state = { path = "../../sov-state", version = "0.3" }
+sov-bank = { path = "../sov-bank" }
+sov-modules-api = { path = "../../sov-modules-api" }
+sov-state = { path = "../../sov-state" }
 
 
 [features]
 default = ["native"]
-native = ["serde_json", "schemars", "sov-state/native", "sov-modules-api/native"]
+native = [
+    "serde_json",
+    "schemars",
+    "sov-state/native",
+    "sov-modules-api/native",
+]

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
@@ -18,27 +18,40 @@ arbitrary = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
-sov-bank = { path = "../sov-bank", version = "0.3" }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.3", default-features = false }
-sov-state = { path = "../../sov-state", version = "0.3" }
+sov-bank = { path = "../sov-bank" }
+sov-modules-api = { path = "../../sov-modules-api", default-features = false }
+sov-state = { path = "../../sov-state" }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 borsh = { workspace = true, features = ["rc"] }
-jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
-sov-zk-cycle-macros = { path = "../../../utils/zk-cycle-macros", version = "0.3", optional = true }
-risc0-zkvm = { workspace = true, default-features = false, features = ["std"], optional = true }
+jsonrpsee = { workspace = true, features = [
+    "macros",
+    "client-core",
+    "server",
+], optional = true }
+sov-zk-cycle-macros = { path = "../../../utils/zk-cycle-macros", optional = true }
+risc0-zkvm = { workspace = true, default-features = false, features = [
+    "std",
+], optional = true }
 risc0-zkvm-platform = { workspace = true, optional = true }
-sov-zk-cycle-utils = { path = "../../../utils/zk-cycle-utils", version = "0.3", optional = true }
+sov-zk-cycle-utils = { path = "../../../utils/zk-cycle-utils", optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 sov-sequencer-registry = { path = ".", features = ["native"] }
 sov-mock-da = { path = "../../../adapters/mock-da", features = ["native"] }
-sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = ["test-utils"] }
+sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-manager", features = [
+    "test-utils",
+] }
 
 [features]
-bench = ["sov-zk-cycle-macros/bench", "risc0-zkvm", "risc0-zkvm-platform", "sov-zk-cycle-utils"]
+bench = [
+    "sov-zk-cycle-macros/bench",
+    "risc0-zkvm",
+    "risc0-zkvm-platform",
+    "sov-zk-cycle-utils",
+]
 default = []
 arbitrary = ["dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
 native = [
@@ -55,4 +68,9 @@ native = [
 serde = []
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["risc0-zkvm", "risc0-zkvm-platform", "sov-zk-cycle-macros", "sov-zk-cycle-utils"]
+normal = [
+    "risc0-zkvm",
+    "risc0-zkvm-platform",
+    "sov-zk-cycle-macros",
+    "sov-zk-cycle-utils",
+]

--- a/crates/sovereign-sdk/module-system/sov-cli/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-cli/Cargo.toml
@@ -16,13 +16,11 @@ path = "src/lib.rs"
 
 
 [dependencies]
-sov-modules-api = { path = "../sov-modules-api", version = "0.3", features = [
+sov-modules-api = { path = "../sov-modules-api", features = ["native"] }
+sov-bank = { path = "../module-implementations/sov-bank", features = [
     "native",
 ] }
-sov-bank = { path = "../module-implementations/sov-bank", version = "0.3", features = [
-    "native",
-] }
-sov-accounts = { path = "../module-implementations/sov-accounts", version = "0.3", features = [
+sov-accounts = { path = "../module-implementations/sov-accounts", features = [
     "native",
 ] }
 directories = "5.0.1"

--- a/crates/sovereign-sdk/module-system/sov-modules-api/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/Cargo.toml
@@ -15,10 +15,10 @@ resolver = "2"
 jsonrpsee = { workspace = true, optional = true }
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
-sov-state = { path = "../sov-state", version = "0.3" }
-sov-modules-core = { path = "../sov-modules-core", version = "0.3" }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
-sov-modules-macros = { path = "../sov-modules-macros", version = "0.3", optional = true, default-features = false }
+sov-state = { path = "../sov-state" }
+sov-modules-core = { path = "../sov-modules-core" }
+sov-rollup-interface = { path = "../../rollup-interface" }
+sov-modules-macros = { path = "../sov-modules-macros", optional = true, default-features = false }
 sov-prover-storage-manager = { path = "../../full-node/sov-prover-storage-manager", optional = true }
 serde = { workspace = true }
 borsh = { workspace = true }

--- a/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/Cargo.toml
@@ -14,23 +14,22 @@ publish = true
 [dependencies]
 sov-rollup-interface = { path = "../../rollup-interface", features = [
     "native",
-], version = "0.3" }
+] }
 sov-stf-runner = { path = "../../full-node/sov-stf-runner", features = [
     "native",
-], version = "0.3" }
-citrea-sequencer = { path = "../../../sequencer", features = [
-], version = "0.3" }
-sov-state = { path = "../sov-state", version = "0.3" }
+] }
+citrea-sequencer = { path = "../../../sequencer", features = [] }
+sov-state = { path = "../sov-state" }
 sequencer-client = { path = "../../../sequencer-client" }
 sov-modules-api = { path = "../../module-system/sov-modules-api", features = [
     "native",
-], version = "0.3" }
+] }
 sov-cli = { path = "../../module-system/sov-cli" }
 
 sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-blueprint", features = [
     "native",
-], version = "0.3" }
-sov-db = { path = "../../full-node/db/sov-db", version = "0.3" }
+] }
+sov-db = { path = "../../full-node/db/sov-db" }
 
 sov-ledger-rpc = { path = "../../full-node/sov-ledger-rpc", features = [
     "server",

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/Cargo.toml
@@ -20,11 +20,11 @@ tracing = { workspace = true }
 jmt = { workspace = true }
 hex = { workspace = true }
 
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
-sov-state = { path = "../sov-state", version = "0.3" }
-sov-modules-api = { path = "../sov-modules-api", version = "0.3", default-features = false }
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.3", optional = true }
-sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", version = "0.3", optional = true }
+sov-rollup-interface = { path = "../../rollup-interface" }
+sov-state = { path = "../sov-state" }
+sov-modules-api = { path = "../sov-modules-api", default-features = false }
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
+sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", optional = true }
 risc0-zkvm = { workspace = true, default-features = false, features = [
     "std",
 ], optional = true }
@@ -35,11 +35,7 @@ jsonrpsee = { workspace = true, features = ["server"], optional = true }
 [features]
 bench = ["sov-zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]
 default = []
-native = [
-    "sov-state/native",
-    "sov-modules-api/native",
-    "jsonrpsee",
-]
+native = ["sov-state/native", "sov-modules-api/native", "jsonrpsee"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = [

--- a/crates/sovereign-sdk/module-system/sov-state/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-state/Cargo.toml
@@ -21,15 +21,17 @@ proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
-sov-modules-core = { path = "../sov-modules-core", version = "0.3" }
-sov-db = { path = "../../full-node/db/sov-db", version = "0.3", optional = true }
+sov-rollup-interface = { path = "../../rollup-interface" }
+sov-modules-core = { path = "../sov-modules-core" }
+sov-db = { path = "../../full-node/db/sov-db", optional = true }
 jmt = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }
 
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.3", optional = true }
-risc0-zkvm = { workspace = true, default-features = false, features = ["std"], optional = true }
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
+risc0-zkvm = { workspace = true, default-features = false, features = [
+    "std",
+], optional = true }
 risc0-zkvm-platform = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/sovereign-sdk/rollup-interface/src/lib.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/lib.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 /// The current version of Citrea.
 ///
 /// Mostly used for web3_clientVersion RPC calls and might be used for other purposes.
+#[cfg(feature = "native")]
 pub const CITREA_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 mod state_machine;

--- a/crates/sovereign-sdk/utils/zk-cycle-utils/tracer/Cargo.toml
+++ b/crates/sovereign-sdk/utils/zk-cycle-utils/tracer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracer"
-version = "0.3.0"
+version = { workspace = true }
 edition = "2018"
 
 [workspace]


### PR DESCRIPTION
# Description
moves CITRA_VERSION under native flag so things like RPC fixes won't change the risc0 method ids. (we orignally planned citrea version would be used for forks so putting it under rollup interface made sense. however with this change we should find it a better place.)

on skip guest builds, now prints out the method id's so a full node can verify without building the risc0 elfs.

removes versioned imports for workspace imports (updated versions for packages under crates that are not in the workspace cargo.toml -- open to revert those changes.)

