### PR TITLE
JSONRPC request-response logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "citrea-primitives",
+ "futures",
  "hyper 1.4.1",
  "jsonrpsee",
  "lru",
@@ -1758,6 +1759,7 @@ dependencies = [
  "sov-rollup-interface",
  "tokio",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -14,11 +14,13 @@ resolver = "2"
 # 3rd-party deps
 anyhow = { workspace = true }
 backoff = { workspace = true }
+futures = { workspace = true }
 hyper = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 lru = { workspace = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }
+tracing = { workspace = true }
 
 # Sov SDK deps
 sov-db = { path = "../sovereign-sdk/full-node/db/sov-db" }

--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -81,7 +81,7 @@ pub fn get_cors_layer() -> CorsLayer {
         .allow_headers(Any)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Logger<S>(pub S);
 
 impl<'a, S> RpcServiceT<'a> for Logger<S>

--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -94,13 +94,13 @@ where
         let req_id = req.id();
         let req_method = req.method_name().to_string();
 
-        tracing::info!(id = ?req_id, method = ?req_method, params = ?req.params().as_str(), "rpc_request");
+        tracing::debug!(id = ?req_id, method = ?req_method, params = ?req.params().as_str(), "rpc_request");
 
         let service = self.0.clone();
         async move {
             let resp = service.call(req).await;
             if resp.is_success() {
-                tracing::info!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_success");
+                tracing::debug!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_success");
             } else {
                 tracing::warn!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_error");
             }

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -9,7 +9,7 @@ use citrea_common::cache::L1BlockCache;
 use citrea_common::da::get_da_block_at_height;
 use citrea_primitives::types::SoftConfirmationHash;
 use jsonrpsee::core::client::Error as JsonrpseeError;
-use jsonrpsee::server::{BatchRequestConfig, ServerBuilder};
+use jsonrpsee::server::{BatchRequestConfig, RpcServiceBuilder, ServerBuilder};
 use jsonrpsee::RpcModule;
 use sequencer_client::{GetSoftConfirmationResponse, SequencerClient};
 use sov_db::ledger_db::NodeLedgerOps;
@@ -176,6 +176,7 @@ where
         let middleware = tower::ServiceBuilder::new()
             .layer(citrea_common::rpc::get_cors_layer())
             .layer(citrea_common::rpc::get_healthcheck_proxy_layer());
+        let rpc_middleware = RpcServiceBuilder::new().layer_fn(citrea_common::rpc::Logger);
 
         let _handle = tokio::spawn(async move {
             let server = ServerBuilder::default()
@@ -185,6 +186,7 @@ where
                 .max_response_body_size(max_response_body_size)
                 .set_batch_request_config(BatchRequestConfig::Limit(batch_requests_limit))
                 .set_http_middleware(middleware)
+                .set_rpc_middleware(rpc_middleware)
                 .build([listen_address].as_ref())
                 .await;
 

--- a/crates/sequencer-client/src/lib.rs
+++ b/crates/sequencer-client/src/lib.rs
@@ -28,7 +28,7 @@ impl SequencerClient {
     }
 
     /// Gets l2 block given l2 height
-    #[instrument(level = "trace", skip(self), err, ret)]
+    #[instrument(level = "trace", skip(self), ret)]
     pub async fn get_soft_confirmation<DaSpec: sov_rollup_interface::da::DaSpec>(
         &self,
         num: u64,
@@ -48,7 +48,7 @@ impl SequencerClient {
     }
 
     /// Gets l2 blocks given a range
-    #[instrument(level = "trace", skip(self), err, ret)]
+    #[instrument(level = "trace", skip(self), ret)]
     pub async fn get_soft_confirmation_range<DaSpec: sov_rollup_interface::da::DaSpec>(
         &self,
         range: RangeInclusive<u64>,
@@ -71,7 +71,7 @@ impl SequencerClient {
     }
 
     /// Gets l2 block height
-    #[instrument(level = "trace", skip(self), err, ret)]
+    #[instrument(level = "trace", skip(self), ret)]
     pub async fn block_number(&self) -> Result<u64, Error> {
         self.client
             .request("ledger_getHeadSoftConfirmationHeight", rpc_params![])
@@ -79,14 +79,14 @@ impl SequencerClient {
     }
 
     /// Sends raw tx to sequencer
-    #[instrument(level = "trace", skip_all, err, ret)]
+    #[instrument(level = "trace", skip_all, ret)]
     pub async fn send_raw_tx(&self, tx: Bytes) -> Result<B256, Error> {
         self.client
             .request("eth_sendRawTransaction", rpc_params![tx])
             .await
     }
 
-    #[instrument(level = "trace", skip(self), err, ret)]
+    #[instrument(level = "trace", skip(self), ret)]
     pub async fn get_tx_by_hash(
         &self,
         tx_hash: B256,

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -17,7 +17,7 @@ use citrea_stf::runtime::Runtime;
 use digest::Digest;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::StreamExt;
-use jsonrpsee::server::{BatchRequestConfig, ServerBuilder};
+use jsonrpsee::server::{BatchRequestConfig, RpcServiceBuilder, ServerBuilder};
 use jsonrpsee::RpcModule;
 use parking_lot::Mutex;
 use reth_primitives::{Address, IntoRecoveredTransaction, TxHash};
@@ -212,6 +212,7 @@ where
 
         let middleware = tower::ServiceBuilder::new().layer(citrea_common::rpc::get_cors_layer());
         //  .layer(citrea_common::rpc::get_healthcheck_proxy_layer());
+        let rpc_middleware = RpcServiceBuilder::new().layer_fn(citrea_common::rpc::Logger);
 
         let _handle = tokio::spawn(async move {
             let server = ServerBuilder::default()
@@ -221,6 +222,7 @@ where
                 .max_response_body_size(max_response_body_size)
                 .set_batch_request_config(BatchRequestConfig::Limit(batch_requests_limit))
                 .set_http_middleware(middleware)
+                .set_rpc_middleware(rpc_middleware)
                 .build([listen_address].as_ref())
                 .await;
 


### PR DESCRIPTION
# Description

Added logging to each JSONRPC request and response to be able to have better debuggability of our nodes. Each request and successful response is logged with debug tracing level. Error responses are logged with warn level since it is highly likely that the error is caused by the client-side.

Original idea was to add a new tracing level for rpc request logging. But such behavior is not possible with tracing crate. Instead of that, errors are now logged to warn level, and can be searched with a filter such as level = WARN && message = rpc_error.

I initially logged the request and success responses to info level, but due to full nodes constantly spamming sequencer for new blocks through rpc, sequencer logs became full with useless rpc calls, which is not good. Another potential approach might be to make Sequencer RPC logs debug, but full node rpc logs info.

Also, prover doesn't have any rpc logs as it is unnecessary.

## Linked Issues
- Fixes #1227 

## Testing
I ran sequencer and full node and sent rpc requests and observed logs.