### PR TITLE
Remove end 0 from rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.79"
 components = ["rustfmt", "rust-src", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
# Description

For some reason, when installed rust toolchain is installed as 1.79.0, it doesn't work with Darwin binaries. when it is converted to 1.79, it works.