### PR TITLE
Allow RocksDB max open file to be set through config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ install-dev-tools:  ## Installs all necessary cargo helpers
 	cargo install cargo-udeps
 	cargo install flaky-finder
 	cargo install cargo-nextest --locked
-	cargo install cargo-binstall
+	cargo install cargo-binstall@1.6.9
 	cargo binstall cargo-risczero
 ifeq ($(shell uname -ms), Darwin x86_64)
 	cargo risczero build-toolchain

--- a/bin/citrea/src/bitcoin_rollup.rs
+++ b/bin/citrea/src/bitcoin_rollup.rs
@@ -92,6 +92,7 @@ impl RollupBlueprint for BitcoinRollup {
     ) -> Result<Self::StorageManager, anyhow::Error> {
         let storage_config = StorageConfig {
             path: rollup_config.storage.path.clone(),
+            db_max_open_files: rollup_config.storage.db_max_open_files,
         };
         ProverStorageManager::new(storage_config)
     }

--- a/bin/citrea/src/mock_rollup.rs
+++ b/bin/citrea/src/mock_rollup.rs
@@ -113,6 +113,7 @@ impl RollupBlueprint for MockDemoRollup {
     ) -> anyhow::Result<Self::StorageManager> {
         let storage_config = StorageConfig {
             path: rollup_config.storage.path.clone(),
+            db_max_open_files: rollup_config.storage.db_max_open_files,
         };
         ProverStorageManager::new(storage_config)
     }

--- a/bin/citrea/src/test_rpc.rs
+++ b/bin/citrea/src/test_rpc.rs
@@ -9,6 +9,7 @@ use reqwest::header::CONTENT_TYPE;
 use serde_json::json;
 use sha2::Digest;
 use sov_db::ledger_db::{LedgerDB, SlotCommit};
+use sov_db::rocks_db_config::RocksdbConfig;
 use sov_mock_da::MockDaSpec;
 #[cfg(test)]
 use sov_mock_da::{MockBlock, MockBlockHeader, MockHash};
@@ -80,7 +81,8 @@ fn test_helper(
     rt.block_on(async {
         // Initialize the ledger database, which stores blocks, transactions, events, etc.
         let tmpdir = tempfile::tempdir().unwrap();
-        let mut ledger_db = LedgerDB::with_path(tmpdir.path()).unwrap();
+        let mut ledger_db =
+            LedgerDB::with_config(&RocksdbConfig::new(tmpdir.path(), None)).unwrap();
         populate_ledger(&mut ledger_db, slots, soft_batch_receipts);
         let server = jsonrpsee::server::ServerBuilder::default()
             .build("127.0.0.1:0")

--- a/bin/citrea/tests/test_helpers/mod.rs
+++ b/bin/citrea/tests/test_helpers/mod.rs
@@ -121,6 +121,7 @@ pub fn create_default_rollup_config(
         },
         storage: StorageConfig {
             path: rollup_path.to_path_buf(),
+            db_max_open_files: None,
         },
         rpc: RpcConfig {
             bind_host: "127.0.0.1".into(),

--- a/configs/mock/rollup_config.toml
+++ b/configs/mock/rollup_config.toml
@@ -10,7 +10,7 @@ db_path = "da-db"
 [storage]
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.
 path = "full-node-db"
-db_max_open_files = 256
+db_max_open_files = 5000
 
 [rpc]
 # the host and port to bind the rpc server for

--- a/configs/mock/rollup_config.toml
+++ b/configs/mock/rollup_config.toml
@@ -10,6 +10,7 @@ db_path = "da-db"
 [storage]
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.
 path = "full-node-db"
+db_max_open_files = 256
 
 [rpc]
 # the host and port to bind the rpc server for

--- a/configs/mock/sequencer_rollup_config.toml
+++ b/configs/mock/sequencer_rollup_config.toml
@@ -10,6 +10,7 @@ db_path = "da-db"
 [storage]
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.
 path = "sequencer-db"
+db_max_open_files = 256
 
 [rpc]
 # the host and port to bind the rpc server for

--- a/configs/mock/sequencer_rollup_config.toml
+++ b/configs/mock/sequencer_rollup_config.toml
@@ -10,7 +10,7 @@ db_path = "da-db"
 [storage]
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.
 path = "sequencer-db"
-db_max_open_files = 256
+db_max_open_files = 5000
 
 [rpc]
 # the host and port to bind the rpc server for

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -1,4 +1,3 @@
-use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use serde::Serialize;
@@ -9,7 +8,7 @@ use sov_rollup_interface::zk::Proof;
 use sov_schema_db::{Schema, SchemaBatch, SeekKeyEncoder, DB};
 use tracing::instrument;
 
-use crate::rocks_db_config::gen_rocksdb_options;
+use crate::rocks_db_config::RocksdbConfig;
 use crate::schema::tables::{
     BatchByHash, BatchByNumber, CommitmentsByNumber, EventByKey, EventByNumber, L2RangeByL1Height,
     LastSequencerCommitmentSent, ProofBySlotNumber, ProverLastScannedSlot, SlotByHash,
@@ -97,13 +96,13 @@ impl LedgerDB {
     /// Open a [`LedgerDB`] (backed by RocksDB) at the specified path.
     /// The returned instance will be at the path `{path}/ledger-db`.
     #[instrument(level = "trace", skip_all, err)]
-    pub fn with_path(path: impl AsRef<Path>) -> Result<Self, anyhow::Error> {
-        let path = path.as_ref().join(LEDGER_DB_PATH_SUFFIX);
+    pub fn with_config(cfg: &RocksdbConfig) -> Result<Self, anyhow::Error> {
+        let path = cfg.path.join(LEDGER_DB_PATH_SUFFIX);
         let inner = DB::open(
             path,
             "ledger-db",
             LEDGER_TABLES.iter().copied(),
-            &gen_rocksdb_options(&Default::default(), false),
+            &cfg.as_rocksdb_options(false),
         )?;
 
         let next_item_numbers = ItemNumbers {

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/rpc.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/rpc.rs
@@ -610,11 +610,13 @@ mod tests {
     use sov_rollup_interface::rpc::LedgerRpcProvider;
 
     use crate::ledger_db::{LedgerDB, SlotCommit};
+    use crate::rocks_db_config::RocksdbConfig;
+
     #[test]
     fn test_slot_subscription() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let path = temp_dir.path();
-        let db = LedgerDB::with_path(path).unwrap();
+        // let path = temp_dir.path();
+        let db = LedgerDB::with_config(&RocksdbConfig::new(temp_dir.path(), None)).unwrap();
 
         let mut rx = db.subscribe_slots().unwrap();
         db.commit_slot(SlotCommit::<_, MockBlob, Vec<u8>>::new(MockBlock::default()))

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/native_db.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/native_db.rs
@@ -1,10 +1,9 @@
-use std::path::Path;
 use std::sync::Arc;
 
 use sov_schema_db::snapshot::{DbSnapshot, QueryManager, ReadOnlyDbSnapshot};
 use sov_schema_db::SchemaBatch;
 
-use crate::rocks_db_config::gen_rocksdb_options;
+use crate::rocks_db_config::RocksdbConfig;
 use crate::schema::tables::{ModuleAccessoryState, NATIVE_TABLES};
 use crate::schema::types::AccessoryKey;
 
@@ -32,13 +31,13 @@ impl<Q> NativeDB<Q> {
     const DB_NAME: &'static str = "native";
 
     /// Initialize [`sov_schema_db::DB`] that matches tables and columns for NativeDB
-    pub fn setup_schema_db(path: impl AsRef<Path>) -> anyhow::Result<sov_schema_db::DB> {
-        let path = path.as_ref().join(Self::DB_PATH_SUFFIX);
+    pub fn setup_schema_db(cfg: &RocksdbConfig) -> anyhow::Result<sov_schema_db::DB> {
+        let path = cfg.path.join(Self::DB_PATH_SUFFIX);
         sov_schema_db::DB::open(
             path,
             Self::DB_NAME,
             NATIVE_TABLES.iter().copied(),
-            &gen_rocksdb_options(&Default::default(), false),
+            &cfg.as_rocksdb_options(false),
         )
     }
 

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/rocks_db_config.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/rocks_db_config.rs
@@ -1,9 +1,10 @@
 // Adapted from Aptos-Core.
 // Modified to remove serde dependency
 
+use std::path::Path;
+
 use rlimit::{getrlimit, Resource};
 use rocksdb::Options;
-use std::path::Path;
 use tracing::warn;
 
 /// Port selected RocksDB options for tuning underlying rocksdb instance of our state db.

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/rocks_db_config.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/rocks_db_config.rs
@@ -3,6 +3,7 @@
 
 use rlimit::{getrlimit, Resource};
 use rocksdb::Options;
+use std::path::Path;
 use tracing::warn;
 
 /// Port selected RocksDB options for tuning underlying rocksdb instance of our state db.
@@ -10,7 +11,9 @@ use tracing::warn;
 /// see <https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h>
 /// for detailed explanations.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct RocksdbConfig {
+pub struct RocksdbConfig<'a> {
+    /// Path to the RocksDB file
+    pub path: &'a Path,
     /// The maximum number of files that can be open concurrently. Defaults to operating system limit.
     /// In the case of not being able to read from the operating system, it defaults to 256.
     pub max_open_files: i32,
@@ -21,27 +24,15 @@ pub struct RocksdbConfig {
     pub max_background_jobs: i32,
 }
 
-impl Default for RocksdbConfig {
-    fn default() -> Self {
-        let (soft_limit, _) = getrlimit(Resource::NOFILE).unwrap_or_else(|err| {
-            warn!(
-                "Failed to retrieve max open file limit from the os, defaulting to 256. err={}",
-                err
-            );
-            // Default is 256 due to it being the lowest default limit among operating systems, namely OSX.
-            (256, 0)
-        });
-
-        let soft_limit = if soft_limit > (i32::MAX as u64) {
-            i32::MAX
-        } else {
-            soft_limit as i32
-        };
-
+impl<'a> RocksdbConfig<'a> {
+    /// Creates new instance of [`RocksdbConfig`]
+    pub fn new(path: &'a Path, max_open_files: Option<i32>) -> Self {
+        let max_open_files = max_open_files.unwrap_or_else(|| get_fd_limit());
         Self {
+            path,
             // Allow db to close old sst files, saving memory.
             // TODO: in case of multiple RocksDB instances, there is still a possibility of going over the limit, fix that.
-            max_open_files: soft_limit,
+            max_open_files,
             // For now we set the max total WAL size to be 1G. This config can be useful when column
             // families are updated at non-uniform frequencies.
             max_total_wal_size: 1u64 << 30,
@@ -50,19 +41,36 @@ impl Default for RocksdbConfig {
             max_background_jobs: 16,
         }
     }
+
+    /// Build [`rocksdb::Options`] from [`RocksdbConfig`]
+    pub fn as_rocksdb_options(&self, readonly: bool) -> Options {
+        let mut db_opts = Options::default();
+        db_opts.set_max_open_files(self.max_open_files);
+        db_opts.set_max_total_wal_size(self.max_total_wal_size);
+        db_opts.set_max_background_jobs(self.max_background_jobs);
+        if !readonly {
+            db_opts.create_if_missing(true);
+            db_opts.create_missing_column_families(true);
+            db_opts.set_atomic_flush(true);
+        }
+
+        db_opts
+    }
 }
 
-/// Generate [`rocksdb::Options`] corresponding to the given [`RocksdbConfig`].
-pub fn gen_rocksdb_options(config: &RocksdbConfig, readonly: bool) -> Options {
-    let mut db_opts = Options::default();
-    db_opts.set_max_open_files(config.max_open_files);
-    db_opts.set_max_total_wal_size(config.max_total_wal_size);
-    db_opts.set_max_background_jobs(config.max_background_jobs);
-    if !readonly {
-        db_opts.create_if_missing(true);
-        db_opts.create_missing_column_families(true);
-        db_opts.set_atomic_flush(true);
-    }
+fn get_fd_limit() -> i32 {
+    let (soft_limit, _) = getrlimit(Resource::NOFILE).unwrap_or_else(|err| {
+        warn!(
+            "Failed to retrieve max open file limit from the os, defaulting to 256. err={}",
+            err
+        );
+        // Default is 256 due to it being the lowest default limit among operating systems, namely OSX.
+        (256, 0)
+    });
 
-    db_opts
+    if soft_limit > (i32::MAX as u64) {
+        i32::MAX
+    } else {
+        soft_limit as i32
+    }
 }

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/rocks_db_config.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/rocks_db_config.rs
@@ -27,7 +27,7 @@ pub struct RocksdbConfig<'a> {
 impl<'a> RocksdbConfig<'a> {
     /// Creates new instance of [`RocksdbConfig`]
     pub fn new(path: &'a Path, max_open_files: Option<i32>) -> Self {
-        let max_open_files = max_open_files.unwrap_or_else(|| get_fd_limit());
+        let max_open_files = max_open_files.unwrap_or_else(get_fd_limit);
         Self {
             path,
             // Allow db to close old sst files, saving memory.

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/state_db.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/state_db.rs
@@ -1,4 +1,3 @@
-use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use jmt::storage::{HasPreimage, TreeReader, TreeWriter};
@@ -6,7 +5,7 @@ use jmt::{KeyHash, Version};
 use sov_schema_db::snapshot::{DbSnapshot, QueryManager, ReadOnlyDbSnapshot};
 use sov_schema_db::SchemaBatch;
 
-use crate::rocks_db_config::gen_rocksdb_options;
+use crate::rocks_db_config::RocksdbConfig;
 use crate::schema::tables::{JmtNodes, JmtValues, KeyHashToKey, STATE_TABLES};
 use crate::schema::types::StateKey;
 
@@ -40,13 +39,13 @@ impl<Q> StateDB<Q> {
     const DB_NAME: &'static str = "state-db";
 
     /// Initialize [`sov_schema_db::DB`] that should be used by snapshots.
-    pub fn setup_schema_db(path: impl AsRef<Path>) -> anyhow::Result<sov_schema_db::DB> {
-        let state_db_path = path.as_ref().join(Self::DB_PATH_SUFFIX);
+    pub fn setup_schema_db(cfg: &RocksdbConfig) -> anyhow::Result<sov_schema_db::DB> {
+        let state_db_path = cfg.path.join(Self::DB_PATH_SUFFIX);
         sov_schema_db::DB::open(
             state_db_path,
             Self::DB_NAME,
             STATE_TABLES.iter().copied(),
-            &gen_rocksdb_options(&Default::default(), false),
+            &cfg.as_rocksdb_options(false),
         )
     }
 

--- a/crates/sovereign-sdk/full-node/sov-ledger-rpc/src/server.rs
+++ b/crates/sovereign-sdk/full-node/sov-ledger-rpc/src/server.rs
@@ -21,11 +21,12 @@ const LEDGER_RPC_ERROR: &str = "LEDGER_RPC_ERROR";
 /// use sov_ledger_rpc::server::rpc_module;
 /// use tempfile::tempdir;
 /// use sov_db::ledger_db::LedgerDB;
+/// use sov_db::rocks_db_config::RocksdbConfig;
 ///
 /// /// Creates a new [`LedgerDB`] and starts serving JSON-RPC requests.
 /// async fn rpc_server() -> jsonrpsee::server::ServerHandle {
 ///     let dir = tempdir().unwrap();
-///     let db = LedgerDB::with_path(dir).unwrap();
+///     let db = LedgerDB::with_config(&RocksdbConfig::new(dir.path(), None)).unwrap();
 ///     let rpc_module = rpc_module::<LedgerDB, u32, u32>(db).unwrap();
 ///
 ///     let server = jsonrpsee::server::ServerBuilder::default()

--- a/crates/sovereign-sdk/full-node/sov-ledger-rpc/tests/empty_ledger.rs
+++ b/crates/sovereign-sdk/full-node/sov-ledger-rpc/tests/empty_ledger.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::core::params::ArrayParams;
 use sov_db::ledger_db::LedgerDB;
+use sov_db::rocks_db_config::RocksdbConfig;
 use sov_ledger_rpc::client::RpcClient;
 use sov_ledger_rpc::server::rpc_module;
 use sov_ledger_rpc::HexHash;
@@ -16,7 +17,7 @@ use tempfile::tempdir;
 
 async fn rpc_server() -> (jsonrpsee::server::ServerHandle, SocketAddr) {
     let dir = tempdir().unwrap();
-    let db = LedgerDB::with_path(dir).unwrap();
+    let db = LedgerDB::with_config(&RocksdbConfig::new(dir.path(), None)).unwrap();
     let rpc_module = rpc_module::<LedgerDB, u32, u32>(db).unwrap();
 
     let server = jsonrpsee::server::ServerBuilder::default()

--- a/crates/sovereign-sdk/full-node/sov-prover-storage-manager/benches/single_thread_progression.rs
+++ b/crates/sovereign-sdk/full-node/sov-prover-storage-manager/benches/single_thread_progression.rs
@@ -51,6 +51,7 @@ fn setup_storage(
 ) -> TestData {
     let config = sov_state::config::Config {
         path: path.to_path_buf(),
+        db_max_open_files: None,
     };
 
     let mut storage_manager = ProverStorageManager::<Da, S>::new(config).unwrap();

--- a/crates/sovereign-sdk/full-node/sov-prover-storage-manager/src/lib.rs
+++ b/crates/sovereign-sdk/full-node/sov-prover-storage-manager/src/lib.rs
@@ -71,13 +71,10 @@ where
 
     /// Create new [`ProverStorageManager`] from state config
     pub fn new(config: sov_state::config::Config) -> anyhow::Result<Self> {
-        let path = config.path;
+        let rocksdb_config = RocksdbConfig::new(config.path.as_path(), config.db_max_open_files);
         let state_db =
-            StateDB::<SnapshotManager>::setup_schema_db(&RocksdbConfig::new(path.as_path(), None))?;
-        let native_db = NativeDB::<SnapshotManager>::setup_schema_db(&RocksdbConfig::new(
-            path.as_path(),
-            None,
-        ))?;
+            StateDB::<SnapshotManager>::setup_schema_db(&rocksdb_config)?;
+        let native_db = NativeDB::<SnapshotManager>::setup_schema_db(&rocksdb_config)?;
 
         Ok(Self::with_db_handles(state_db, native_db))
     }

--- a/crates/sovereign-sdk/full-node/sov-prover-storage-manager/src/lib.rs
+++ b/crates/sovereign-sdk/full-node/sov-prover-storage-manager/src/lib.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 use std::sync::{Arc, RwLock};
 
 use sov_db::native_db::NativeDB;
+use sov_db::rocks_db_config::RocksdbConfig;
 use sov_db::state_db::StateDB;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
@@ -71,8 +72,12 @@ where
     /// Create new [`ProverStorageManager`] from state config
     pub fn new(config: sov_state::config::Config) -> anyhow::Result<Self> {
         let path = config.path;
-        let state_db = StateDB::<SnapshotManager>::setup_schema_db(&path)?;
-        let native_db = NativeDB::<SnapshotManager>::setup_schema_db(&path)?;
+        let state_db =
+            StateDB::<SnapshotManager>::setup_schema_db(&RocksdbConfig::new(path.as_path(), None))?;
+        let native_db = NativeDB::<SnapshotManager>::setup_schema_db(&RocksdbConfig::new(
+            path.as_path(),
+            None,
+        ))?;
 
         Ok(Self::with_db_handles(state_db, native_db))
     }
@@ -430,11 +435,13 @@ where
 pub fn new_orphan_storage<S: MerkleProofSpec>(
     path: impl AsRef<std::path::Path>,
 ) -> anyhow::Result<ProverStorage<S, SnapshotManager>> {
-    let state_db_raw = StateDB::<SnapshotManager>::setup_schema_db(path.as_ref())?;
+    let state_db_raw =
+        StateDB::<SnapshotManager>::setup_schema_db(&RocksdbConfig::new(path.as_ref(), None))?;
     let state_db_sm = Arc::new(RwLock::new(SnapshotManager::orphan(state_db_raw)));
     let state_db_snapshot = DbSnapshot::<SnapshotManager>::new(0, state_db_sm.into());
     let state_db = StateDB::with_db_snapshot(state_db_snapshot)?;
-    let native_db_raw = NativeDB::<SnapshotManager>::setup_schema_db(path.as_ref())?;
+    let native_db_raw =
+        NativeDB::<SnapshotManager>::setup_schema_db(&RocksdbConfig::new(path.as_ref(), None))?;
     let native_db_sm = Arc::new(RwLock::new(SnapshotManager::orphan(native_db_raw)));
     let native_db_snapshot = DbSnapshot::<SnapshotManager>::new(0, native_db_sm.into());
     let native_db = NativeDB::with_db_snapshot(native_db_snapshot)?;
@@ -511,8 +518,10 @@ mod tests {
     }
 
     fn build_dbs(path: &std::path::Path) -> (sov_schema_db::DB, sov_schema_db::DB) {
-        let state_db = StateDB::<SnapshotManager>::setup_schema_db(path).unwrap();
-        let native_db = NativeDB::<SnapshotManager>::setup_schema_db(path).unwrap();
+        let state_db =
+            StateDB::<SnapshotManager>::setup_schema_db(&RocksdbConfig::new(path, None)).unwrap();
+        let native_db =
+            NativeDB::<SnapshotManager>::setup_schema_db(&RocksdbConfig::new(path, None)).unwrap();
 
         (state_db, native_db)
     }

--- a/crates/sovereign-sdk/full-node/sov-prover-storage-manager/src/lib.rs
+++ b/crates/sovereign-sdk/full-node/sov-prover-storage-manager/src/lib.rs
@@ -72,8 +72,7 @@ where
     /// Create new [`ProverStorageManager`] from state config
     pub fn new(config: sov_state::config::Config) -> anyhow::Result<Self> {
         let rocksdb_config = RocksdbConfig::new(config.path.as_path(), config.db_max_open_files);
-        let state_db =
-            StateDB::<SnapshotManager>::setup_schema_db(&rocksdb_config)?;
+        let state_db = StateDB::<SnapshotManager>::setup_schema_db(&rocksdb_config)?;
         let native_db = NativeDB::<SnapshotManager>::setup_schema_db(&rocksdb_config)?;
 
         Ok(Self::with_db_handles(state_db, native_db))

--- a/crates/sovereign-sdk/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
+++ b/crates/sovereign-sdk/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
@@ -284,7 +284,7 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::{Arc, RwLock};
 
-    use sov_db::rocks_db_config::gen_rocksdb_options;
+    use sov_db::rocks_db_config::RocksdbConfig;
     use sov_schema_db::schema::{KeyDecoder, ValueCodec};
     use sov_schema_db::snapshot::{DbSnapshot, NoopQueryManager, QueryManager};
     use sov_schema_db::test::TestField;
@@ -303,7 +303,7 @@ mod tests {
             path,
             "test_db",
             tables,
-            &gen_rocksdb_options(&Default::default(), false),
+            &RocksdbConfig::new(path, None).as_rocksdb_options(false),
         )
         .unwrap()
     }

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/src/config.rs
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/src/config.rs
@@ -66,6 +66,8 @@ const fn default_batch_requests_limit() -> u32 {
 pub struct StorageConfig {
     /// Path that can be utilized by concrete rollup implementation
     pub path: PathBuf,
+    /// File descriptor limit for RocksDB
+    pub db_max_open_files: Option<i32>,
 }
 
 /// Important public keys for the rollup
@@ -191,6 +193,7 @@ mod tests {
             },
             storage: StorageConfig {
                 path: "/tmp/rollup".into(),
+                db_max_open_files: None,
             },
             rpc: RpcConfig {
                 bind_host: "127.0.0.1".to_string(),

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/tests/runner_initialization_tests.rs
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/tests/runner_initialization_tests.rs
@@ -106,6 +106,7 @@ fn initialize_runner(
 
     let storage_config = sov_state::config::Config {
         path: rollup_storage_path.to_path_buf(),
+        db_max_open_files: None,
     };
     let storage_manager = ProverStorageManager::new(storage_config).unwrap();
 

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/tests/runner_initialization_tests.rs
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/tests/runner_initialization_tests.rs
@@ -11,6 +11,7 @@ use sov_stf_runner::{
 mod hash_stf;
 
 use hash_stf::HashStf;
+use sov_db::rocks_db_config::RocksdbConfig;
 
 type MockInitVariant =
     InitVariant<HashStf<MockValidityCond>, MockZkvm<MockValidityCond>, MockDaSpec>;
@@ -70,6 +71,7 @@ fn initialize_runner(
     let rollup_config = RollupConfig::<MockDaConfig> {
         storage: StorageConfig {
             path: rollup_storage_path.clone(),
+            db_max_open_files: None,
         },
         rpc: RpcConfig {
             bind_host: "127.0.0.1".to_string(),
@@ -97,7 +99,8 @@ fn initialize_runner(
 
     let da_service = MockDaService::new(address, &da_storage_path);
 
-    let ledger_db = LedgerDB::with_path(rollup_storage_path.clone()).unwrap();
+    let ledger_db =
+        LedgerDB::with_config(&RocksdbConfig::new(rollup_storage_path.as_path(), None)).unwrap();
 
     let stf = HashStf::<MockValidityCond>::new();
 

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/tests/runner_reorg_tests.rs
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/tests/runner_reorg_tests.rs
@@ -13,6 +13,7 @@ mod hash_stf;
 
 use hash_stf::{get_result_from_blocks, HashStf, Q, S};
 use sov_db::ledger_db::LedgerDB;
+use sov_db::rocks_db_config::RocksdbConfig;
 use sov_mock_zkvm::MockCodeCommitment;
 use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::services::da::DaService;
@@ -121,6 +122,7 @@ async fn runner_execution(
     let rollup_config = RollupConfig::<MockDaConfig> {
         storage: StorageConfig {
             path: rollup_storage_path.clone(),
+            db_max_open_files: None,
         },
         rpc: RpcConfig {
             bind_host: "127.0.0.1".to_string(),
@@ -146,7 +148,8 @@ async fn runner_execution(
         },
     };
 
-    let ledger_db = LedgerDB::with_path(rollup_storage_path.clone()).unwrap();
+    let ledger_db =
+        LedgerDB::with_config(&RocksdbConfig::new(rollup_storage_path.as_path(), None)).unwrap();
 
     let stf = HashStf::<MockValidityCond>::new();
 
@@ -203,7 +206,7 @@ fn get_saved_root_hash(
     let mut storage_manager = ProverStorageManager::<MockDaSpec, S>::new(storage_config).unwrap();
     let finalized_storage = storage_manager.create_finalized_storage()?;
 
-    let ledger_db = LedgerDB::with_path(path).unwrap();
+    let ledger_db = LedgerDB::with_config(&RocksdbConfig::new(path, None)).unwrap();
 
     ledger_db
         .get_head_slot()?

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/tests/runner_reorg_tests.rs
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/tests/runner_reorg_tests.rs
@@ -155,6 +155,7 @@ async fn runner_execution(
 
     let storage_config = sov_state::config::Config {
         path: rollup_storage_path,
+        db_max_open_files: None,
     };
     let mut storage_manager = ProverStorageManager::new(storage_config).unwrap();
 
@@ -202,6 +203,7 @@ fn get_saved_root_hash(
 ) -> anyhow::Result<Option<<ProverStorage<S, Q> as Storage>::Root>> {
     let storage_config = sov_state::config::Config {
         path: path.to_path_buf(),
+        db_max_open_files: None,
     };
     let mut storage_manager = ProverStorageManager::<MockDaSpec, S>::new(storage_config).unwrap();
     let finalized_storage = storage_manager.create_finalized_storage()?;

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/containers/mod.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/containers/mod.rs
@@ -72,6 +72,7 @@ mod test {
         let tests = create_tests();
         let storage_config = sov_state::config::Config {
             path: tempdir.path().to_path_buf(),
+            db_max_open_files: None,
         };
         {
             let mut storage_manager =
@@ -123,6 +124,7 @@ mod test {
         let tempdir = tempfile::tempdir().unwrap();
         let storage_config = sov_state::config::Config {
             path: tempdir.path().to_path_buf(),
+            db_max_open_files: None,
         };
         {
             let mut storage_manager =

--- a/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
@@ -123,11 +123,8 @@ pub trait RollupBlueprint: Sized + Send + Sync {
     ) -> Result<Self::StorageManager, anyhow::Error>;
 
     /// Creates instance of a LedgerDB.
-    fn create_ledger_db(&self, rollup_config: &RollupConfig<Self::DaConfig>) -> LedgerDB {
-        LedgerDB::with_config(&RocksdbConfig::new(
-            &rollup_config.storage.path,
-            rollup_config.storage.db_max_open_files,
-        ))
+    fn create_ledger_db(&self, rocksdb_config: &RocksdbConfig) -> LedgerDB {
+        LedgerDB::with_config(rocksdb_config)
         .expect("Ledger DB failed to open")
     }
 
@@ -146,12 +143,12 @@ pub trait RollupBlueprint: Sized + Send + Sync {
         <Self::NativeContext as Spec>::Storage: NativeStorage,
     {
         let da_service = self.create_da_service(&rollup_config).await;
-
         // TODO: Double check what kind of storage needed here.
         // Maybe whole "prev_root" can be initialized inside runner
         // Getting block here, so prover_service doesn't have to be `Send`
 
-        let ledger_db = self.create_ledger_db(&rollup_config);
+        let rocksdb_config = RocksdbConfig::new(rollup_config.storage.path.as_path(), rollup_config.storage.db_max_open_files);
+        let ledger_db = self.create_ledger_db(&rocksdb_config);
         let genesis_config = self.create_genesis_config(runtime_genesis_paths, &rollup_config)?;
 
         let mut storage_manager = self.create_storage_manager(&rollup_config)?;
@@ -221,7 +218,8 @@ pub trait RollupBlueprint: Sized + Send + Sync {
         // Maybe whole "prev_root" can be initialized inside runner
         // Getting block here, so prover_service doesn't have to be `Send`
 
-        let ledger_db = self.create_ledger_db(&rollup_config);
+        let rocksdb_config = RocksdbConfig::new(rollup_config.storage.path.as_path(), rollup_config.storage.db_max_open_files);
+        let ledger_db = self.create_ledger_db(&rocksdb_config);
         let genesis_config = self.create_genesis_config(runtime_genesis_paths, &rollup_config)?;
 
         let mut storage_manager = self.create_storage_manager(&rollup_config)?;
@@ -294,7 +292,8 @@ pub trait RollupBlueprint: Sized + Send + Sync {
         // Maybe whole "prev_root" can be initialized inside runner
         // Getting block here, so prover_service doesn't have to be `Send`
 
-        let ledger_db = self.create_ledger_db(&rollup_config);
+        let rocksdb_config = RocksdbConfig::new(rollup_config.storage.path.as_path(), rollup_config.storage.db_max_open_files);
+        let ledger_db = self.create_ledger_db(&rocksdb_config);
         let genesis_config = self.create_genesis_config(runtime_genesis_paths, &rollup_config)?;
 
         let mut storage_manager = self.create_storage_manager(&rollup_config)?;

--- a/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
@@ -124,8 +124,7 @@ pub trait RollupBlueprint: Sized + Send + Sync {
 
     /// Creates instance of a LedgerDB.
     fn create_ledger_db(&self, rocksdb_config: &RocksdbConfig) -> LedgerDB {
-        LedgerDB::with_config(rocksdb_config)
-        .expect("Ledger DB failed to open")
+        LedgerDB::with_config(rocksdb_config).expect("Ledger DB failed to open")
     }
 
     /// Creates a new sequencer
@@ -147,7 +146,10 @@ pub trait RollupBlueprint: Sized + Send + Sync {
         // Maybe whole "prev_root" can be initialized inside runner
         // Getting block here, so prover_service doesn't have to be `Send`
 
-        let rocksdb_config = RocksdbConfig::new(rollup_config.storage.path.as_path(), rollup_config.storage.db_max_open_files);
+        let rocksdb_config = RocksdbConfig::new(
+            rollup_config.storage.path.as_path(),
+            rollup_config.storage.db_max_open_files,
+        );
         let ledger_db = self.create_ledger_db(&rocksdb_config);
         let genesis_config = self.create_genesis_config(runtime_genesis_paths, &rollup_config)?;
 
@@ -218,7 +220,10 @@ pub trait RollupBlueprint: Sized + Send + Sync {
         // Maybe whole "prev_root" can be initialized inside runner
         // Getting block here, so prover_service doesn't have to be `Send`
 
-        let rocksdb_config = RocksdbConfig::new(rollup_config.storage.path.as_path(), rollup_config.storage.db_max_open_files);
+        let rocksdb_config = RocksdbConfig::new(
+            rollup_config.storage.path.as_path(),
+            rollup_config.storage.db_max_open_files,
+        );
         let ledger_db = self.create_ledger_db(&rocksdb_config);
         let genesis_config = self.create_genesis_config(runtime_genesis_paths, &rollup_config)?;
 
@@ -292,7 +297,10 @@ pub trait RollupBlueprint: Sized + Send + Sync {
         // Maybe whole "prev_root" can be initialized inside runner
         // Getting block here, so prover_service doesn't have to be `Send`
 
-        let rocksdb_config = RocksdbConfig::new(rollup_config.storage.path.as_path(), rollup_config.storage.db_max_open_files);
+        let rocksdb_config = RocksdbConfig::new(
+            rollup_config.storage.path.as_path(),
+            rollup_config.storage.db_max_open_files,
+        );
         let ledger_db = self.create_ledger_db(&rocksdb_config);
         let genesis_config = self.create_genesis_config(runtime_genesis_paths, &rollup_config)?;
 

--- a/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use citrea_sequencer::{CitreaSequencer, SequencerConfig};
 pub use runtime_rpc::*;
 use sov_db::ledger_db::LedgerDB;
+use sov_db::rocks_db_config::RocksdbConfig;
 use sov_modules_api::{Context, DaSpec, Spec};
 use sov_modules_stf_blueprint::{GenesisParams, Runtime as RuntimeTrait, StfBlueprint};
 use sov_rollup_interface::services::da::DaService;
@@ -123,7 +124,11 @@ pub trait RollupBlueprint: Sized + Send + Sync {
 
     /// Creates instance of a LedgerDB.
     fn create_ledger_db(&self, rollup_config: &RollupConfig<Self::DaConfig>) -> LedgerDB {
-        LedgerDB::with_path(&rollup_config.storage.path).expect("Ledger DB failed to open")
+        LedgerDB::with_config(&RocksdbConfig::new(
+            &rollup_config.storage.path,
+            rollup_config.storage.db_max_open_files,
+        ))
+        .expect("Ledger DB failed to open")
     }
 
     /// Creates a new sequencer

--- a/crates/sovereign-sdk/module-system/sov-state/src/config.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/config.rs
@@ -8,4 +8,6 @@ use std::path::PathBuf;
 pub struct Config {
     /// Path to folder where storage files will be stored.
     pub path: PathBuf,
+    /// File descriptor limit for RocksDB
+    pub db_max_open_files: Option<i32>,
 }


### PR DESCRIPTION
# Description
Introduced a new optional config variable [storage.db_max_open_files] to allow specification of max open files in the RocksDB.

## Linked Issues
- Fixes #810 
