### PR TITLE
Build nightly-build-and-push without REPR_GUEST_BUILD

### DIFF
--- a/.github/workflows/nightly_build_push.yml
+++ b/.github/workflows/nightly_build_push.yml
@@ -1,6 +1,7 @@
 name: nightly-build-and-push
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - nightly
@@ -19,24 +20,24 @@ jobs:
         run: |
           echo "Raw EXPECTED_BITCOIN_DA_ID value:"
           echo "$EXPECTED_BITCOIN_DA_ID"
-          
+
           echo "Length of EXPECTED_BITCOIN_DA_ID: ${#EXPECTED_BITCOIN_DA_ID}"
-          
+
           if [ -z "${EXPECTED_BITCOIN_DA_ID// }" ]; then
             echo "Error: EXPECTED_BITCOIN_DA_ID is not set, empty, or contains only spaces"
             exit 1
           fi
-          
+
           # Remove any trailing newline or carriage return
           EXPECTED_BITCOIN_DA_ID=$(echo "$EXPECTED_BITCOIN_DA_ID" | tr -d '\n\r')
-          
+
           # Count commas and spaces
           comma_count=$(echo "$EXPECTED_BITCOIN_DA_ID" | tr -cd ',' | wc -c)
           space_count=$(echo "$EXPECTED_BITCOIN_DA_ID" | tr -cd ' ' | wc -c)
-          
+
           echo "Number of commas: $comma_count"
           echo "Number of spaces: $space_count"
-          
+
           # Split the string into an array and trim each element
           IFS=', ' read -ra raw_numbers <<< "$EXPECTED_BITCOIN_DA_ID"
           numbers=()
@@ -44,16 +45,16 @@ jobs:
             trimmed_num=$(echo "$num" | tr -d '[:space:]')  # Remove all whitespace
             numbers+=("$trimmed_num")
           done
-          
+
           echo "Number of elements after splitting and trimming: ${#numbers[@]}"
-          
+
           # Check if there are exactly 8 numbers
           if [ ${#numbers[@]} -ne 8 ]; then
             echo "Error: EXPECTED_BITCOIN_DA_ID should contain exactly 8 numbers"
             echo "Actual number of elements: ${#numbers[@]}"
             exit 1
           fi
-          
+
           # Check if all numbers are valid u32
           for i in "${!numbers[@]}"; do
             num=${numbers[$i]}
@@ -68,10 +69,10 @@ jobs:
               exit 1
             fi
           done
-          
+
           # Reconstruct the trimmed DA_ID
           trimmed_da_id=$(IFS=', '; echo "${numbers[*]}")
-          
+
           # Final check
           if [ $comma_count -eq 7 ] && [ $space_count -eq 7 ] && [ ${#numbers[@]} -eq 8 ]; then
             echo "EXPECTED_BITCOIN_DA_ID is valid:"
@@ -128,7 +129,6 @@ jobs:
 
       - name: Build Project
         env:
-          REPR_GUEST_BUILD: 1
           SHORT_PREFIX: ${{ matrix.short_prefix }}
           SKIP_GUEST_BUILD: 0
         run: |
@@ -143,8 +143,8 @@ jobs:
             echo "Check passed successfully."
             echo "Expected: BITCOIN_DA_ID ${{ env.EXPECTED_BITCOIN_DA_ID }} "
             echo "Actual: $RESULT"
-              
-          else      
+
+          else
             echo "Check failed. Expected: BITCOIN_DA_ID ${{ env.EXPECTED_BITCOIN_DA_ID }} "
             echo "Actual: $RESULT"
             exit 1


### PR DESCRIPTION
# Description

- ENV is not correctly passed down to docker build when using `REPR_GUEST_BUILD`
- Remove REPR_GUEST_BUILD for this job lest we it `Prover must be honest: NonRelevantTxInProof` since we'll have a prefix mismatch between prover and main binary
