### PR TITLE
Only spawn_blocking for tx creation in DA queue

### DIFF
--- a/crates/bitcoin-da/src/helpers/builders/light_client_proof_namespace.rs
+++ b/crates/bitcoin-da/src/helpers/builders/light_client_proof_namespace.rs
@@ -85,9 +85,9 @@ impl TxListWithReveal for LightClientTxs {
 // Creates the light client transactions (commit and reveal)
 #[allow(clippy::too_many_arguments)]
 #[instrument(level = "trace", skip_all, err)]
-pub fn create_zkproof_transactions(
+pub async fn create_zkproof_transactions(
     body: Vec<u8>,
-    da_private_key: &SecretKey,
+    da_private_key: SecretKey,
     prev_utxo: Option<UTXO>,
     utxos: Vec<UTXO>,
     change_address: Address,
@@ -95,35 +95,41 @@ pub fn create_zkproof_transactions(
     commit_fee_rate: u64,
     reveal_fee_rate: u64,
     network: Network,
-    reveal_tx_prefix: &[u8],
+    reveal_tx_prefix: Vec<u8>,
 ) -> Result<LightClientTxs, anyhow::Error> {
-    if body.len() < MAX_TXBODY_SIZE {
-        create_inscription_type_0(
-            body,
-            da_private_key,
-            prev_utxo,
-            utxos,
-            change_address,
-            reveal_value,
-            commit_fee_rate,
-            reveal_fee_rate,
-            network,
-            reveal_tx_prefix,
-        )
-    } else {
-        create_inscription_type_1(
-            body,
-            da_private_key,
-            prev_utxo,
-            utxos,
-            change_address,
-            reveal_value,
-            commit_fee_rate,
-            reveal_fee_rate,
-            network,
-            reveal_tx_prefix,
-        )
-    }
+    // Since this is CPU bound work, we use spawn_blocking
+    // to release the tokio runtime execution
+    tokio::task::spawn_blocking(move || {
+        if body.len() < MAX_TXBODY_SIZE {
+            create_inscription_type_0(
+                body,
+                &da_private_key,
+                prev_utxo,
+                utxos,
+                change_address,
+                reveal_value,
+                commit_fee_rate,
+                reveal_fee_rate,
+                network,
+                &reveal_tx_prefix,
+            )
+        } else {
+            create_inscription_type_1(
+                body,
+                &da_private_key,
+                prev_utxo,
+                utxos,
+                change_address,
+                reveal_value,
+                commit_fee_rate,
+                reveal_fee_rate,
+                network,
+                &reveal_tx_prefix,
+            )
+        }
+    })
+    .await
+    .expect("No JoinErrors")
 }
 
 // TODO: parametrize hardness

--- a/crates/bitcoin-da/src/helpers/builders/tests.rs
+++ b/crates/bitcoin-da/src/helpers/builders/tests.rs
@@ -452,8 +452,8 @@ fn build_reveal_transaction() {
     assert!(tx.is_err());
     assert_eq!(format!("{}", tx.unwrap_err()), "input UTXO not big enough");
 }
-#[test]
-fn create_inscription_transactions() {
+#[tokio::test]
+async fn create_inscription_transactions() {
     let (body, address, utxos) = get_mock_data();
 
     let da_private_key = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
@@ -465,7 +465,7 @@ fn create_inscription_transactions() {
     let LightClientTxs::Complete { commit, reveal } =
         super::light_client_proof_namespace::create_zkproof_transactions(
             body.clone(),
-            &da_private_key,
+            da_private_key,
             None,
             utxos.clone(),
             address.clone(),
@@ -473,8 +473,9 @@ fn create_inscription_transactions() {
             12,
             10,
             bitcoin::Network::Bitcoin,
-            tx_prefix,
+            tx_prefix.to_vec(),
         )
+        .await
         .unwrap()
     else {
         panic!("Unexpected tx kind was produced");

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -183,92 +183,85 @@ impl BitcoinService {
         self: Arc<Self>,
         mut rx: UnboundedReceiver<Option<SenderWithNotifier<TxidWrapper>>>,
     ) {
-        // This should be spawn_blocking, since it is a CPU-bound worker.
-        // When spawned with tokio::spawn, it blocks other futures and
-        // disrupts tokio runtime.
-        tokio::task::spawn_blocking(|| {
-            tokio::runtime::Handle::current().block_on(async move {
-                let mut prev_utxo = match self.get_prev_utxo().await {
-                    Ok(Some(prev_utxo)) => Some(prev_utxo),
-                    Ok(None) => {
-                        info!("No pending transactions found");
-                        None
-                    }
-                    Err(e) => {
-                        error!(?e, "Failed to get pending transactions");
-                        None
-                    }
-                };
+        tokio::spawn(async move {
+            let mut prev_utxo = match self.get_prev_utxo().await {
+                Ok(Some(prev_utxo)) => Some(prev_utxo),
+                Ok(None) => {
+                    info!("No pending transactions found");
+                    None
+                }
+                Err(e) => {
+                    error!(?e, "Failed to get pending transactions");
+                    None
+                }
+            };
 
-                trace!("BitcoinDA queue is initialized. Waiting for the first request...");
+            trace!("BitcoinDA queue is initialized. Waiting for the first request...");
 
-                loop {
-                    select! {
-                        request_opt = rx.recv() => {
-                            if let Some(request_opt) = request_opt {
-                                match request_opt {
-                                    Some(request) => {
-                                        trace!("A new request is received");
-                                        let prev = prev_utxo.take();
-                                        loop {
-                                            // Build and send tx with retries:
-                                            let fee_sat_per_vbyte = match self.get_fee_rate().await {
-                                                Ok(rate) => rate,
-                                                Err(e) => {
-                                                    error!(?e, "Failed to call get_fee_rate. Retrying...");
-                                                    tokio::time::sleep(Duration::from_secs(1)).await;
-                                                    continue;
-                                                }
-                                            };
-                                            match self
-                                                .send_transaction_with_fee_rate(
-                                                    prev.clone(),
-                                                    request.da_data.clone(),
-                                                    fee_sat_per_vbyte,
-                                                )
-                                                .await
-                                            {
-                                                Ok(tx) => {
-                                                    let tx_id = TxidWrapper(tx.id);
-                                                    info!(%tx.id, "Sent tx to BitcoinDA");
-                                                    prev_utxo = Some(UTXO {
-                                                        tx_id: tx.id,
-                                                        vout: 0,
-                                                        script_pubkey: tx.tx.output[0].script_pubkey.to_hex_string(),
-                                                        address: None,
-                                                        amount: tx.tx.output[0].value.to_sat(),
-                                                        confirmations: 0,
-                                                        spendable: true,
-                                                        solvable: true,
-                                                    });
-
-                                                    let _ = request.notify.send(Ok(tx_id));
-                                                }
-                                                Err(e) => {
-                                                    error!(?e, "Failed to send transaction to DA layer");
-                                                    tokio::time::sleep(Duration::from_secs(1)).await;
-                                                    continue;
-                                                }
+            loop {
+                select! {
+                    request_opt = rx.recv() => {
+                        if let Some(request_opt) = request_opt {
+                            match request_opt {
+                                Some(request) => {
+                                    trace!("A new request is received");
+                                    let prev = prev_utxo.take();
+                                    loop {
+                                        // Build and send tx with retries:
+                                        let fee_sat_per_vbyte = match self.get_fee_rate().await {
+                                            Ok(rate) => rate,
+                                            Err(e) => {
+                                                error!(?e, "Failed to call get_fee_rate. Retrying...");
+                                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                                continue;
                                             }
-                                            break;
-                                        }
-                                    }
+                                        };
+                                        match self
+                                            .send_transaction_with_fee_rate(
+                                                prev.clone(),
+                                                request.da_data.clone(),
+                                                fee_sat_per_vbyte,
+                                            )
+                                            .await
+                                        {
+                                            Ok(tx) => {
+                                                let tx_id = TxidWrapper(tx.id);
+                                                info!(%tx.id, "Sent tx to BitcoinDA");
+                                                prev_utxo = Some(UTXO {
+                                                    tx_id: tx.id,
+                                                    vout: 0,
+                                                    script_pubkey: tx.tx.output[0].script_pubkey.to_hex_string(),
+                                                    address: None,
+                                                    amount: tx.tx.output[0].value.to_sat(),
+                                                    confirmations: 0,
+                                                    spendable: true,
+                                                    solvable: true,
+                                                });
 
-                                    None => {
-                                        info!("Shutdown signal received. Stopping BitcoinDA queue.");
+                                                let _ = request.notify.send(Ok(tx_id));
+                                            }
+                                            Err(e) => {
+                                                error!(?e, "Failed to send transaction to DA layer");
+                                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                                continue;
+                                            }
+                                        }
                                         break;
                                     }
                                 }
+
+                                None => {
+                                    info!("Shutdown signal received. Stopping BitcoinDA queue.");
+                                    break;
+                                }
                             }
-                        },
-                        _ = signal::ctrl_c() => {
-                            return;
                         }
+                    },
+                    _ = signal::ctrl_c() => {
+                        return;
                     }
                 }
-            });
-
-            error!("BitcoinDA queue stopped");
+            }
         });
     }
 
@@ -377,7 +370,7 @@ impl BitcoinService {
                 // create inscribe transactions
                 let inscription_txs = create_zkproof_transactions(
                     blob,
-                    &da_private_key,
+                    da_private_key,
                     prev_utxo,
                     utxos,
                     address,
@@ -385,8 +378,9 @@ impl BitcoinService {
                     fee_sat_per_vbyte,
                     fee_sat_per_vbyte,
                     network,
-                    &self.reveal_light_client_prefix,
-                )?;
+                    self.reveal_light_client_prefix.clone(),
+                )
+                .await?;
 
                 // write txs to file, it can be used to continue revealing blob if something goes wrong
                 inscription_txs.write_to_file(self.tx_backup_dir.clone())?;
@@ -412,7 +406,7 @@ impl BitcoinService {
                 // create inscribe transactions
                 let inscription_txs = create_seqcommitment_transactions(
                     blob,
-                    &da_private_key,
+                    da_private_key,
                     prev_utxo,
                     utxos,
                     address,
@@ -420,8 +414,9 @@ impl BitcoinService {
                     fee_sat_per_vbyte,
                     fee_sat_per_vbyte,
                     network,
-                    &self.reveal_batch_prover_prefix,
-                )?;
+                    self.reveal_batch_prover_prefix.clone(),
+                )
+                .await?;
 
                 // write txs to file, it can be used to continue revealing blob if something goes wrong
                 inscription_txs.write_to_file(self.tx_backup_dir.clone())?;


### PR DESCRIPTION
# Description

It doesn't make much sense to spawn the whole DA queue in a spawn_blocking, due to the fact that it waits empty for messages most of the time, hence, it doesn't need a whole thread to itself. Instead, with this PR, queue is spawned as a tokio runtime worker, so it doesn't occupy any resources while waiting, but only acquires a thread with spawn_blocking when it's time to create the transaction and find the right prefix (or nonce).

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
