### PR TITLE
RISC0 guest optimization: Compiler parameter optimizations & Lower memory copies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,16 +2416,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rustc_version 0.4.0",
  "subtle",
  "zeroize",
@@ -5769,12 +5768,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "plotters"

--- a/bin/citrea/provers/risc0/guest-bitcoin/Cargo.lock
+++ b/bin/citrea/provers/risc0/guest-bitcoin/Cargo.lock
@@ -2185,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "platforms"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
+checksum = "0e4c7666f2019727f9e8e14bf14456e99c707d780922869f1ba473eee101fa49"
 
 [[package]]
 name = "powerfmt"

--- a/bin/citrea/provers/risc0/guest-bitcoin/Cargo.toml
+++ b/bin/citrea/provers/risc0/guest-bitcoin/Cargo.toml
@@ -33,19 +33,9 @@ lto = true
 opt-level = 3
 codegen-units = 1
 
-[profile.dev.build-override]
-debug = 0
-opt-level = 3
-codegen-units = 1
-
 [profile.release]
 debug = 0
 lto = true
-opt-level = 3
-codegen-units = 1
-
-[profile.release.build-override]
-debug = 0
 opt-level = 3
 codegen-units = 1
 

--- a/bin/citrea/provers/risc0/guest-bitcoin/Cargo.toml
+++ b/bin/citrea/provers/risc0/guest-bitcoin/Cargo.toml
@@ -28,17 +28,26 @@ secp256k1_v028 = { package = "secp256k1", version = "0.28", git = "https://githu
 k256 = { package = "k256", version = "0.13.3", git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
 
 [profile.dev]
+debug = 0
+lto = true
 opt-level = 3
+codegen-units = 1
 
 [profile.dev.build-override]
+debug = 0
 opt-level = 3
+codegen-units = 1
 
 [profile.release]
-debug = 1
+debug = 0
 lto = true
+opt-level = 3
+codegen-units = 1
 
 [profile.release.build-override]
+debug = 0
 opt-level = 3
+codegen-units = 1
 
 [features]
 bench = [

--- a/bin/citrea/provers/risc0/guest-bitcoin/Cargo.toml
+++ b/bin/citrea/provers/risc0/guest-bitcoin/Cargo.toml
@@ -27,12 +27,6 @@ crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag
 secp256k1_v028 = { package = "secp256k1", version = "0.28", git = "https://github.com/Sovereign-Labs/rust-secp256k1.git", branch = "risc0-compatible-0-28-2" }
 k256 = { package = "k256", version = "0.13.3", git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
 
-[profile.dev]
-debug = 0
-lto = true
-opt-level = 3
-codegen-units = 1
-
 [profile.release]
 debug = 0
 lto = true

--- a/bin/citrea/provers/risc0/guest-mock/Cargo.toml
+++ b/bin/citrea/provers/risc0/guest-mock/Cargo.toml
@@ -25,12 +25,6 @@ crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag
 secp256k1_v028 = { package = "secp256k1", version = "0.28", git = "https://github.com/Sovereign-Labs/rust-secp256k1.git", branch = "risc0-compatible-0-28-2" }
 k256 = { package = "k256", version = "0.13.3", git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
 
-[profile.dev]
-debug = 0
-lto = true
-opt-level = 3
-codegen-units = 1
-
 [profile.release]
 debug = 0
 lto = true

--- a/bin/citrea/provers/risc0/guest-mock/Cargo.toml
+++ b/bin/citrea/provers/risc0/guest-mock/Cargo.toml
@@ -26,17 +26,26 @@ secp256k1_v028 = { package = "secp256k1", version = "0.28", git = "https://githu
 k256 = { package = "k256", version = "0.13.3", git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
 
 [profile.dev]
+debug = 0
+lto = true
 opt-level = 3
+codegen-units = 1
 
 [profile.dev.build-override]
+debug = 0
 opt-level = 3
+codegen-units = 1
 
 [profile.release]
-debug = 1
+debug = 0
 lto = true
+opt-level = 3
+codegen-units = 1
 
 [profile.release.build-override]
+debug = 0
 opt-level = 3
+codegen-units = 1
 
 [features]
 bench = [

--- a/bin/citrea/provers/risc0/guest-mock/Cargo.toml
+++ b/bin/citrea/provers/risc0/guest-mock/Cargo.toml
@@ -31,19 +31,9 @@ lto = true
 opt-level = 3
 codegen-units = 1
 
-[profile.dev.build-override]
-debug = 0
-opt-level = 3
-codegen-units = 1
-
 [profile.release]
 debug = 0
 lto = true
-opt-level = 3
-codegen-units = 1
-
-[profile.release.build-override]
-debug = 0
 opt-level = 3
 codegen-units = 1
 

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -139,7 +139,7 @@ impl DaVerifier for BitcoinVerifier {
                     let wtxids = inclusion_proof
                         .wtxids
                         .iter()
-                        .map(|wtxid| Txid::from_slice(wtxid).unwrap());
+                        .map(|wtxid| Txid::from_byte_array(*wtxid));
 
                     let merkle_root = merkle_tree::calculate_root(wtxids).unwrap();
 
@@ -254,7 +254,7 @@ impl DaVerifier for BitcoinVerifier {
         let tx_hashes = inclusion_proof
             .txids
             .iter()
-            .map(|txid| Txid::from_slice(txid).unwrap());
+            .map(|txid| Txid::from_byte_array(*txid));
 
         if let Some(root_from_inclusion) = merkle_tree::calculate_root(tx_hashes) {
             let root_from_inclusion = root_from_inclusion.to_raw_hash().to_byte_array();

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -97,10 +97,13 @@ impl DaVerifier for BitcoinVerifier {
         // check that wtxid's of transactions in completeness proof are included in the InclusionMultiProof
         // and are in the same order as in the completeness proof
         let mut iter = inclusion_proof.wtxids.iter();
-        completeness_proof.iter().all(|tx| {
+        let is_wtxs_found_in_proof = completeness_proof.iter().all(|tx| {
             let wtxid = tx.wtxid();
             iter.any(|y| y == wtxid.as_byte_array())
         });
+        if !is_wtxs_found_in_proof {
+            return Err(ValidationError::IncorrectInclusionProof);
+        }
 
         // verify that one of the outputs of the coinbase transaction has script pub key starting with 0x6a24aa21a9ed,
         // and the rest of the script pub key is the commitment of witness data.

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -254,8 +254,8 @@ impl DaVerifier for BitcoinVerifier {
         // Inclusion proof is all the txs in the block.
         let tx_hashes = inclusion_proof
             .txids
-            .iter()
-            .map(|txid| Txid::from_byte_array(*txid));
+            .into_iter()
+            .map(Txid::from_byte_array);
 
         if let Some(root_from_inclusion) = merkle_tree::calculate_root(tx_hashes) {
             let root_from_inclusion = root_from_inclusion.to_raw_hash().to_byte_array();

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -96,12 +96,10 @@ impl DaVerifier for BitcoinVerifier {
 
         // check that wtxid's of transactions in completeness proof are included in the InclusionMultiProof
         // and are in the same order as in the completeness proof
+        let mut iter = inclusion_proof.wtxids.iter();
         completeness_proof.iter().all(|tx| {
             let wtxid = tx.wtxid();
-            inclusion_proof
-                .wtxids
-                .iter()
-                .any(|y| y == wtxid.as_byte_array())
+            iter.any(|y| y == wtxid.as_byte_array())
         });
 
         // verify that one of the outputs of the coinbase transaction has script pub key starting with 0x6a24aa21a9ed,

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -13,6 +13,8 @@ use crate::helpers::compression::decompress_blob;
 use crate::helpers::parsers::parse_transaction;
 use crate::spec::BitcoinSpec;
 
+pub const WITNESS_COMMITMENT_PREFIX: &[u8] = &[0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+
 pub struct BitcoinVerifier {
     rollup_name: String,
     reveal_tx_id_prefix: Vec<u8>,
@@ -188,7 +190,7 @@ impl DaVerifier for BitcoinVerifier {
                 output
                     .script_pubkey
                     .as_bytes()
-                    .starts_with(&[0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed])
+                    .starts_with(WITNESS_COMMITMENT_PREFIX)
             });
             match commitment_idx {
                 // If commitmet does not exist
@@ -284,7 +286,7 @@ mod tests {
     use crate::spec::proof::InclusionMultiProof;
     use crate::spec::transaction::TransactionWrapper;
     use crate::spec::RollupParams;
-    use crate::verifier::{ChainValidityCondition, ValidationError};
+    use crate::verifier::{ChainValidityCondition, ValidationError, WITNESS_COMMITMENT_PREFIX};
 
     #[test]
     fn correct() {
@@ -342,7 +344,7 @@ mod tests {
             output
                 .script_pubkey
                 .to_bytes()
-                .starts_with(&[0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed])
+                .starts_with(WITNESS_COMMITMENT_PREFIX)
         });
         assert!(idx.is_none());
 
@@ -500,7 +502,7 @@ mod tests {
                 output
                     .script_pubkey
                     .to_bytes()
-                    .starts_with(&[0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed])
+                    .starts_with(WITNESS_COMMITMENT_PREFIX)
             })
             .unwrap();
 

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -97,12 +97,12 @@ impl DaVerifier for BitcoinVerifier {
         // check that wtxid's of transactions in completeness proof are included in the InclusionMultiProof
         // and are in the same order as in the completeness proof
         let mut iter = inclusion_proof.wtxids.iter();
-        let is_wtxs_found_in_proof = completeness_proof.iter().all(|tx| {
+        let is_wtxs_found_in_block = completeness_proof.iter().all(|tx| {
             let wtxid = tx.wtxid();
             iter.any(|y| y == wtxid.as_byte_array())
         });
-        if !is_wtxs_found_in_proof {
-            return Err(ValidationError::IncorrectInclusionProof);
+        if !is_wtxs_found_in_block {
+            return Err(ValidationError::RelevantTxNotFoundInBlock);
         }
 
         // verify that one of the outputs of the coinbase transaction has script pub key starting with 0x6a24aa21a9ed,

--- a/crates/citrea-stf/src/verifier.rs
+++ b/crates/citrea-stf/src/verifier.rs
@@ -37,6 +37,7 @@ where
         zkvm: Zk,
         pre_state: Stf::PreState,
     ) -> Result<(), Da::Error> {
+        // don't delete useful for debugging
         // println!("Running sequencer commitments in DA slot");
         let data: StateTransitionData<Stf::StateRoot, _, Da::Spec> = zkvm.read_from_host();
         let validity_condition = self.da_verifier.verify_relevant_tx_list(
@@ -46,6 +47,7 @@ where
             data.completeness_proof,
         )?;
 
+        // don't delete useful for debugging
         // println!("going into apply_soft_confirmations_from_sequencer_commitments");
         let (final_state_root, state_diff) = self
             .app
@@ -63,6 +65,7 @@ where
                 data.soft_confirmations,
             );
 
+        // don't delete useful for debugging
         // println!("out of apply_soft_confirmations_from_sequencer_commitments");
         assert_eq!(
             final_state_root.as_ref(),

--- a/crates/citrea-stf/src/verifier.rs
+++ b/crates/citrea-stf/src/verifier.rs
@@ -37,7 +37,7 @@ where
         zkvm: Zk,
         pre_state: Stf::PreState,
     ) -> Result<(), Da::Error> {
-        println!("Running sequencer commitments in DA slot");
+        // println!("Running sequencer commitments in DA slot");
         let data: StateTransitionData<Stf::StateRoot, _, Da::Spec> = zkvm.read_from_host();
         let validity_condition = self.da_verifier.verify_relevant_tx_list(
             &data.da_block_header_of_commitments,
@@ -46,7 +46,7 @@ where
             data.completeness_proof,
         )?;
 
-        println!("going into apply_soft_confirmations_from_sequencer_commitments");
+        // println!("going into apply_soft_confirmations_from_sequencer_commitments");
         let (final_state_root, state_diff) = self
             .app
             .apply_soft_confirmations_from_sequencer_commitments(
@@ -63,7 +63,7 @@ where
                 data.soft_confirmations,
             );
 
-        println!("out of apply_soft_confirmations_from_sequencer_commitments");
+        // println!("out of apply_soft_confirmations_from_sequencer_commitments");
         assert_eq!(
             final_state_root.as_ref(),
             data.final_state_root.as_ref(),

--- a/crates/citrea-stf/src/verifier.rs
+++ b/crates/citrea-stf/src/verifier.rs
@@ -37,8 +37,7 @@ where
         zkvm: Zk,
         pre_state: Stf::PreState,
     ) -> Result<(), Da::Error> {
-        // don't delete useful for debugging
-        // println!("Running sequencer commitments in DA slot");
+        println!("Running sequencer commitments in DA slot");
         let data: StateTransitionData<Stf::StateRoot, _, Da::Spec> = zkvm.read_from_host();
         let validity_condition = self.da_verifier.verify_relevant_tx_list(
             &data.da_block_header_of_commitments,
@@ -47,8 +46,7 @@ where
             data.completeness_proof,
         )?;
 
-        // don't delete useful for debugging
-        // println!("going into apply_soft_confirmations_from_sequencer_commitments");
+        println!("going into apply_soft_confirmations_from_sequencer_commitments");
         let (final_state_root, state_diff) = self
             .app
             .apply_soft_confirmations_from_sequencer_commitments(
@@ -65,8 +63,7 @@ where
                 data.soft_confirmations,
             );
 
-        // don't delete useful for debugging
-        // println!("out of apply_soft_confirmations_from_sequencer_commitments");
+        println!("out of apply_soft_confirmations_from_sequencer_commitments");
         assert_eq!(
             final_state_root.as_ref(),
             data.final_state_root.as_ref(),

--- a/crates/risc0-bonsai/src/host.rs
+++ b/crates/risc0-bonsai/src/host.rs
@@ -368,12 +368,12 @@ impl<'a> ZkvmHost for Risc0BonsaiHost<'a> {
 
             let session = executor.run()?;
             // don't delete useful while benchmarking
-            // println!(
-            //     "user cycles: {}\ntotal cycles: {}\nsegments: {}",
-            //     session.user_cycles,
-            //     session.total_cycles,
-            //     session.segments.len()
-            // );
+            println!(
+                "user cycles: {}\ntotal cycles: {}\nsegments: {}",
+                session.user_cycles,
+                session.total_cycles,
+                session.segments.len()
+            );
             let data = bincode::serialize(&session.journal.expect("Journal shouldn't be empty"))?;
 
             Ok(Proof::PublicInput(data))

--- a/crates/risc0-bonsai/src/host.rs
+++ b/crates/risc0-bonsai/src/host.rs
@@ -370,12 +370,12 @@ impl<'a> ZkvmHost for Risc0BonsaiHost<'a> {
 
             let session = executor.run()?;
             // don't delete useful while benchmarking
-            println!(
-                "user cycles: {}\ntotal cycles: {}\nsegments: {}",
-                session.user_cycles,
-                session.total_cycles,
-                session.segments.len()
-            );
+            // println!(
+            //     "user cycles: {}\ntotal cycles: {}\nsegments: {}",
+            //     session.user_cycles,
+            //     session.total_cycles,
+            //     session.segments.len()
+            // );
             let data = bincode::serialize(&session.journal.expect("Journal shouldn't be empty"))?;
 
             Ok(Proof::PublicInput(data))

--- a/crates/risc0-bonsai/src/host.rs
+++ b/crates/risc0-bonsai/src/host.rs
@@ -412,6 +412,15 @@ impl<'a> ZkvmHost for Risc0BonsaiHost<'a> {
                         .expect("API error, missing receipt on completed session");
 
                     tracing::info!("Receipt URL: {}", receipt_url);
+                    if let Some(stats) = res.stats {
+                        tracing::info!(
+                            "User cycles: {} - Total cycles: {} - Segments: {}",
+                            stats.cycles,
+                            stats.total_cycles,
+                            stats.segments,
+                        );
+                    }
+
                     let receipt_buf = client.download(receipt_url);
 
                     let receipt: Receipt = bincode::deserialize(&receipt_buf).unwrap();

--- a/crates/risc0-bonsai/src/host.rs
+++ b/crates/risc0-bonsai/src/host.rs
@@ -14,7 +14,7 @@ use risc0_zkvm::{
 };
 use sov_risc0_adapter::guest::Risc0Guest;
 use sov_rollup_interface::zk::{Proof, Zkvm, ZkvmHost};
-use tracing::{debug, error, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 /// Requests to bonsai client. Each variant represents its own method.
 #[derive(Clone)]
@@ -342,6 +342,8 @@ impl<'a> ZkvmHost for Risc0BonsaiHost<'a> {
         // For running in "execute" mode.
 
         let buf = borsh::to_vec(&item).expect("Risc0 hint serialization is infallible");
+        info!("Added hint to guest with size {}", buf.len());
+
         // write buf
         self.env.extend_from_slice(&buf);
 

--- a/docs/run.md
+++ b/docs/run.md
@@ -3,10 +3,13 @@
 This document covers how to run Citrea sequencer and a full node locally using a mock DA layer and Bitcoin Regtest.
 
 ## Prerequisites
+
 Follow the instructions in [this document.](./dev-setup.md)
 
 ## Building and running
+
 Build citrea:
+
 ```sh
 make build
 ```
@@ -21,12 +24,15 @@ If running Postgres is prefered, you can execute the following command:
 docker compose -f docker-compose.postgres.yml up -d
 
 ```
+
 this will run postgres in a dockerized daemon mode.
 
 ### Run on Mock DA
+
 Run on a local da layer, sharable between nodes that run on your computer.
 
 Run sequencer on Mock DA:
+
 ```sh
 ./target/debug/citrea --da-layer mock --rollup-config-path resources/configs/mock/sequencer_rollup_config.toml --sequencer-config-path resources/configs/mock/sequencer_config.toml --genesis-paths resources/genesis/mock/
 ```
@@ -34,6 +40,7 @@ Run sequencer on Mock DA:
 Sequencer RPC is accessible at `127.0.0.1:12345`
 
 _Optional_: Run full node on Mock DA:
+
 ```sh
 ./target/debug/citrea --rollup-config-path resources/configs/mock/sequencer_rollup_config.toml --genesis-paths resources/test-data/demo-tests/mock
 ```
@@ -41,6 +48,7 @@ _Optional_: Run full node on Mock DA:
 Full node RPC is accessible at `127.0.0.1:12346`
 
 If test_mode is set to false in the sequencer config, the sequencer will publish blocks every 2 seconds. To also publish mock DA blocks, run this script:
+
 ```sh
 ./configs/mock-dockerized/publish_da_block.sh
 ```
@@ -50,18 +58,22 @@ If test_mode is set to false in the sequencer config, the sequencer will publish
 Run on local Bitcoin network.
 
 Run Bitcoin Regtest:
+
 ```sh
 bitcoind -regtest -txindex=1
 ```
+
 Keep this terminal open.
 
 Create bitcoin wallet for Bitcoin DA adapter.
+
 ```sh
 bitcoin-cli -regtest createwallet citreatesting
 bitcoin-cli -regtest loadwallet citreatesting
 ```
 
 Mine blocks so that the wallet has BTC:
+
 ```sh
 bitcoin-cli -regtest -generate 201
 ```
@@ -74,11 +86,12 @@ Edit `resources/configs/bitcoin-regtest/sequencer_rollup_config.toml` and `resou
 node_url = ""
 # fill here
 node_username = ""
-# fill here                                       
+# fill here
 node_password = ""
 ```
 
 Run sequencer:
+
 ```sh
 ./target/debug/citrea --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/sequencer_rollup_config.toml --sequencer-config-path resources/configs/bitcoin-regtest/sequencer_config.toml --genesis-paths resources/genesis/bitcoin-regtest/
 ```
@@ -88,16 +101,25 @@ Sequencer RPC is accessible at `127.0.0.1:12345`
 _Optional_: Run full node
 
 Run full node:
+
 ```sh
 ./target/debug/citrea --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/rollup_config.toml --genesis-paths resources/genesis/bitcoin-regtest/
 ```
 
 Full node RPC is accessible at `127.0.0.1:12346`
 
+_Optional_: Run prover:
+
+```sh
+./target/debug/citrea --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/prover_rollup_config.toml --prover-config-path resources/configs/bitcoin-regtest/prover_config.toml --genesis-paths resources/genesis/bitcoin-regtest
+```
+
+If you want to test proofs, make sure to set `proof_sampling_number` in `resources/configs/bitcion-regtest/prover_config.toml` to 0, and you can lower the `min_soft_confirmations_per_commitment` to a number between 5-50, as higher numbers than that takes too long even if you run the prover in execute mode.
+
 To publish blocks on Bitcoin Regtest, run the sequencer with `test_mode` in sequencer config set to false and blocks will be published every two seconds.
 
-
 To delete sequencer or full nodes databases run:
+
 ```sh
 make clean-node
 ```
@@ -105,7 +127,9 @@ make clean-node
 ## Testing
 
 To run tests:
+
 ```sh
 make test
 ```
+
 This will run [`cargo nextest`](https://nexte.st).


### PR DESCRIPTION
# Description

Introduced optimizations to RISC0 guest code. Here are the results:

**Testing runs with 10 blocks within a proof**

**nightly**
data size: 296637
user cycles: 52044801
total cycles: 82313216
segments: 79

**+ compiler optimizations**
data size: 297619
user cycles: 49478904
total cycles: 78643200
segments: 75

**+ lower mem copies in BitcoinVerifier**
data size: 298711
user cycles: 49470336
total cycles: 78118912
segments: 75

**+ BTreeSet instead of HashSet in BitcoinVerifier**
data size: 297440
user cycles: 49278291
total cycles: 77856768
segments: 75

*NOTE:*
- BTreeSet is suggested to be used by RISC0 docs. Lower mem copies and BTreeSet didn't provide big optimizations. But I believe that is because these tests were run against empty blocks with no transaction. Hence there was nothing to very little to copy anyways. Despite that it can be seen that they still provided very little improvement.
- Also this PR fixes a bug as well. If you check the following piece of code
```rs
let mut iter = inclusion_proof.wtxids.iter();
completeness_proof
            .iter()
            .all(|tx| iter.any(|&y| y == tx.wtxid().to_byte_array()));
```
you can see that the output of the `completeness_proof_iter().all(...)` is unused, so even if it returns false, the execution continues. The fix is to zip the txid and wtxids in inclusion proof, and searching for that exact tx in completeness proof.

## Linked Issues
- Related to #945 

## Testing
- Run BitcoinDA in regtest mode
- Run sequencer and prover
- Wait until a commitment is created and prover proves it