### PR TITLE
Commitment rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10559,9 +10559,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -10570,9 +10570,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2 1.0.85",
  "quote 1.0.36",

--- a/bin/citrea/provers/risc0/guest-bitcoin/Cargo.lock
+++ b/bin/citrea/provers/risc0/guest-bitcoin/Cargo.lock
@@ -3852,9 +3852,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3863,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bin/citrea/provers/risc0/guest-mock/Cargo.lock
+++ b/bin/citrea/provers/risc0/guest-mock/Cargo.lock
@@ -3640,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3651,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bin/citrea/src/lib.rs
+++ b/bin/citrea/src/lib.rs
@@ -23,6 +23,7 @@ pub fn initialize_logging(level: Level) {
             "alloy_transport_http=info".to_owned(),
             // Limit output as much as possible, use WARN.
             "risc0_zkvm=warn".to_owned(),
+            "risc0_circuit_rv32im=info".to_owned(),
             "guest_execution=info".to_owned(),
             "jsonrpsee-server=info".to_owned(),
             "reqwest=info".to_owned(),

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -2921,9 +2921,9 @@ async fn test_all_flow() {
         prover_proof_data.state_transition.sequencer_public_key
     );
 
-    wait_for_proof(&full_node_test_client, 5, Some(Duration::from_secs(120))).await;
+    wait_for_proof(&full_node_test_client, 6, Some(Duration::from_secs(120))).await;
     let full_node_proof_data = full_node_test_client
-        .ledger_get_verified_proofs_by_slot_height(5)
+        .ledger_get_verified_proofs_by_slot_height(6)
         .await
         .unwrap();
 

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -1070,7 +1070,7 @@ async fn execute_blocks(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_soft_confirmations_status_one_l1() -> Result<(), anyhow::Error> {
-    // citrea::initialize_logging(tracing::Level::DEBUG);
+    // citrea::initialize_logging(tracing::Level::INFO);
 
     let storage_dir = tempdir_with_children(&["DA", "sequencer", "full-node"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();
@@ -1139,7 +1139,7 @@ async fn test_soft_confirmations_status_one_l1() -> Result<(), anyhow::Error> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_soft_confirmations_status_two_l1() -> Result<(), anyhow::Error> {
-    // citrea::initialize_logging(tracing::Level::DEBUG);
+    // citrea::initialize_logging(tracing::Level::INFO);
 
     let storage_dir = tempdir_with_children(&["DA", "sequencer", "full-node"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -1106,20 +1106,9 @@ async fn test_soft_confirmations_status_one_l1() -> Result<(), anyhow::Error> {
         assert_eq!(SoftConfirmationStatus::Trusted, status_node.unwrap());
     }
 
-    // publish new da block
-    //
-    // This will trigger the sequencer's DA monitor to see a newly published
-    // block and will therefore initiate a commitment submission to the MockDA.
-    // Therefore, creating yet another DA block.
-    da_service.publish_test_block().await.unwrap();
-
-    // The above L1 block has been created,
-    // we wait until the block is actually received by the DA monitor.
-    wait_for_l1_block(&da_service, 2, None).await;
-
-    // Wait for DA block #3 containing the commitment
+    // Wait for DA block #2 containing the commitment
     // submitted by sequencer.
-    wait_for_l1_block(&da_service, 3, None).await;
+    wait_for_l1_block(&da_service, 2, None).await;
 
     // now retrieve confirmation status from the sequencer and full node and check if they are the same
     for i in 1..=6 {

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -1070,7 +1070,7 @@ async fn execute_blocks(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_soft_confirmations_status_one_l1() -> Result<(), anyhow::Error> {
-    // citrea::initialize_logging(tracing::Level::INFO);
+    // citrea::initialize_logging(tracing::Level::DEBUG);
 
     let storage_dir = tempdir_with_children(&["DA", "sequencer", "full-node"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();
@@ -1139,7 +1139,7 @@ async fn test_soft_confirmations_status_one_l1() -> Result<(), anyhow::Error> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_soft_confirmations_status_two_l1() -> Result<(), anyhow::Error> {
-    // citrea::initialize_logging(tracing::Level::INFO);
+    // citrea::initialize_logging(tracing::Level::DEBUG);
 
     let storage_dir = tempdir_with_children(&["DA", "sequencer", "full-node"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();
@@ -1159,40 +1159,31 @@ async fn test_soft_confirmations_status_two_l1() -> Result<(), anyhow::Error> {
         .await;
 
     // first publish a few blocks fast make it land in the same da block
-    for _ in 1..=2 {
+    for _ in 1..=3 {
         seq_test_client.send_publish_batch_request().await;
     }
 
-    wait_for_l2_block(&seq_test_client, 2, None).await;
-
-    // publish new da block
-    da_service.publish_test_block().await.unwrap();
+    wait_for_l2_block(&seq_test_client, 3, None).await;
+    // L2 blocks 1-3 would create an L1 block with commitment
     wait_for_l1_block(&da_service, 2, None).await;
 
-    for _ in 2..=6 {
+    for _ in 4..=6 {
         seq_test_client.send_publish_batch_request().await;
     }
 
-    wait_for_l2_block(&full_node_test_client, 7, None).await;
+    wait_for_l2_block(&full_node_test_client, 6, None).await;
+    // L2 blocks 4-6 would create an L1 block with commitment
+    wait_for_l1_block(&da_service, 3, None).await;
 
     // now retrieve confirmation status from the sequencer and full node and check if they are the same
-    for i in 1..=2 {
+    for i in 1..=3 {
         let status_node = full_node_test_client
             .ledger_get_soft_confirmation_status(i)
             .await
             .unwrap();
 
-        assert_eq!(SoftConfirmationStatus::Trusted, status_node.unwrap());
+        assert_eq!(SoftConfirmationStatus::Finalized, status_node.unwrap());
     }
-
-    // publish new da block
-    da_service.publish_test_block().await.unwrap();
-    wait_for_l1_block(&da_service, 3, None).await;
-
-    seq_test_client.send_publish_batch_request().await;
-    seq_test_client.send_publish_batch_request().await;
-
-    wait_for_l2_block(&full_node_test_client, 9, None).await;
 
     // Check that these L2 blocks are bounded on different L1 block
     let mut batch_infos = vec![];
@@ -1203,10 +1194,16 @@ async fn test_soft_confirmations_status_two_l1() -> Result<(), anyhow::Error> {
             .unwrap();
         batch_infos.push(full_node_soft_conf);
     }
-    assert_eq!(batch_infos[0].da_slot_height, batch_infos[1].da_slot_height);
-    assert!(batch_infos[2..]
+
+    // First three blocks got created on L1 height 1.
+    assert!(batch_infos[0..3]
         .iter()
-        .all(|x| x.da_slot_height == batch_infos[2].da_slot_height));
+        .all(|x| { x.da_slot_height == batch_infos[0].da_slot_height }));
+
+    // Blocks 4, 5, 6 were created on L1 height 2
+    assert!(batch_infos[3..6]
+        .iter()
+        .all(|x| { x.da_slot_height == batch_infos[3].da_slot_height }));
     assert_ne!(batch_infos[0].da_slot_height, batch_infos[5].da_slot_height);
 
     // now retrieve confirmation status from the sequencer and full node and check if they are the same
@@ -1381,7 +1378,7 @@ async fn test_prover_sync_with_commitments() -> Result<(), anyhow::Error> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_reopen_prover() -> Result<(), anyhow::Error> {
-    citrea::initialize_logging(tracing::Level::INFO);
+    // citrea::initialize_logging(tracing::Level::INFO);
 
     let storage_dir = tempdir_with_children(&["DA", "sequencer", "prover"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();
@@ -2070,7 +2067,7 @@ async fn sequencer_crash_and_replace_full_node() -> Result<(), anyhow::Error> {
     assert_eq!(commitments[0].l2_start_height, 1);
     assert_eq!(commitments[0].l2_end_height, 4);
     assert_eq!(commitments[1].l2_start_height, 5);
-    assert_eq!(commitments[1].l2_end_height, 9);
+    assert_eq!(commitments[1].l2_end_height, 8);
 
     seq_task.abort();
 
@@ -2421,11 +2418,8 @@ async fn test_db_get_proof() {
     test_client.send_publish_batch_request().await;
     wait_for_l2_block(&test_client, 4, None).await;
 
-    da_service.publish_test_block().await.unwrap();
     // Commitment
     wait_for_l1_block(&da_service, 3, None).await;
-    // Proof
-    wait_for_l1_block(&da_service, 4, None).await;
 
     // wait here until we see from prover's rpc that it finished proving
     wait_for_prover_l1_height(
@@ -2438,7 +2432,7 @@ async fn test_db_get_proof() {
     wait_for_postgres_proofs(&db_test_client, 1, Some(Duration::from_secs(60))).await;
 
     let ledger_proof = prover_node_test_client
-        .ledger_get_proof_by_slot_height(4)
+        .ledger_get_proof_by_slot_height(3)
         .await;
 
     let db_proofs = db_test_client.get_all_proof_data().await.unwrap();
@@ -2570,27 +2564,23 @@ async fn full_node_verify_proof_and_store() {
     test_client.send_publish_batch_request().await;
     wait_for_l2_block(&full_node_test_client, 4, None).await;
 
-    // submits with new da block, triggers commitment submission.
-    da_service.publish_test_block().await.unwrap();
-    // This is the above block created.
-    wait_for_l1_block(&da_service, 3, None).await;
     // Commitment submitted
-    wait_for_l1_block(&da_service, 4, None).await;
+    wait_for_l1_block(&da_service, 3, None).await;
 
     // Full node sync commitment block
     test_client.send_publish_batch_request().await;
-    wait_for_l2_block(&full_node_test_client, 6, None).await;
+    wait_for_l2_block(&full_node_test_client, 5, None).await;
 
     // wait here until we see from prover's rpc that it finished proving
     wait_for_prover_l1_height(
         &prover_node_test_client,
-        5,
+        4,
         Some(Duration::from_secs(DEFAULT_PROOF_WAIT_DURATION)),
     )
     .await;
 
     let commitments = prover_node_test_client
-        .ledger_get_sequencer_commitments_on_slot_by_number(4)
+        .ledger_get_sequencer_commitments_on_slot_by_number(3)
         .await
         .unwrap()
         .unwrap();
@@ -2599,37 +2589,37 @@ async fn full_node_verify_proof_and_store() {
     assert_eq!(commitments[0].l2_start_block_number, 1);
     assert_eq!(commitments[0].l2_end_block_number, 4);
 
-    assert_eq!(commitments[0].found_in_l1, 4);
+    assert_eq!(commitments[0].found_in_l1, 3);
 
-    let fourth_block_hash = da_service.get_block_at(4).await.unwrap().header.hash;
+    let third_block_hash = da_service.get_block_at(3).await.unwrap().header.hash;
 
     let commitments_hash = prover_node_test_client
-        .ledger_get_sequencer_commitments_on_slot_by_hash(fourth_block_hash.0)
+        .ledger_get_sequencer_commitments_on_slot_by_hash(third_block_hash.0)
         .await
         .unwrap()
         .unwrap();
     assert_eq!(commitments_hash, commitments);
 
     let prover_proof = prover_node_test_client
-        .ledger_get_proof_by_slot_height(4)
+        .ledger_get_proof_by_slot_height(3)
         .await;
 
-    // The proof will be in l1 block #5 because prover publishes it after the commitment and
+    // The proof will be in l1 block #4 because prover publishes it after the commitment and
     // in mock da submitting proof and commitments creates a new block.
-    // For full node to see the proof, we publish another l2 block and now it will check #5 l1 block
-    wait_for_l1_block(&da_service, 5, None).await;
+    // For full node to see the proof, we publish another l2 block and now it will check #4 l1 block
+    wait_for_l1_block(&da_service, 4, None).await;
 
     // Up until this moment, Full node has only seen 2 DA blocks.
-    // We need to force it to sync up to 5th DA block.
-    for i in 7..=8 {
+    // We need to force it to sync up to 4th DA block.
+    for i in 6..=7 {
         test_client.send_publish_batch_request().await;
         wait_for_l2_block(&full_node_test_client, i, None).await;
     }
 
-    // So the full node should see the proof in block 5
-    wait_for_proof(&full_node_test_client, 5, Some(Duration::from_secs(60))).await;
+    // So the full node should see the proof in block 4
+    wait_for_proof(&full_node_test_client, 4, Some(Duration::from_secs(60))).await;
     let full_node_proof = full_node_test_client
-        .ledger_get_verified_proofs_by_slot_height(5)
+        .ledger_get_verified_proofs_by_slot_height(4)
         .await
         .unwrap();
     assert_eq!(prover_proof.proof, full_node_proof[0].proof);
@@ -2783,18 +2773,8 @@ async fn test_all_flow() {
     test_client.send_publish_batch_request().await;
     wait_for_l2_block(&test_client, 4, None).await;
 
-    // Submit commitment
-    da_service.publish_test_block().await.unwrap();
     // Commitment
     wait_for_l1_block(&da_service, 3, None).await;
-    // Proof
-    wait_for_l1_block(&da_service, 4, None).await;
-    // Full node sync - commitment DA
-    test_client.send_publish_batch_request().await;
-    wait_for_l2_block(&full_node_test_client, 5, None).await;
-    // Full node sync - Proof DA
-    test_client.send_publish_batch_request().await;
-    wait_for_l2_block(&full_node_test_client, 6, None).await;
 
     // wait here until we see from prover's rpc that it finished proving
     wait_for_prover_l1_height(
@@ -2805,7 +2785,7 @@ async fn test_all_flow() {
     .await;
 
     let commitments = prover_node_test_client
-        .ledger_get_sequencer_commitments_on_slot_by_number(4)
+        .ledger_get_sequencer_commitments_on_slot_by_number(3)
         .await
         .unwrap()
         .unwrap();
@@ -2814,19 +2794,19 @@ async fn test_all_flow() {
     assert_eq!(commitments[0].l2_start_block_number, 1);
     assert_eq!(commitments[0].l2_end_block_number, 4);
 
-    assert_eq!(commitments[0].found_in_l1, 4);
+    assert_eq!(commitments[0].found_in_l1, 3);
 
-    let fourth_block_hash = da_service.get_block_at(4).await.unwrap().header.hash;
+    let third_block_hash = da_service.get_block_at(3).await.unwrap().header.hash;
 
     let commitments_hash = prover_node_test_client
-        .ledger_get_sequencer_commitments_on_slot_by_hash(fourth_block_hash.0)
+        .ledger_get_sequencer_commitments_on_slot_by_hash(third_block_hash.0)
         .await
         .unwrap()
         .unwrap();
     assert_eq!(commitments_hash, commitments);
 
     let prover_proof = prover_node_test_client
-        .ledger_get_proof_by_slot_height(4)
+        .ledger_get_proof_by_slot_height(3)
         .await;
 
     let db_proofs = db_test_client.get_all_proof_data().await.unwrap();
@@ -2842,17 +2822,17 @@ async fn test_all_flow() {
     );
     assert_eq!(db_proofs[0].l1_tx_id, prover_proof.l1_tx_id);
 
-    // the proof will be in l1 block #5 because prover publishes it after the commitment and in mock da submitting proof and commitments creates a new block
-    // For full node to see the proof, we publish another l2 block and now it will check #5 l1 block
-    // 7th soft batch
-    wait_for_l1_block(&da_service, 5, None).await;
+    // the proof will be in l1 block #4 because prover publishes it after the commitment and in mock da submitting proof and commitments creates a new block
+    // For full node to see the proof, we publish another l2 block and now it will check #4 l1 block
+    // 6th soft batch
+    wait_for_l1_block(&da_service, 4, None).await;
     test_client.send_publish_batch_request().await;
-    wait_for_l2_block(&full_node_test_client, 7, None).await;
+    wait_for_l2_block(&full_node_test_client, 6, None).await;
 
     // So the full node should see the proof in block 5
-    wait_for_proof(&full_node_test_client, 5, Some(Duration::from_secs(120))).await;
+    wait_for_proof(&full_node_test_client, 4, Some(Duration::from_secs(120))).await;
     let full_node_proof = full_node_test_client
-        .ledger_get_verified_proofs_by_slot_height(5)
+        .ledger_get_verified_proofs_by_slot_height(4)
         .await
         .unwrap();
 
@@ -2901,34 +2881,32 @@ async fn test_all_flow() {
         .send_eth(addr, None, None, None, 1e18 as u128)
         .await
         .unwrap();
-    // 8th soft batch
-    test_client.send_publish_batch_request().await;
-    wait_for_l2_block(&full_node_test_client, 8, None).await;
 
-    // Submit a commitment
-    da_service.publish_test_block().await.unwrap();
+    for i in 7..=8 {
+        test_client.send_publish_batch_request().await;
+        wait_for_l2_block(&full_node_test_client, i, None).await;
+    }
+
     // Commitment
-    wait_for_l1_block(&da_service, 6, None).await;
-    // Proof
-    wait_for_l1_block(&da_service, 7, None).await;
+    wait_for_l1_block(&da_service, 5, None).await;
 
     // wait here until we see from prover's rpc that it finished proving
     wait_for_prover_l1_height(
         &prover_node_test_client,
-        7,
+        5,
         Some(Duration::from_secs(DEFAULT_PROOF_WAIT_DURATION)),
     )
     .await;
 
     let commitments = prover_node_test_client
-        .ledger_get_sequencer_commitments_on_slot_by_number(7)
+        .ledger_get_sequencer_commitments_on_slot_by_number(5)
         .await
         .unwrap()
         .unwrap();
     assert_eq!(commitments.len(), 1);
 
     let prover_proof_data = prover_node_test_client
-        .ledger_get_proof_by_slot_height(7)
+        .ledger_get_proof_by_slot_height(5)
         .await;
 
     let db_proofs = db_test_client.get_all_proof_data().await.unwrap();
@@ -2943,15 +2921,9 @@ async fn test_all_flow() {
         prover_proof_data.state_transition.sequencer_public_key
     );
 
-    // let full node see the proof
-    for i in 9..13 {
-        test_client.send_publish_batch_request().await;
-        wait_for_l2_block(&full_node_test_client, i, None).await;
-    }
-
-    wait_for_proof(&full_node_test_client, 8, Some(Duration::from_secs(120))).await;
+    wait_for_proof(&full_node_test_client, 5, Some(Duration::from_secs(120))).await;
     let full_node_proof_data = full_node_test_client
-        .ledger_get_verified_proofs_by_slot_height(8)
+        .ledger_get_verified_proofs_by_slot_height(5)
         .await
         .unwrap();
 
@@ -2984,16 +2956,13 @@ async fn test_all_flow() {
         assert_eq!(status, SoftConfirmationStatus::Proven);
     }
 
-    wait_for_l2_block(&test_client, 14, None).await;
-    assert_eq!(test_client.eth_block_number().await, 14);
-
     // Synced up to the latest block
-    wait_for_l2_block(&full_node_test_client, 14, Some(Duration::from_secs(60))).await;
-    assert!(full_node_test_client.eth_block_number().await >= 14);
+    wait_for_l2_block(&full_node_test_client, 8, Some(Duration::from_secs(60))).await;
+    assert!(full_node_test_client.eth_block_number().await == 8);
 
     // Synced up to the latest commitment
-    wait_for_l2_block(&prover_node_test_client, 9, Some(Duration::from_secs(60))).await;
-    assert!(prover_node_test_client.eth_block_number().await >= 9);
+    wait_for_l2_block(&prover_node_test_client, 8, Some(Duration::from_secs(60))).await;
+    assert!(prover_node_test_client.eth_block_number().await == 8);
 
     seq_task.abort();
     prover_node_task.abort();
@@ -3301,9 +3270,9 @@ async fn test_full_node_sync_status() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sequencer_commitment_threshold() {
-    // citrea::initialize_logging(tracing::Level::DEBUG);
+    citrea::initialize_logging(tracing::Level::DEBUG);
 
-    let storage_dir = tempdir_with_children(&["DA", "sequencer", "full-node"]);
+    let storage_dir = tempdir_with_children(&["DA", "sequencer"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();
     let sequencer_db_dir = storage_dir.path().join("sequencer").to_path_buf();
 
@@ -3313,7 +3282,10 @@ async fn test_sequencer_commitment_threshold() {
         .await
         .unwrap();
 
-    let mut sequencer_config = create_default_sequencer_config(4, Some(true), 10);
+    // Put a large number for commitment threshold
+    let min_soft_confirmations_per_commitment = 1_000_000;
+    let mut sequencer_config =
+        create_default_sequencer_config(min_soft_confirmations_per_commitment, Some(true), 10);
 
     sequencer_config.db_config = Some(SharedBackupDbConfig::default().set_db_name(psql_db_name));
     sequencer_config.mempool_conf = SequencerMempoolConfig {
@@ -3324,7 +3296,7 @@ async fn test_sequencer_commitment_threshold() {
     let (seq_port_tx, seq_port_rx) = tokio::sync::oneshot::channel();
 
     let da_db_dir_cloned = da_db_dir.clone();
-    let seq_task = tokio::spawn(async {
+    let seq_task = tokio::spawn(async move {
         start_rollup(
             seq_port_tx,
             GenesisPaths::from_dir(TEST_DATA_GENESIS_PATH),
@@ -3332,7 +3304,7 @@ async fn test_sequencer_commitment_threshold() {
             NodeMode::SequencerNode,
             sequencer_db_dir,
             da_db_dir_cloned,
-            1_000_000, // Put a large number for commitment threshold
+            min_soft_confirmations_per_commitment,
             true,
             None,
             Some(sequencer_config),

--- a/crates/sequencer/src/commitment_controller.rs
+++ b/crates/sequencer/src/commitment_controller.rs
@@ -49,6 +49,14 @@ pub fn get_commitment_info(
         return Ok(None);
     }
 
+    if l2_range_length >= min_soft_confirmations_per_commitment {
+        debug!("Enough soft confirmations to submit commitment");
+    }
+
+    if state_diff_threshold_reached {
+        debug!("State diff threshold reached. Committing...");
+    }
+
     debug!("L2 range to submit: {}..{}", l2_start, l2_end);
 
     Ok(Some(CommitmentInfo {

--- a/crates/sequencer/src/commitment_controller.rs
+++ b/crates/sequencer/src/commitment_controller.rs
@@ -27,7 +27,7 @@ pub fn get_commitment_info(
     // to commit.
     let last_committed_l2_height = ledger_db
         .get_last_sequencer_commitment_l2_height()?
-        .unwrap_or(BatchNumber(1));
+        .unwrap_or(BatchNumber(0));
 
     let Some((head_soft_batch_number, _)) = ledger_db.get_head_soft_batch()? else {
         // No soft batches have been created yet.

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -603,6 +603,8 @@ where
         let min_soft_confirmations_per_commitment =
             self.config.min_soft_confirmations_per_commitment;
 
+        println!("MIN SOFT CONF: {}", min_soft_confirmations_per_commitment);
+
         let commitment_info = commitment_controller::get_commitment_info(
             &self.ledger_db,
             min_soft_confirmations_per_commitment,
@@ -610,7 +612,6 @@ where
         )?;
 
         if let Some(commitment_info) = commitment_info {
-            debug!("Sequencer: enough soft confirmations to submit commitment");
             let l2_range_to_submit = commitment_info.l2_height_range.clone();
 
             // calculate exclusive range end

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -603,8 +603,6 @@ where
         let min_soft_confirmations_per_commitment =
             self.config.min_soft_confirmations_per_commitment;
 
-        println!("MIN SOFT CONF: {}", min_soft_confirmations_per_commitment);
-
         let commitment_info = commitment_controller::get_commitment_info(
             &self.ledger_db,
             min_soft_confirmations_per_commitment,

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -13,7 +13,7 @@ use tracing::instrument;
 use crate::rocks_db_config::gen_rocksdb_options;
 use crate::schema::tables::{
     BatchByHash, BatchByNumber, CommitmentsByNumber, EventByKey, EventByNumber, L2RangeByL1Height,
-    L2Witness, LastSequencerCommitmentSentL2, LastStateDiff, ProofBySlotNumber,
+    L2Witness, LastSequencerCommitmentSent, LastStateDiff, ProofBySlotNumber,
     ProverLastScannedSlot, SlotByHash, SlotByNumber, SoftBatchByHash, SoftBatchByNumber,
     SoftConfirmationStatus, TxByHash, TxByNumber, VerifiedProofsBySlotNumber, LEDGER_TABLES,
 };
@@ -462,7 +462,7 @@ impl LedgerDB {
         let mut schema_batch = SchemaBatch::new();
 
         schema_batch
-            .put::<LastSequencerCommitmentSentL2>(&(), &l2_height)
+            .put::<LastSequencerCommitmentSent>(&(), &l2_height)
             .unwrap();
         self.db.write_schemas(schema_batch)?;
 
@@ -530,7 +530,7 @@ impl LedgerDB {
     /// Returns L2 height.
     #[instrument(level = "trace", skip(self), err, ret)]
     pub fn get_last_sequencer_commitment_l2_height(&self) -> anyhow::Result<Option<BatchNumber>> {
-        self.db.get::<LastSequencerCommitmentSentL2>(&())
+        self.db.get::<LastSequencerCommitmentSent>(&())
     }
 
     /// Get L2 height range for a given L1 height.

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
@@ -59,7 +59,6 @@ pub const LEDGER_TABLES: &[&str] = &[
     L2Witness::table_name(),
     LastStateDiff::table_name(),
     LastSequencerCommitmentSent::table_name(),
-    LastSequencerCommitmentSentL2::table_name(),
     ProverLastScannedSlot::table_name(),
     BatchByHash::table_name(),
     BatchByNumber::table_name(),
@@ -264,12 +263,7 @@ define_table_with_default_codec!(
 
 define_table_with_seek_key_codec!(
     /// Sequencer uses this table to store the last commitment it sent
-    (LastSequencerCommitmentSent) () => SlotNumber
-);
-
-define_table_with_seek_key_codec!(
-    /// Sequencer uses this table to store the last commitment it sent
-    (LastSequencerCommitmentSentL2) () => BatchNumber
+    (LastSequencerCommitmentSent) () => BatchNumber
 );
 
 define_table_with_seek_key_codec!(


### PR DESCRIPTION
# Description

Simplifies commitment rules by removing L1 dependency and ruling to commit based on minimum soft confirmations per commitment and/or commitment threshold

## Linked Issues
- Fixes #856 

## TODOs:
- [x] Removing dependency on L1 related stuff in our commit/don't commit logic and controller.
- [x] Removing last committed l1 height table, and code where it's used.
- [x] This might affect some tests because with the new logic the sequencer might commit before the test expects :). But should be fairly easy to fix.
- [x] Simplify tests, we would not need the "publish L2, publish L1, publish L2" logic anymore.

The last TODO is partially done since the prover L1 / L2 sync was not separated so we still need to publish L1 / L2 blocks for the prover to prove commitments.