### PR TITLE
Check SKIP_GUEST_BUILD value

### DIFF
--- a/bin/citrea/provers/risc0/build.rs
+++ b/bin/citrea/provers/risc0/build.rs
@@ -7,28 +7,39 @@ fn main() {
     println!("cargo:rerun-if-env-changed=REPR_GUEST_BUILD");
     println!("cargo:rerun-if-env-changed=OUT_DIR");
 
-    match std::env::var("SKIP_GUEST_BUILD").as_deref() {
-        Ok("1") | Ok("true") => {
-            println!("cargo:warning=Skipping guest build");
-            let out_dir = std::env::var_os("OUT_DIR").unwrap();
-            let out_dir = std::path::Path::new(&out_dir);
-            let methods_path = out_dir.join("methods.rs");
+    match std::env::var("SKIP_GUEST_BUILD") {
+        Ok(value) => match value.as_str() {
+            "1" | "true" => {
+                println!("cargo:warning=Skipping guest build");
+                let out_dir = std::env::var_os("OUT_DIR").unwrap();
+                let out_dir = std::path::Path::new(&out_dir);
+                let methods_path = out_dir.join("methods.rs");
 
-            let elf = r#"
-            pub const BITCOIN_DA_ELF: &[u8] = &[];
-            pub const MOCK_DA_ELF: &[u8] = &[];
-            pub const BITCOIN_DA_ID: [u32; 8] = [0u32; 8];
-            pub const MOCK_DA_ID: [u32; 8] = [0u32; 8];
-        "#;
+                let elf = r#"
+                pub const BITCOIN_DA_ELF: &[u8] = &[];
+                pub const MOCK_DA_ELF: &[u8] = &[];
+                pub const BITCOIN_DA_ID: [u32; 8] = [0u32; 8];
+                pub const MOCK_DA_ID: [u32; 8] = [0u32; 8];
+                "#;
 
-            std::fs::write(methods_path, elf).expect("Failed to write mock rollup elf");
+                return std::fs::write(methods_path, elf).expect("Failed to write mock rollup elf");
+            }
+            "0" | "false" => {
+                println!("cargo:warning=Performing guest build");
+            }
+            _ => {
+                println!("cargo:warning=Invalid value for SKIP_GUEST_BUILD: '{}'. Expected '0', '1', 'true', or 'false'. Defaulting to performing guest build.", value);
+            }
+        },
+        Err(std::env::VarError::NotPresent) => {
+            println!("cargo:warning=SKIP_GUEST_BUILD not set. Performing guest build.");
         }
-        Ok("0") | Ok("false") | Err(std::env::VarError::NotPresent) | _ => {
-            println!("cargo:warning=Performing guest build");
-            let guest_pkg_to_options = get_guest_options();
-            embed_methods_with_options(guest_pkg_to_options);
+        Err(std::env::VarError::NotUnicode(_)) => {
+            println!("cargo:warning=SKIP_GUEST_BUILD contains invalid Unicode. Defaulting to performing guest build.");
         }
     }
+    let guest_pkg_to_options = get_guest_options();
+    embed_methods_with_options(guest_pkg_to_options);
 }
 
 fn get_guest_options() -> HashMap<&'static str, risc0_build::GuestOptions> {


### PR DESCRIPTION
# Description

- Current behaviour does not check for the inside Ok(value). It will skip guest build for `SKIP_GUEST_BUILD=false` and `SKIP_GUEST_BUILD=0`.