### PR TITLE
stf blueprint cleanup

### DIFF
--- a/crates/citrea-stf/src/hooks_impl.rs
+++ b/crates/citrea-stf/src/hooks_impl.rs
@@ -75,7 +75,7 @@ impl<C: Context, Da: DaSpec> ApplySoftConfirmationHooks<Da> for Runtime<C, Da> {
 
     #[cfg_attr(
         feature = "native",
-        instrument(level = "trace", skip(self, working_set), err(Debug), ret)
+        instrument(level = "trace", skip(self, working_set), err, ret)
     )]
     fn begin_soft_confirmation_hook(
         &self,
@@ -91,10 +91,7 @@ impl<C: Context, Da: DaSpec> ApplySoftConfirmationHooks<Da> for Runtime<C, Da> {
         Ok(())
     }
 
-    #[cfg_attr(
-        feature = "native",
-        instrument(level = "trace", skip_all, err(Debug), ret)
-    )]
+    #[cfg_attr(feature = "native", instrument(level = "trace", skip_all, err, ret))]
     fn end_soft_confirmation_hook(
         &self,
         working_set: &mut WorkingSet<C>,

--- a/crates/citrea-stf/src/hooks_impl.rs
+++ b/crates/citrea-stf/src/hooks_impl.rs
@@ -1,7 +1,7 @@
 use sov_accounts::AccountsTxHook;
 use sov_modules_api::hooks::{
-    ApplyBlobHooks, ApplySoftConfirmationError, ApplySoftConfirmationHooks, FinalizeHook,
-    HookSoftConfirmationInfo, SlotHooks, TxHooks,
+    ApplyBlobHooks, ApplySoftConfirmationHooks, FinalizeHook, HookSoftConfirmationInfo, SlotHooks,
+    SoftConfirmationError, TxHooks,
 };
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{AccessoryWorkingSet, Context, Spec, WorkingSet};
@@ -75,13 +75,13 @@ impl<C: Context, Da: DaSpec> ApplySoftConfirmationHooks<Da> for Runtime<C, Da> {
 
     #[cfg_attr(
         feature = "native",
-        instrument(level = "trace", skip(self, working_set), err, ret)
+        instrument(level = "trace", skip(self, working_set), err(Debug), ret)
     )]
     fn begin_soft_confirmation_hook(
         &self,
         soft_confirmation: &mut HookSoftConfirmationInfo,
         working_set: &mut WorkingSet<Self::Context>,
-    ) -> Result<(), ApplySoftConfirmationError> {
+    ) -> Result<(), SoftConfirmationError> {
         self.soft_confirmation_rule_enforcer
             .begin_soft_confirmation_hook(soft_confirmation, working_set)?;
 
@@ -91,11 +91,14 @@ impl<C: Context, Da: DaSpec> ApplySoftConfirmationHooks<Da> for Runtime<C, Da> {
         Ok(())
     }
 
-    #[cfg_attr(feature = "native", instrument(level = "trace", skip_all, err, ret))]
+    #[cfg_attr(
+        feature = "native",
+        instrument(level = "trace", skip_all, err(Debug), ret)
+    )]
     fn end_soft_confirmation_hook(
         &self,
         working_set: &mut WorkingSet<C>,
-    ) -> Result<(), ApplySoftConfirmationError> {
+    ) -> Result<(), SoftConfirmationError> {
         self.evm.end_soft_confirmation_hook(working_set);
         Ok(())
     }

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -441,9 +441,10 @@ where
 
         // TODO: consider returning a Result from apply_soft_confirmation
         // and then we wouldn't to make receipt Option
-        let receipt = soft_confirmation_result
-            .soft_confirmation_receipt
-            .unwrap_or_else(|| bail!("Soft confirmation failed at height: {}", l2_height))?;
+        let receipt = match soft_confirmation_result.soft_confirmation_receipt {
+            Some(receipt) => receipt,
+            None => bail!("Soft confirmation receipt is None"),
+        };
 
         let next_state_root = soft_confirmation_result.state_root;
         // Check if post state root is the same as the one in the soft confirmation

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -426,24 +426,22 @@ where
             .storage_manager
             .create_storage_on_l2_height(l2_height)?;
 
-        let soft_confirmation_result = self.stf.apply_soft_confirmation(
-            self.fork_manager.active_fork().spec_id,
-            self.sequencer_pub_key.as_slice(),
-            // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
-            &self.state_root,
-            pre_state,
-            Default::default(),
-            current_l1_block.header(),
-            &current_l1_block.validity_condition(),
-            &mut soft_confirmation.clone().into(),
-        );
+        let soft_confirmation_result = self
+            .stf
+            .apply_soft_confirmation(
+                self.fork_manager.active_fork().spec_id,
+                self.sequencer_pub_key.as_slice(),
+                // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
+                &self.state_root,
+                pre_state,
+                Default::default(),
+                current_l1_block.header(),
+                &current_l1_block.validity_condition(),
+                &mut soft_confirmation.clone().into(),
+            )
+            .map_err(anyhow::Error::from)?;
 
-        // TODO: consider returning a Result from apply_soft_confirmation
-        // and then we wouldn't to make receipt Option
-        let receipt = match soft_confirmation_result.soft_confirmation_receipt {
-            Some(receipt) => receipt,
-            None => bail!("Soft confirmation receipt is None"),
-        };
+        let receipt = soft_confirmation_result.soft_confirmation_receipt;
 
         let next_state_root = soft_confirmation_result.state_root;
         // Check if post state root is the same as the one in the soft confirmation

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -421,13 +421,13 @@ where
             bail!("Previous hash mismatch at height: {}", l2_height);
         }
 
-        let mut data_to_commit = SlotCommit::new(current_l1_block.clone());
+        // let mut data_to_commit = SlotCommit::new(current_l1_block.clone());
 
         let pre_state = self
             .storage_manager
             .create_storage_on_l2_height(l2_height)?;
 
-        let slot_result = self.stf.apply_soft_confirmation(
+        let soft_confirmation_result = self.stf.apply_soft_confirmation(
             self.fork_manager.active_fork().spec_id,
             self.sequencer_pub_key.as_slice(),
             // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
@@ -439,45 +439,28 @@ where
             &mut soft_confirmation.clone().into(),
         );
 
-        let next_state_root = slot_result.state_root;
+        // TODO: consider returning a Result from apply_soft_confirmation
+        // and then we wouldn't to make receipt Option
+        let receipt = soft_confirmation_result
+            .soft_confirmation_receipt
+            .unwrap_or_else(|| bail!("Soft confirmation failed at height: {}", l2_height))?;
+
+        let next_state_root = soft_confirmation_result.state_root;
         // Check if post state root is the same as the one in the soft confirmation
         if next_state_root.as_ref().to_vec() != soft_confirmation.state_root {
             bail!("Post state root mismatch at height: {}", l2_height)
         }
 
-        for receipt in slot_result.batch_receipts {
-            data_to_commit.add_batch(receipt);
-        }
-
-        let batch_receipt = data_to_commit.batch_receipts()[0].clone();
-
-        let soft_confirmation_receipt = SoftConfirmationReceipt::<_, _, Da::Spec> {
-            state_root: next_state_root.as_ref().to_vec(),
-            phantom_data: PhantomData::<u64>,
-            hash: soft_confirmation.hash,
-            prev_hash: soft_confirmation.prev_hash,
-            da_slot_hash: current_l1_block.header().hash(),
-            da_slot_height: current_l1_block.header().height(),
-            da_slot_txs_commitment: current_l1_block.header().txs_commitment(),
-            tx_receipts: batch_receipt.tx_receipts,
-            soft_confirmation_signature: soft_confirmation.soft_confirmation_signature,
-            pub_key: soft_confirmation.pub_key,
-            deposit_data: soft_confirmation
-                .deposit_data
-                .into_iter()
-                .map(|x| x.tx)
-                .collect(),
-            l1_fee_rate: soft_confirmation.l1_fee_rate,
-            timestamp: soft_confirmation.timestamp,
-        };
-
         self.storage_manager
-            .save_change_set_l2(l2_height, slot_result.change_set)?;
+            .save_change_set_l2(l2_height, soft_confirmation_result.change_set)?;
 
         self.storage_manager.finalize_l2(l2_height)?;
 
-        self.ledger_db
-            .commit_soft_confirmation(soft_confirmation_receipt, self.include_tx_body)?;
+        self.ledger_db.commit_soft_confirmation(
+            next_state_root.as_ref(),
+            receipt,
+            self.include_tx_body,
+        )?;
 
         self.ledger_db.extend_l2_range_of_l1_slot(
             SlotNumber(current_l1_block.header().height()),

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, VecDeque};
-use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -16,7 +15,7 @@ use jsonrpsee::RpcModule;
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
 use sequencer_client::{GetSoftConfirmationResponse, SequencerClient};
-use sov_db::ledger_db::{NodeLedgerOps, SlotCommit};
+use sov_db::ledger_db::NodeLedgerOps;
 use sov_db::schema::types::{
     BatchNumber, SlotNumber, StoredSoftConfirmation, StoredStateTransition,
 };
@@ -29,7 +28,7 @@ use sov_rollup_interface::rpc::SoftConfirmationStatus;
 use sov_rollup_interface::services::da::{DaService, SlotData};
 use sov_rollup_interface::spec::SpecId;
 pub use sov_rollup_interface::stf::BatchReceipt;
-use sov_rollup_interface::stf::{SoftConfirmationReceipt, StateTransitionFunction};
+use sov_rollup_interface::stf::StateTransitionFunction;
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::{Proof, Zkvm, ZkvmHost};
 use sov_stf_runner::{InitVariant, RollupPublicKeys, RpcConfig, RunnerConfig};

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -420,26 +420,21 @@ where
             bail!("Previous hash mismatch at height: {}", l2_height);
         }
 
-        // let mut data_to_commit = SlotCommit::new(current_l1_block.clone());
-
         let pre_state = self
             .storage_manager
             .create_storage_on_l2_height(l2_height)?;
 
-        let soft_confirmation_result = self
-            .stf
-            .apply_soft_confirmation(
-                self.fork_manager.active_fork().spec_id,
-                self.sequencer_pub_key.as_slice(),
-                // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
-                &self.state_root,
-                pre_state,
-                Default::default(),
-                current_l1_block.header(),
-                &current_l1_block.validity_condition(),
-                &mut soft_confirmation.clone().into(),
-            )
-            .map_err(anyhow::Error::from)?;
+        let soft_confirmation_result = self.stf.apply_soft_confirmation(
+            self.fork_manager.active_fork().spec_id,
+            self.sequencer_pub_key.as_slice(),
+            // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
+            &self.state_root,
+            pre_state,
+            Default::default(),
+            current_l1_block.header(),
+            &current_l1_block.validity_condition(),
+            &mut soft_confirmation.clone().into(),
+        )?;
 
         let receipt = soft_confirmation_result.soft_confirmation_receipt;
 

--- a/crates/fullnode/tests/hash_stf.rs
+++ b/crates/fullnode/tests/hash_stf.rs
@@ -9,7 +9,9 @@ use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::fork::Fork;
 use sov_rollup_interface::spec::SpecId;
-use sov_rollup_interface::stf::{SlotResult, StateTransitionFunction};
+use sov_rollup_interface::stf::{
+    SlotResult, SoftConfirmationReceipt, SoftConfirmationResult, StateTransitionFunction,
+};
 use sov_rollup_interface::zk::{CumulativeStateDiff, ValidityCondition, Zkvm};
 use sov_state::storage::{NativeStorage, StorageKey, StorageValue};
 use sov_state::{
@@ -108,7 +110,7 @@ impl<C: Context, Da: DaSpec, Vm: Zkvm, Cond: ValidityCondition> StfBlueprintTrai
         >,
         _batch_workspace: sov_modules_api::WorkingSet<C>,
     ) -> (
-        sov_modules_stf_blueprint::BatchReceipt<(), sov_modules_stf_blueprint::TxEffect>,
+        SoftConfirmationReceipt<sov_modules_stf_blueprint::TxEffect, Da>,
         sov_modules_api::StateCheckpoint<C>,
     ) {
         unimplemented!()
@@ -117,19 +119,16 @@ impl<C: Context, Da: DaSpec, Vm: Zkvm, Cond: ValidityCondition> StfBlueprintTrai
     fn finalize_soft_confirmation(
         &self,
         _current_spec: SpecId,
-        _batch_receipt: sov_modules_stf_blueprint::BatchReceipt<
-            (),
-            sov_modules_stf_blueprint::TxEffect,
-        >,
+        _sc_receipt: SoftConfirmationReceipt<sov_modules_stf_blueprint::TxEffect, Da>,
         _checkpoint: sov_modules_api::StateCheckpoint<C>,
         _pre_state: Self::PreState,
         _soft_confirmation: &mut sov_modules_api::SignedSoftConfirmationBatch,
-    ) -> SlotResult<
+    ) -> SoftConfirmationResult<
         Self::StateRoot,
         Self::ChangeSet,
-        Self::BatchReceiptContents,
         Self::TxReceiptContents,
         Self::Witness,
+        Da,
     > {
         unimplemented!()
     }
@@ -220,12 +219,12 @@ impl<Vm: Zkvm, Cond: ValidityCondition, Da: DaSpec> StateTransitionFunction<Vm, 
         _slot_header: &<Da as DaSpec>::BlockHeader,
         _validity_condition: &<Da as DaSpec>::ValidityCondition,
         _soft_confirmation: &mut sov_modules_api::SignedSoftConfirmationBatch,
-    ) -> SlotResult<
+    ) -> SoftConfirmationResult<
         Self::StateRoot,
         Self::ChangeSet,
-        Self::BatchReceiptContents,
         Self::TxReceiptContents,
         Self::Witness,
+        Da,
     > {
         todo!()
     }

--- a/crates/fullnode/tests/hash_stf.rs
+++ b/crates/fullnode/tests/hash_stf.rs
@@ -3,6 +3,7 @@ use sov_mock_da::{
     MockAddress, MockBlob, MockBlock, MockBlockHeader, MockDaSpec, MockValidityCond,
 };
 use sov_mock_zkvm::MockZkvm;
+use sov_modules_api::hooks::SoftConfirmationError;
 use sov_modules_api::Context;
 use sov_modules_stf_blueprint::StfBlueprintTrait;
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
@@ -82,7 +83,7 @@ impl<C: Context, Da: DaSpec, Vm: Zkvm, Cond: ValidityCondition> StfBlueprintTrai
         _slot_header: &<Da as DaSpec>::BlockHeader,
         _soft_confirmation: &mut sov_modules_api::SignedSoftConfirmationBatch,
     ) -> (
-        Result<(), sov_modules_api::hooks::ApplySoftConfirmationError>,
+        Result<(), SoftConfirmationError>,
         sov_modules_api::WorkingSet<C>,
     ) {
         unimplemented!()
@@ -110,7 +111,10 @@ impl<C: Context, Da: DaSpec, Vm: Zkvm, Cond: ValidityCondition> StfBlueprintTrai
         >,
         _batch_workspace: sov_modules_api::WorkingSet<C>,
     ) -> (
-        SoftConfirmationReceipt<sov_modules_stf_blueprint::TxEffect, Da>,
+        Result<
+            SoftConfirmationReceipt<sov_modules_stf_blueprint::TxEffect, Da>,
+            SoftConfirmationError,
+        >,
         sov_modules_api::StateCheckpoint<C>,
     ) {
         unimplemented!()
@@ -219,12 +223,15 @@ impl<Vm: Zkvm, Cond: ValidityCondition, Da: DaSpec> StateTransitionFunction<Vm, 
         _slot_header: &<Da as DaSpec>::BlockHeader,
         _validity_condition: &<Da as DaSpec>::ValidityCondition,
         _soft_confirmation: &mut sov_modules_api::SignedSoftConfirmationBatch,
-    ) -> SoftConfirmationResult<
-        Self::StateRoot,
-        Self::ChangeSet,
-        Self::TxReceiptContents,
-        Self::Witness,
-        Da,
+    ) -> Result<
+        SoftConfirmationResult<
+            Self::StateRoot,
+            Self::ChangeSet,
+            Self::TxReceiptContents,
+            Self::Witness,
+            Da,
+        >,
+        SoftConfirmationError,
     > {
         todo!()
     }

--- a/crates/prover/src/runner.rs
+++ b/crates/prover/src/runner.rs
@@ -344,25 +344,23 @@ where
             .storage_manager
             .create_storage_on_l2_height(l2_height)?;
 
-        let soft_confirmation_result = self.stf.apply_soft_confirmation(
-            self.fork_manager.active_fork().spec_id,
-            self.sequencer_pub_key.as_slice(),
-            // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
-            &self.state_root,
-            pre_state,
-            Default::default(),
-            current_l1_block.header(),
-            &current_l1_block.validity_condition(),
-            &mut soft_confirmation.clone().into(),
-        );
+        let soft_confirmation_result = self
+            .stf
+            .apply_soft_confirmation(
+                self.fork_manager.active_fork().spec_id,
+                self.sequencer_pub_key.as_slice(),
+                // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
+                &self.state_root,
+                pre_state,
+                Default::default(),
+                current_l1_block.header(),
+                &current_l1_block.validity_condition(),
+                &mut soft_confirmation.clone().into(),
+            )
+            .map_err(anyhow::Error::from)?;
 
         // TODO: maybe for prover we should accept this as valid and continue with proving
-        // TODO: consider returning a Result from apply_soft_confirmation
-        // and then we wouldn't to make receipt Option
-        let receipt = match soft_confirmation_result.soft_confirmation_receipt {
-            Some(receipt) => receipt,
-            None => bail!("Soft confirmation receipt is None"),
-        };
+        let receipt = soft_confirmation_result.soft_confirmation_receipt;
 
         let next_state_root = soft_confirmation_result.state_root;
         // Check if post state root is the same as the one in the soft confirmation

--- a/crates/prover/src/runner.rs
+++ b/crates/prover/src/runner.rs
@@ -341,13 +341,11 @@ where
             bail!("Previous hash mismatch at height: {}", l2_height);
         }
 
-        let mut data_to_commit = SlotCommit::new(current_l1_block.clone());
-
         let pre_state = self
             .storage_manager
             .create_storage_on_l2_height(l2_height)?;
 
-        let slot_result = self.stf.apply_soft_confirmation(
+        let soft_confirmation_result = self.stf.apply_soft_confirmation(
             self.fork_manager.active_fork().spec_id,
             self.sequencer_pub_key.as_slice(),
             // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
@@ -359,7 +357,14 @@ where
             &mut soft_confirmation.clone().into(),
         );
 
-        let next_state_root = slot_result.state_root;
+        // TODO: maybe for prover we should accept this as valid and continue with proving
+        // TODO: consider returning a Result from apply_soft_confirmation
+        // and then we wouldn't to make receipt Option
+        let receipt = soft_confirmation_result
+            .soft_confirmation_receipt
+            .unwrap_or_else(|| bail!("Soft confirmation failed at height: {}", l2_height))?;
+
+        let next_state_root = soft_confirmation_result.state_root;
         // Check if post state root is the same as the one in the soft confirmation
         if next_state_root.as_ref().to_vec() != soft_confirmation.state_root {
             bail!("Post state root mismatch at height: {}", l2_height)
@@ -367,44 +372,18 @@ where
 
         // Save state diff to ledger DB
         self.ledger_db
-            .set_l2_state_diff(BatchNumber(l2_height), slot_result.state_diff)?;
+            .set_l2_state_diff(BatchNumber(l2_height), soft_confirmation_result.state_diff)?;
         // Save witness data to ledger db
         self.ledger_db
-            .set_l2_witness(l2_height, &slot_result.witness)?;
-
-        for receipt in slot_result.batch_receipts {
-            data_to_commit.add_batch(receipt);
-        }
+            .set_l2_witness(l2_height, &soft_confirmation_result.witness)?;
 
         self.storage_manager
-            .save_change_set_l2(l2_height, slot_result.change_set)?;
+            .save_change_set_l2(l2_height, soft_confirmation_result.change_set)?;
 
         self.storage_manager.finalize_l2(l2_height)?;
 
-        let batch_receipt = data_to_commit.batch_receipts()[0].clone();
-
-        let soft_confirmation_receipt = SoftConfirmationReceipt::<_, _, Da::Spec> {
-            state_root: next_state_root.as_ref().to_vec(),
-            phantom_data: PhantomData::<u64>,
-            hash: soft_confirmation.hash,
-            prev_hash: soft_confirmation.prev_hash,
-            da_slot_hash: current_l1_block.header().hash(),
-            da_slot_height: current_l1_block.header().height(),
-            da_slot_txs_commitment: current_l1_block.header().txs_commitment(),
-            tx_receipts: batch_receipt.tx_receipts,
-            soft_confirmation_signature: soft_confirmation.soft_confirmation_signature,
-            pub_key: soft_confirmation.pub_key,
-            deposit_data: soft_confirmation
-                .deposit_data
-                .into_iter()
-                .map(|x| x.tx)
-                .collect(),
-            l1_fee_rate: soft_confirmation.l1_fee_rate,
-            timestamp: soft_confirmation.timestamp,
-        };
-
         self.ledger_db
-            .commit_soft_confirmation(soft_confirmation_receipt, true)?;
+            .commit_soft_confirmation(next_state_root.as_ref(), receipt, true)?;
 
         self.ledger_db.extend_l2_range_of_l1_slot(
             SlotNumber(current_l1_block.header().height()),

--- a/crates/prover/src/runner.rs
+++ b/crates/prover/src/runner.rs
@@ -344,22 +344,18 @@ where
             .storage_manager
             .create_storage_on_l2_height(l2_height)?;
 
-        let soft_confirmation_result = self
-            .stf
-            .apply_soft_confirmation(
-                self.fork_manager.active_fork().spec_id,
-                self.sequencer_pub_key.as_slice(),
-                // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
-                &self.state_root,
-                pre_state,
-                Default::default(),
-                current_l1_block.header(),
-                &current_l1_block.validity_condition(),
-                &mut soft_confirmation.clone().into(),
-            )
-            .map_err(anyhow::Error::from)?;
+        let soft_confirmation_result = self.stf.apply_soft_confirmation(
+            self.fork_manager.active_fork().spec_id,
+            self.sequencer_pub_key.as_slice(),
+            // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
+            &self.state_root,
+            pre_state,
+            Default::default(),
+            current_l1_block.header(),
+            &current_l1_block.validity_condition(),
+            &mut soft_confirmation.clone().into(),
+        )?;
 
-        // TODO: maybe for prover we should accept this as valid and continue with proving
         let receipt = soft_confirmation_result.soft_confirmation_receipt;
 
         let next_state_root = soft_confirmation_result.state_root;

--- a/crates/prover/src/runner.rs
+++ b/crates/prover/src/runner.rs
@@ -360,9 +360,10 @@ where
         // TODO: maybe for prover we should accept this as valid and continue with proving
         // TODO: consider returning a Result from apply_soft_confirmation
         // and then we wouldn't to make receipt Option
-        let receipt = soft_confirmation_result
-            .soft_confirmation_receipt
-            .unwrap_or_else(|| bail!("Soft confirmation failed at height: {}", l2_height))?;
+        let receipt = match soft_confirmation_result.soft_confirmation_receipt {
+            Some(receipt) => receipt,
+            None => bail!("Soft confirmation receipt is None"),
+        };
 
         let next_state_root = soft_confirmation_result.state_root;
         // Check if post state root is the same as the one in the soft confirmation

--- a/crates/prover/src/runner.rs
+++ b/crates/prover/src/runner.rs
@@ -1,6 +1,5 @@
 use core::panic;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,7 +17,7 @@ use jsonrpsee::server::{BatchRequestConfig, ServerBuilder};
 use jsonrpsee::RpcModule;
 use rand::Rng;
 use sequencer_client::{GetSoftConfirmationResponse, SequencerClient};
-use sov_db::ledger_db::{ProverLedgerOps, SlotCommit};
+use sov_db::ledger_db::ProverLedgerOps;
 use sov_db::schema::types::{BatchNumber, SlotNumber, StoredStateTransition};
 use sov_modules_api::storage::HierarchicalStorageManager;
 use sov_modules_api::{BlobReaderTrait, Context, SignedSoftConfirmationBatch, SlotData, StateDiff};
@@ -27,7 +26,7 @@ use sov_rollup_interface::da::{BlockHeaderTrait, DaData, DaSpec, SequencerCommit
 use sov_rollup_interface::rpc::SoftConfirmationStatus;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::spec::SpecId;
-use sov_rollup_interface::stf::{SoftConfirmationReceipt, StateTransitionFunction};
+use sov_rollup_interface::stf::StateTransitionFunction;
 use sov_rollup_interface::zk::{Proof, StateTransitionData, ZkvmHost};
 use sov_stf_runner::{
     InitVariant, ProverConfig, ProverService, RollupPublicKeys, RpcConfig, RunnerConfig,

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -487,8 +487,7 @@ where
                     batch_workspace,
                 );
 
-                let soft_confirmation_receipt =
-                    soft_confirmation_receipt.map_err(anyhow::Error::from)?;
+                let soft_confirmation_receipt = soft_confirmation_receipt?;
 
                 // Finalize soft confirmation
                 let soft_confirmation_result = self.stf.finalize_soft_confirmation(

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -487,6 +487,9 @@ where
                     batch_workspace,
                 );
 
+                let soft_confirmation_receipt =
+                    soft_confirmation_receipt.map_err(anyhow::Error::from)?;
+
                 // Finalize soft confirmation
                 let soft_confirmation_result = self.stf.finalize_soft_confirmation(
                     active_fork_spec,
@@ -496,22 +499,10 @@ where
                     &mut signed_soft_confirmation,
                 );
 
-                // TODO: consider returning a Result from apply_soft_confirmation
-                // and then we wouldn't to make receipt Option
-                let receipt = match soft_confirmation_result.soft_confirmation_receipt {
-                    Some(receipt) => receipt,
-                    None => bail!("Soft confirmation receipt is None"),
-                };
+                let receipt = soft_confirmation_result.soft_confirmation_receipt;
 
                 if soft_confirmation_result.state_root.as_ref() == self.state_root.as_ref() {
                     bail!("Max L2 blocks per L1 is reached for the current L1 block. State root is the same as before, skipping");
-                    // TODO: Check if below is legit
-                    // self.storage_manager
-                    //     .save_change_set_l2(l2_height, soft_confirmation_result.change_set)?;
-
-                    // tracing::debug!("Finalizing l2 height: {:?}", l2_height);
-                    // self.storage_manager.finalize_l2(l2_height)?;
-                    // return Ok((last_used_l1_height, false));
                 }
 
                 trace!(

--- a/crates/soft-confirmation-rule-enforcer/src/hooks.rs
+++ b/crates/soft-confirmation-rule-enforcer/src/hooks.rs
@@ -1,4 +1,4 @@
-use sov_modules_api::hooks::{ApplySoftConfirmationError, HookSoftConfirmationInfo};
+use sov_modules_api::hooks::{HookSoftConfirmationInfo, SoftConfirmationError};
 use sov_modules_api::{Context, DaSpec, StateMapAccessor, StateValueAccessor, WorkingSet};
 use sov_state::Storage;
 #[cfg(feature = "native")]
@@ -15,12 +15,15 @@ where
     /// If the number of L2 blocks exceeds the max L2 blocks per L1, the soft confirmation should fail and not be accepted by full nodes.
     /// This ensures the sequencer cannot publish more than the allowed number of L2 blocks per L1 block.
     /// Thus blocks the ability of the sequencer to censor the forced transactions in a future L1 block by not using that block.
-    #[cfg_attr(feature = "native", instrument(level = "trace", skip_all, err, ret))]
+    #[cfg_attr(
+        feature = "native",
+        instrument(level = "trace", skip_all, err(Debug), ret)
+    )]
     fn apply_block_count_rule(
         &self,
         soft_confirmation_info: &mut HookSoftConfirmationInfo,
         working_set: &mut WorkingSet<C>,
-    ) -> Result<(), ApplySoftConfirmationError> {
+    ) -> Result<(), SoftConfirmationError> {
         let da_root_hash = soft_confirmation_info.da_slot_hash();
         let l2_block_count = self
             .da_root_hash_to_number
@@ -34,13 +37,9 @@ where
         // Adding one more l2 block will exceed the max L2 blocks per L1
         if l2_block_count + 1 > max_l2_blocks_per_l1 {
             // block count per l1 block should not be more than max L2 blocks per L1
-            return Err(
-                ApplySoftConfirmationError::TooManySoftConfirmationsOnDaSlot {
-                    hash: da_root_hash,
-                    sequencer_pub_key: soft_confirmation_info.sequencer_pub_key().to_vec(),
-                    max_l2_blocks_per_l1,
-                },
-            );
+            return Err(SoftConfirmationError::Other(
+                "Too many soft confirmations on DA slot".to_string(),
+            ));
         }
 
         // increment the block count
@@ -56,12 +55,15 @@ where
     /// This ensures the sequencer cannot change the fee rate more than the allowed percentage.
     /// Thus blocks the ability of the sequencer to raise the L1 fee rates arbitrarily and charging a transaction maliciously.
     /// An ideal solution would have the L1 fee trustlessly determined by the L2 users, but that is not possible currently.
-    #[cfg_attr(feature = "native", instrument(level = "trace", skip_all, err, ret))]
+    #[cfg_attr(
+        feature = "native",
+        instrument(level = "trace", skip_all, err(Debug), ret)
+    )]
     fn apply_fee_rate_rule(
         &self,
         soft_confirmation: &mut HookSoftConfirmationInfo,
         working_set: &mut WorkingSet<C>,
-    ) -> Result<(), ApplySoftConfirmationError> {
+    ) -> Result<(), SoftConfirmationError> {
         let l1_fee_rate = soft_confirmation.l1_fee_rate();
         let last_l1_fee_rate = self.last_l1_fee_rate.get(working_set).unwrap_or(0);
 
@@ -83,12 +85,9 @@ where
         if l1_fee_rate * 100 < last_l1_fee_rate * (100 - l1_fee_rate_change_percentage)
             || l1_fee_rate * 100 > last_l1_fee_rate * (100 + l1_fee_rate_change_percentage)
         {
-            return Err(
-                ApplySoftConfirmationError::L1FeeRateChangeMoreThanAllowedPercentage {
-                    l1_fee_rate,
-                    l1_fee_rate_change_percentage,
-                },
-            );
+            return Err(SoftConfirmationError::Other(
+                "L1 fee rate changed more than allowed".to_string(),
+            ));
         }
 
         self.last_l1_fee_rate
@@ -99,22 +98,22 @@ where
 
     /// Checks that the current block's timestamp.
     /// This is to make sure that the set timestamp is greater than the last block's timestamp.
-    #[cfg_attr(feature = "native", instrument(level = "trace", skip_all, err, ret))]
+    #[cfg_attr(
+        feature = "native",
+        instrument(level = "trace", skip_all, err(Debug), ret)
+    )]
     fn apply_timestamp_rule(
         &self,
         soft_confirmation: &mut HookSoftConfirmationInfo,
         working_set: &mut WorkingSet<C>,
-    ) -> Result<(), ApplySoftConfirmationError> {
+    ) -> Result<(), SoftConfirmationError> {
         let current_timestamp = soft_confirmation.timestamp();
         let last_timestamp = self.last_timestamp.get(working_set).unwrap_or(0);
 
         if current_timestamp < last_timestamp {
-            return Err(
-                ApplySoftConfirmationError::CurrentTimestampIsNotGreaterThanPrev {
-                    current: current_timestamp,
-                    prev: last_timestamp,
-                },
-            );
+            return Err(SoftConfirmationError::Other(
+                "Timestamp should be greater than last timestamp".to_string(),
+            ));
         }
 
         self.last_timestamp.set(&current_timestamp, working_set);
@@ -126,13 +125,13 @@ where
     /// Checks two rules: block count rule and fee rate rule.
     #[cfg_attr(
         feature = "native",
-        instrument(level = "trace", skip(self, working_set), err, ret)
+        instrument(level = "trace", skip(self, working_set), err(Debug), ret)
     )]
     pub fn begin_soft_confirmation_hook(
         &self,
         soft_confirmation: &mut HookSoftConfirmationInfo,
         working_set: &mut WorkingSet<C>,
-    ) -> Result<(), ApplySoftConfirmationError> {
+    ) -> Result<(), SoftConfirmationError> {
         self.apply_block_count_rule(soft_confirmation, working_set)?;
 
         self.apply_fee_rate_rule(soft_confirmation, working_set)?;

--- a/crates/soft-confirmation-rule-enforcer/src/hooks.rs
+++ b/crates/soft-confirmation-rule-enforcer/src/hooks.rs
@@ -15,10 +15,7 @@ where
     /// If the number of L2 blocks exceeds the max L2 blocks per L1, the soft confirmation should fail and not be accepted by full nodes.
     /// This ensures the sequencer cannot publish more than the allowed number of L2 blocks per L1 block.
     /// Thus blocks the ability of the sequencer to censor the forced transactions in a future L1 block by not using that block.
-    #[cfg_attr(
-        feature = "native",
-        instrument(level = "trace", skip_all, err(Debug), ret)
-    )]
+    #[cfg_attr(feature = "native", instrument(level = "trace", skip_all, err, ret))]
     fn apply_block_count_rule(
         &self,
         soft_confirmation_info: &mut HookSoftConfirmationInfo,
@@ -55,10 +52,7 @@ where
     /// This ensures the sequencer cannot change the fee rate more than the allowed percentage.
     /// Thus blocks the ability of the sequencer to raise the L1 fee rates arbitrarily and charging a transaction maliciously.
     /// An ideal solution would have the L1 fee trustlessly determined by the L2 users, but that is not possible currently.
-    #[cfg_attr(
-        feature = "native",
-        instrument(level = "trace", skip_all, err(Debug), ret)
-    )]
+    #[cfg_attr(feature = "native", instrument(level = "trace", skip_all, err, ret))]
     fn apply_fee_rate_rule(
         &self,
         soft_confirmation: &mut HookSoftConfirmationInfo,
@@ -98,10 +92,7 @@ where
 
     /// Checks that the current block's timestamp.
     /// This is to make sure that the set timestamp is greater than the last block's timestamp.
-    #[cfg_attr(
-        feature = "native",
-        instrument(level = "trace", skip_all, err(Debug), ret)
-    )]
+    #[cfg_attr(feature = "native", instrument(level = "trace", skip_all, err, ret))]
     fn apply_timestamp_rule(
         &self,
         soft_confirmation: &mut HookSoftConfirmationInfo,
@@ -125,7 +116,7 @@ where
     /// Checks two rules: block count rule and fee rate rule.
     #[cfg_attr(
         feature = "native",
-        instrument(level = "trace", skip(self, working_set), err(Debug), ret)
+        instrument(level = "trace", skip(self, working_set), err, ret)
     )]
     pub fn begin_soft_confirmation_hook(
         &self,

--- a/crates/soft-confirmation-rule-enforcer/src/tests/hooks_tests.rs
+++ b/crates/soft-confirmation-rule-enforcer/src/tests/hooks_tests.rs
@@ -125,7 +125,7 @@ fn begin_soft_confirmation_hook_checks_l1_fee_rate() {
                     .unwrap()
             )
         ),
-        format!("{}", res.unwrap_err())
+        format!("{:?}", res.unwrap_err())
     );
 
     // now call with 110 fee rate
@@ -222,7 +222,7 @@ fn begin_soft_confirmation_hook_checks_l1_fee_rate() {
                     .unwrap()
             )
         ),
-        format!("{}", res.unwrap_err())
+        format!("{:?}", res.unwrap_err())
     );
 
     signed_soft_confirmation_batch.set_l1_fee_rate(90);
@@ -326,7 +326,7 @@ fn begin_soft_confirmation_hook_checks_timestamp() {
                     .unwrap()
             )
         ),
-        format!("{}", res.unwrap_err())
+        format!("{:?}", res.unwrap_err())
     );
 
     // now call with a timestamp after the original one.

--- a/crates/soft-confirmation-rule-enforcer/src/tests/hooks_tests.rs
+++ b/crates/soft-confirmation-rule-enforcer/src/tests/hooks_tests.rs
@@ -1,11 +1,10 @@
 use std::str::FromStr;
 
-use anyhow::anyhow;
 use sov_mock_da::MockDaSpec;
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::hooks::HookSoftConfirmationInfo;
 use sov_modules_api::utils::generate_address;
-use sov_modules_api::{Context, Module, Spec, StateValueAccessor};
+use sov_modules_api::{Context, Module, Spec};
 use sov_rollup_interface::soft_confirmation::SignedSoftConfirmationBatch;
 use sov_rollup_interface::spec::SpecId;
 
@@ -114,18 +113,8 @@ fn begin_soft_confirmation_hook_checks_l1_fee_rate() {
 
     assert!(res.is_err());
     assert_eq!(
-        format!(
-            "{}",
-            anyhow!(
-                "L1 fee rate {} changed more than allowed limit %{}",
-                signed_soft_confirmation_batch.l1_fee_rate(),
-                soft_confirmation_rule_enforcer
-                    .l1_fee_rate_change_percentage
-                    .get(&mut working_set)
-                    .unwrap()
-            )
-        ),
-        format!("{:?}", res.unwrap_err())
+        "Other error: L1 fee rate changed more than allowed",
+        format!("{}", res.unwrap_err())
     );
 
     // now call with 110 fee rate
@@ -211,18 +200,8 @@ fn begin_soft_confirmation_hook_checks_l1_fee_rate() {
     assert!(res.is_err());
 
     assert_eq!(
-        format!(
-            "{}",
-            anyhow!(
-                "L1 fee rate {} changed more than allowed limit %{}",
-                signed_soft_confirmation_batch.l1_fee_rate(),
-                soft_confirmation_rule_enforcer
-                    .l1_fee_rate_change_percentage
-                    .get(&mut working_set)
-                    .unwrap()
-            )
-        ),
-        format!("{:?}", res.unwrap_err())
+        "Other error: L1 fee rate changed more than allowed",
+        format!("{}", res.unwrap_err())
     );
 
     signed_soft_confirmation_batch.set_l1_fee_rate(90);
@@ -315,18 +294,8 @@ fn begin_soft_confirmation_hook_checks_timestamp() {
     assert!(res.is_err());
 
     assert_eq!(
-        format!(
-            "{}",
-            anyhow!(
-                "Current block's timestamp {} is not greater than the previous block's one {}",
-                signed_soft_confirmation_batch.timestamp(),
-                soft_confirmation_rule_enforcer
-                    .last_timestamp
-                    .get(&mut working_set)
-                    .unwrap()
-            )
-        ),
-        format!("{:?}", res.unwrap_err())
+        "Other error: Timestamp should be greater than last timestamp",
+        format!("{}", res.unwrap_err())
     );
 
     // now call with a timestamp after the original one.

--- a/crates/sovereign-sdk/examples/demo-simple-stf/src/lib.rs
+++ b/crates/sovereign-sdk/examples/demo-simple-stf/src/lib.rs
@@ -7,7 +7,9 @@ use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 use sov_rollup_interface::fork::Fork;
 use sov_rollup_interface::soft_confirmation::SignedSoftConfirmationBatch;
 use sov_rollup_interface::spec::SpecId;
-use sov_rollup_interface::stf::{BatchReceipt, SlotResult, StateTransitionFunction};
+use sov_rollup_interface::stf::{
+    BatchReceipt, SlotResult, SoftConfirmationResult, StateTransitionFunction,
+};
 use sov_rollup_interface::zk::{CumulativeStateDiff, ValidityCondition, Zkvm};
 
 /// An implementation of the [`StateTransitionFunction`]
@@ -123,12 +125,12 @@ impl<Vm: Zkvm, Cond: ValidityCondition, Da: DaSpec> StateTransitionFunction<Vm, 
         _slot_header: &<Da as DaSpec>::BlockHeader,
         _validity_condition: &<Da as DaSpec>::ValidityCondition,
         _soft_confirmation: &mut SignedSoftConfirmationBatch,
-    ) -> SlotResult<
+    ) -> SoftConfirmationResult<
         Self::StateRoot,
         Self::ChangeSet,
-        Self::BatchReceiptContents,
         Self::TxReceiptContents,
         Self::Witness,
+        Da,
     > {
         todo!()
     }

--- a/crates/sovereign-sdk/examples/demo-simple-stf/src/lib.rs
+++ b/crates/sovereign-sdk/examples/demo-simple-stf/src/lib.rs
@@ -8,7 +8,8 @@ use sov_rollup_interface::fork::Fork;
 use sov_rollup_interface::soft_confirmation::SignedSoftConfirmationBatch;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::stf::{
-    BatchReceipt, SlotResult, SoftConfirmationResult, StateTransitionFunction,
+    BatchReceipt, SlotResult, SoftConfirmationError, SoftConfirmationResult,
+    StateTransitionFunction,
 };
 use sov_rollup_interface::zk::{CumulativeStateDiff, ValidityCondition, Zkvm};
 
@@ -125,12 +126,15 @@ impl<Vm: Zkvm, Cond: ValidityCondition, Da: DaSpec> StateTransitionFunction<Vm, 
         _slot_header: &<Da as DaSpec>::BlockHeader,
         _validity_condition: &<Da as DaSpec>::ValidityCondition,
         _soft_confirmation: &mut SignedSoftConfirmationBatch,
-    ) -> SoftConfirmationResult<
-        Self::StateRoot,
-        Self::ChangeSet,
-        Self::TxReceiptContents,
-        Self::Witness,
-        Da,
+    ) -> Result<
+        SoftConfirmationResult<
+            Self::StateRoot,
+            Self::ChangeSet,
+            Self::TxReceiptContents,
+            Self::Witness,
+            Da,
+        >,
+        SoftConfirmationError,
     > {
         todo!()
     }

--- a/crates/sovereign-sdk/examples/demo-stf/src/hooks_impl.rs
+++ b/crates/sovereign-sdk/examples/demo-stf/src/hooks_impl.rs
@@ -1,8 +1,8 @@
 use sov_accounts::AccountsTxHook;
 use sov_bank::BankTxHook;
 use sov_modules_api::hooks::{
-    ApplyBlobHooks, ApplySoftConfirmationError, ApplySoftConfirmationHooks, FinalizeHook,
-    HookSoftConfirmationInfo, SlotHooks, TxHooks,
+    ApplyBlobHooks, ApplySoftConfirmationHooks, FinalizeHook, HookSoftConfirmationInfo, SlotHooks,
+    SoftConfirmationError, TxHooks,
 };
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{AccessoryWorkingSet, Context, Spec, WorkingSet};
@@ -78,7 +78,7 @@ impl<C: Context, Da: DaSpec> ApplySoftConfirmationHooks<Da> for Runtime<C, Da> {
         &self,
         _soft_confirmation: &mut HookSoftConfirmationInfo,
         _working_set: &mut WorkingSet<Self::Context>,
-    ) -> Result<(), ApplySoftConfirmationError> {
+    ) -> Result<(), SoftConfirmationError> {
         // Before executing each batch, check that the sender is registered as a sequencer
         Ok(())
     }
@@ -86,7 +86,7 @@ impl<C: Context, Da: DaSpec> ApplySoftConfirmationHooks<Da> for Runtime<C, Da> {
     fn end_soft_confirmation_hook(
         &self,
         _working_set: &mut WorkingSet<C>,
-    ) -> Result<(), ApplySoftConfirmationError> {
+    ) -> Result<(), SoftConfirmationError> {
         Ok(())
     }
 }

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -204,9 +204,10 @@ impl SharedLedgerOps for LedgerDB {
     }
 
     /// Commits a soft confirmation to the database by inserting its transactions and batches before
-    fn commit_soft_confirmation<B: Serialize, T: Serialize, DS: DaSpec>(
+    fn commit_soft_confirmation<T: Serialize, DS: DaSpec>(
         &self,
-        mut soft_confirmation_receipt: SoftConfirmationReceipt<B, T, DS>,
+        state_root: &[u8],
+        mut soft_confirmation_receipt: SoftConfirmationReceipt<T, DS>,
         include_tx_body: bool,
     ) -> Result<(), anyhow::Error> {
         // Create a scope to ensure that the lock is released before we commit to the db
@@ -270,7 +271,7 @@ impl SharedLedgerOps for LedgerDB {
             prev_hash: soft_confirmation_receipt.prev_hash,
             tx_range: TxNumber(first_tx_number)..TxNumber(last_tx_number),
             txs,
-            state_root: soft_confirmation_receipt.state_root,
+            state_root: state_root.to_vec(),
             soft_confirmation_signature: soft_confirmation_receipt.soft_confirmation_signature,
             pub_key: soft_confirmation_receipt.pub_key,
             deposit_data: soft_confirmation_receipt.deposit_data,

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
@@ -40,9 +40,10 @@ pub trait SharedLedgerOps {
     ) -> Result<()>;
 
     /// Commits a soft confirmation to the database by inserting its transactions and batches before
-    fn commit_soft_confirmation<B: Serialize, T: Serialize, DS: DaSpec>(
+    fn commit_soft_confirmation<T: Serialize, DS: DaSpec>(
         &self,
-        batch_receipt: SoftConfirmationReceipt<B, T, DS>,
+        state_root: &[u8],
+        sc_receipt: SoftConfirmationReceipt<T, DS>,
         include_tx_body: bool,
     ) -> Result<()>;
 

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/src/mock/mod.rs
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/src/mock/mod.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use sov_modules_api::hooks::SoftConfirmationError;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::fork::Fork;
 use sov_rollup_interface::spec::SpecId;
@@ -78,12 +79,15 @@ impl<Vm: Zkvm, Cond: ValidityCondition, Da: DaSpec> StateTransitionFunction<Vm, 
         _slot_header: &<Da as DaSpec>::BlockHeader,
         _validity_condition: &<Da as DaSpec>::ValidityCondition,
         _soft_confirmation: &mut sov_modules_api::SignedSoftConfirmationBatch,
-    ) -> SoftConfirmationResult<
-        Self::StateRoot,
-        Self::ChangeSet,
-        Self::TxReceiptContents,
-        Self::Witness,
-        Da,
+    ) -> Result<
+        SoftConfirmationResult<
+            Self::StateRoot,
+            Self::ChangeSet,
+            Self::TxReceiptContents,
+            Self::Witness,
+            Da,
+        >,
+        SoftConfirmationError,
     > {
         todo!()
     }

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/src/mock/mod.rs
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/src/mock/mod.rs
@@ -3,7 +3,9 @@ use std::marker::PhantomData;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::fork::Fork;
 use sov_rollup_interface::spec::SpecId;
-use sov_rollup_interface::stf::{BatchReceipt, SlotResult, StateTransitionFunction};
+use sov_rollup_interface::stf::{
+    BatchReceipt, SlotResult, SoftConfirmationResult, StateTransitionFunction,
+};
 use sov_rollup_interface::zk::{CumulativeStateDiff, ValidityCondition, Zkvm};
 
 /// A mock implementation of the [`StateTransitionFunction`]
@@ -76,12 +78,12 @@ impl<Vm: Zkvm, Cond: ValidityCondition, Da: DaSpec> StateTransitionFunction<Vm, 
         _slot_header: &<Da as DaSpec>::BlockHeader,
         _validity_condition: &<Da as DaSpec>::ValidityCondition,
         _soft_confirmation: &mut sov_modules_api::SignedSoftConfirmationBatch,
-    ) -> SlotResult<
+    ) -> SoftConfirmationResult<
         Self::StateRoot,
         Self::ChangeSet,
-        Self::BatchReceiptContents,
         Self::TxReceiptContents,
         Self::Witness,
+        Da,
     > {
         todo!()
     }

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/hooks.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/hooks.rs
@@ -4,44 +4,9 @@ use sov_modules_core::{AccessoryWorkingSet, Context, Spec, Storage, WorkingSet};
 use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 use sov_rollup_interface::soft_confirmation::SignedSoftConfirmationBatch;
 use sov_rollup_interface::spec::SpecId;
-use thiserror::Error;
+pub use sov_rollup_interface::stf::SoftConfirmationError;
 
 use crate::transaction::Transaction;
-
-/// Soft confirmation error
-#[derive(Debug, Error)]
-pub enum ApplySoftConfirmationError {
-    /// Checks count of soft confirmations on the slot
-    #[error(
-        "Too many soft confirmations on the slot {:?} by sequencer {:?} with max L2 blocks per L1 {}",
-        hash,
-        sequencer_pub_key,
-        max_l2_blocks_per_l1
-    )]
-    TooManySoftConfirmationsOnDaSlot {
-        /// Hash of the slot
-        hash: [u8; 32],
-        /// Sequencer public key
-        sequencer_pub_key: Vec<u8>,
-        /// max L2 blocks per L1
-        max_l2_blocks_per_l1: u64,
-    },
-    #[error(
-        "L1 fee rate {} changed more than allowed limit %{}",
-        l1_fee_rate,
-        l1_fee_rate_change_percentage
-    )]
-    L1FeeRateChangeMoreThanAllowedPercentage {
-        l1_fee_rate: u128,
-        l1_fee_rate_change_percentage: u128,
-    },
-    #[error(
-        "Current block's timestamp {} is not greater than the previous block's one {}",
-        current,
-        prev
-    )]
-    CurrentTimestampIsNotGreaterThanPrev { current: u64, prev: u64 },
-}
 
 /// Hooks that execute within the `StateTransitionFunction::apply_blob` function for each processed transaction.
 ///
@@ -102,14 +67,14 @@ pub trait ApplySoftConfirmationHooks<Da: DaSpec> {
         &self,
         soft_confirmation: &mut HookSoftConfirmationInfo,
         working_set: &mut WorkingSet<Self::Context>,
-    ) -> Result<(), ApplySoftConfirmationError>;
+    ) -> Result<(), SoftConfirmationError>;
 
     /// Executes at the end of apply_blob and rewards or slashes the sequencer
     /// If this hook returns Err rollup panics
     fn end_soft_confirmation_hook(
         &self,
         working_set: &mut WorkingSet<Self::Context>,
-    ) -> Result<(), ApplySoftConfirmationError>;
+    ) -> Result<(), SoftConfirmationError>;
 }
 
 /// Information about the soft confirmation block

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/Cargo.toml
@@ -43,6 +43,7 @@ default = []
 native = [
   "sov-state/native",
   "sov-modules-api/native",
+  "sov-rollup-interface/native",
   "dep:tracing",
   "jsonrpsee",
 ]

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -310,7 +310,7 @@ where
             sc_receipt.tx_receipts.len(),
         );
 
-        // TODO: do this only on native
+        #[cfg(feature = "native")]
         for (i, tx_receipt) in sc_receipt.tx_receipts.iter().enumerate() {
             native_debug!(
                 "tx #{} hash: 0x{} result {:?}",

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -172,7 +172,7 @@ pub trait StfBlueprintTrait<C: Context, Da: DaSpec, Vm: Zkvm>:
     fn finalize_soft_confirmation(
         &self,
         current_spec: SpecId,
-        batch_receipt: SoftConfirmationReceipt<TxEffect, Da>,
+        sc_receipt: SoftConfirmationReceipt<TxEffect, Da>,
         checkpoint: StateCheckpoint<C>,
         pre_state: Self::PreState,
         soft_confirmation: &mut SignedSoftConfirmationBatch,

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -727,7 +727,10 @@ where
                         validity_condition,
                         &mut soft_confirmation,
                     )
-                    .expect("Soft confirmation must succeed"); // TODO: this can be just ignoring the failing seq. com.
+                    // TODO: this can be just ignoring the failing seq. com.
+                    // We can count a failed soft confirmation as a valid state transition.
+                    // for now we don't allow "broken" seq. com.s
+                    .expect("Soft confirmation must succeed");
 
                 current_state_root = result.state_root;
                 state_diff.extend(result.state_diff);

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
@@ -28,7 +28,7 @@ pub struct StfBlueprint<C: Context, Da: DaSpec, Vm, RT: Runtime<C, Da>> {
     phantom_da: PhantomData<Da>,
 }
 
-type ApplySoftConfirmationResult<Da: DaSpec> =
+type ApplySoftConfirmationResult<Da> =
     Result<SoftConfirmationReceipt<TxEffect, Da>, ApplySoftConfirmationError>;
 
 impl<C, Vm, Da, RT> Default for StfBlueprint<C, Da, Vm, RT>

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
@@ -4,9 +4,9 @@ use sov_modules_api::hooks::{ApplySoftConfirmationError, HookSoftConfirmationInf
 use sov_modules_api::{
     native_debug, native_error, Context, DaSpec, DispatchCall, StateCheckpoint, WorkingSet,
 };
-use sov_rollup_interface::soft_confirmation::{self, SignedSoftConfirmationBatch};
+use sov_rollup_interface::soft_confirmation::SignedSoftConfirmationBatch;
 use sov_rollup_interface::spec::SpecId;
-use sov_rollup_interface::stf::{BatchReceipt, SoftConfirmationReceipt, TransactionReceipt};
+use sov_rollup_interface::stf::{SoftConfirmationReceipt, TransactionReceipt};
 use sov_state::Storage;
 #[cfg(all(target_os = "zkvm", feature = "bench"))]
 use sov_zk_cycle_macros::cycle_tracker;

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
@@ -228,7 +228,7 @@ pub trait BlobReaderTrait:
 /// Trait with collection of trait bounds for a block hash.
 pub trait BlockHashTrait:
     // so it is compatible with StorageManager implementation?
-    BorshDeserialize + BorshSerialize + Serialize + DeserializeOwned + PartialEq + Debug + Send + Sync + Clone + Eq + Into<[u8; 32]> + core::hash::Hash
+    BorshDeserialize + BorshSerialize + Serialize + DeserializeOwned + PartialEq + Debug + Send + Sync + Clone + Eq + From<[u8; 32]> + Into<[u8; 32]> + core::hash::Hash
 {
 }
 

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
@@ -312,6 +312,29 @@ pub enum SoftConfirmationError {
     Other(String),
 }
 
+#[cfg(feature = "native")]
+impl std::error::Error for SoftConfirmationError {}
+
+#[cfg(feature = "native")]
+impl std::fmt::Display for SoftConfirmationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SoftConfirmationError::SequencerPublicKeyMismatch => {
+                write!(f, "Sequencer public key mismatch")
+            }
+            SoftConfirmationError::InvalidDaHash => write!(f, "Invalid DA hash"),
+            SoftConfirmationError::InvalidDaTxsCommitment => write!(f, "Invalid DA txs commitment"),
+            SoftConfirmationError::InvalidSoftConfirmationHash => {
+                write!(f, "Invalid soft confirmation hash")
+            }
+            SoftConfirmationError::InvalidSoftConfirmationSignature => {
+                write!(f, "Invalid soft confirmation signature")
+            }
+            SoftConfirmationError::Other(s) => write!(f, "Other error: {}", s),
+        }
+    }
+}
+
 /// A key-value pair representing a change to the rollup state
 #[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
@@ -7,6 +7,7 @@
 extern crate alloc;
 
 use alloc::collections::VecDeque;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;


### PR DESCRIPTION
# Description
Removes dependency on `BatchReceipt`, renames a few variables here and there.
Removes a lot of unnecessary code regarding SoftConfirmationReceipts
STF blueprint function types make way more sense now. (regarding soft confirmation functions)

## Linked Issues
Closes #174 (to some extent)