### PR TITLE
Make l2 height of GetSoftConfirmationResponse public

### DIFF
--- a/crates/sequencer-client/src/lib.rs
+++ b/crates/sequencer-client/src/lib.rs
@@ -104,7 +104,7 @@ impl SequencerClient {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSoftConfirmationResponse {
-    l2_height: u64,
+    pub l2_height: u64,
     #[serde(with = "hex::serde")]
     pub hash: SoftConfirmationHash,
     #[serde(with = "hex::serde")]


### PR DESCRIPTION
# Description
Makes l2_height field of GetSoftConfirmationResponse public
Needed for batch explorer


