### PR TITLE
Fix empty l2 block having one tx

### DIFF
--- a/bin/citrea/tests/e2e/sequencer_behaviour.rs
+++ b/bin/citrea/tests/e2e/sequencer_behaviour.rs
@@ -306,7 +306,7 @@ async fn transaction_failing_on_l1_is_removed_from_mempool() -> Result<(), anyho
 
     assert_eq!(block.transactions.len(), 0);
     assert!(tx_from_mempool.is_none());
-    assert_eq!(soft_confirmation.txs.unwrap().len(), 1); // TODO: if we can also remove the tx from soft confirmation, that'd be very efficient
+    assert_eq!(soft_confirmation.txs.unwrap().len(), 0);
 
     wait_for_l2_block(&full_node_test_client, block.header.number.unwrap(), None).await;
 

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -445,20 +445,23 @@ where
             (Ok(()), mut batch_workspace) => {
                 let mut txs = vec![];
                 let mut tx_receipts = vec![];
-                
+
                 let evm_txs_count = txs_to_run.len();
                 if evm_txs_count > 0 {
                     let call_txs = CallMessage { txs: txs_to_run };
                     let raw_message =
-                        <Runtime<C, Da::Spec> as EncodeCall<citrea_evm::Evm<C>>>::encode_call(call_txs);
+                        <Runtime<C, Da::Spec> as EncodeCall<citrea_evm::Evm<C>>>::encode_call(
+                            call_txs,
+                        );
                     let signed_blob = self.make_blob(raw_message, &mut batch_workspace)?;
                     txs.push(signed_blob);
 
-                    let (apply_batch_workspace, apply_tx_receipts) = self.stf.apply_soft_confirmation_txs(
-                        self.fork_manager.active_fork(),
-                        txs.clone(),
-                        batch_workspace,
-                    );
+                    let (apply_batch_workspace, apply_tx_receipts) =
+                        self.stf.apply_soft_confirmation_txs(
+                            self.fork_manager.active_fork(),
+                            txs.clone(),
+                            batch_workspace,
+                        );
                     batch_workspace = apply_batch_workspace;
                     tx_receipts = apply_tx_receipts;
                 }

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -456,14 +456,11 @@ where
                     let signed_blob = self.make_blob(raw_message, &mut batch_workspace)?;
                     txs.push(signed_blob);
 
-                    let (apply_batch_workspace, apply_tx_receipts) =
-                        self.stf.apply_soft_confirmation_txs(
-                            self.fork_manager.active_fork(),
-                            txs.clone(),
-                            batch_workspace,
-                        );
-                    batch_workspace = apply_batch_workspace;
-                    tx_receipts = apply_tx_receipts;
+                    (batch_workspace, tx_receipts) = self.stf.apply_soft_confirmation_txs(
+                        self.fork_manager.active_fork(),
+                        txs.clone(),
+                        batch_workspace,
+                    );
                 }
 
                 // create the unsigned batch with the txs then sign th sc

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -443,18 +443,25 @@ where
             &mut signed_batch,
         ) {
             (Ok(()), mut batch_workspace) => {
+                let mut txs = vec![];
+                let mut tx_receipts = vec![];
+                
                 let evm_txs_count = txs_to_run.len();
-                let call_txs = CallMessage { txs: txs_to_run };
-                let raw_message =
-                    <Runtime<C, Da::Spec> as EncodeCall<citrea_evm::Evm<C>>>::encode_call(call_txs);
-                let signed_blob = self.make_blob(raw_message, &mut batch_workspace)?;
-                let txs = vec![signed_blob.clone()];
+                if evm_txs_count > 0 {
+                    let call_txs = CallMessage { txs: txs_to_run };
+                    let raw_message =
+                        <Runtime<C, Da::Spec> as EncodeCall<citrea_evm::Evm<C>>>::encode_call(call_txs);
+                    let signed_blob = self.make_blob(raw_message, &mut batch_workspace)?;
+                    txs.push(signed_blob);
 
-                let (batch_workspace, tx_receipts) = self.stf.apply_soft_confirmation_txs(
-                    self.fork_manager.active_fork(),
-                    txs.clone(),
-                    batch_workspace,
-                );
+                    let (apply_batch_workspace, apply_tx_receipts) = self.stf.apply_soft_confirmation_txs(
+                        self.fork_manager.active_fork(),
+                        txs.clone(),
+                        batch_workspace,
+                    );
+                    batch_workspace = apply_batch_workspace;
+                    tx_receipts = apply_tx_receipts;
+                }
 
                 // create the unsigned batch with the txs then sign th sc
                 let unsigned_batch = UnsignedSoftConfirmationBatch::new(


### PR DESCRIPTION
# Description

I observed when debugging prover that, every block had always 1 transaction, even though I didn't push any. It seems that we create a CallMessage even if the inner evm txs is empty. This PR should prevent meaningless tx to be pushed into empty l2 blocks.

