### PR TITLE
Use spawn_blocking in bitcoin service not in tx builders

### DIFF
--- a/crates/bitcoin-da/src/helpers/builders/batch_proof_namespace.rs
+++ b/crates/bitcoin-da/src/helpers/builders/batch_proof_namespace.rs
@@ -52,7 +52,7 @@ impl TxListWithReveal for BatchProvingTxs {
 // Creates the batch proof transactions (commit and reveal)
 #[allow(clippy::too_many_arguments)]
 #[instrument(level = "trace", skip_all, err)]
-pub async fn create_seqcommitment_transactions(
+pub fn create_seqcommitment_transactions(
     body: Vec<u8>,
     da_private_key: SecretKey,
     prev_utxo: Option<UTXO>,
@@ -64,24 +64,18 @@ pub async fn create_seqcommitment_transactions(
     network: Network,
     reveal_tx_prefix: Vec<u8>,
 ) -> Result<BatchProvingTxs, anyhow::Error> {
-    // Since this is CPU bound work, we use spawn_blocking
-    // to release the tokio runtime execution
-    tokio::task::spawn_blocking(move || {
-        create_batchproof_type_0(
-            body,
-            &da_private_key,
-            prev_utxo,
-            utxos,
-            change_address,
-            reveal_value,
-            commit_fee_rate,
-            reveal_fee_rate,
-            network,
-            &reveal_tx_prefix,
-        )
-    })
-    .await
-    .expect("No JoinErrors")
+    create_batchproof_type_0(
+        body,
+        &da_private_key,
+        prev_utxo,
+        utxos,
+        change_address,
+        reveal_value,
+        commit_fee_rate,
+        reveal_fee_rate,
+        network,
+        &reveal_tx_prefix,
+    )
 }
 
 // Creates the batch proof transactions Type 0 - BatchProvingTxs - SequencerCommitment

--- a/crates/bitcoin-da/src/helpers/builders/light_client_proof_namespace.rs
+++ b/crates/bitcoin-da/src/helpers/builders/light_client_proof_namespace.rs
@@ -85,7 +85,7 @@ impl TxListWithReveal for LightClientTxs {
 // Creates the light client transactions (commit and reveal)
 #[allow(clippy::too_many_arguments)]
 #[instrument(level = "trace", skip_all, err)]
-pub async fn create_zkproof_transactions(
+pub fn create_zkproof_transactions(
     body: Vec<u8>,
     da_private_key: SecretKey,
     prev_utxo: Option<UTXO>,
@@ -97,39 +97,33 @@ pub async fn create_zkproof_transactions(
     network: Network,
     reveal_tx_prefix: Vec<u8>,
 ) -> Result<LightClientTxs, anyhow::Error> {
-    // Since this is CPU bound work, we use spawn_blocking
-    // to release the tokio runtime execution
-    tokio::task::spawn_blocking(move || {
-        if body.len() < MAX_TXBODY_SIZE {
-            create_inscription_type_0(
-                body,
-                &da_private_key,
-                prev_utxo,
-                utxos,
-                change_address,
-                reveal_value,
-                commit_fee_rate,
-                reveal_fee_rate,
-                network,
-                &reveal_tx_prefix,
-            )
-        } else {
-            create_inscription_type_1(
-                body,
-                &da_private_key,
-                prev_utxo,
-                utxos,
-                change_address,
-                reveal_value,
-                commit_fee_rate,
-                reveal_fee_rate,
-                network,
-                &reveal_tx_prefix,
-            )
-        }
-    })
-    .await
-    .expect("No JoinErrors")
+    if body.len() < MAX_TXBODY_SIZE {
+        create_inscription_type_0(
+            body,
+            &da_private_key,
+            prev_utxo,
+            utxos,
+            change_address,
+            reveal_value,
+            commit_fee_rate,
+            reveal_fee_rate,
+            network,
+            &reveal_tx_prefix,
+        )
+    } else {
+        create_inscription_type_1(
+            body,
+            &da_private_key,
+            prev_utxo,
+            utxos,
+            change_address,
+            reveal_value,
+            commit_fee_rate,
+            reveal_fee_rate,
+            network,
+            &reveal_tx_prefix,
+        )
+    }
 }
 
 // TODO: parametrize hardness

--- a/crates/bitcoin-da/src/helpers/builders/tests.rs
+++ b/crates/bitcoin-da/src/helpers/builders/tests.rs
@@ -452,8 +452,9 @@ fn build_reveal_transaction() {
     assert!(tx.is_err());
     assert_eq!(format!("{}", tx.unwrap_err()), "input UTXO not big enough");
 }
-#[tokio::test]
-async fn create_inscription_transactions() {
+
+#[test]
+fn create_inscription_transactions() {
     let (body, address, utxos) = get_mock_data();
 
     let da_private_key = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
@@ -475,7 +476,6 @@ async fn create_inscription_transactions() {
             bitcoin::Network::Bitcoin,
             tx_prefix.to_vec(),
         )
-        .await
         .unwrap()
     else {
         panic!("Unexpected tx kind was produced");

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -368,19 +368,23 @@ impl BitcoinService {
                 let blob = borsh::to_vec(&data).expect("DaDataLightClient serialize must not fail");
                 let blob = compress_blob(&blob);
                 // create inscribe transactions
-                let inscription_txs = create_zkproof_transactions(
-                    blob,
-                    da_private_key,
-                    prev_utxo,
-                    utxos,
-                    address,
-                    REVEAL_OUTPUT_AMOUNT,
-                    fee_sat_per_vbyte,
-                    fee_sat_per_vbyte,
-                    network,
-                    self.reveal_light_client_prefix.clone(),
-                )
-                .await?;
+                let inscription_txs = tokio::task::spawn_blocking(move || {
+                    // Since this is CPU bound work, we use spawn_blocking
+                    // to release the tokio runtime execution
+                    create_zkproof_transactions(
+                        blob,
+                        da_private_key,
+                        prev_utxo,
+                        utxos,
+                        address,
+                        REVEAL_OUTPUT_AMOUNT,
+                        fee_sat_per_vbyte,
+                        fee_sat_per_vbyte,
+                        network,
+                        self.reveal_light_client_prefix.clone(),
+                    )
+                })
+                .await??;
 
                 // write txs to file, it can be used to continue revealing blob if something goes wrong
                 inscription_txs.write_to_file(self.tx_backup_dir.clone())?;
@@ -404,19 +408,23 @@ impl BitcoinService {
                 let data = DaDataBatchProof::SequencerCommitment(comm);
                 let blob = borsh::to_vec(&data).expect("DaDataBatchProof serialize must not fail");
                 // create inscribe transactions
-                let inscription_txs = create_seqcommitment_transactions(
-                    blob,
-                    da_private_key,
-                    prev_utxo,
-                    utxos,
-                    address,
-                    REVEAL_OUTPUT_AMOUNT,
-                    fee_sat_per_vbyte,
-                    fee_sat_per_vbyte,
-                    network,
-                    self.reveal_batch_prover_prefix.clone(),
-                )
-                .await?;
+                let inscription_txs = tokio::task::spawn_blocking(move || {
+                    // Since this is CPU bound work, we use spawn_blocking
+                    // to release the tokio runtime execution
+                    create_seqcommitment_transactions(
+                        blob,
+                        da_private_key,
+                        prev_utxo,
+                        utxos,
+                        address,
+                        REVEAL_OUTPUT_AMOUNT,
+                        fee_sat_per_vbyte,
+                        fee_sat_per_vbyte,
+                        network,
+                        self.reveal_batch_prover_prefix.clone(),
+                    )
+                })
+                .await??;
 
                 // write txs to file, it can be used to continue revealing blob if something goes wrong
                 inscription_txs.write_to_file(self.tx_backup_dir.clone())?;

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -367,6 +367,8 @@ impl BitcoinService {
                 let data = DaDataLightClient::ZKProof(zkproof);
                 let blob = borsh::to_vec(&data).expect("DaDataLightClient serialize must not fail");
                 let blob = compress_blob(&blob);
+
+                let reveal_light_client_prefix = self.reveal_light_client_prefix.clone();
                 // create inscribe transactions
                 let inscription_txs = tokio::task::spawn_blocking(move || {
                     // Since this is CPU bound work, we use spawn_blocking
@@ -381,7 +383,7 @@ impl BitcoinService {
                         fee_sat_per_vbyte,
                         fee_sat_per_vbyte,
                         network,
-                        self.reveal_light_client_prefix.clone(),
+                        reveal_light_client_prefix,
                     )
                 })
                 .await??;
@@ -407,6 +409,8 @@ impl BitcoinService {
             DaData::SequencerCommitment(comm) => {
                 let data = DaDataBatchProof::SequencerCommitment(comm);
                 let blob = borsh::to_vec(&data).expect("DaDataBatchProof serialize must not fail");
+
+                let reveal_batch_prover_prefix = self.reveal_batch_prover_prefix.clone();
                 // create inscribe transactions
                 let inscription_txs = tokio::task::spawn_blocking(move || {
                     // Since this is CPU bound work, we use spawn_blocking
@@ -421,7 +425,7 @@ impl BitcoinService {
                         fee_sat_per_vbyte,
                         fee_sat_per_vbyte,
                         network,
-                        self.reveal_batch_prover_prefix.clone(),
+                        reveal_batch_prover_prefix,
                     )
                 })
                 .await??;


### PR DESCRIPTION
# Description

Follow up https://github.com/chainwayxyz/citrea/pull/1321

`create_zkproof_transactions` and `create_seqcommitment_transactions` are pure functions, no need to wrap them in async to spawn_blocking inside. We may spawn_blocking in BitcoinService, to block while running those fns.