### PR TITLE
Add genesis production mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,3 +110,7 @@ pr:
 # Set genesis from system contract source files
 genesis:
 	$(MAKE) -C crates/evm/src/evm/system_contracts genesis
+
+# Set production genesis from system contract source files
+genesis-prod:
+	$(MAKE) -C crates/evm/src/evm/system_contracts genesis-prod

--- a/crates/evm/src/evm/system_contracts/Makefile
+++ b/crates/evm/src/evm/system_contracts/Makefile
@@ -6,3 +6,6 @@ help: ## Display this help message
 # Set genesis from system contract source files
 genesis:
 	forge script script/GenesisGenerator.s.sol:GenesisGenerator --ffi
+
+genesis-prod:
+	forge script script/GenesisGenerator.s.sol:GenesisGenerator --ffi --sig "runProd()"

--- a/crates/evm/src/evm/system_contracts/script/GenesisToEvmJson.py
+++ b/crates/evm/src/evm/system_contracts/script/GenesisToEvmJson.py
@@ -1,8 +1,11 @@
 import json
 import sys
+import os
 
 with open(sys.argv[1], "r") as file:
     data = json.load(file)
+
+isProd = True if (sys.argv[3] == "true") else False
 
 # Sort the data by key
 data = {k: data[k] for k in sorted(data)}
@@ -20,7 +23,12 @@ for key in data:
 
 evm_json = {}
 evm_json["data"] = new_data
-evm_json["chain_id"] = 5655
+if not isProd:
+    evm_json["chain_id"] = 5655
+else:
+    if os.environ.get("CHAIN_ID") is None:
+        raise Exception("CHAIN_ID environment variable is not set")
+    evm_json["chain_id"] = os.getenv("CHAIN_ID")
 evm_json["limit_contract_code_size"] = None
 evm_json["spec"] = {"0": "SHANGHAI"}
 evm_json["coinbase"] = "0x3100000000000000000000000000000000000005"
@@ -47,11 +55,12 @@ paths = [
     "../../../../../resources/test-data/integration-tests-low-max-l2-blocks-per-l1/evm.json"
 ]
 
-for path in paths:
-    with open(path, "w") as file:
-        if path == "../../../../../resources/test-data/integration-tests-low-block-gas-limit/evm.json":
-            new_evm_json = evm_json.copy()
-            new_evm_json["block_gas_limit"] = 1500000
-            json.dump(new_evm_json, file, indent=2)
-            continue
-        json.dump(evm_json, file, indent=2)
+if not isProd:
+    for path in paths:
+        with open(path, "w") as file:
+            if path == "../../../../../resources/test-data/integration-tests-low-block-gas-limit/evm.json":
+                new_evm_json = evm_json.copy()
+                new_evm_json["block_gas_limit"] = 1500000
+                json.dump(new_evm_json, file, indent=2)
+                continue
+            json.dump(evm_json, file, indent=2)


### PR DESCRIPTION
# Description
Adds a production mode for genesis state generation scripts.

Differences from development mode:
- Does not give balance to testing addresses.
- Instead of setting the owner roles to a hardcoded address, expects environment variables `UPGRADE_OWNER`, `BRIDGE_OWNER` and `FEE_VAULT_OWNER`. `UPGRADE_OWNER` is the admin of the `ProxyAdmin` contract and thus has the authority to upgrade contracts, `BRIDGE_OWNER` has the ability to set the deposit script and the deposit processing operator address in `Bridge`, `FEE_VAULT_OWNER` and can set the minimum withdraw amount and the fee recipient of the fee vaults.
- Instead of setting the fee recipients of fee vaults to a hardcoded address, expects an environment variable `FEE_RECIPIENT`.
- Expects an environment variable `CHAIN_ID`.
- Optionally takes in the environment variable `PROD_JSON_PATH`, if no path is provided the default destination path for the generated production `evm.json` is `state/evmProd.json` under `system_contracts`.

# Related Issues
Fixes #872.