### PR TITLE
Fix estiamte gas l1 fee issue when metamask max amount is selected

### DIFF
--- a/crates/evm/src/evm/handler.rs
+++ b/crates/evm/src/evm/handler.rs
@@ -25,11 +25,11 @@ use crate::system_events::SYSTEM_SIGNER;
 use crate::{BASE_FEE_VAULT, L1_FEE_VAULT};
 
 /// Eoa size is reduced because code_hash for eoas are None on state diff, converted to empty Keccak  internally for evm operations
-const DB_ACCOUNT_SIZE_EOA: usize = 42;
+pub(crate) const DB_ACCOUNT_SIZE_EOA: usize = 42;
 const DB_ACCOUNT_SIZE_CONTRACT: usize = 75;
 
 /// Normally db account key is: 6 bytes of prefix ("Evm/a/") + 1 byte for size of remaining data + 20 bytes of address = 27 bytes
-const DB_ACCOUNT_KEY_SIZE: usize = 27;
+pub(crate) const DB_ACCOUNT_KEY_SIZE: usize = 27;
 
 /// Storage key is 59 bytes because of sov sdk prefix ("Evm/s/")
 const STORAGE_KEY_SIZE: usize = 59;
@@ -70,9 +70,9 @@ Let's consider a batch of 1 block with the following transactions:
     If every user pays 0.75 of the balance state diff they created, the total balance state diff will be covered
 */
 /// Nonce and balance are stored together so we use single constant
-const NONCE_DISCOUNTED_PERCENTAGE: usize = 55;
+pub(crate) const NONCE_DISCOUNTED_PERCENTAGE: usize = 55;
 const STORAGE_DISCOUNTED_PERCENTAGE: usize = 66;
-const ACCOUNT_DISCOUNTED_PERCENTAGE: usize = 29;
+pub(crate) const ACCOUNT_DISCOUNTED_PERCENTAGE: usize = 29;
 
 #[derive(Copy, Clone, Default, Debug)]
 pub struct TxInfo {

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -39,6 +39,10 @@ use crate::evm::db::EvmDb;
 use crate::evm::primitive_types::{BlockEnv, Receipt, SealedBlock, TransactionSignedAndRecovered};
 use crate::evm::DbAccount;
 use crate::handler::TxInfo;
+use crate::handler::{
+    ACCOUNT_DISCOUNTED_PERCENTAGE, DB_ACCOUNT_KEY_SIZE, DB_ACCOUNT_SIZE_EOA,
+    NONCE_DISCOUNTED_PERCENTAGE,
+};
 use crate::rpc_helpers::*;
 use crate::{BloomFilter, Evm, EvmChainConfig, FilterBlockOption, FilterError};
 
@@ -71,8 +75,7 @@ impl EstimatedTxExpenses {
     /// Return total estimated gas used including evm gas and L1 fee.
     pub(crate) fn gas_with_l1_overhead(&self) -> U256 {
         // Actually not an L1 fee but l1_fee / base_fee.
-        let l1_fee_overhead =
-            U256::from(1).max(self.l1_fee / (self.base_fee + U256::from(GWEI_TO_WEI))); // assume 1 gwei priority fee
+        let l1_fee_overhead = U256::from(1).max(self.l1_fee.div_ceil(self.base_fee)); // assume 1 gwei priority fee
         l1_fee_overhead + U256::from(self.gas_used)
     }
 }
@@ -879,11 +882,31 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
                     if let Ok((res, tx_info)) = res {
                         if res.result.is_success() {
+                            // If value is zero we should add extra balance transfer diff size assuming the first estimate gas was done by metamask
+                            // we do this because on metamask when trying to send max amount to an address it will send 2 estimate_gas requests
+                            // One with 0 value and the other with the remaining balance that extract from the current balance after the gas fee is deducted
+                            // This causes the diff size to be lower than the actual diff size, and the tx to fail due to not enough l1 fee
+                            let mut diff_size = tx_info.l1_diff_size;
+                            let mut l1_fee = tx_info.l1_fee;
+                            if tx_env.value.is_zero() {
+                                // Calculation taken from diff size calculation in handler.rs
+                                let balance_diff_size =
+                                    (DB_ACCOUNT_KEY_SIZE * ACCOUNT_DISCOUNTED_PERCENTAGE / 100)
+                                        as u64
+                                        + ((DB_ACCOUNT_SIZE_EOA + DB_ACCOUNT_KEY_SIZE)
+                                            * NONCE_DISCOUNTED_PERCENTAGE
+                                            / 100) as u64;
+
+                                diff_size += balance_diff_size;
+                                l1_fee = l1_fee.saturating_add(
+                                    U256::from(l1_fee_rate) * (U256::from(balance_diff_size)),
+                                );
+                            }
                             return Ok(EstimatedTxExpenses {
                                 gas_used: U64::from(MIN_TRANSACTION_GAS),
                                 base_fee: env_base_fee,
-                                l1_fee: tx_info.l1_fee,
-                                l1_diff_size: tx_info.l1_diff_size,
+                                l1_fee,
+                                l1_diff_size: diff_size,
                             });
                         }
                     }

--- a/crates/sovereign-sdk/adapters/mock-da/src/service.rs
+++ b/crates/sovereign-sdk/adapters/mock-da/src/service.rs
@@ -502,8 +502,8 @@ impl DaService for MockDaService {
     }
 
     async fn get_fee_rate(&self) -> Result<u128, Self::Error> {
-        // Mock constant
-        Ok(10_u128)
+        // Mock constant, use min possible in bitcoin
+        Ok(2500000000_u128)
     }
 
     async fn get_block_by_hash(


### PR DESCRIPTION
# Description
Metamask initially sends an estimate_gas request with 0 value, due to there is no balance transfer diff size of balance transfer is not calculated and added to the fee, thus results in a rather low gas estimated. This causes an issue when we select the max amount possible to transfer, so this pr updates estimate_gas so that if value is 0 it adds balance transfer diff size l1 fee to the total l1 fee and calculates the estimated gas accordingly. With this we can use the max amount button in metamask


<img width="137" alt="Screenshot 2024-10-02 at 16 13 57" src="https://github.com/user-attachments/assets/8c3bfbfb-cdc9-4b8d-9831-04f7fe7c8025">

## Linked Issues

- Fixes #693
