### PR TITLE
chore: Bitcoin RPC cleanup

### DIFF
--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -1,6 +1,7 @@
 use core::fmt::{Debug, Display};
 use core::str::FromStr;
 
+use anyhow::Result;
 use bitcoin::block::{Header, Version};
 use bitcoin::hash_types::{TxMerkleNode, WitnessMerkleNode};
 use bitcoin::hashes::Hash;
@@ -44,6 +45,7 @@ pub struct BitcoinNode {
     url: String,
     client: reqwest::Client,
 }
+
 impl BitcoinNode {
     #[instrument(level = "trace", ret)]
     pub fn new(url: String, username: String, password: String) -> Self {
@@ -105,7 +107,7 @@ impl BitcoinNode {
         &self,
         method: &str,
         params: Vec<serde_json::Value>,
-    ) -> Result<T, anyhow::Error> {
+    ) -> Result<T> {
         let mut attempt = 1;
         loop {
             match self.call_inner(method, &params).await {
@@ -130,18 +132,18 @@ impl BitcoinNode {
     }
 
     // get_block_count returns the current block height
-    pub async fn get_block_count(&self) -> Result<u64, anyhow::Error> {
+    pub async fn get_block_count(&self) -> Result<u64> {
         self.call::<u64>("getblockcount", vec![]).await
     }
 
     // get_block_hash returns the block hash of the block at the given height
-    pub async fn get_block_hash(&self, height: u64) -> Result<String, anyhow::Error> {
+    pub async fn get_block_hash(&self, height: u64) -> Result<String> {
         self.call::<String>("getblockhash", vec![to_value(height)?])
             .await
     }
 
     // get_best_blockhash returns the best blockhash of the chain
-    pub async fn get_best_blockhash(&self) -> Result<String, anyhow::Error> {
+    pub async fn get_best_blockhash(&self) -> Result<String> {
         self.call::<String>("getbestblockhash", vec![]).await
     }
 
@@ -158,14 +160,14 @@ impl BitcoinNode {
     }
 
     // get_block_header returns a particular block header with a given hash
-    pub async fn get_block_header(&self, hash: String) -> Result<HeaderWrapper, anyhow::Error> {
+    pub async fn get_block_header(&self, hash: String) -> Result<HeaderWrapper> {
         // The full block is requested here because txs_commitment is the witness root
         let full_block = self.get_block(hash).await?;
         Ok(full_block.header)
     }
 
     // get_block returns the block at the given hash
-    pub async fn get_block(&self, hash: String) -> Result<BitcoinBlock, anyhow::Error> {
+    pub async fn get_block(&self, hash: String) -> Result<BitcoinBlock> {
         let result = self
             .call::<Box<RawValue>>("getblock", vec![to_value(hash.clone())?, to_value(3)?])
             .await?
@@ -209,7 +211,7 @@ impl BitcoinNode {
     }
 
     // get_utxos returns all unspent transaction outputs for the wallets of bitcoind
-    pub async fn get_utxos(&self) -> Result<Vec<UTXO>, anyhow::Error> {
+    pub async fn get_utxos(&self) -> Result<Vec<UTXO>> {
         let utxos = self
             .call::<Vec<UTXO>>("listunspent", vec![to_value(0)?, to_value(9999999)?])
             .await?;
@@ -219,7 +221,7 @@ impl BitcoinNode {
 
     // estimate_smart_fee estimates the fee to confirm a transaction in the next block
     #[instrument(level = "trace", skip(self), err, ret)]
-    pub async fn estimate_smart_fee(&self) -> Result<f64, anyhow::Error> {
+    pub async fn estimate_smart_fee(&self) -> Result<f64> {
         let result = self
             .call::<Box<RawValue>>("estimatesmartfee", vec![to_value(1)?])
             .await?
@@ -242,7 +244,7 @@ impl BitcoinNode {
     pub async fn sign_raw_transaction_with_wallet(
         &self,
         tx: String,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<String> {
         let result = self
             .call::<Box<RawValue>>("signrawtransactionwithwallet", vec![to_value(tx)?])
             .await?
@@ -254,12 +256,12 @@ impl BitcoinNode {
     }
 
     // send_raw_transaction sends a raw transaction to the network
-    pub async fn send_raw_transaction(&self, tx: String) -> Result<String, anyhow::Error> {
+    pub async fn send_raw_transaction(&self, tx: String) -> Result<String> {
         self.call::<String>("sendrawtransaction", vec![to_value(tx)?])
             .await
     }
 
-    pub async fn list_wallets(&self) -> Result<Vec<String>, anyhow::Error> {
+    pub async fn list_wallets(&self) -> Result<Vec<String>> {
         let res = self.call::<Vec<String>>("listwallets", vec![]).await;
         match res {
             Ok(wallets) => Ok(wallets),
@@ -268,7 +270,7 @@ impl BitcoinNode {
     }
 
     /// Get unconfirmed utxos
-    pub async fn get_pending_utxos(&self) -> Result<Vec<ListUnspentEntry>, anyhow::Error> {
+    pub async fn get_pending_utxos(&self) -> Result<Vec<ListUnspentEntry>> {
         let utxos = self
             .call::<Vec<ListUnspentEntry>>("listunspent", vec![to_value(0)?, to_value(0)?])
             .await?;
@@ -277,7 +279,7 @@ impl BitcoinNode {
     }
 
     /// Get a raw transaction by its txid
-    pub async fn get_raw_transaction(&self, txid: String) -> Result<String, anyhow::Error> {
+    pub async fn get_raw_transaction(&self, txid: String) -> Result<String> {
         self.call::<String>("getrawtransaction", vec![to_value(txid)?])
             .await
     }

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -138,8 +138,7 @@ impl BitcoinNode {
 
     // get_block_hash returns the block hash of the block at the given height
     pub async fn get_block_hash(&self, height: u64) -> Result<BlockHash> {
-        self.call("getblockhash", vec![to_value(height)?])
-            .await
+        self.call("getblockhash", vec![to_value(height)?]).await
     }
 
     // get_best_blockhash returns the best blockhash of the chain
@@ -241,10 +240,7 @@ impl BitcoinNode {
     }
 
     // sign_raw_transaction_with_wallet signs a raw transaction with the wallet of bitcoind
-    pub async fn sign_raw_transaction_with_wallet(
-        &self,
-        tx: String,
-    ) -> Result<String> {
+    pub async fn sign_raw_transaction_with_wallet(&self, tx: String) -> Result<String> {
         let result = self
             .call::<Box<RawValue>>("signrawtransactionwithwallet", vec![to_value(tx)?])
             .await?
@@ -257,8 +253,7 @@ impl BitcoinNode {
 
     // send_raw_transaction sends a raw transaction to the network
     pub async fn send_raw_transaction(&self, tx: String) -> Result<Txid> {
-        self.call("sendrawtransaction", vec![to_value(tx)?])
-            .await
+        self.call("sendrawtransaction", vec![to_value(tx)?]).await
     }
 
     pub async fn list_wallets(&self) -> Result<Vec<String>> {
@@ -280,7 +275,6 @@ impl BitcoinNode {
 
     /// Get a raw transaction by its txid
     pub async fn get_raw_transaction(&self, txid: Txid) -> Result<String> {
-        self.call("getrawtransaction", vec![to_value(txid)?])
-            .await
+        self.call("getrawtransaction", vec![to_value(txid)?]).await
     }
 }

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -133,18 +133,18 @@ impl BitcoinNode {
 
     // get_block_count returns the current block height
     pub async fn get_block_count(&self) -> Result<u64> {
-        self.call::<u64>("getblockcount", vec![]).await
+        self.call("getblockcount", vec![]).await
     }
 
     // get_block_hash returns the block hash of the block at the given height
     pub async fn get_block_hash(&self, height: u64) -> Result<BlockHash> {
-        self.call::<BlockHash>("getblockhash", vec![to_value(height)?])
+        self.call("getblockhash", vec![to_value(height)?])
             .await
     }
 
     // get_best_blockhash returns the best blockhash of the chain
     pub async fn get_best_blockhash(&self) -> Result<BlockHash> {
-        self.call::<BlockHash>("getbestblockhash", vec![]).await
+        self.call("getbestblockhash", vec![]).await
     }
 
     fn calculate_witness_root(txdata: &[TransactionWrapper]) -> Option<WitnessMerkleNode> {
@@ -213,7 +213,7 @@ impl BitcoinNode {
     // get_utxos returns all unspent transaction outputs for the wallets of bitcoind
     pub async fn get_utxos(&self) -> Result<Vec<UTXO>> {
         let utxos = self
-            .call::<Vec<UTXO>>("listunspent", vec![to_value(0)?, to_value(9999999)?])
+            .call("listunspent", vec![to_value(0)?, to_value(9999999)?])
             .await?;
 
         Ok(utxos)
@@ -272,7 +272,7 @@ impl BitcoinNode {
     /// Get unconfirmed utxos
     pub async fn get_pending_utxos(&self) -> Result<Vec<ListUnspentEntry>> {
         let utxos = self
-            .call::<Vec<ListUnspentEntry>>("listunspent", vec![to_value(0)?, to_value(0)?])
+            .call("listunspent", vec![to_value(0)?, to_value(0)?])
             .await?;
 
         Ok(utxos)
@@ -280,7 +280,7 @@ impl BitcoinNode {
 
     /// Get a raw transaction by its txid
     pub async fn get_raw_transaction(&self, txid: Txid) -> Result<String> {
-        self.call::<String>("getrawtransaction", vec![to_value(txid)?])
+        self.call("getrawtransaction", vec![to_value(txid)?])
             .await
     }
 }

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -168,7 +168,7 @@ impl BitcoinNode {
     // get_block returns the block at the given hash
     pub async fn get_block(&self, hash: BlockHash) -> Result<BitcoinBlock> {
         let result = self
-            .call::<Box<RawValue>>("getblock", vec![to_value(hash.clone())?, to_value(3)?])
+            .call::<Box<RawValue>>("getblock", vec![to_value(hash)?, to_value(3)?])
             .await?
             .to_string();
 

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -237,7 +237,7 @@ impl BitcoinService {
         let mut scanned_txids = HashSet::new();
 
         for utxo in pending_utxos.iter() {
-            let txid = utxo.txid.clone();
+            let txid = utxo.txid;
             // Check if tx is already in the pending transactions vector
             if scanned_txids.contains(&txid) {
                 continue;
@@ -245,7 +245,7 @@ impl BitcoinService {
 
             let raw_tx = self
                 .client
-                .get_raw_transaction(txid.clone())
+                .get_raw_transaction(txid)
                 .await
                 .expect("Transaction should exist with existing utxo");
             let parsed_tx = parse_hex_transaction(&raw_tx).expect("Rpc tx should be parsable");

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -555,7 +555,7 @@ impl DaService for BitcoinService {
 
         let hash = BlockHash::from_byte_array(hash);
 
-        let block = self.client.get_block(hash.to_string()).await?;
+        let block = self.client.get_block(hash).await?;
         Ok(block)
     }
 

--- a/crates/bitcoin-da/src/spec/utxo.rs
+++ b/crates/bitcoin-da/src/spec/utxo.rs
@@ -49,7 +49,7 @@ impl<'de> serde::Deserialize<'de> for UTXO {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListUnspentEntry {
-    pub txid: String,
+    pub txid: Txid,
     pub vout: u64,
     pub address: String,
     pub label: Option<String>,


### PR DESCRIPTION
# Description

- Consistent use of `anyhow::Result`
- Use type inference 
- Stricter type usage

# Notes:

Have we considered using a library such as like https://github.com/rust-bitcoin/rust-bitcoincore-rpc/ instead of re-implementing it ourselves ? It comes with a few footguns we will need to be mindful of 