### PR TITLE
Avoid calling spawn_da_queue for full node

### DIFF
--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -144,9 +144,11 @@ impl RollupBlueprint for BitcoinRollup {
             .await?
         };
         let service = Arc::new(bitcoin_service);
-
-        Arc::clone(&service).spawn_da_queue(rx);
-
+        // until forced transactions are implemented,
+        // require_wallet_check is set false for non-sequencer full node
+        if require_wallet_check { // spawn_da_queue only for sequencer and prover
+            Arc::clone(&service).spawn_da_queue(rx);
+        } 
         Ok(service)
     }
 

--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -146,9 +146,10 @@ impl RollupBlueprint for BitcoinRollup {
         let service = Arc::new(bitcoin_service);
         // until forced transactions are implemented,
         // require_wallet_check is set false for non-sequencer full node
-        if require_wallet_check { // spawn_da_queue only for sequencer and prover
+        if require_wallet_check {
+            // spawn_da_queue only for sequencer and prover
             Arc::clone(&service).spawn_da_queue(rx);
-        } 
+        }
         Ok(service)
     }
 

--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -145,7 +145,7 @@ impl RollupBlueprint for BitcoinRollup {
         };
         let service = Arc::new(bitcoin_service);
         // until forced transactions are implemented,
-        // require_wallet_check is set false for non-sequencer full node
+        // require_wallet_check is set false for full nodes.
         if require_wallet_check {
             // spawn_da_queue only for sequencer and prover
             Arc::clone(&service).spawn_da_queue(rx);


### PR DESCRIPTION
# Description
Avoid calling spawn_da_queue for non-sequencer full node, as they don't write to DA

## Linked Issues
- Fixes #1159 