### PR TITLE
E2E prover test: wait for a zkproof on full node

### DIFF
--- a/bin/citrea/tests/bitcoin_e2e/tests/prover_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/tests/prover_test.rs
@@ -20,6 +20,7 @@ impl TestCase for BasicProverTest {
     fn test_config() -> TestCaseConfig {
         TestCaseConfig {
             with_prover: true,
+            with_full_node: true,
             ..Default::default()
         }
     }
@@ -39,6 +40,10 @@ impl TestCase for BasicProverTest {
 
         let Some(prover) = &f.prover else {
             bail!("Prover not running. Set TestCaseConfig with_prover to true")
+        };
+
+        let Some(full_node) = &f.full_node else {
+            bail!("FullNode not running. Set TestCaseConfig with_full_node to true")
         };
 
         let Some(da) = f.bitcoin_nodes.get(0) else {
@@ -63,8 +68,31 @@ impl TestCase for BasicProverTest {
         da.generate(5, None).await?;
         let finalized_height = da.get_finalized_height().await?;
         prover
-            .wait_for_l1_height(finalized_height, Some(Duration::from_secs(600)))
+            .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
             .await;
+
+        da.generate(5, None).await?;
+        let proofs = full_node
+            .wait_for_zkproofs(finalized_height + 5, Some(Duration::from_secs(120)))
+            .await
+            .unwrap();
+
+        {
+            // print some debug info about state diff
+            let state_diff = &proofs[0].state_transition.state_diff;
+            let state_diff_size: usize = state_diff
+                .iter()
+                .map(|(k, v)| k.len() + v.as_ref().map(|v| v.len()).unwrap_or_default())
+                .sum();
+            let borshed_state_diff = borsh::to_vec(state_diff).unwrap();
+            let compressed_state_diff =
+                bitcoin_da::helpers::compression::compress_blob(&borshed_state_diff);
+            println!(
+                "StateDiff: size {}, compressed {}",
+                state_diff_size,
+                compressed_state_diff.len()
+            );
+        }
 
         Ok(())
     }

--- a/crates/bitcoin-da/src/lib.rs
+++ b/crates/bitcoin-da/src/lib.rs
@@ -1,4 +1,4 @@
-mod helpers;
+pub mod helpers;
 pub mod spec;
 
 #[cfg(feature = "native")]


### PR DESCRIPTION
# Description

Prints:

```
Running bitcoind with args : ["-regtest", "-datadir=/tmp/.tmpeYjSor/bitcoin/0", "-port=35623", "-rpcport=36241", "-rpcuser=user", "-rpcpassword=password", "-server", "-daemon", "-txindex", "-addresstype=bech32m"]
Bitcoin Core starting
bitcoin RPC is ready
Logs available at /tmp/.tmpeYjSor
Bitcoin logs available at : /tmp/.tmpeYjSor/bitcoin/0/regtest/debug.log
Sequencer logs available at /tmp/.tmpeYjSor/sequencer/stdout.log
Full node logs available at /tmp/.tmpeYjSor/full-node/stdout.log
Prover logs available at /tmp/.tmpeYjSor/prover/stdout.log
test bitcoin_e2e::tests::prover_test::basic_prover_test has been running for over 60 seconds
StateDiff: size 5036, compressed 1239
Stopping framework...
Successfully stopped sequencer
Successfully stopped prover
Successfully stopped full_node
Successfully stopped bitcoin nodes
test bitcoin_e2e::tests::prover_test::basic_prover_test ... ok
```

## Testing

It's a test itself