### PR TITLE
Adjust diff size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-sol-types",
  "anyhow",
+ "bcs",
  "borsh",
  "bytes",
  "citrea-primitives",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -47,6 +47,7 @@ secp256k1 = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["consensus", "providers", "signers", "signer-local"] }
+bcs ={ workspace = true }
 bytes = { workspace = true }
 lazy_static = "1.4.0"
 rand = { workspace = true }

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -47,7 +47,7 @@ secp256k1 = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["consensus", "providers", "signers", "signer-local"] }
-bcs ={ workspace = true }
+bcs = { workspace = true }
 bytes = { workspace = true }
 lazy_static = "1.4.0"
 rand = { workspace = true }

--- a/crates/evm/src/evm/handler.rs
+++ b/crates/evm/src/evm/handler.rs
@@ -450,6 +450,9 @@ fn calc_diff_size<EXT, DB: Database>(
     let slot_size = 2 * size_of::<U256>(); // key + value;
     let mut diff_size = 0usize;
     let db_account_size = 256;
+    // Normally db account key is: 24 bytes of prefix + 1 byte for size of remaining data + 20 bytes of address = 45 bytes
+    // But we already add address size to diff size, so we don't need to add it here
+    let db_account_key_size = 25;
 
     // no matter the type of transaction or its fee rates, a tx must pay at least base fee and L1 fee
     // thus we increment the diff size by 20 (coinbase address) + 32 (coinbase balance change)
@@ -468,6 +471,7 @@ fn calc_diff_size<EXT, DB: Database>(
 
             // All the nonce, balance and code_hash fields are updated and written to the state with DbAccount
             diff_size += db_account_size; // DbAccount size
+            diff_size += db_account_key_size; // DbAccount key size
 
             // Retrieve code from DB and apply its size
             if let Some(info) = db.basic(*addr)? {
@@ -485,6 +489,7 @@ fn calc_diff_size<EXT, DB: Database>(
             // DbAccount size is added because when any of those changes the db account is written to the state
             // because these fields are part of the account info and not state values
             diff_size += db_account_size;
+            diff_size += db_account_key_size; // DbAccount key size
         }
 
         // Apply size of changed slots

--- a/crates/evm/src/evm/handler.rs
+++ b/crates/evm/src/evm/handler.rs
@@ -417,6 +417,7 @@ fn calc_diff_size<EXT, DB: Database>(
                 account.account_info_changed = true;
             }
             JournalEntry::BalanceTransfer { from, to, .. } => {
+                // No need to check balance for 0 value sent, revm does not add it to the journal
                 let from = account_changes.entry(from).or_default();
                 from.account_info_changed = true;
                 let to = account_changes.entry(to).or_default();

--- a/crates/evm/src/evm/handler.rs
+++ b/crates/evm/src/evm/handler.rs
@@ -480,14 +480,10 @@ fn calc_diff_size<EXT, DB: Database>(
             continue;
         }
 
-        // Apply size of changed nonce
-        if account.nonce_changed {
-            diff_size += size_of::<u64>(); // Nonces are u64
-        }
-
-        // Apply size of changed balances
-        if account.balance_changed {
-            diff_size += size_of::<U256>(); // Balances are U256
+        if account.nonce_changed || account.balance_changed || account.code_changed {
+            // DbAccount size is added because when any of those changes the db account is written to the state
+            // because these fields are part of the account info and not state values
+            diff_size += 256;
         }
 
         // Apply size of changed slots
@@ -496,7 +492,7 @@ fn calc_diff_size<EXT, DB: Database>(
         // Apply size of changed codes
         if account.code_changed {
             let account = &state[addr];
-            diff_size += size_of::<B256>(); // Code hashes are B256
+
             if let Some(code) = account.info.code.as_ref() {
                 diff_size += code.len()
             } else {

--- a/crates/evm/src/tests/call_tests.rs
+++ b/crates/evm/src/tests/call_tests.rs
@@ -118,7 +118,7 @@ fn call_multiple_test() {
                 },
                 gas_used: 132943,
                 log_index_start: 0,
-                l1_diff_size: 973,
+                l1_diff_size: 1023,
             },
             Receipt {
                 receipt: reth_primitives::Receipt {
@@ -221,7 +221,7 @@ fn call_test() {
                 },
                 gas_used: 132943,
                 log_index_start: 0,
-                l1_diff_size: 973,
+                l1_diff_size: 1023,
             },
             Receipt {
                 receipt: reth_primitives::Receipt {
@@ -910,7 +910,7 @@ fn test_l1_fee_success() {
                 },
                 gas_used: 114235,
                 log_index_start: 0,
-                l1_diff_size: 885,
+                l1_diff_size: 935,
             },]
         )
     }
@@ -927,11 +927,11 @@ fn test_l1_fee_success() {
     );
     run_tx(
         1,
-        U256::from(100000000000000u64 - gas_fee_paid * 10000001 - 885),
+        U256::from(100000000000000u64 - gas_fee_paid * 10000001 - 935),
         // priority fee goes to coinbase
         U256::from(gas_fee_paid),
         U256::from(gas_fee_paid * 10000000),
-        U256::from(885),
+        U256::from(935),
     );
 }
 
@@ -1069,7 +1069,7 @@ fn test_l1_fee_halt() {
                 },
                 gas_used: 106947,
                 log_index_start: 0,
-                l1_diff_size: 853,
+                l1_diff_size: 903,
             },
             Receipt {
                 receipt: reth_primitives::Receipt {
@@ -1091,7 +1091,7 @@ fn test_l1_fee_halt() {
         .unwrap();
 
     let expenses = 1106947_u64 * 10000000 + // evm gas
-        853  + // l1 contract deploy fee
+        903  + // l1 contract deploy fee
         52; // l1 contract call fee
     assert_eq!(
         db_account.info.balance,
@@ -1108,5 +1108,5 @@ fn test_l1_fee_halt() {
         base_fee_valut.info.balance,
         U256::from(1106947_u64 * 10000000)
     );
-    assert_eq!(l1_fee_valut.info.balance, U256::from(853 + 52));
+    assert_eq!(l1_fee_valut.info.balance, U256::from(903 + 52));
 }

--- a/crates/evm/src/tests/call_tests.rs
+++ b/crates/evm/src/tests/call_tests.rs
@@ -129,7 +129,7 @@ fn call_multiple_test() {
                 },
                 gas_used: 43730,
                 log_index_start: 0,
-                l1_diff_size: 136,
+                l1_diff_size: 437,
             },
             Receipt {
                 receipt: reth_primitives::Receipt {
@@ -140,7 +140,7 @@ fn call_multiple_test() {
                 },
                 gas_used: 26630,
                 log_index_start: 0,
-                l1_diff_size: 136,
+                l1_diff_size: 437,
             },
             Receipt {
                 receipt: reth_primitives::Receipt {
@@ -151,7 +151,7 @@ fn call_multiple_test() {
                 },
                 gas_used: 26630,
                 log_index_start: 0,
-                l1_diff_size: 136,
+                l1_diff_size: 437,
             }
         ]
     )
@@ -232,7 +232,7 @@ fn call_test() {
                 },
                 gas_used: 43730,
                 log_index_start: 0,
-                l1_diff_size: 136,
+                l1_diff_size: 437,
             }
         ]
     )
@@ -1080,7 +1080,7 @@ fn test_l1_fee_halt() {
                 },
                 gas_used: 1000000,
                 log_index_start: 0,
-                l1_diff_size: 52,
+                l1_diff_size: 353,
             },
         ]
     );
@@ -1092,7 +1092,7 @@ fn test_l1_fee_halt() {
 
     let expenses = 1106947_u64 * 10000000 + // evm gas
         903  + // l1 contract deploy fee
-        52; // l1 contract call fee
+        353; // l1 contract call fee
     assert_eq!(
         db_account.info.balance,
         U256::from(
@@ -1108,5 +1108,5 @@ fn test_l1_fee_halt() {
         base_fee_valut.info.balance,
         U256::from(1106947_u64 * 10000000)
     );
-    assert_eq!(l1_fee_valut.info.balance, U256::from(903 + 52));
+    assert_eq!(l1_fee_valut.info.balance, U256::from(903 + 353));
 }

--- a/crates/evm/src/tests/call_tests.rs
+++ b/crates/evm/src/tests/call_tests.rs
@@ -91,6 +91,12 @@ fn call_multiple_test() {
     evm.finalize_hook(&[99u8; 32].into(), &mut working_set.accessory_state());
 
     let db_account = evm.accounts.get(&contract_addr, &mut working_set).unwrap();
+
+    // Make sure the db account size is 256 bytes
+    let db_account_len = bcs::to_bytes(&db_account)
+        .expect("Failed to serialize value")
+        .len();
+    assert_eq!(db_account_len, 256);
     let storage_value = db_account
         .storage
         .get(&U256::ZERO, &mut working_set)
@@ -112,7 +118,7 @@ fn call_multiple_test() {
                 },
                 gas_used: 132943,
                 log_index_start: 0,
-                l1_diff_size: 565,
+                l1_diff_size: 973,
             },
             Receipt {
                 receipt: reth_primitives::Receipt {
@@ -215,7 +221,7 @@ fn call_test() {
                 },
                 gas_used: 132943,
                 log_index_start: 0,
-                l1_diff_size: 565,
+                l1_diff_size: 973,
             },
             Receipt {
                 receipt: reth_primitives::Receipt {
@@ -904,7 +910,7 @@ fn test_l1_fee_success() {
                 },
                 gas_used: 114235,
                 log_index_start: 0,
-                l1_diff_size: 477,
+                l1_diff_size: 885,
             },]
         )
     }
@@ -921,11 +927,11 @@ fn test_l1_fee_success() {
     );
     run_tx(
         1,
-        U256::from(100000000000000u64 - gas_fee_paid * 10000001 - 477),
+        U256::from(100000000000000u64 - gas_fee_paid * 10000001 - 885),
         // priority fee goes to coinbase
         U256::from(gas_fee_paid),
         U256::from(gas_fee_paid * 10000000),
-        U256::from(477),
+        U256::from(885),
     );
 }
 
@@ -1063,7 +1069,7 @@ fn test_l1_fee_halt() {
                 },
                 gas_used: 106947,
                 log_index_start: 0,
-                l1_diff_size: 445,
+                l1_diff_size: 853,
             },
             Receipt {
                 receipt: reth_primitives::Receipt {
@@ -1085,7 +1091,7 @@ fn test_l1_fee_halt() {
         .unwrap();
 
     let expenses = 1106947_u64 * 10000000 + // evm gas
-        445  + // l1 contract deploy fee
+        853  + // l1 contract deploy fee
         52; // l1 contract call fee
     assert_eq!(
         db_account.info.balance,
@@ -1102,5 +1108,5 @@ fn test_l1_fee_halt() {
         base_fee_valut.info.balance,
         U256::from(1106947_u64 * 10000000)
     );
-    assert_eq!(l1_fee_valut.info.balance, U256::from(445 + 52));
+    assert_eq!(l1_fee_valut.info.balance, U256::from(853 + 52));
 }

--- a/crates/evm/src/tests/queries/basic_queries.rs
+++ b/crates/evm/src/tests/queries/basic_queries.rs
@@ -453,7 +453,7 @@ fn check_against_third_block_receipts(receipts: Vec<AnyTransactionReceipt>) {
         "from": "0x9e1abd37ec34bbc688b6a2b7d9387d9256cf1773",
         "to": "0x819c5497b157177315e1204f52e588b393771719",
         "l1FeeRate": "0x1",
-        "l1DiffSize": "0x34",
+        "l1DiffSize": "0x161",
         "contractAddress": null,
         "logs": [
             {
@@ -504,7 +504,7 @@ fn check_against_third_block_receipts(receipts: Vec<AnyTransactionReceipt>) {
         "from": "0x9e1abd37ec34bbc688b6a2b7d9387d9256cf1773",
         "to": "0x819c5497b157177315e1204f52e588b393771719",
         "l1FeeRate": "0x1",
-        "l1DiffSize": "0x34",
+        "l1DiffSize": "0x161",
         "contractAddress": null,
         "logs": [
             {
@@ -555,7 +555,7 @@ fn check_against_third_block_receipts(receipts: Vec<AnyTransactionReceipt>) {
         "from": "0x9e1abd37ec34bbc688b6a2b7d9387d9256cf1773",
         "to": "0x819c5497b157177315e1204f52e588b393771719",
         "l1FeeRate": "0x1",
-        "l1DiffSize": "0x34",
+        "l1DiffSize": "0x161",
         "contractAddress": null,
         "logs": [
             {
@@ -606,7 +606,7 @@ fn check_against_third_block_receipts(receipts: Vec<AnyTransactionReceipt>) {
         "from": "0x9e1abd37ec34bbc688b6a2b7d9387d9256cf1773",
         "to": "0x819c5497b157177315e1204f52e588b393771719",
         "l1FeeRate": "0x1",
-        "l1DiffSize": "0x34",
+        "l1DiffSize": "0x161",
         "contractAddress": null,
         "logs": [
             {

--- a/crates/evm/src/tests/queries/estimate_gas_tests.rs
+++ b/crates/evm/src/tests/queries/estimate_gas_tests.rs
@@ -93,7 +93,7 @@ fn test_tx_request_fields_gas() {
     );
     assert_eq!(
         contract_diff_size.unwrap(),
-        serde_json::from_value::<EstimatedDiffSize>(json![{"gas":"0x6601","l1DiffSize":"0x34"}])
+        serde_json::from_value::<EstimatedDiffSize>(json![{"gas":"0x6601","l1DiffSize":"0x161"}])
             .unwrap()
     );
 

--- a/crates/evm/src/tests/sys_tx_tests.rs
+++ b/crates/evm/src/tests/sys_tx_tests.rs
@@ -50,7 +50,7 @@ fn test_sys_bitcoin_light_client() {
                 },
                 gas_used: 50751,
                 log_index_start: 0,
-                l1_diff_size: 136,
+                l1_diff_size: 437,
             },
             Receipt { // BitcoinLightClient::setBlockInfo(U256, U256)
                 receipt: reth_primitives::Receipt {
@@ -69,7 +69,7 @@ fn test_sys_bitcoin_light_client() {
                 },
                 gas_used: 80720,
                 log_index_start: 0,
-                l1_diff_size: 264,
+                l1_diff_size: 565,
             },
             Receipt {
                 receipt: reth_primitives::Receipt {
@@ -95,7 +95,7 @@ fn test_sys_bitcoin_light_client() {
                 },
                 gas_used: 261215,
                 log_index_start: 1,
-                l1_diff_size: 712,
+                l1_diff_size: 1013,
             }
         ]
     );
@@ -208,7 +208,7 @@ fn test_sys_bitcoin_light_client() {
                 },
                 gas_used: 80720,
                 log_index_start: 0,
-                l1_diff_size: 264,
+                l1_diff_size: 565,
             },
             Receipt {
                 receipt: reth_primitives::Receipt {

--- a/crates/evm/src/tests/sys_tx_tests.rs
+++ b/crates/evm/src/tests/sys_tx_tests.rs
@@ -219,7 +219,7 @@ fn test_sys_bitcoin_light_client() {
                 },
                 gas_used: 114235,
                 log_index_start: 1,
-                l1_diff_size: 885,
+                l1_diff_size: 935,
             },
         ]
     );
@@ -230,7 +230,7 @@ fn test_sys_bitcoin_light_client() {
         base_fee_vault.info.balance,
         U256::from(114235u64 * 10000000)
     );
-    assert_eq!(l1_fee_vault.info.balance, U256::from(885));
+    assert_eq!(l1_fee_vault.info.balance, U256::from(935));
 
     let hash = evm
         .get_call(

--- a/crates/evm/src/tests/sys_tx_tests.rs
+++ b/crates/evm/src/tests/sys_tx_tests.rs
@@ -219,7 +219,7 @@ fn test_sys_bitcoin_light_client() {
                 },
                 gas_used: 114235,
                 log_index_start: 1,
-                l1_diff_size: 477,
+                l1_diff_size: 885,
             },
         ]
     );
@@ -230,7 +230,7 @@ fn test_sys_bitcoin_light_client() {
         base_fee_vault.info.balance,
         U256::from(114235u64 * 10000000)
     );
-    assert_eq!(l1_fee_vault.info.balance, U256::from(477));
+    assert_eq!(l1_fee_vault.info.balance, U256::from(885));
 
     let hash = evm
         .get_call(


### PR DESCRIPTION
# Description
Adjusts diff sizes on balance, nonce and code changes
This pr is introduced because due to our architecture whenever an accounts balance, nonce or code changes the entire struct DbAccount is written to the storage with it's key and then they are added to the state diff.
DbAccount in total is 256 bytes, the key has 24 bytes of prefix and 1 byte of size descriptor and 20 bytes of address. I removed 20 bytes from address as we default add it for every operation. 
So in this pr we add 256 + 25 = 281 more bytes for every nonce, balance or code changed.

## Linked Issues
- Fixes #1035 
