### PR TITLE
Use tree based structures in EVM handler

### DIFF
--- a/crates/evm/src/evm/handler.rs
+++ b/crates/evm/src/evm/handler.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::mem::size_of;
 use std::sync::Arc;
 
@@ -64,7 +64,7 @@ impl<T: CitreaExternalExt> CitreaExternalExt for &mut T {
 pub(crate) struct CitreaExternal {
     l1_fee_rate: u128,
     current_tx_hash: Option<B256>,
-    tx_infos: HashMap<B256, TxInfo>,
+    tx_infos: BTreeMap<B256, TxInfo>,
 }
 
 impl CitreaExternal {
@@ -391,10 +391,10 @@ fn calc_diff_size<EXT, DB: Database>(
         nonce_changed: bool,
         code_changed: bool,
         balance_changed: bool,
-        storage_changes: HashSet<&'a U256>,
+        storage_changes: BTreeSet<&'a U256>,
     }
 
-    let mut account_changes: HashMap<&Address, AccountChange<'_>> = HashMap::new();
+    let mut account_changes: BTreeMap<&Address, AccountChange<'_>> = BTreeMap::new();
 
     for entry in &journal {
         match entry {

--- a/crates/sovereign-sdk/adapters/risc0-bonsai/src/host.rs
+++ b/crates/sovereign-sdk/adapters/risc0-bonsai/src/host.rs
@@ -381,6 +381,13 @@ impl<'a> ZkvmHost for Risc0BonsaiHost<'a> {
             let mut executor = ExecutorImpl::from_elf(env, self.elf)?;
 
             let session = executor.run()?;
+            // don't delete useful while benchmarking
+            // println!(
+            //     "user cycles: {}\ntotal cycles: {}\nsegments: {}",
+            //     session.user_cycles,
+            //     session.total_cycles,
+            //     session.segments.len()
+            // );
             let data = bincode::serialize(&session.journal.expect("Journal shouldn't be empty"))?;
 
             Ok(Proof::PublicInput(data))


### PR DESCRIPTION
# Description
**Hash based structure**
user cycles: 21452123
total cycles: 30408704
segments: 29

**Tree based structure**
user cycles: 21240308
total cycles: 30408704
segments: 29


200k less cycles on test `e2e::test_prover_sync_with_commitments`. didn't test but on a test with more contract storage changes we'd have a better discount :) 


PS: see [When you need a map, use BTreeMap instead of HashMap](https://dev.risczero.com/api/zkvm/optimization#tldr-and-quick-wins)
## Linked ### Issues
Fixes #835 (title was a bit wrong)
