### PR TITLE
Add backtrace to coverage check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -189,6 +189,8 @@ jobs:
           path: crates/evm/ethereum-tests
       - name: Run coverage
         run: make coverage
+        env:
+          RUST_BACKTRACE: 1
       - name: Upload coverage
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
# Description

This makes it easy to see where exactly the tests fail especially when the test is a timeout. The backtrace would show which line in which test failed instead of `test_helpers` line of code.
