### PR TITLE
Further restrict eth_getLogs

### DIFF
--- a/crates/evm/src/rpc_helpers/filter.rs
+++ b/crates/evm/src/rpc_helpers/filter.rs
@@ -16,9 +16,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::evm::error::result::rpc_error_with_code;
 
 /// The maximum number of blocks that can be queried in a single eth_getLogs request.
-pub const DEFAULT_MAX_BLOCKS_PER_FILTER: u64 = 100_000;
+pub const DEFAULT_MAX_BLOCKS_PER_FILTER: u64 = 1_000;
 /// The maximum number of logs that can be returned in a single eth_getLogs response.
-pub const DEFAULT_MAX_LOGS_PER_RESPONSE: usize = 20_000;
+pub const DEFAULT_MAX_LOGS_PER_RESPONSE: usize = 5_000;
 /// The maximum number of headers we read at once when handling a range filter.
 pub const MAX_HEADERS_RANGE: u64 = 1_000; // with ~530bytes? per header this is ~500kb?
 

--- a/crates/evm/src/tests/queries/log_tests.rs
+++ b/crates/evm/src/tests/queries/log_tests.rs
@@ -529,7 +529,7 @@ fn test_log_limits() {
         FilterSet::default(),
     ];
 
-    for _ in 1..100_001 {
+    for _ in 1..1001 {
         let soft_confirmation_info = HookSoftConfirmationInfo {
             l2_height,
             da_slot_hash: [5u8; 32],
@@ -553,7 +553,7 @@ fn test_log_limits() {
     let filter = Filter {
         block_option: crate::FilterBlockOption::Range {
             from_block: Some(BlockNumberOrTag::Number(1)),
-            to_block: Some(BlockNumberOrTag::Number(100_001)),
+            to_block: Some(BlockNumberOrTag::Number(1_001)),
         },
         address: FilterSet::default(),
         topics: empty_topics.clone(),
@@ -564,6 +564,6 @@ fn test_log_limits() {
     assert!(rpc_logs.is_err());
     assert_eq!(
         rpc_logs.err().unwrap().message(),
-        "query exceeds max block range 100000".to_string()
+        "query exceeds max block range 1000".to_string()
     );
 }

--- a/crates/evm/src/tests/queries/log_tests.rs
+++ b/crates/evm/src/tests/queries/log_tests.rs
@@ -517,7 +517,7 @@ fn test_log_limits() {
     if let Err(rpc_err) = rpc_logs {
         assert_eq!(
             rpc_err.message(),
-            "query exceeds max results 20000".to_string()
+            "query exceeds max results 5000".to_string()
         );
     }
 


### PR DESCRIPTION
# Description
Decreases the max limit of block count that can be queried with `eth_getLogs` and the count of logs per response.

## Linked Issues
- Fixes #1158