### PR TITLE
Fix Prove mode serialization panic

### DIFF
--- a/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
+++ b/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
@@ -135,15 +135,12 @@ impl<ValidityCond: ValidityCondition> sov_rollup_interface::zk::Zkvm for MockZkv
         Ok(&serialized_proof[33..])
     }
 
-    fn verify_and_extract_output<
-        Da: sov_rollup_interface::da::DaSpec,
-        Root: serde::Serialize + serde::de::DeserializeOwned,
-    >(
+    fn verify_and_extract_output<Da: sov_rollup_interface::da::DaSpec, Root: BorshDeserialize>(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
     ) -> Result<sov_rollup_interface::zk::StateTransition<Da, Root>, Self::Error> {
         let output = Self::verify(serialized_proof, code_commitment)?;
-        Ok(bincode::deserialize(output)?)
+        Ok(BorshDeserialize::deserialize(&mut &*output)?)
     }
 }
 
@@ -216,10 +213,7 @@ impl sov_rollup_interface::zk::Zkvm for MockZkGuest {
         unimplemented!()
     }
 
-    fn verify_and_extract_output<
-        Da: sov_rollup_interface::da::DaSpec,
-        Root: Serialize + serde::de::DeserializeOwned,
-    >(
+    fn verify_and_extract_output<Da: sov_rollup_interface::da::DaSpec, Root: BorshDeserialize>(
         _serialized_proof: &[u8],
         _code_commitment: &Self::CodeCommitment,
     ) -> Result<sov_rollup_interface::zk::StateTransition<Da, Root>, Self::Error> {

--- a/crates/sovereign-sdk/adapters/risc0/src/guest/mod.rs
+++ b/crates/sovereign-sdk/adapters/risc0/src/guest/mod.rs
@@ -3,8 +3,7 @@
 //!  for host(native) and guest(zkvm) part.
 //! The host implementation is used for tests only and brings no real value.
 
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use borsh::BorshDeserialize;
 use sov_rollup_interface::zk::Zkvm;
 
 use crate::Risc0MethodId;
@@ -37,10 +36,7 @@ impl Zkvm for Risc0Guest {
         todo!("Implement once risc0 supports recursion: https://github.com/Sovereign-Labs/sovereign-sdk/issues/633")
     }
 
-    fn verify_and_extract_output<
-        Da: sov_rollup_interface::da::DaSpec,
-        Root: Serialize + DeserializeOwned,
-    >(
+    fn verify_and_extract_output<Da: sov_rollup_interface::da::DaSpec, Root: BorshDeserialize>(
         _serialized_proof: &[u8],
         _code_commitment: &Self::CodeCommitment,
     ) -> Result<sov_rollup_interface::zk::StateTransition<Da, Root>, Self::Error> {

--- a/crates/sovereign-sdk/adapters/risc0/src/host.rs
+++ b/crates/sovereign-sdk/adapters/risc0/src/host.rs
@@ -2,8 +2,6 @@
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use risc0_zkvm::{ExecutorEnvBuilder, ExecutorImpl, InnerReceipt, Journal, Receipt, Session};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use sov_rollup_interface::zk::{Proof, Zkvm, ZkvmHost};
 
 use crate::guest::Risc0Guest;
@@ -121,15 +119,12 @@ impl<'host> Zkvm for Risc0Host<'host> {
         verify_from_slice(serialized_proof, code_commitment)
     }
 
-    fn verify_and_extract_output<
-        Da: sov_rollup_interface::da::DaSpec,
-        Root: Serialize + DeserializeOwned,
-    >(
+    fn verify_and_extract_output<Da: sov_rollup_interface::da::DaSpec, Root: BorshDeserialize>(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
     ) -> Result<sov_rollup_interface::zk::StateTransition<Da, Root>, Self::Error> {
         let output = Self::verify(serialized_proof, code_commitment)?;
-        Ok(risc0_zkvm::serde::from_slice(output)?)
+        Ok(BorshDeserialize::deserialize(&mut &*output)?)
     }
 }
 
@@ -148,15 +143,12 @@ impl Zkvm for Risc0Verifier {
         verify_from_slice(serialized_proof, code_commitment)
     }
 
-    fn verify_and_extract_output<
-        Da: sov_rollup_interface::da::DaSpec,
-        Root: Serialize + DeserializeOwned,
-    >(
+    fn verify_and_extract_output<Da: sov_rollup_interface::da::DaSpec, Root: BorshDeserialize>(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
     ) -> Result<sov_rollup_interface::zk::StateTransition<Da, Root>, Self::Error> {
         let output = Self::verify(serialized_proof, code_commitment)?;
-        Ok(risc0_zkvm::serde::from_slice(output)?)
+        Ok(BorshDeserialize::deserialize(&mut &*output)?)
     }
 }
 

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
@@ -75,7 +75,7 @@ pub trait Zkvm: Send + Sync {
     /// Same as [`verify`](Zkvm::verify), except that instead of returning the output
     /// as a serialized array, it returns a state transition structure.
     /// TODO: specify a deserializer for the output
-    fn verify_and_extract_output<Da: DaSpec, Root: Serialize + DeserializeOwned>(
+    fn verify_and_extract_output<Da: DaSpec, Root: BorshDeserialize>(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
     ) -> Result<StateTransition<Da, Root>, Self::Error>;


### PR DESCRIPTION
# Description

We are committing the data as borsh serialized. But in the `verify_and_extract_output` method, we were not decoding using borsh decode, which caused panic when deserializing the `StateTransition` committed from the guest. This PR fixes this.

## Linked Issues
- Fixes #948

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
