### PR TITLE
Rename Evm fields with 1 letter

### DIFF
--- a/crates/evm/src/evm/mod.rs
+++ b/crates/evm/src/evm/mod.rs
@@ -44,7 +44,7 @@ pub const L1_FEE_VAULT: Address = address!("310000000000000000000000000000000000
 pub const PRIORITY_FEE_VAULT: Address = address!("3100000000000000000000000000000000000005");
 
 /// asd
-pub const STORAGE_DBACCOUNT_PREFIX: [u8; 8] = *b"Evm/stg/";
+pub const STORAGE_DBACCOUNT_PREFIX: [u8; 6] = *b"Evm/s/";
 
 // Stores information about an EVM account
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
@@ -81,9 +81,9 @@ impl DbAccount {
     }
 
     fn create_storage_prefix(address: Address) -> Prefix {
-        let mut prefix = [0u8; 28];
-        prefix[0..8].copy_from_slice(&STORAGE_DBACCOUNT_PREFIX);
-        prefix[8..].copy_from_slice(address.as_raw_slice());
+        let mut prefix = [0u8; 26];
+        prefix[0..6].copy_from_slice(&STORAGE_DBACCOUNT_PREFIX);
+        prefix[6..].copy_from_slice(address.as_raw_slice());
         Prefix::new(prefix.to_vec())
     }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -72,7 +72,7 @@ pub struct Evm<C: sov_modules_api::Context> {
     pub(crate) address: C::Address,
 
     /// Mapping from account address to account state.
-    #[state]
+    #[state(rename = "a")]
     pub(crate) accounts: sov_modules_api::StateMap<Address, AccountInfo, BcsCodec>,
 
     /// Mapping from code hash to code. Used for lazy-loading code into a contract account.
@@ -99,13 +99,13 @@ pub struct Evm<C: sov_modules_api::Context> {
     pub(crate) head: sov_modules_api::StateValue<Block, BcsCodec>,
 
     /// Last seen L1 block hash.
-    #[state]
+    #[state(rename = "l")]
     pub(crate) last_l1_hash: sov_modules_api::StateValue<B256, BcsCodec>,
 
     /// Last 256 block hashes. Latest blockhash is populated in `begin_slot_hook`.
     /// Removes the oldest blockhash in `finalize_hook`
     /// Used by the EVM to calculate the `blockhash` opcode.
-    #[state]
+    #[state(rename = "h")]
     pub(crate) latest_block_hashes: sov_modules_api::StateMap<U256, B256, BcsCodec>,
 
     /// Transaction's hash that failed to pay the L1 fee.

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/src/module_info.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/src/module_info.rs
@@ -75,7 +75,7 @@ fn impl_module_info(
 
     for field in fields.iter() {
         match &field.attr {
-            ModuleFieldAttribute::State { codec_builder } => {
+            ModuleFieldAttribute::State { codec_builder, .. } => {
                 impl_self_init.push(make_init_state(
                     field,
                     &codec_builder
@@ -146,8 +146,16 @@ fn make_prefix_func(
     field: &ModuleField,
     module_ident: &proc_macro2::Ident,
 ) -> proc_macro2::TokenStream {
+    let ModuleFieldAttribute::State { rename, .. } = &field.attr else {
+        unreachable!("Prefix is implemented for state only");
+    };
     let field_ident = &field.ident;
     let prefix_func_ident = prefix_func_ident(field_ident);
+    let field_name = if let Some(name) = rename {
+        quote::quote! { #name }
+    } else {
+        quote::quote! { stringify!(#field_ident) }
+    };
 
     // generates prefix functions:
     //   fn _prefix_field_ident() -> sov_modules_api::ModulePrefix {
@@ -157,7 +165,7 @@ fn make_prefix_func(
     quote::quote! {
         fn #prefix_func_ident() -> sov_modules_api::ModulePrefix {
             let module_path = module_path!();
-            sov_modules_api::ModulePrefix::new_storage(module_path, stringify!(#module_ident), stringify!(#field_ident))
+            sov_modules_api::ModulePrefix::new_storage(module_path, stringify!(#module_ident), #field_name)
         }
     }
 }
@@ -333,7 +341,10 @@ pub mod parsing {
     pub enum ModuleFieldAttribute {
         Module,
         KernelModule,
-        State { codec_builder: Option<syn::Path> },
+        State {
+            codec_builder: Option<syn::Path>,
+            rename: Option<syn::LitStr>,
+        },
         Address,
         Gas,
     }
@@ -394,6 +405,7 @@ pub mod parsing {
         let meta = if attr.tokens.is_empty() {
             return Ok(ModuleFieldAttribute::State {
                 codec_builder: None,
+                rename: None,
             });
         } else {
             attr.parse_meta()?
@@ -403,21 +415,37 @@ pub mod parsing {
             syn::Meta::List(l) if !l.nested.is_empty() => l,
             _ => return Err(syntax_err),
         };
-        let name_value = match &meta_list.nested[0] {
-            syn::NestedMeta::Meta(syn::Meta::NameValue(nv)) => nv,
-            _ => return Err(syntax_err),
-        };
-
-        if name_value.path.get_ident().map(Ident::to_string).as_deref() != Some("codec_builder") {
-            return Err(syntax_err);
+        let mut codec_builder = None;
+        let mut rename = None;
+        for nested in meta_list.nested {
+            let nv = match nested {
+                syn::NestedMeta::Meta(syn::Meta::NameValue(nv)) => nv,
+                _ => return Err(syntax_err),
+            };
+            let Some(ident) = nv.path.get_ident() else {
+                return Err(syntax_err);
+            };
+            match ident.to_string().as_str() {
+                "codec_builder" => {
+                    let path = match &nv.lit {
+                        syn::Lit::Str(lit) => lit.parse_with(syn::Path::parse_mod_style)?,
+                        _ => return Err(syntax_err),
+                    };
+                    codec_builder = Some(path)
+                }
+                "rename" => {
+                    let name = match &nv.lit {
+                        syn::Lit::Str(lit) => lit.to_owned(),
+                        _ => return Err(syntax_err),
+                    };
+                    rename = Some(name)
+                }
+                _ => return Err(syntax_err),
+            }
         }
-
-        let codec_builder_path = match &name_value.lit {
-            syn::Lit::Str(lit) => lit.parse_with(syn::Path::parse_mod_style)?,
-            _ => return Err(syntax_err),
-        };
         Ok(ModuleFieldAttribute::State {
-            codec_builder: Some(codec_builder_path),
+            codec_builder,
+            rename,
         })
     }
 


### PR DESCRIPTION
# Description

Rename prefixes for storage:

```
#[derive(ModuleInfo, Clone)]
pub struct Evm<C: sov_modules_api::Context> {
    #[state(rename = "a")]
    pub(crate) accounts: sov_modules_api::StateMap<Address, AccountInfo, BcsCodec>,
```

StateDiff: size 3933, compressed 1178