### PR TITLE
Fix intersecting l2 commitment blocks

### DIFF
--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -1919,7 +1919,7 @@ async fn sequencer_crash_and_replace_full_node() -> Result<(), anyhow::Error> {
 
     sequencer_config.db_config = Some(SharedBackupDbConfig::default().set_db_name(psql_db_name));
 
-    let da_service = MockDaService::with_finality(MockAddress::from([0; 32]), 2, &da_db_dir);
+    let da_service = MockDaService::with_finality(MockAddress::from([0; 32]), 0, &da_db_dir);
     da_service.publish_test_block().await.unwrap();
 
     let (seq_port_tx, seq_port_rx) = tokio::sync::oneshot::channel();
@@ -2067,9 +2067,7 @@ async fn sequencer_crash_and_replace_full_node() -> Result<(), anyhow::Error> {
     assert_eq!(commitments.len(), 2);
     assert_eq!(commitments[0].l2_start_height, 1);
     assert_eq!(commitments[0].l2_end_height, 4);
-    // TODO: This is a bug that should be checked.
-    // The second commitment L2 start height should be 5
-    assert_eq!(commitments[1].l2_start_height, 1);
+    assert_eq!(commitments[1].l2_start_height, 5);
     assert_eq!(commitments[1].l2_end_height, 9);
 
     seq_task.abort();

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -1036,8 +1036,7 @@ where
             .get_soft_batch_range(
                 &(BatchNumber(db_commitment.l2_start_height)
                     ..BatchNumber(db_commitment.l2_start_height + 1)),
-            )
-            .unwrap();
+            )?;
         let start_batch = &batches[0];
         self.ledger_db
             .set_last_sequencer_commitment_l1_height(SlotNumber(start_batch.da_slot_height))?;

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -1032,12 +1032,12 @@ where
             .set_last_sequencer_commitment_l2_height(BatchNumber(db_commitment.l2_end_height))?;
 
         let batches = self.ledger_db.get_soft_batch_range(
-            &(BatchNumber(db_commitment.l2_start_height)
-                ..BatchNumber(db_commitment.l2_start_height + 1)),
+            &(BatchNumber(db_commitment.l2_end_height)
+                ..BatchNumber(db_commitment.l2_end_height + 1)),
         )?;
-        let start_batch = &batches[0];
+        let l2_end_batch = &batches[0];
         self.ledger_db
-            .set_last_sequencer_commitment_l1_height(SlotNumber(start_batch.da_slot_height))?;
+            .set_last_sequencer_commitment_l1_height(SlotNumber(l2_end_batch.da_slot_height))?;
 
         Ok(())
     }

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -1031,12 +1031,10 @@ where
         self.ledger_db
             .set_last_sequencer_commitment_l2_height(BatchNumber(db_commitment.l2_end_height))?;
 
-        let batches = self
-            .ledger_db
-            .get_soft_batch_range(
-                &(BatchNumber(db_commitment.l2_start_height)
-                    ..BatchNumber(db_commitment.l2_start_height + 1)),
-            )?;
+        let batches = self.ledger_db.get_soft_batch_range(
+            &(BatchNumber(db_commitment.l2_start_height)
+                ..BatchNumber(db_commitment.l2_start_height + 1)),
+        )?;
         let start_batch = &batches[0];
         self.ledger_db
             .set_last_sequencer_commitment_l1_height(SlotNumber(start_batch.da_slot_height))?;

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -675,7 +675,7 @@ where
         if let Some(db_config) = self.config.db_config.clone() {
             pg_pool = match PostgresConnector::new(db_config).await {
                 Ok(pg_connector) => {
-                    match self.compare_commitments_from_db(pg_connector.clone()).await {
+                    match self.sync_commitments_from_db(pg_connector.clone()).await {
                         Ok(()) => debug!("Sequencer: Commitments are in sync"),
                         Err(e) => {
                             warn!("Sequencer: Offchain db error: {:?}", e);
@@ -1012,7 +1012,7 @@ where
         Ok(())
     }
 
-    pub async fn compare_commitments_from_db(
+    pub async fn sync_commitments_from_db(
         &self,
         pg_connector: PostgresConnector,
     ) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
# Description

The issue was caused by the fact that when the sequencer is restarted, the sync of ledger db from postgres was problematic. This PR fixes the `compare_commitments_from_db` method.

## Linked Issues
- Fixes #842 

## Testing
Existing test `sequencer_crash_and_replace_full_node` works now.
