### PR TITLE
Fix commitment threshold test

### DIFF
--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -3284,7 +3284,7 @@ async fn test_full_node_sync_status() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sequencer_commitment_threshold() {
-    // citrea::initialize_logging(tracing::Level::DEBUG);
+    citrea::initialize_logging(tracing::Level::DEBUG);
 
     let storage_dir = tempdir_with_children(&["DA", "sequencer"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -1925,7 +1925,7 @@ fn find_subarray(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn sequencer_crash_and_replace_full_node() -> Result<(), anyhow::Error> {
-    citrea::initialize_logging(tracing::Level::DEBUG);
+    // citrea::initialize_logging(tracing::Level::DEBUG);
 
     let storage_dir = tempdir_with_children(&["DA", "sequencer", "full-node"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();
@@ -3286,7 +3286,7 @@ async fn test_full_node_sync_status() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sequencer_commitment_threshold() {
-    citrea::initialize_logging(tracing::Level::DEBUG);
+    // citrea::initialize_logging(tracing::Level::DEBUG);
 
     let storage_dir = tempdir_with_children(&["DA", "sequencer"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -1830,6 +1830,8 @@ async fn test_system_tx_effect_on_block_gas_limit() -> Result<(), anyhow::Error>
     let last_in_receipt = last_in_tx.unwrap().get_receipt().await.unwrap();
 
     wait_for_l2_block(&seq_test_client, 1, None).await;
+    // Wait for storage
+    sleep(Duration::from_secs(1)).await;
 
     let initial_soft_batch = seq_test_client
         .ledger_get_soft_batch_by_number::<MockDaSpec>(1)
@@ -3452,6 +3454,10 @@ async fn test_sequencer_fill_missing_da_blocks() -> Result<(), anyhow::Error> {
     // publish an extra l2 block
     seq_test_client.send_publish_batch_request().await;
     wait_for_l2_block(&seq_test_client, last_filler_l2_block + 1, None).await;
+
+    // Wait for storage
+    sleep(Duration::from_secs(1)).await;
+
     // ensure that the latest l2 block points to latest da block and has correct height
     let head_soft_batch = seq_test_client
         .ledger_get_head_soft_batch()

--- a/bin/citrea/tests/evm/archival_state.rs
+++ b/bin/citrea/tests/evm/archival_state.rs
@@ -16,7 +16,7 @@ use crate::{
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_archival_state() -> Result<(), anyhow::Error> {
-    // citrea::initialize_logging(tracing::Level::INFO);
+    citrea::initialize_logging(tracing::Level::DEBUG);
 
     let storage_dir = tempdir_with_children(&["DA", "sequencer", "full-node"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();

--- a/bin/citrea/tests/evm/archival_state.rs
+++ b/bin/citrea/tests/evm/archival_state.rs
@@ -16,7 +16,7 @@ use crate::{
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_archival_state() -> Result<(), anyhow::Error> {
-    citrea::initialize_logging(tracing::Level::DEBUG);
+    // citrea::initialize_logging(tracing::Level::DEBUG);
 
     let storage_dir = tempdir_with_children(&["DA", "sequencer", "full-node"]);
     let da_db_dir = storage_dir.path().join("DA").to_path_buf();


### PR DESCRIPTION
# Description
- Sequencer was not clearing state diffs properly which is why diff threshold test was failing.
- Some tests are failing because we've changed `wait_for_l2_block` from `get_eth_number` to `get_head_soft_batch_height` which blocks and might cause some delays being written to the filesystem.