### PR TITLE
chore: fix Citrea STF README

### DIFF
--- a/crates/citrea-stf/README.md
+++ b/crates/citrea-stf/README.md
@@ -4,7 +4,7 @@ This is the State Transition Function crate for the Citrea rollup.
 
 The Citrea State Transition Function consists of 3 modules:
 - [EVM](../../evm/README.md): Used for handling EVM functionality.
-- [sov-accounts](../../../sovereign-sdk/module-system/module-implementations/sov-accounts/README.md): Used for checking the sequencer's nonce.
+- [sov-accounts](../../sovereign-sdk/module-system/module-implementations/sov-accounts/README.md): Used for checking the sequencer's nonce.
 - [Soft Confirmation Rule Enforcer](../soft-confirmation-rule-enforcer/README.md): Used for enforcing Citrea's soft confirmation rules.
 
 

--- a/crates/citrea-stf/README.md
+++ b/crates/citrea-stf/README.md
@@ -5,7 +5,7 @@ This is the State Transition Function crate for the Citrea rollup.
 The Citrea State Transition Function consists of 3 modules:
 - [EVM](../evm/README.md): Used for handling EVM functionality.
 - [sov-accounts](../sovereign-sdk/module-system/module-implementations/sov-accounts/README.md): Used for checking the sequencer's nonce.
-- [Soft Confirmation Rule Enforcer](../soft-confirmation-rule-enforcer/README.md): Used for enforcing Citrea's soft confirmation rules.
+- [Soft Confirmation Rule Enforcer](../soft-confirmation-rule-enforcer/README.md): Used for enforcing Citrea's soft confirmation rules..
 
-crates/sovereign-sdk/module-system/module-implementations/sov-accounts/README.md
+
 Through applying transaction/blob/soft confirmation hooks (see [`hooks_impl.rs`](./src/hooks_impl.rs)), it runs the rollup via the [`Runtime`](./src/runtime.rs).

--- a/crates/citrea-stf/README.md
+++ b/crates/citrea-stf/README.md
@@ -3,9 +3,9 @@
 This is the State Transition Function crate for the Citrea rollup.
 
 The Citrea State Transition Function consists of 3 modules:
-- [EVM](../../evm/README.md): Used for handling EVM functionality.
-- [sov-accounts](../../sovereign-sdk/module-system/module-implementations/sov-accounts/README.md): Used for checking the sequencer's nonce.
+- [EVM](../evm/README.md): Used for handling EVM functionality.
+- [sov-accounts](../sovereign-sdk/module-system/module-implementations/sov-accounts/README.md): Used for checking the sequencer's nonce.
 - [Soft Confirmation Rule Enforcer](../soft-confirmation-rule-enforcer/README.md): Used for enforcing Citrea's soft confirmation rules.
 
-
+crates/sovereign-sdk/module-system/module-implementations/sov-accounts/README.md
 Through applying transaction/blob/soft confirmation hooks (see [`hooks_impl.rs`](./src/hooks_impl.rs)), it runs the rollup via the [`Runtime`](./src/runtime.rs).

--- a/crates/citrea-stf/README.md
+++ b/crates/citrea-stf/README.md
@@ -5,7 +5,7 @@ This is the State Transition Function crate for the Citrea rollup.
 The Citrea State Transition Function consists of 3 modules:
 - [EVM](../../evm/README.md): Used for handling EVM functionality.
 - [sov-accounts](../../../sovereign-sdk/module-system/module-implementations/sov-accounts/README.md): Used for checking the sequencer's nonce.
-- [Soft Confirmation Rule Enforcer](../../soft-confirmation-rule-enforcer/README.md): Used for enforcing Citrea's soft confirmation rules.
+- [Soft Confirmation Rule Enforcer](../soft-confirmation-rule-enforcer/README.md): Used for enforcing Citrea's soft confirmation rules.
 
 
 Through applying transaction/blob/soft confirmation hooks (see [`hooks_impl.rs`](./src/hooks_impl.rs)), it runs the rollup via the [`Runtime`](./src/runtime.rs).


### PR DESCRIPTION
# Description
This pull request fixes the README links for the State Transition function crate so they point to the correct modules. 

## Testing
The updates involved documentation links; therefore, no code execution changes were tested. Please review the updated links.

## Docs
The changes are within the `crates/citrea-stf/README.md` file.
