### PR TITLE
REPR_GUEST_BUILD env

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -187,7 +187,6 @@ jobs:
         run: make coverage
         env:
           RUST_BACKTRACE: 1
-          GUEST_BUILD_NO_DOCKER: 1
       - name: Upload coverage
         uses: codecov/codecov-action@v4
         with:
@@ -393,6 +392,7 @@ jobs:
         run: make test
         env:
           RUST_BACKTRACE: 1
+          REPR_GUEST_BUILD: 1
           BONSAI_API_URL: ${{ secrets.BONSAI_API_URL }} # TODO: remove this once we don't use the client on tests
           BONSAI_API_KEY: ${{ secrets.BONSAI_API_KEY }} # TODO: remove this once we don't use the client on tests
 

--- a/bin/citrea/provers/risc0/build.rs
+++ b/bin/citrea/provers/risc0/build.rs
@@ -4,11 +4,11 @@ use risc0_build::{embed_methods_with_options, DockerOptions, GuestOptions};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=SKIP_GUEST_BUILD");
-    println!("cargo:rerun-if-env-changed=GUEST_BUILD_NO_DOCKER");
+    println!("cargo:rerun-if-env-changed=REPR_GUEST_BUILD");
     println!("cargo:rerun-if-env-changed=OUT_DIR");
 
     if std::env::var("SKIP_GUEST_BUILD").is_ok() {
-        println!("Skipping guest build for CI run");
+        println!("cargo:warning=Skipping guest build");
         let out_dir = std::env::var_os("OUT_DIR").unwrap();
         let out_dir = std::path::Path::new(&out_dir);
         let methods_path = out_dir.join("methods.rs");
@@ -34,15 +34,15 @@ fn get_guest_options() -> HashMap<&'static str, risc0_build::GuestOptions> {
     if cfg!(feature = "bench") {
         features.push("bench".to_string());
     }
-    let use_docker = if std::env::var("GUEST_BUILD_NO_DOCKER").is_ok() {
-        println!("Skipping guest build for CI run");
-        None
-    } else {
+    let use_docker = if std::env::var("REPR_GUEST_BUILD").is_ok() {
         let this_package_dir = std::env!("CARGO_MANIFEST_DIR");
         let root_dir = format!("{this_package_dir}/../../../../");
         Some(DockerOptions {
             root_dir: Some(root_dir.into()),
         })
+    } else {
+        println!("cargo:warning=Guest code is not built in docker");
+        None
     };
 
     guest_pkg_to_options.insert(


### PR DESCRIPTION
# Description
Build guest code in docker only when env REPR_GUEST_BUILD is set.

Linked issue: https://github.com/chainwayxyz/citrea/pull/841

# Documentation

env `REPR_GUEST_BUILD` must be documented.
