### PR TITLE
Sleep 5 secs after Bonsai IO error

### DIFF
--- a/crates/sovereign-sdk/adapters/risc0-bonsai/src/host.rs
+++ b/crates/sovereign-sdk/adapters/risc0-bonsai/src/host.rs
@@ -78,10 +78,12 @@ impl BonsaiClient {
                             }
                             HttpErr(e) => {
                                 error!(?e, "Reconnecting to Bonsai");
+                                std::thread::sleep(Duration::from_secs(5));
                                 continue $client_loop
                             }
                             HttpHeaderErr(e) => {
                                 error!(?e, "Reconnecting to Bonsai");
+                                std::thread::sleep(Duration::from_secs(5));
                                 continue $client_loop
                             }
                             e => {


### PR DESCRIPTION
# Description
Bonsai doesn't send any requests after building a new client until we actually request/call something. In case of an IO/networking error: sleep 5 secs, retry building a new client and retry request.

## Linked Issues
- Follow up of https://github.com/chainwayxyz/citrea/pull/601
