### PR TITLE
add locked flag to cargo-udeps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install-dev-tools:  ## Installs all necessary cargo helpers
 	cargo install --locked dprint
 	cargo install cargo-llvm-cov
 	cargo install cargo-hack
-	cargo install cargo-udeps
+	cargo install cargo-udeps --locked
 	cargo install flaky-finder
 	cargo install cargo-nextest --locked
 	cargo install --version 1.7.0 cargo-binstall

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,11 @@ install-dev-tools:  ## Installs all necessary cargo helpers
 	cargo install --locked dprint
 	cargo install cargo-llvm-cov
 	cargo install cargo-hack
-	cargo install cargo-udeps --locked
+	cargo install --locked cargo-udeps
 	cargo install flaky-finder
-	cargo install cargo-nextest --locked
+	cargo install --locked cargo-nextest
 	cargo install --version 1.7.0 cargo-binstall
-	cargo binstall cargo-risczero@1.0.5 --no-confirm
+	cargo binstall --no-confirm cargo-risczero@1.0.5
 	cargo risczero install --version r0.1.79.0-2
 	rustup target add thumbv6m-none-eabi
 	rustup component add llvm-tools-preview


### PR DESCRIPTION
# Description

cargo install cargo-udeps was not working without the locked flag, error I got with cargo install cargo-udeps:

error: failed to compile `cargo-udeps v0.1.50`, intermediate artifacts can be found at `/var/folders/70/j4h5vq3s1m989g_7ptp_259c0000gn/T/cargo-installYck3ry`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.79.0 is not supported by the following package:
    orion@0.17.7 requires rustc 1.80
  Try re-running `cargo install` with `--locked`