### PR TITLE
Remove redundant build

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -354,8 +354,6 @@ jobs:
         run: cargo risczero install --version r0.1.79.0-2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build citrea
-        run: make build
         # `cargo-nextest` is much faster than standard `cargo test`.
       - uses: taiki-e/install-action@nextest
       - name: Cache ethereum-tests


### PR DESCRIPTION
# Description

In my previous PR: #1101 i didn't pay attention that the `nextest` workflow had a redundant build as well.

Removing this since `make coverage` and `make test` have `make build` as a dependency
