### PR TITLE
RISC0 guest read optimization

### DIFF
--- a/bin/citrea/src/lib.rs
+++ b/bin/citrea/src/lib.rs
@@ -22,6 +22,7 @@ pub fn initialize_logging(level: Level) {
             "hyper=info".to_owned(),
             "alloy_transport_http=info".to_owned(),
             // Limit output as much as possible, use WARN.
+            "[executor]=info".to_owned(), // risc0 guest code stats logging
             "risc0_zkvm=warn".to_owned(),
             "risc0_circuit_rv32im=info".to_owned(),
             "guest_execution=info".to_owned(),

--- a/crates/risc0-bonsai/src/host.rs
+++ b/crates/risc0-bonsai/src/host.rs
@@ -372,12 +372,12 @@ impl<'a> ZkvmHost for Risc0BonsaiHost<'a> {
 
             let session = executor.run()?;
             // don't delete useful while benchmarking
-            println!(
-                "user cycles: {}\ntotal cycles: {}\nsegments: {}",
-                session.user_cycles,
-                session.total_cycles,
-                session.segments.len()
-            );
+            // println!(
+            //     "user cycles: {}\ntotal cycles: {}\nsegments: {}",
+            //     session.user_cycles,
+            //     session.total_cycles,
+            //     session.segments.len()
+            // );
             let data = bincode::serialize(&session.journal.expect("Journal shouldn't be empty"))?;
 
             Ok(Proof::PublicInput(data))

--- a/crates/risc0-bonsai/src/host.rs
+++ b/crates/risc0-bonsai/src/host.rs
@@ -325,15 +325,13 @@ impl<'a> Risc0BonsaiHost<'a> {
         }
     }
 
-    fn add_hint_bonsai<T: BorshSerialize>(&mut self, item: T) {
-        // For running in "prove" mode.
-
-        // Prepare input data and upload it.
-        let client = self.client.as_ref().unwrap();
-        let buf = borsh::to_vec(&item).expect("Risc0 hint serialization is infallible");
-
+    fn upload_to_bonsai(&mut self, buf: Vec<u8>) {
         // handle error
-        let input_id = client.upload_input(buf);
+        let input_id = self
+            .client
+            .as_ref()
+            .expect("Bonsai client is not initialized")
+            .upload_input(buf);
         tracing::info!("Uploaded input with id: {}", input_id);
         self.last_input_id = Some(input_id);
     }
@@ -350,7 +348,7 @@ impl<'a> ZkvmHost for Risc0BonsaiHost<'a> {
         self.env.extend_from_slice(&buf);
 
         if self.client.is_some() {
-            self.add_hint_bonsai(item)
+            self.upload_to_bonsai(buf);
         }
     }
 

--- a/crates/risc0-bonsai/src/host.rs
+++ b/crates/risc0-bonsai/src/host.rs
@@ -287,7 +287,7 @@ impl BonsaiClient {
 #[derive(Clone)]
 pub struct Risc0BonsaiHost<'a> {
     elf: &'a [u8],
-    env: Vec<u32>,
+    env: Vec<u8>,
     image_id: Digest,
     client: Option<BonsaiClient>,
     last_input_id: Option<String>,
@@ -330,13 +330,7 @@ impl<'a> Risc0BonsaiHost<'a> {
 
         // Prepare input data and upload it.
         let client = self.client.as_ref().unwrap();
-
-        let mut buf = borsh::to_vec(&item).expect("Risc0 hint serialization is infallible");
-        // append [0..] alignment to cast &[u8] to &[u32]
-        let rem = buf.len() % 4;
-        if rem > 0 {
-            buf.extend(vec![0; 4 - rem]);
-        }
+        let buf = borsh::to_vec(&item).expect("Risc0 hint serialization is infallible");
 
         // handle error
         let input_id = client.upload_input(buf);
@@ -351,15 +345,9 @@ impl<'a> ZkvmHost for Risc0BonsaiHost<'a> {
     fn add_hint<T: BorshSerialize>(&mut self, item: T) {
         // For running in "execute" mode.
 
-        let mut buf = borsh::to_vec(&item).expect("Risc0 hint serialization is infallible");
-        // append [0..] alignment to cast &[u8] to &[u32]
-        let rem = buf.len() % 4;
-        if rem > 0 {
-            buf.extend(vec![0; 4 - rem]);
-        }
-        let buf: &[u32] = bytemuck::cast_slice(&buf);
+        let buf = borsh::to_vec(&item).expect("Risc0 hint serialization is infallible");
         // write buf
-        self.env.extend_from_slice(buf);
+        self.env.extend_from_slice(&buf);
 
         if self.client.is_some() {
             self.add_hint_bonsai(item)
@@ -384,12 +372,12 @@ impl<'a> ZkvmHost for Risc0BonsaiHost<'a> {
 
             let session = executor.run()?;
             // don't delete useful while benchmarking
-            // println!(
-            //     "user cycles: {}\ntotal cycles: {}\nsegments: {}",
-            //     session.user_cycles,
-            //     session.total_cycles,
-            //     session.segments.len()
-            // );
+            println!(
+                "user cycles: {}\ntotal cycles: {}\nsegments: {}",
+                session.user_cycles,
+                session.total_cycles,
+                session.segments.len()
+            );
             let data = bincode::serialize(&session.journal.expect("Journal shouldn't be empty"))?;
 
             Ok(Proof::PublicInput(data))

--- a/crates/sovereign-sdk/adapters/risc0/src/guest/zkvm.rs
+++ b/crates/sovereign-sdk/adapters/risc0/src/guest/zkvm.rs
@@ -18,16 +18,9 @@ impl Risc0Guest {
 
 impl ZkvmGuest for Risc0Guest {
     fn read_from_host<T: BorshDeserialize>(&self) -> T {
-        // read len(u64) in LE
-        let mut len_buf = [0u8; 8];
-        env::read_slice(&mut len_buf);
-        let len = u64::from_le_bytes(len_buf);
-        // read buf
-        let mut buf: Vec<u32> = vec![0; len as usize];
-        env::read_slice(&mut buf);
-        let slice: &[u8] = bytemuck::cast_slice(&buf);
+        let mut reader = env::stdin();
         // deserialize
-        BorshDeserialize::deserialize(&mut &*slice).expect("Failed to deserialize input from host")
+        BorshDeserialize::deserialize_reader(&mut reader).expect("Failed to deserialize input from host")
     }
 
     fn commit<T: BorshSerialize>(&self, item: &T) {

--- a/crates/sovereign-sdk/adapters/risc0/src/guest/zkvm.rs
+++ b/crates/sovereign-sdk/adapters/risc0/src/guest/zkvm.rs
@@ -20,7 +20,8 @@ impl ZkvmGuest for Risc0Guest {
     fn read_from_host<T: BorshDeserialize>(&self) -> T {
         let mut reader = env::stdin();
         // deserialize
-        BorshDeserialize::deserialize_reader(&mut reader).expect("Failed to deserialize input from host")
+        BorshDeserialize::deserialize_reader(&mut reader)
+            .expect("Failed to deserialize input from host")
     }
 
     fn commit<T: BorshSerialize>(&self, item: &T) {

--- a/crates/sovereign-sdk/adapters/risc0/src/host.rs
+++ b/crates/sovereign-sdk/adapters/risc0/src/host.rs
@@ -73,7 +73,7 @@ impl<'a> ZkvmHost for Risc0Host<'a> {
     fn add_hint<T: BorshSerialize>(&mut self, item: T) {
         let buf = borsh::to_vec(&item).expect("Risc0 hint serialization is infallible");
         // write buf
-        self.env.extend_from_slice(&buf);
+        self.env.extend(buf);
     }
 
     fn simulate_with_hints(&mut self) -> Self::Guest {


### PR DESCRIPTION
# Description

When sending data from host to guest, we are length prefixing the data at the host, and allocating the whole data at once when reading back at the guest.

Instead of this, implementing a reader proved to be a more efficient solution in terms of cycles. You can see the #876 about the details of the cycle improvement.

To see the code to test the cycles in isolation (where the only operation is ser-de), see #941 

## Linked Issues
- Fixes #876 
