### PR TITLE
Suppress warning in bitcoin-da

### DIFF
--- a/crates/bitcoin-da/src/lib.rs
+++ b/crates/bitcoin-da/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 mod helpers;
 #[cfg(feature = "native")]
 mod rpc;


### PR DESCRIPTION
# Description

I am guessing that we do not want to remove the unused code for now, so this would suppress the warnings.

```
citrea-bitcoin-prover: warning: constant `REVEAL_OUTPUT_AMOUNT` is never used
citrea-bitcoin-prover:   --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/lib.rs:10:7
citrea-bitcoin-prover:    |
citrea-bitcoin-prover: 10 | const REVEAL_OUTPUT_AMOUNT: u64 = 546;
citrea-bitcoin-prover:    |       ^^^^^^^^^^^^^^^^^^^^
citrea-bitcoin-prover:    |
citrea-bitcoin-prover:    = note: `#[warn(dead_code)]` on by default
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: function `compress_blob` is never used
citrea-bitcoin-prover:   --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/helpers/builders.rs:33:8
citrea-bitcoin-prover:    |
citrea-bitcoin-prover: 33 | pub fn compress_blob(blob: &[u8]) -> Vec<u8> {
citrea-bitcoin-prover:    |        ^^^^^^^^^^^^^
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: function `sign_blob_with_private_key` is never used
citrea-bitcoin-prover:   --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/helpers/builders.rs:46:8
citrea-bitcoin-prover:    |
citrea-bitcoin-prover: 46 | pub fn sign_blob_with_private_key(
citrea-bitcoin-prover:    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: function `get_size` is never used
citrea-bitcoin-prover:   --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/helpers/builders.rs:61:4
citrea-bitcoin-prover:    |
citrea-bitcoin-prover: 61 | fn get_size(
citrea-bitcoin-prover:    |    ^^^^^^^^
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: function `choose_utxos` is never used
citrea-bitcoin-prover:   --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/helpers/builders.rs:91:4
citrea-bitcoin-prover:    |
citrea-bitcoin-prover: 91 | fn choose_utxos(
citrea-bitcoin-prover:    |    ^^^^^^^^^^^^
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: function `build_commit_transaction` is never used
citrea-bitcoin-prover:    --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/helpers/builders.rs:149:4
citrea-bitcoin-prover:     |
citrea-bitcoin-prover: 149 | fn build_commit_transaction(
citrea-bitcoin-prover:     |    ^^^^^^^^^^^^^^^^^^^^^^^^
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: function `build_reveal_transaction` is never used
citrea-bitcoin-prover:    --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/helpers/builders.rs:275:4
citrea-bitcoin-prover:     |
citrea-bitcoin-prover: 275 | fn build_reveal_transaction(
citrea-bitcoin-prover:     |    ^^^^^^^^^^^^^^^^^^^^^^^^
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: function `create_inscription_transactions` is never used
citrea-bitcoin-prover:    --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/helpers/builders.rs:345:8
citrea-bitcoin-prover:     |
citrea-bitcoin-prover: 345 | pub fn create_inscription_transactions(
citrea-bitcoin-prover:     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: function `write_reveal_tx` is never used
citrea-bitcoin-prover:    --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/helpers/builders.rs:543:8
citrea-bitcoin-prover:     |
citrea-bitcoin-prover: 543 | pub fn write_reveal_tx(tx: &[u8], tx_id: String) {
citrea-bitcoin-prover:     |        ^^^^^^^^^^^^^^^
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: function `parse_hex_transaction` is never used
citrea-bitcoin-prover:    --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/helpers/parsers.rs:187:8
citrea-bitcoin-prover:     |
citrea-bitcoin-prover: 187 | pub fn parse_hex_transaction(
citrea-bitcoin-prover:     |        ^^^^^^^^^^^^^^^^^^^^^
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: associated function `new` is never used
citrea-bitcoin-prover:   --> /home/rakan/Work/Chainway/citrea/crates/bitcoin-da/src/spec/proof.rs:15:19
citrea-bitcoin-prover:    |
citrea-bitcoin-prover: 14 | impl InclusionMultiProof {
citrea-bitcoin-prover:    | ------------------------ associated function in this implementation
citrea-bitcoin-prover: 15 |     pub(crate) fn new(
citrea-bitcoin-prover:    |                   ^^^
citrea-bitcoin-prover:
citrea-bitcoin-prover: warning: `bitcoin-da` (lib) generated 11 warnings
```