### PR TITLE
Sequencer scan L1 and resubmit mined commitments

### DIFF
--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -18,7 +18,7 @@ use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::services::da::{BlobWithNotifier, DaService};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use tokio::sync::oneshot::channel as oneshot_channel;
-use tracing::{error, info, instrument, trace};
+use tracing::{debug, error, info, instrument, trace};
 
 use crate::helpers::builders::{
     create_inscription_transactions, sign_blob_with_private_key, write_reveal_tx, TxWithId,
@@ -366,7 +366,7 @@ impl DaService for BitcoinService {
     // If no such block exists, block until one does.
     #[instrument(level = "trace", skip(self), err)]
     async fn get_block_at(&self, height: u64) -> Result<Self::FilteredBlock, Self::Error> {
-        info!("Getting block at height {}", height);
+        debug!("Getting block at height {}", height);
 
         let block_hash;
         loop {
@@ -437,7 +437,7 @@ impl DaService for BitcoinService {
         &self,
         block: &Self::FilteredBlock,
     ) -> Vec<<Self::Spec as sov_rollup_interface::da::DaSpec>::BlobTransaction> {
-        info!(
+        debug!(
             "Extracting relevant txs from block {:?}",
             block.header.block_hash()
         );

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -634,7 +634,7 @@ where
         let last_commitment_l1_height = self
             .ledger_db
             .get_last_sequencer_commitment_l1_height()?
-            .unwrap_or(SlotNumber(0));
+            .unwrap_or(SlotNumber(1));
         let mined_commitments = self
             .get_mined_commitments_from(last_commitment_l1_height)
             .await?;

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -622,12 +622,14 @@ where
 
     #[instrument(level = "trace", skip(self), err, ret)]
     pub async fn resubmit_pending_commitments(&mut self) -> anyhow::Result<()> {
+        info!("Resubmitting pending commitments");
+
         let pending_db_commitments = self.ledger_db.get_pending_commitments_l2_range()?;
         debug!("Pending db commitments: {:?}", pending_db_commitments);
 
         let pending_mempool_commitments = self.get_pending_mempool_commitments().await;
         debug!(
-            "Pending mempool commitments: {:?}",
+            "Commitments that are already in DA mempool: {:?}",
             pending_mempool_commitments
         );
 
@@ -638,7 +640,10 @@ where
         let mined_commitments = self
             .get_mined_commitments_from(last_commitment_l1_height)
             .await?;
-        debug!("Unsaved mined commitments: {:?}", mined_commitments);
+        debug!(
+            "Commitments that are already mined by DA: {:?}",
+            mined_commitments
+        );
 
         let mut pending_commitments_to_remove = vec![];
         pending_commitments_to_remove.extend(pending_mempool_commitments);

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -671,8 +671,6 @@ where
             }
         }
 
-        self.ledger_db.get_last_sequencer_commitment_l2_height()?;
-
         Ok(())
     }
 

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -633,7 +633,7 @@ where
 
         let last_commitment_l1_height = self
             .ledger_db
-            .get_last_sequencer_commitment_l1_height()?
+            .get_l1_height_of_last_commitment()?
             .unwrap_or(SlotNumber(1));
         let mined_commitments = self
             .get_mined_commitments_from(last_commitment_l1_height)

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -624,11 +624,29 @@ where
     pub async fn resubmit_pending_commitments(&mut self) -> anyhow::Result<()> {
         let pending_db_commitments = self.ledger_db.get_pending_commitments_l2_range()?;
         debug!("Pending db commitments: {:?}", pending_db_commitments);
-        let pending_da_commitments = self.get_pending_da_commitments().await;
-        debug!("Pending da commitments: {:?}", pending_da_commitments);
+
+        let pending_mempool_commitments = self.get_pending_mempool_commitments().await;
+        debug!(
+            "Pending mempool commitments: {:?}",
+            pending_mempool_commitments
+        );
+
+        let last_commitment_l1_height = self
+            .ledger_db
+            .get_last_sequencer_commitment_l1_height()?
+            .unwrap_or(SlotNumber(0));
+        let mined_commitments = self
+            .get_mined_commitments_from(last_commitment_l1_height)
+            .await?;
+        debug!("Unsaved mined commitments: {:?}", mined_commitments);
+
+        let mut pending_commitments_to_remove = vec![];
+        pending_commitments_to_remove.extend(pending_mempool_commitments);
+        pending_commitments_to_remove.extend(mined_commitments);
+
         // TODO: also take mined DA blocks into account
         for (l2_start, l2_end) in pending_db_commitments {
-            if pending_da_commitments.iter().any(|commitment| {
+            if pending_commitments_to_remove.iter().any(|commitment| {
                 commitment.l2_start_block_number == l2_start.0
                     && commitment.l2_end_block_number == l2_end.0
             }) {
@@ -652,6 +670,8 @@ where
                 self.submit_commitment(commitment_info, true).await?;
             }
         }
+
+        self.ledger_db.get_last_sequencer_commitment_l2_height()?;
 
         Ok(())
     }
@@ -763,7 +783,7 @@ where
         Ok(())
     }
 
-    async fn get_pending_da_commitments(&self) -> Vec<SequencerCommitment> {
+    async fn get_pending_mempool_commitments(&self) -> Vec<SequencerCommitment> {
         self.da_service
             .get_relevant_blobs_of_pending_transactions()
             .await
@@ -779,6 +799,42 @@ where
                 }
             })
             .collect()
+    }
+
+    async fn get_mined_commitments_from(
+        &self,
+        da_height: SlotNumber,
+    ) -> anyhow::Result<Vec<SequencerCommitment>> {
+        let head_da_height = self
+            .da_service
+            .get_head_block_header()
+            .await
+            .map_err(|e| anyhow!(e))?
+            .height();
+        let mut mined_commitments = vec![];
+        for height in da_height.0..=head_da_height {
+            let block = self
+                .da_service
+                .get_block_at(height)
+                .await
+                .map_err(|e| anyhow!(e))?;
+            let blobs = self.da_service.extract_relevant_blobs(&block);
+            let iter = blobs.into_iter().filter_map(|mut blob| {
+                match DaData::try_from_slice(blob.full_data()) {
+                    Ok(da_data) => match da_data {
+                        DaData::SequencerCommitment(commitment) => Some(commitment),
+                        _ => None,
+                    },
+                    Err(err) => {
+                        warn!("Pending transaction blob failed to be parsed: {}", err);
+                        None
+                    }
+                }
+            });
+            mined_commitments.extend(iter);
+        }
+
+        Ok(mined_commitments)
     }
 
     #[instrument(level = "trace", skip(self), err, ret)]

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -705,10 +705,9 @@ impl SequencerLedgerOps for LedgerDB {
         self.db.get::<LastSequencerCommitmentSent>(&())
     }
 
-    /// Get the most recent committed batch
-    /// Returns L1 height.
+    /// Get the most recent commitment's l1 height
     #[instrument(level = "trace", skip(self), err, ret)]
-    fn get_last_sequencer_commitment_l1_height(&self) -> anyhow::Result<Option<SlotNumber>> {
+    fn get_l1_height_of_last_commitment(&self) -> anyhow::Result<Option<SlotNumber>> {
         let l2_height = self.get_last_sequencer_commitment_l2_height()?;
         match l2_height {
             Some(l2_height) => {

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
@@ -213,4 +213,7 @@ pub trait SequencerLedgerOps: SharedLedgerOps {
     /// Get the most recent committed batch
     /// Returns L2 height.
     fn get_last_sequencer_commitment_l2_height(&self) -> anyhow::Result<Option<BatchNumber>>;
+
+    /// Get the most recent commitment's l1 height
+    fn get_last_sequencer_commitment_l1_height(&self) -> anyhow::Result<Option<SlotNumber>>;
 }

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
@@ -215,5 +215,5 @@ pub trait SequencerLedgerOps: SharedLedgerOps {
     fn get_last_sequencer_commitment_l2_height(&self) -> anyhow::Result<Option<BatchNumber>>;
 
     /// Get the most recent commitment's l1 height
-    fn get_last_sequencer_commitment_l1_height(&self) -> anyhow::Result<Option<SlotNumber>>;
+    fn get_l1_height_of_last_commitment(&self) -> anyhow::Result<Option<SlotNumber>>;
 }


### PR DESCRIPTION
# Description

We already had resubmission logic for commitments in local database. We also cross-checked whether if any pending marked commitments actually made it to mempool without sequencer being able to update its local database.

This PR adds also checks the potentially mined commitments. If a sequencer:
1. submitted a commitment
2. valid tx nonce is found and commitment submitted to DA
3. restarted right before it was able to update its local pending commitments database
4. during the off time of the restart, the commitment is mined and included in a block
this causes sequencer to double commit the same l2 heights, which is a gas expensive operation.

Now we check the last committed L1 height to the head L1 block to see if there was any commitments included and update their pending status if so. 

## Linked Issues
- Fixes #897 
