### PR TITLE
Add dprint to make lints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ endif
 
 lint:  ## cargo check and clippy. Skip clippy on guest code since it's not supported by risc0
 	## fmt first, because it's the cheapest
+	dprint check
 	cargo +nightly fmt --all --check
 	cargo check --all-targets --all-features
 	$(MAKE) check-fuzz


### PR DESCRIPTION
# Description

- Add dprint to lint-fix
- Would prevent such https://github.com/chainwayxyz/citrea/pull/956 PR
- Uses `dprint` as it is already part of `install-dev-tools`