### PR TITLE
set 1.78.0 as build version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.78.0
           override: true
           components: rustfmt, clippy
       - name: Install Rust
@@ -165,7 +165,7 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.78.0
         with:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@nextest
@@ -197,7 +197,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.78.0
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -247,7 +247,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.78.0
       - uses: dcarbone/install-jq-action@v2
       - name: Install cargo-risczero
         uses: taiki-e/install-action@v2
@@ -281,7 +281,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.78.0
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -328,13 +328,13 @@ jobs:
       - name: Install Rust Bare Metal
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.78.0
           target: thumbv6m-none-eabi
           override: true
       - name: Install Rust WASM
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.78.0
           target: wasm32-unknown-unknown
           override: true
       - name: cargo install cargo-hack
@@ -375,7 +375,7 @@ jobs:
       - name: Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.78.0
           override: true
           components: rustfmt, clippy
       - name: Install Rust

--- a/builder-dockerfile
+++ b/builder-dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+RUN apt update && apt -y install curl gcc cpp cmake clang llvm && apt -y autoremove && apt clean && rm -rf /var/lib/apt/lists/*
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.78.0
+RUN /root/.cargo/bin/cargo +1.78.0 install --version 1.6.9 cargo-binstall
+RUN /root/.cargo/bin/cargo +1.78.0 binstall --version 0.21.0 -y cargo-risczero
+RUN /root/.cargo/bin/cargo +1.78.0 risczero install --version v2024-04-22.0
+COPY . .
+WORKDIR /citrea
+RUN /root/.cargo/bin/cargo +1.78.0 build --release

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest AS runtime
+FROM rust:1.78 AS runtime
 WORKDIR /app
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.78.0"
 components = [ "rustfmt", "rust-src", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
# Description
having stable in `rust-toolchain.toml` changed our method id for guests. setting to 1.78.0