### PR TITLE
Esad/attempt fix flaky tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -273,9 +273,9 @@ jobs:
         run: |
           RUST_LOG=off ./target/debug/citrea --da-layer mock --rollup-config-path resources/configs/mock/sequencer_rollup_config.toml --sequencer-config-path resources/configs/mock/sequencer_config.toml --genesis-paths resources/genesis/mock/ &
           sleep 2
-          RUST_LOG=off ./target/debug/citrea --rollup-config-path resources/configs/mock/rollup_config.toml --genesis-paths resources/genesis/mock/ &
+          RUST_LOG=off ./target/debug/citrea --da-layer mock --rollup-config-path resources/configs/mock/rollup_config.toml --genesis-paths resources/genesis/mock/ &
           sleep 2
-          ./resources/configs/mock-dockerized/publish_da_block.sh &
+          # ./resources/configs/mock-dockerized/publish_da_block.sh &
           cd ./bin/citrea/tests/evm/web3_py
           python test.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 demo-rollup-readme.sh
+*.db
 /target
 
 .idea/

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -3280,7 +3280,6 @@ async fn test_full_node_sync_status() {
 
     match status {
         CitreaStatus::Syncing(syncing) => {
-            println!("{:?}", syncing);
             assert!(syncing.synced_block_number > 0 && syncing.synced_block_number < 300);
             assert_eq!(syncing.head_block_number, 300);
         }

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -3286,7 +3286,7 @@ async fn test_full_node_sync_status() {
     let full_node_port = full_node_port_rx.await.unwrap();
     let full_node_test_client = make_test_client(full_node_port).await;
 
-    wait_for_l2_block(&full_node_test_client, 10, Some(Duration::from_secs(60))).await;
+    // wait_for_l2_block(&full_node_test_client, 10, Some(Duration::from_secs(60))).await;
 
     let status = full_node_test_client.citrea_sync_status().await;
 

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -2627,7 +2627,7 @@ async fn full_node_verify_proof_and_store() {
     }
 
     // So the full node should see the proof in block 5
-    wait_for_proof(&full_node_test_client, 5, None).await;
+    wait_for_proof(&full_node_test_client, 5, Some(Duration::from_secs(60))).await;
     let full_node_proof = full_node_test_client
         .ledger_get_verified_proofs_by_slot_height(5)
         .await
@@ -2850,7 +2850,7 @@ async fn test_all_flow() {
     wait_for_l2_block(&full_node_test_client, 7, None).await;
 
     // So the full node should see the proof in block 5
-    wait_for_proof(&full_node_test_client, 5, None).await;
+    wait_for_proof(&full_node_test_client, 5, Some(Duration::from_secs(120))).await;
     let full_node_proof = full_node_test_client
         .ledger_get_verified_proofs_by_slot_height(5)
         .await
@@ -2949,7 +2949,7 @@ async fn test_all_flow() {
         wait_for_l2_block(&full_node_test_client, i, None).await;
     }
 
-    wait_for_proof(&full_node_test_client, 8, None).await;
+    wait_for_proof(&full_node_test_client, 8, Some(Duration::from_secs(120))).await;
     let full_node_proof_data = full_node_test_client
         .ledger_get_verified_proofs_by_slot_height(8)
         .await

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -3252,7 +3252,7 @@ async fn test_full_node_sync_status() {
     let seq_test_client = init_test_rollup(seq_port).await;
     let addr = Address::from_str("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266").unwrap();
 
-    for _ in 0..1000 {
+    for _ in 0..300 {
         let _pending = seq_test_client
             .send_eth(addr, None, None, None, 0u128)
             .await
@@ -3260,7 +3260,7 @@ async fn test_full_node_sync_status() {
         seq_test_client.send_publish_batch_request().await;
     }
 
-    wait_for_l2_block(&seq_test_client, 1000, Some(Duration::from_secs(60))).await;
+    wait_for_l2_block(&seq_test_client, 300, Some(Duration::from_secs(60))).await;
 
     let (full_node_port_tx, full_node_port_rx) = tokio::sync::oneshot::channel();
 
@@ -3293,18 +3293,18 @@ async fn test_full_node_sync_status() {
     match status {
         CitreaStatus::Syncing(syncing) => {
             println!("{:?}", syncing);
-            assert!(syncing.synced_block_number > 0 && syncing.synced_block_number < 1000);
-            assert_eq!(syncing.head_block_number, 1000);
+            assert!(syncing.synced_block_number > 0 && syncing.synced_block_number < 300);
+            assert_eq!(syncing.head_block_number, 300);
         }
         _ => panic!("Expected syncing status"),
     }
 
-    wait_for_l2_block(&full_node_test_client, 1000, None).await;
+    wait_for_l2_block(&full_node_test_client, 300, Some(Duration::from_secs(60))).await;
 
     let status = full_node_test_client.citrea_sync_status().await;
 
     match status {
-        CitreaStatus::Synced(synced_up_to) => assert_eq!(synced_up_to, 1000),
+        CitreaStatus::Synced(synced_up_to) => assert_eq!(synced_up_to, 300),
         _ => panic!("Expected synced status"),
     }
 

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -3252,7 +3252,7 @@ async fn test_full_node_sync_status() {
     let seq_test_client = init_test_rollup(seq_port).await;
     let addr = Address::from_str("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266").unwrap();
 
-    for _ in 0..100 {
+    for _ in 0..1000 {
         let _pending = seq_test_client
             .send_eth(addr, None, None, None, 0u128)
             .await
@@ -3260,7 +3260,7 @@ async fn test_full_node_sync_status() {
         seq_test_client.send_publish_batch_request().await;
     }
 
-    wait_for_l2_block(&seq_test_client, 100, Some(Duration::from_secs(60))).await;
+    wait_for_l2_block(&seq_test_client, 1000, Some(Duration::from_secs(60))).await;
 
     let (full_node_port_tx, full_node_port_rx) = tokio::sync::oneshot::channel();
 
@@ -3286,24 +3286,25 @@ async fn test_full_node_sync_status() {
     let full_node_port = full_node_port_rx.await.unwrap();
     let full_node_test_client = make_test_client(full_node_port).await;
 
-    // wait_for_l2_block(&full_node_test_client, 10, Some(Duration::from_secs(60))).await;
+    wait_for_l2_block(&full_node_test_client, 5, Some(Duration::from_secs(60))).await;
 
     let status = full_node_test_client.citrea_sync_status().await;
 
     match status {
         CitreaStatus::Syncing(syncing) => {
-            assert!(syncing.synced_block_number > 0 && syncing.synced_block_number < 100);
-            assert_eq!(syncing.head_block_number, 100);
+            println!("{:?}", syncing);
+            assert!(syncing.synced_block_number > 0 && syncing.synced_block_number < 1000);
+            assert_eq!(syncing.head_block_number, 1000);
         }
         _ => panic!("Expected syncing status"),
     }
 
-    wait_for_l2_block(&full_node_test_client, 100, None).await;
+    wait_for_l2_block(&full_node_test_client, 1000, None).await;
 
     let status = full_node_test_client.citrea_sync_status().await;
 
     match status {
-        CitreaStatus::Synced(synced_up_to) => assert_eq!(synced_up_to, 100),
+        CitreaStatus::Synced(synced_up_to) => assert_eq!(synced_up_to, 1000),
         _ => panic!("Expected synced status"),
     }
 

--- a/bin/citrea/tests/evm/ethers_js/test.js
+++ b/bin/citrea/tests/evm/ethers_js/test.js
@@ -1,7 +1,7 @@
 import { ethers, JsonRpcProvider } from "ethers";
 import { expect } from 'chai';
 
-let provider = new JsonRpcProvider('http://127.0.0.1:12345');
+let provider = new JsonRpcProvider('http://127.0.0.1:12346');
 
 describe("RpcTests", function() {
     let first_tx_receipt;

--- a/bin/citrea/tests/evm/mod.rs
+++ b/bin/citrea/tests/evm/mod.rs
@@ -257,7 +257,7 @@ async fn test_getlogs(client: &Box<TestClient>) -> Result<(), Box<dyn std::error
         )
         .await;
     client.send_publish_batch_request().await;
-    wait_for_l2_block(client, 1, None).await;
+    wait_for_l2_block(client, 2, None).await;
 
     let empty_filter = serde_json::json!({});
     // supposed to get all the logs

--- a/bin/citrea/tests/evm/web3_py/test.py
+++ b/bin/citrea/tests/evm/web3_py/test.py
@@ -4,7 +4,7 @@ from web3 import Web3
 
 class TestWeb3(unittest.TestCase):
     def setUp(self):
-        self.web3 = Web3(Web3.HTTPProvider('http://127.0.0.1:12345'))
+        self.web3 = Web3(Web3.HTTPProvider('http://127.0.0.1:12346'))
         transaction = {
             'from': "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
             'to': "0x0000000000000000000000000000000000000000",

--- a/bin/citrea/tests/test_helpers/mod.rs
+++ b/bin/citrea/tests/test_helpers/mod.rs
@@ -190,13 +190,13 @@ pub fn tempdir_with_children(children: &[&str]) -> TempDir {
     db_dir
 }
 
-#[instrument(level = "debug", skip(sequencer_client))]
-pub async fn wait_for_l2_block(sequencer_client: &TestClient, num: u64, timeout: Option<Duration>) {
+#[instrument(level = "debug", skip(client))]
+pub async fn wait_for_l2_block(client: &TestClient, num: u64, timeout: Option<Duration>) {
     let start = SystemTime::now();
     let timeout = timeout.unwrap_or(Duration::from_secs(30)); // Default 30 seconds timeout
     loop {
         debug!("Waiting for soft batch {}", num);
-        let latest_block = sequencer_client
+        let latest_block = client
             .ledger_get_head_soft_batch_height()
             .await
             .unwrap()

--- a/bin/citrea/tests/test_helpers/mod.rs
+++ b/bin/citrea/tests/test_helpers/mod.rs
@@ -6,7 +6,6 @@ use citrea::{CitreaRollupBlueprint, MockDemoRollup};
 use citrea_primitives::TEST_PRIVATE_KEY;
 use citrea_sequencer::SequencerConfig;
 use citrea_stf::genesis_config::GenesisPaths;
-use reth_rpc_types::BlockNumberOrTag;
 use shared_backup_db::PostgresConnector;
 use sov_mock_da::{MockAddress, MockDaConfig, MockDaService};
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;

--- a/bin/citrea/tests/test_helpers/mod.rs
+++ b/bin/citrea/tests/test_helpers/mod.rs
@@ -198,18 +198,18 @@ pub async fn wait_for_l2_block(sequencer_client: &TestClient, num: u64, timeout:
     loop {
         debug!("Waiting for soft batch {}", num);
         let latest_block = sequencer_client
-            .eth_get_block_by_number_with_detail(Some(BlockNumberOrTag::Latest))
-            .await;
-        if latest_block.header.number >= Some(num) {
+            .ledger_get_head_soft_batch_height()
+            .await
+            .unwrap()
+            .expect("Expected height to be Some");
+
+        if latest_block >= num {
             break;
         }
 
         let now = SystemTime::now();
         if start + timeout <= now {
-            panic!(
-                "Timeout. Latest L2 block is {:?}",
-                latest_block.header.number
-            );
+            panic!("Timeout. Latest L2 block is {:?}", latest_block);
         }
 
         sleep(Duration::from_secs(1)).await;
@@ -284,7 +284,7 @@ pub async fn wait_for_proof(test_client: &TestClient, slot_height: u64, timeout:
 
         sleep(Duration::from_secs(1)).await;
     }
-    // Let knowledgage of the new DA block propagate
+    // Let knowledge of the new DA block propagate
     sleep(Duration::from_secs(2)).await;
 }
 

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -535,9 +535,6 @@ where
             data_to_commit.add_batch(receipt);
         }
 
-        self.storage_manager
-            .save_change_set_l2(l2_height, slot_result.change_set)?;
-
         let batch_receipt = data_to_commit.batch_receipts()[0].clone();
 
         let soft_batch_receipt = SoftBatchReceipt::<_, _, Da::Spec> {
@@ -556,13 +553,18 @@ where
             timestamp: soft_batch.timestamp,
         };
 
-        self.ledger_db
-            .commit_soft_batch(soft_batch_receipt, self.include_tx_body)?;
+        self.storage_manager
+            .save_change_set_l2(l2_height, slot_result.change_set)?;
+
+        self.storage_manager.finalize_l2(l2_height)?;
 
         self.ledger_db.extend_l2_range_of_l1_slot(
             SlotNumber(current_l1_block.header().height()),
             BatchNumber(l2_height),
         )?;
+
+        self.ledger_db
+            .commit_soft_batch(soft_batch_receipt, self.include_tx_body)?;
 
         self.state_root = next_state_root;
 
@@ -570,8 +572,6 @@ where
             "New State Root after soft confirmation #{} is: {:?}",
             l2_height, self.state_root
         );
-
-        self.storage_manager.finalize_l2(l2_height)?;
 
         Ok(())
     }


### PR DESCRIPTION
# Description
Working on:
- [ ] test_eth_get_logs
- [ ] test_full_node_sync_status (this didn't happen on ci, but my mac)
- [ ] test_system_tx_effect_on_block_gas_limit
- [ ] test_ledger_get_commitments_on_slot
- [ ] test_all_flow
- [ ] Web3.py yeterince block beklememe mevzusu
- [ ] test_prover_sync_with_commitments (this might be due to db problems on my machine)

## Linked Issues
fixes #802 

