### PR TITLE
update docs and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ adapters/solana/libyellowstone_grpc_geyser.dylib
 reveal_*.tx
 
 db
+*.txs

--- a/docs/run-dev.md
+++ b/docs/run-dev.md
@@ -67,7 +67,9 @@ Mine blocks so that the wallet has BTC:
 bitcoin-cli -regtest -generate 201
 ```
 
-Edit `resources/configs/bitcoin-regtest/sequencer_rollup_config.toml` and `resources/configs/bitcoin-regtest/sequencer_config.toml` files and put in your rpc url, username and password:
+Edit `resources/configs/bitcoin-regtest/sequencer_config.toml` to adjust the sequencer settings.
+
+Edit `resources/configs/bitcoin-regtest/sequencer_rollup_config.toml` file and put in your rpc url, username and password:
 
 ```toml
 [da]

--- a/resources/configs/bitcoin-regtest/rollup_config.toml
+++ b/resources/configs/bitcoin-regtest/rollup_config.toml
@@ -11,6 +11,8 @@ node_username = ""
 # fill here
 node_password = ""
 network = "regtest"
+tx_backup_dir = ""
+da_private_key = "E9873D79C6D87DC0FB6A5778633389F4453213303DA61F20BD67FC233AA33262"
 
 [storage]
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.


### PR DESCRIPTION
# Description
Commit 1: Updated the run-dev documentation to correct a misstatement regarding sequencer settings.
Commit 2: Added tx_backup_dir and da_private_key to the rollup_config.
Commit 3: Added *.txs files to the .gitignore to prevent unnecessary tracking of transaction-related files.

## Linked Issues
--

## Testing

- The documentation update was manually reviewed to ensure clarity and accuracy in the sequencer settings description.
- Changes to the rollup_config were tested locally by running the system in development mode to verify that tx_backup_dir and da_private_key are correctly configured and used.
- The .gitignore update was tested by verifying that no *.txs files are included in future commits.

## Docs
--