### PR TITLE
Keep bitcoincore-rpc behind native feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-rpc"
 version = "0.18.0"
-source = "git+https://github.com/jfldde/rust-bitcoincore-rpc.git?rev=5527a8d#5527a8df4bde0f2154e8fe3cb2c661bd3ed27286"
+source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=5527a8d#5527a8df4bde0f2154e8fe3cb2c661bd3ed27286"
 dependencies = [
  "async-trait",
  "bitcoincore-rpc-json",
@@ -1278,7 +1278,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-rpc-json"
 version = "0.18.0"
-source = "git+https://github.com/jfldde/rust-bitcoincore-rpc.git?rev=5527a8d#5527a8df4bde0f2154e8fe3cb2c661bd3ed27286"
+source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=5527a8d#5527a8df4bde0f2154e8fe3cb2c661bd3ed27286"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,4 +178,4 @@ sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8
 # crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 secp256k1_v028 = { package = "secp256k1", version = "0.28", git = "https://github.com/Sovereign-Labs/rust-secp256k1.git", branch = "risc0-compatible-0-28-2" }
 k256 = { package = "k256", version = "0.13.3", git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
-bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/jfldde/rust-bitcoincore-rpc.git", rev = "5527a8d" }
+bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "5527a8d" }

--- a/bin/citrea/provers/risc0/guest-bitcoin/Cargo.lock
+++ b/bin/citrea/provers/risc0/guest-bitcoin/Cargo.lock
@@ -537,12 +537,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -627,7 +621,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitcoin",
- "bitcoincore-rpc",
  "borsh",
  "brotli",
  "futures",
@@ -657,30 +650,6 @@ dependencies = [
  "bitcoin-internals",
  "hex-conservative",
  "serde",
-]
-
-[[package]]
-name = "bitcoincore-rpc"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb70725a621848c83b3809913d5314c0d20ca84877d99dd909504b564edab00"
-dependencies = [
- "bitcoincore-rpc-json",
- "jsonrpc",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "bitcoincore-rpc-json"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856ffbee2e492c23bca715d72ea34aae80d58400f2bda26a82015d6bc2ec3662"
-dependencies = [
- "bitcoin",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1897,17 +1866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonrpc"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8128f36b47411cd3f044be8c1f5cc0c9e24d1d1bfdc45f0a57897b32513053f2"
-dependencies = [
- "base64 0.13.1",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/crates/bitcoin-da/Cargo.toml
+++ b/crates/bitcoin-da/Cargo.toml
@@ -31,7 +31,7 @@ bitcoin = { workspace = true }
 brotli = { workspace = true }
 futures.workspace = true
 
-bitcoincore-rpc.workspace = true
+bitcoincore-rpc = { workspace = true, optional = true }
 
 [features]
 default = []
@@ -40,4 +40,5 @@ native = [
   "dep:pin-project",
   "dep:tracing",
   "sov-rollup-interface/native",
+  "dep:bitcoincore-rpc"
 ]

--- a/crates/bitcoin-da/src/spec/utxo.rs
+++ b/crates/bitcoin-da/src/spec/utxo.rs
@@ -1,5 +1,6 @@
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Txid};
+#[cfg(feature = "native")]
 use bitcoincore_rpc::json::ListUnspentResultEntry;
 use serde::{Deserialize, Serialize};
 
@@ -15,6 +16,7 @@ pub struct UTXO {
     pub solvable: bool,
 }
 
+#[cfg(feature = "native")]
 impl From<ListUnspentResultEntry> for UTXO {
     fn from(v: ListUnspentResultEntry) -> Self {
         Self {


### PR DESCRIPTION
# Description

- Target https://github.com/chainwayxyz/rust-bitcoincore-rpc repository
- Keep `bitcoincore-rpc` behind native feature
- Prevents `guest-bitcoin` from importing `bitcoincore-rpc` and overriding dependencies
