### PR TITLE
Add abstract fee vault and base fee vault

### DIFF
--- a/crates/evm/src/evm/system_contracts/src/BaseFeeVault.sol
+++ b/crates/evm/src/evm/system_contracts/src/BaseFeeVault.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "./FeeVault.sol";
+
+/// @title Base fee accumulator contract
+/// @author Citrea
+
+contract BaseFeeVault is FeeVault {}

--- a/crates/evm/src/evm/system_contracts/src/FeeVault.sol
+++ b/crates/evm/src/evm/system_contracts/src/FeeVault.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "../lib/Ownable.sol";
+
+/// @title Fee accumulator contract template
+/// @author Citrea
+
+abstract contract FeeVault is Ownable {
+    address public recipient;
+    uint256 public minWithdraw = 0.5 ether;
+
+    event RecipientUpdated(address oldRecipient, address newRecipient);
+    event MinWithdrawUpdated(uint256 oldMinWithdraw, uint256 newMinWithdraw);
+    
+    receive() external payable {}
+
+    function withdraw() external {
+        require(address(this).balance >= minWithdraw, "Withdrawal amount must be greater than minimum withdraw amount");
+        (bool success, ) = payable(recipient).call{value: address(this).balance}("");
+        require(success, "Transfer failed");
+    }
+
+    function setRecipient(address _recipient) external onlyOwner {
+        address oldRecipient = recipient;
+        recipient = _recipient;
+        emit RecipientUpdated(oldRecipient, _recipient);
+    }
+
+    function setMinWithdraw(uint256 _minWithdraw) external onlyOwner {
+        uint256 oldMinWithdraw = minWithdraw;
+        minWithdraw = _minWithdraw;
+        emit MinWithdrawUpdated(oldMinWithdraw, _minWithdraw);
+    }
+}

--- a/crates/evm/src/evm/system_contracts/test/BaseFeeVault.t.sol
+++ b/crates/evm/src/evm/system_contracts/test/BaseFeeVault.t.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "./FeeVault.t.sol";
+import "../src/BaseFeeVault.sol";
+
+contract BaseFeeVaultTest is FeeVaultTest {
+    function setUp() public {
+        feeVault = new BaseFeeVault();
+    }
+}

--- a/crates/evm/src/evm/system_contracts/test/FeeVault.t.sol
+++ b/crates/evm/src/evm/system_contracts/test/FeeVault.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import "../src/FeeVault.sol";
+abstract contract FeeVaultTest is Test {
+    FeeVault feeVault;
+
+    function testWithdraw() public {
+        vm.deal(address(feeVault), 1 ether);
+        address recipient = vm.addr(0x1234);
+        feeVault.setRecipient(recipient);
+        feeVault.withdraw();
+        assertEq(address(recipient).balance, 1 ether);
+    }
+
+    function testCannotWithdrawLessThanMinWithdraw() public {
+        vm.deal(address(feeVault), 0.1 ether);
+        address recipient = vm.addr(0x1234);
+        feeVault.setRecipient(recipient);
+        vm.expectRevert("Withdrawal amount must be greater than minimum withdraw amount");
+        feeVault.withdraw();
+    }
+
+    function testSetRecipient() public {
+        feeVault.setRecipient(address(this));
+        assertEq(feeVault.recipient(), address(this));
+    }
+
+    function testSetMinWithdraw() public {
+        feeVault.setMinWithdraw(1.7 ether);
+        assertEq(feeVault.minWithdraw(), 1.7 ether);
+    }
+
+    function testCanChangeOwnerAndSetState() public {
+        feeVault.setRecipient(address(this));
+        feeVault.setMinWithdraw(1.7 ether);
+        assertEq(feeVault.recipient(), address(this));
+        assertEq(feeVault.minWithdraw(), 1.7 ether);
+
+        address newOwner = vm.addr(0x1234);
+        feeVault.transferOwnership(newOwner);
+        vm.startPrank(newOwner);
+        feeVault.acceptOwnership();
+        feeVault.setRecipient(address(1));
+        feeVault.setMinWithdraw(0.3 ether);
+        assertEq(feeVault.recipient(), address(1));
+        assertEq(feeVault.minWithdraw(), 0.3 ether);
+    }
+
+    function testNonOwnerCannotChangeState() public {
+        address nonOwner = vm.addr(0x1234);
+        vm.startPrank(nonOwner);
+        vm.expectRevert("Caller is not owner");
+        feeVault.setRecipient(address(1));
+        vm.expectRevert("Caller is not owner");
+        feeVault.setMinWithdraw(0.3 ether);
+    }
+}


### PR DESCRIPTION
# Description
Adds fee vaults so that the fees can be accumulated in contracts which can send these funds to a configurable recipient address.

## Linked Issues
- Fixes #755 
- Related to #757 

## Testing
Wrote a foundry test for the abstract fee vault which separate test files for each vault type can inherit.

## Docs
Natspec will be added.