### PR TITLE
doc: Update Running Citrea doc file to correct docker compose command

### DIFF
--- a/docs/run.md
+++ b/docs/run.md
@@ -18,7 +18,7 @@ For production use cases, we leverage PostgreSQL for a few extra features in the
 If running Postgres is prefered, you can execute the following command:
 
 ```sh
-docker compose up -d -f docker-compose.postgres.yml
+docker compose -f docker-compose.postgres.yml up -d
 
 ```
 this will run postgres in a dockerized daemon mode.


### PR DESCRIPTION
# Description

`docker compose` command requires the `-f / --file` flag to be placed before other subcommands, such as `up`, `down` etc.
Otherwise it throws the `unknown shorthand flag: 'f' in -f` error.

Related SO post: https://stackoverflow.com/a/73726070
