### PR TITLE
Fix healthcheck flakiness

### DIFF
--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -1,4 +1,6 @@
 //! Common RPC crate provides helper methods that are needed in rpc servers
+use std::time::Duration;
+
 use hyper::Method;
 use jsonrpsee::core::RegisterMethodError;
 use jsonrpsee::server::middleware::http::ProxyGetRequestLayer;
@@ -7,7 +9,6 @@ use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::RpcModule;
 use sov_db::ledger_db::{LedgerDB, SharedLedgerOps};
 use sov_db::schema::types::BatchNumber;
-use std::time::Duration;
 use tower_http::cors::{Any, CorsLayer};
 
 // Exit early if head_batch_num is below this threshold


### PR DESCRIPTION
# Description

- Flakiness came from two highest batch having same timestamp. It led to tokio sleeping for 0millis and not letting time for another batch to be produced. Fixes it by adding a `.max(1)` on the timestamp diff to make sure to wait at least 1*1500millis
- Clean up error handling

## Linked Issues
- Fixes #1221 
