### PR TITLE
Convert async RPC into blocking RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,6 +1994,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "jsonrpsee",
+ "parking_lot",
  "reth-chainspec",
  "reth-db",
  "reth-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,6 +2811,7 @@ dependencies = [
  "citrea-evm",
  "citrea-primitives",
  "jsonrpsee",
+ "parking_lot",
  "proptest",
  "reth-primitives",
  "reth-rpc-eth-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde
 lazy_static = { version = "1.5.0" }
 log-panics = { version = "2", features = ["with-backtrace"] }
 once_cell = { version = "1.19.0", default-features = false, features = ["alloc"] }
+parking_lot = { version = "0.12.3" }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.3.1", default-features = false, features = ["alloc"] }
 proptest-derive = "0.4.0"

--- a/crates/ethereum-rpc/Cargo.toml
+++ b/crates/ethereum-rpc/Cargo.toml
@@ -12,29 +12,30 @@ readme = "README.md"
 resolver = "2"
 
 [dependencies]
+# 3rd-party dependencies
 anyhow = { workspace = true }
+borsh = { workspace = true }
 citrea-evm = { path = "../evm", features = ["native"] }
 citrea-primitives = { path = "../primitives" }
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
+parking_lot = { workspace = true }
 rustc_version_runtime = { workspace = true }
+schnellru = "0.2.1"
 sequencer-client = { path = "../sequencer-client" }
-tracing = { workspace = true }
-
-borsh = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
+# Reth deps
 reth-primitives = { workspace = true }
 reth-rpc-eth-types = { workspace = true }
 reth-rpc-types = { workspace = true }
 reth-rpc-types-compat = { workspace = true }
 
-schnellru = "0.2.1"
-tokio = { workspace = true }
-
-sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface", features = ["native"] }
-
+# Sovereign-SDK deps
 sov-modules-api = { path = "../sovereign-sdk/module-system/sov-modules-api", default-features = false }
+sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface", features = ["native"] }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/ethereum-rpc/src/ethereum.rs
+++ b/crates/ethereum-rpc/src/ethereum.rs
@@ -80,12 +80,8 @@ impl<C: sov_modules_api::Context, Da: DaService> Ethereum<C, Da> {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub(crate) async fn max_fee_per_gas(&self, working_set: &mut WorkingSet<C>) -> (U256, U256) {
-        let suggested_tip = self
-            .gas_price_oracle
-            .suggest_tip_cap(working_set)
-            .await
-            .unwrap();
+    pub(crate) fn max_fee_per_gas(&self, working_set: &mut WorkingSet<C>) -> (U256, U256) {
+        let suggested_tip = self.gas_price_oracle.suggest_tip_cap(working_set).unwrap();
 
         let evm = Evm::<C>::default();
         let base_fee = evm

--- a/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
+++ b/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
@@ -5,13 +5,13 @@
 
 use citrea_evm::{Evm, SYSTEM_SIGNER};
 use citrea_primitives::basefee::calculate_next_block_base_fee;
+use parking_lot::Mutex;
 use reth_primitives::constants::GWEI_TO_WEI;
 use reth_primitives::{BlockNumberOrTag, B256, U256};
 use reth_rpc_eth_types::error::{EthApiError, EthResult, RpcInvalidTransactionError};
 use reth_rpc_types::{BlockTransactions, FeeHistory};
 use serde::{Deserialize, Serialize};
 use sov_modules_api::WorkingSet;
-use tokio::sync::Mutex;
 use tracing::warn;
 
 use super::cache::BlockCache;
@@ -137,7 +137,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
     }
 
     /// Reports the fee history
-    pub async fn fee_history(
+    pub fn fee_history(
         &self,
         mut block_count: u64,
         newest_block: BlockNumberOrTag,
@@ -193,7 +193,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
         let mut rewards: Vec<Vec<u128>> = Vec::new();
 
         let (fee_entries, resolution) = {
-            let mut fee_history_cache = self.fee_history_cache.lock().await;
+            let mut fee_history_cache = self.fee_history_cache.lock();
 
             (
                 fee_history_cache.get_history(start_block, end_block, working_set),
@@ -239,7 +239,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
     }
 
     /// Suggests a gas price estimate based on recent blocks, using the configured percentile.
-    pub async fn suggest_tip_cap(&self, working_set: &mut WorkingSet<C>) -> EthResult<u128> {
+    pub fn suggest_tip_cap(&self, working_set: &mut WorkingSet<C>) -> EthResult<u128> {
         let header = &self
             .provider
             .get_block_by_number(None, None, working_set)
@@ -247,7 +247,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
             .unwrap()
             .header;
 
-        let mut last_price = self.last_price.lock().await;
+        let mut last_price = self.last_price.lock();
 
         // if we have stored a last price, then we check whether or not it was for the same head
         if last_price.block_hash == header.hash.unwrap() {
@@ -274,8 +274,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
 
         for _ in 0..max_blocks {
             let (parent_hash, block_values) = self
-                .get_block_values(current_hash, SAMPLE_NUMBER as usize, working_set)
-                .await?
+                .get_block_values(current_hash, SAMPLE_NUMBER as usize, working_set)?
                 .ok_or(EthApiError::UnknownBlockNumber)?;
 
             if block_values.is_empty() {
@@ -324,7 +323,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
     /// If the block cannot be found, then this will return `None`.
     ///
     /// This method also returns the parent hash for the given block.
-    async fn get_block_values(
+    fn get_block_values(
         &self,
         block_hash: B256,
         limit: usize,
@@ -332,7 +331,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
     ) -> EthResult<Option<(B256, Vec<u128>)>> {
         // check the cache (this will hit the disk if the block is not cached)
         let block_hit = {
-            let mut cache = self.fee_history_cache.lock().await;
+            let mut cache = self.fee_history_cache.lock();
             cache.block_cache.get_block(block_hash, working_set)?
         };
         let block = match block_hit {

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -89,7 +89,7 @@ fn register_rpc_methods<C: sov_modules_api::Context, Da: DaService>(
         Ok::<_, ErrorObjectOwned>(ethereum.web3_client_version.clone())
     })?;
 
-    rpc.register_async_method("web3_sha3", |params, _, _| async move {
+    rpc.register_blocking_method("web3_sha3", move |params, _, _| {
         info!("eth module: web3_sha3");
         let data: Bytes = params.one()?;
 
@@ -98,12 +98,12 @@ fn register_rpc_methods<C: sov_modules_api::Context, Da: DaService>(
         Ok::<_, ErrorObjectOwned>(hash)
     })?;
 
-    rpc.register_async_method("eth_gasPrice", |_, ethereum, _| async move {
+    rpc.register_blocking_method("eth_gasPrice", move |_, ethereum, _| {
         info!("eth module: eth_gasPrice");
         let price = {
             let mut working_set = WorkingSet::<C>::new(ethereum.storage.clone());
 
-            let (base_fee, suggested_tip) = ethereum.max_fee_per_gas(&mut working_set).await;
+            let (base_fee, suggested_tip) = ethereum.max_fee_per_gas(&mut working_set);
 
             suggested_tip + base_fee
         };
@@ -111,12 +111,12 @@ fn register_rpc_methods<C: sov_modules_api::Context, Da: DaService>(
         Ok::<U256, ErrorObjectOwned>(price)
     })?;
 
-    rpc.register_async_method("eth_maxFeePerGas", |_, ethereum, _| async move {
+    rpc.register_blocking_method("eth_maxFeePerGas", move |_, ethereum, _| {
         info!("eth module: eth_maxFeePerGas");
         let max_fee_per_gas = {
             let mut working_set = WorkingSet::<C>::new(ethereum.storage.clone());
 
-            let (base_fee, suggested_tip) = ethereum.max_fee_per_gas(&mut working_set).await;
+            let (base_fee, suggested_tip) = ethereum.max_fee_per_gas(&mut working_set);
 
             suggested_tip + base_fee
         };
@@ -124,12 +124,12 @@ fn register_rpc_methods<C: sov_modules_api::Context, Da: DaService>(
         Ok::<U256, ErrorObjectOwned>(max_fee_per_gas)
     })?;
 
-    rpc.register_async_method("eth_maxPriorityFeePerGas", |_, ethereum, _| async move {
+    rpc.register_blocking_method("eth_maxPriorityFeePerGas", move |_, ethereum, _| {
         info!("eth module: eth_maxPriorityFeePerGas");
         let max_priority_fee = {
             let mut working_set = WorkingSet::<C>::new(ethereum.storage.clone());
 
-            let (_base_fee, suggested_tip) = ethereum.max_fee_per_gas(&mut working_set).await;
+            let (_base_fee, suggested_tip) = ethereum.max_fee_per_gas(&mut working_set);
 
             suggested_tip
         };
@@ -137,7 +137,7 @@ fn register_rpc_methods<C: sov_modules_api::Context, Da: DaService>(
         Ok::<U256, ErrorObjectOwned>(max_priority_fee)
     })?;
 
-    rpc.register_async_method("eth_feeHistory", |params, ethereum, _| async move {
+    rpc.register_blocking_method("eth_feeHistory", move |params, ethereum, _| {
         info!("eth module: eth_feeHistory");
         let mut params = params.sequence();
 
@@ -151,15 +151,12 @@ fn register_rpc_methods<C: sov_modules_api::Context, Da: DaService>(
         let fee_history = {
             let mut working_set = WorkingSet::<C>::new(ethereum.storage.clone());
 
-            ethereum
-                .gas_price_oracle
-                .fee_history(
-                    block_count,
-                    newest_block,
-                    reward_percentiles,
-                    &mut working_set,
-                )
-                .await?
+            ethereum.gas_price_oracle.fee_history(
+                block_count,
+                newest_block,
+                reward_percentiles,
+                &mut working_set,
+            )?
         };
 
         Ok::<FeeHistory, ErrorObjectOwned>(fee_history)
@@ -396,9 +393,9 @@ fn register_rpc_methods<C: sov_modules_api::Context, Da: DaService>(
     //     Ok::<_, ErrorObjectOwned>(tx_hash)
     // })?;
 
-    rpc.register_async_method::<Result<Vec<GethTrace>, ErrorObjectOwned>, _, _>(
+    rpc.register_blocking_method::<Result<Vec<GethTrace>, ErrorObjectOwned>, _>(
         "debug_traceBlockByHash",
-        |parameters, ethereum, _| async move {
+        move |parameters, ethereum, _| {
             info!("eth module: debug_traceBlockByHash");
 
             let mut params = parameters.sequence();
@@ -420,9 +417,9 @@ fn register_rpc_methods<C: sov_modules_api::Context, Da: DaService>(
         },
     )?;
 
-    rpc.register_async_method::<Result<Vec<GethTrace>, ErrorObjectOwned>, _, _>(
+    rpc.register_blocking_method::<Result<Vec<GethTrace>, ErrorObjectOwned>, _>(
         "debug_traceBlockByNumber",
-        |parameters, ethereum, _| async move {
+        move |parameters, ethereum, _| {
             info!("eth module: debug_traceBlockByNumber");
 
             let mut params = parameters.sequence();
@@ -442,9 +439,9 @@ fn register_rpc_methods<C: sov_modules_api::Context, Da: DaService>(
         },
     )?;
 
-    rpc.register_async_method::<Result<GethTrace, ErrorObjectOwned>, _, _>(
+    rpc.register_blocking_method::<Result<GethTrace, ErrorObjectOwned>, _>(
         "debug_traceTransaction",
-        |parameters, ethereum, _| async move {
+        move |parameters, ethereum, _| {
             // the main rpc handler for debug_traceTransaction
             // Checks the cache in ethereum struct if the trace exists
             // if found; returns the trace

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -23,6 +23,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 hyper = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
+parking_lot = { workspace = true }
 rs_merkle = { workspace = true }
 schnellru = "0.2.1"
 serde = { workspace = true }


### PR DESCRIPTION
# Description

Tokio's default blocking threads is 512 threads. These threads are created on demand when `spawn_blocking` is called.

This PR converts some RPC calls into blocking methods because the only async part of them was using `tokio::sync::Mutex` which is now replaced with `parking_lot::Mutex` since there's nothing else async about it.

This would merge into #1032 

## Linked Issues
- Related to #1018 
