### PR TITLE
Fix flaky tests & configure retries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.default]
+slow-timeout = "3m" # Mark slow tests after exceeding 3 minutes
+retries = 2 # A flaky test is retried a total of 3 times.

--- a/bin/citrea/tests/evm/archival_state.rs
+++ b/bin/citrea/tests/evm/archival_state.rs
@@ -123,13 +123,13 @@ async fn run_archival_valid_tests(addr: Address, seq_test_client: &TestClient) {
         0
     );
 
-    for _ in 0..8 {
+    for i in 1..=8 {
         let _t = seq_test_client
             .send_eth(addr, None, None, None, 1u128)
             .await;
         seq_test_client.send_publish_batch_request().await;
+        wait_for_l2_block(seq_test_client, i, None).await;
     }
-    wait_for_l2_block(seq_test_client, 8, None).await;
 
     // Wait for changeset storage
     sleep(Duration::from_secs(2)).await;
@@ -158,7 +158,7 @@ async fn run_archival_valid_tests(addr: Address, seq_test_client: &TestClient) {
         8
     );
 
-    for i in 1..8 {
+    for i in 1..=8 {
         assert_eq!(
             seq_test_client
                 .eth_get_balance(addr, Some(BlockNumberOrTag::Number(i)))

--- a/bin/citrea/tests/evm/gas_price.rs
+++ b/bin/citrea/tests/evm/gas_price.rs
@@ -108,7 +108,7 @@ async fn execute(
         }
     }
     client.send_publish_batch_request().await;
-    wait_for_l2_block(client, block_index, None).await;
+    wait_for_l2_block(client, block_index, Some(Duration::from_secs(60))).await;
     block_index += 1;
 
     // send 15 transactions from each wallet
@@ -122,7 +122,7 @@ async fn execute(
         }
     }
     client.send_publish_batch_request().await;
-    wait_for_l2_block(client, block_index, None).await;
+    wait_for_l2_block(client, block_index, Some(Duration::from_secs(60))).await;
     block_index += 1;
 
     let block = client.eth_get_block_by_number(None).await;


### PR DESCRIPTION
# Description

Added a nextest config file for retrying flaky tests a total of 3 times per test.

Fixed:
- `test_archival_state`
- `test_gas_price_increase`