### PR TITLE
e2e: Pin bitcoin docker to 27.1

### DIFF
--- a/bin/citrea/tests/bitcoin_e2e/config/bitcoin.rs
+++ b/bin/citrea/tests/bitcoin_e2e/config/bitcoin.rs
@@ -29,7 +29,7 @@ impl Default for BitcoinConfig {
                 .into_path(),
             extra_args: Vec::new(),
             network: Network::Regtest,
-            docker_image: Some("bitcoin/bitcoin:latest".to_string()),
+            docker_image: Some("bitcoin/bitcoin:27.1-alpine".to_string()),
             env: Vec::new(),
             idx: 0,
         }

--- a/bin/citrea/tests/bitcoin_e2e/config/docker.rs
+++ b/bin/citrea/tests/bitcoin_e2e/config/docker.rs
@@ -34,7 +34,7 @@ impl From<&BitcoinConfig> for DockerConfig {
             image: v
                 .docker_image
                 .clone()
-                .unwrap_or_else(|| "bitcoin/bitcoin:latest".to_string()),
+                .unwrap_or_else(|| "bitcoin/bitcoin:27.1-alpine".to_string()),
             cmd: args,
             log_path: v.data_dir.join("regtest").join("debug.log"),
             volume: VolumeConfig {


### PR DESCRIPTION
# Description

Bitcoin 28 is released couple of hours ago, breaking the bitcoincore-rpc ser/de. Pinning version to 27.1 until we update our bitcoincore-rpc repo to be compatible with v28.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
