### PR TITLE
Add enable recovery config

### DIFF
--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -94,6 +94,7 @@ async fn test_all_flow() {
             Some(ProverConfig {
                 proving_mode: sov_stf_runner::ProverGuestRunConfig::Execute,
                 proof_sampling_number: 0,
+                enable_reocvery: true,
             }),
             rollup_config,
             None,

--- a/bin/citrea/tests/e2e/proving.rs
+++ b/bin/citrea/tests/e2e/proving.rs
@@ -62,6 +62,7 @@ async fn full_node_verify_proof_and_store() {
             Some(ProverConfig {
                 proving_mode: sov_stf_runner::ProverGuestRunConfig::Execute,
                 proof_sampling_number: 0,
+                enable_reocvery: true,
             }),
             rollup_config,
             None,

--- a/bin/citrea/tests/e2e/syncing.rs
+++ b/bin/citrea/tests/e2e/syncing.rs
@@ -295,6 +295,7 @@ async fn test_prover_sync_with_commitments() -> Result<(), anyhow::Error> {
             Some(ProverConfig {
                 proving_mode: sov_stf_runner::ProverGuestRunConfig::Execute,
                 proof_sampling_number: 0,
+                enable_reocvery: true,
             }),
             rollup_config,
             None,

--- a/crates/prover/src/da_block_handler.rs
+++ b/crates/prover/src/da_block_handler.rs
@@ -109,8 +109,15 @@ where
     }
 
     pub async fn run(mut self, start_l1_height: u64) {
-        if let Err(e) = self.check_and_recover_ongoing_proving_sessions().await {
-            error!("Failed to recover ongoing proving sessions: {:?}", e);
+        if self.prover_config.enable_reocvery {
+            if let Err(e) = self.check_and_recover_ongoing_proving_sessions().await {
+                error!("Failed to recover ongoing proving sessions: {:?}", e);
+            }
+        } else {
+            // If recovery is disabled, clear pending proving sessions
+            self.ledger_db
+                .clear_pending_proving_sessions()
+                .expect("Failed to clear pending proving sessions");
         }
 
         let (l1_tx, mut l1_rx) = mpsc::channel(1);

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -533,6 +533,22 @@ impl ProverLedgerOps for LedgerDB {
     fn get_l2_state_diff(&self, l2_height: BatchNumber) -> anyhow::Result<Option<StateDiff>> {
         self.db.get::<ProverStateDiffs>(&l2_height)
     }
+
+    #[instrument(level = "trace", skip(self), err)]
+    fn clear_pending_proving_sessions(&self) -> anyhow::Result<()> {
+        let mut schema_batch = SchemaBatch::new();
+        let mut iter = self.db.iter::<PendingProvingSessions>()?;
+        iter.seek_to_first();
+
+        for item in iter {
+            let item = item?;
+            schema_batch.delete::<PendingProvingSessions>(&item.key)?;
+        }
+
+        self.db.write_schemas(schema_batch)?;
+
+        Ok(())
+    }
 }
 
 impl ProvingServiceLedgerOps for LedgerDB {

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
@@ -164,6 +164,9 @@ pub trait ProverLedgerOps: SharedLedgerOps + Send + Sync {
 
     /// Returns an L2 state diff
     fn get_l2_state_diff(&self, l2_height: BatchNumber) -> Result<Option<StateDiff>>;
+
+    /// Clears all pending proving sessions
+    fn clear_pending_proving_sessions(&self) -> Result<()>;
 }
 
 /// Ledger operations for the prover service

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/src/config.rs
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/src/config.rs
@@ -131,6 +131,8 @@ pub struct ProverConfig {
     pub proving_mode: ProverGuestRunConfig,
     /// Average number of commitments to prove
     pub proof_sampling_number: usize,
+    /// If true prover will try to recover ongoing proving sessions
+    pub enable_reocvery: bool,
 }
 
 impl Default for ProverConfig {
@@ -138,6 +140,7 @@ impl Default for ProverConfig {
         Self {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
+            enable_reocvery: true,
         }
     }
 }
@@ -244,6 +247,7 @@ mod tests {
         let config = r#"
             proving_mode = "skip"
             proof_sampling_number = 500
+            enable_reocvery = true
         "#;
 
         let config_file = create_config_from(config);
@@ -252,6 +256,7 @@ mod tests {
         let expected = ProverConfig {
             proving_mode: ProverGuestRunConfig::Skip,
             proof_sampling_number: 500,
+            enable_reocvery: true,
         };
         assert_eq!(config, expected);
     }

--- a/resources/configs/bitcoin-regtest/prover_config.toml
+++ b/resources/configs/bitcoin-regtest/prover_config.toml
@@ -1,2 +1,3 @@
 proving_mode = "execute"
 proof_sampling_number = 500
+enable_recovery = true

--- a/resources/configs/mock/prover_config.toml
+++ b/resources/configs/mock/prover_config.toml
@@ -1,2 +1,3 @@
 proving_mode = "execute"
 proof_sampling_number = 500
+enable_recovery = true


### PR DESCRIPTION
# Description
Currently because of some internal errors in Risc0 bonsai api, we are having troubles on fetching sessions and this causes the l1 handler thread to die because of some panics. When we reopen and try to recover we face the same issues because we are trying to recover the erroneous session and the thread dies again.
 
This pr enables recovery if `enable_recovery` is set to true, we plan on setting this config to false until we have a better handling of internal errors of provers
