### PR TITLE
Customisable workflow dispatch name

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,6 +40,11 @@ name: Checks
 
 on:
   workflow_dispatch:
+    inputs:
+      custom_name:
+        description: 'Custom run name (optional)'
+        required: false
+        type: string
   merge_group:
     types: ["checks_requested"]
   push:
@@ -47,6 +52,8 @@ on:
   pull_request:
     branches: ["nightly", "devnet-freeze", "main"]
     types: [opened, synchronize, reopened, ready_for_review]
+
+run-name: ${{ inputs.custom_name || github.event.pull_request.title || github.sha }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
- Let's one optionally customise checks workflow run name via workflow_dispatch
- Default to PR's name if not set
- Defaults to commit sha if run without name input