### PR TITLE
Lean nightly build push

### DIFF
--- a/.github/workflows/nightly_build_push.yml
+++ b/.github/workflows/nightly_build_push.yml
@@ -7,90 +7,11 @@ on:
       - nightly
 
 env:
-  EXPECTED_BITCOIN_DA_ID: ${{ vars.EXPECTED_BITCOIN_DA_ID }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IMAGE_TAG: ${{ github.sha }}
 
 jobs:
-
-  validate_DA_ID_format:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate EXPECTED_BITCOIN_DA_ID format
-        run: |
-          echo "Raw EXPECTED_BITCOIN_DA_ID value:"
-          echo "$EXPECTED_BITCOIN_DA_ID"
-
-          echo "Length of EXPECTED_BITCOIN_DA_ID: ${#EXPECTED_BITCOIN_DA_ID}"
-
-          if [ -z "${EXPECTED_BITCOIN_DA_ID// }" ]; then
-            echo "Error: EXPECTED_BITCOIN_DA_ID is not set, empty, or contains only spaces"
-            exit 1
-          fi
-
-          # Remove any trailing newline or carriage return
-          EXPECTED_BITCOIN_DA_ID=$(echo "$EXPECTED_BITCOIN_DA_ID" | tr -d '\n\r')
-
-          # Count commas and spaces
-          comma_count=$(echo "$EXPECTED_BITCOIN_DA_ID" | tr -cd ',' | wc -c)
-          space_count=$(echo "$EXPECTED_BITCOIN_DA_ID" | tr -cd ' ' | wc -c)
-
-          echo "Number of commas: $comma_count"
-          echo "Number of spaces: $space_count"
-
-          # Split the string into an array and trim each element
-          IFS=', ' read -ra raw_numbers <<< "$EXPECTED_BITCOIN_DA_ID"
-          numbers=()
-          for num in "${raw_numbers[@]}"; do
-            trimmed_num=$(echo "$num" | tr -d '[:space:]')  # Remove all whitespace
-            numbers+=("$trimmed_num")
-          done
-
-          echo "Number of elements after splitting and trimming: ${#numbers[@]}"
-
-          # Check if there are exactly 8 numbers
-          if [ ${#numbers[@]} -ne 8 ]; then
-            echo "Error: EXPECTED_BITCOIN_DA_ID should contain exactly 8 numbers"
-            echo "Actual number of elements: ${#numbers[@]}"
-            exit 1
-          fi
-
-          # Check if all numbers are valid u32
-          for i in "${!numbers[@]}"; do
-            num=${numbers[$i]}
-            echo "Checking number $((i+1)): '$num'"
-            echo "Hex representation: $(echo -n "$num" | xxd -p)"
-            if ! [[ $num =~ ^[0-9]+$ ]]; then
-              echo "Error: '$num' is not composed of digits only"
-              exit 1
-            fi
-            if [ $num -gt 4294967295 ]; then
-              echo "Error: '$num' is greater than 4294967295"
-              exit 1
-            fi
-          done
-
-          # Reconstruct the trimmed DA_ID
-          trimmed_da_id=$(IFS=', '; echo "${numbers[*]}")
-
-          # Final check
-          if [ $comma_count -eq 7 ] && [ $space_count -eq 7 ] && [ ${#numbers[@]} -eq 8 ]; then
-            echo "EXPECTED_BITCOIN_DA_ID is valid:"
-            echo "- Contains 7 commas"
-            echo "- Contains 7 spaces"
-            echo "- Contains 8 valid u32 numbers"
-            echo "Original value: $EXPECTED_BITCOIN_DA_ID"
-            echo "Trimmed value: $trimmed_da_id"
-          else
-            echo "Error: EXPECTED_BITCOIN_DA_ID format is incorrect"
-            echo "- Comma count: $comma_count (should be 7)"
-            echo "- Space count: $space_count (should be 7)"
-            echo "- Number count: ${#numbers[@]} (should be 8)"
-            exit 1
-          fi
-
   linux_amd64_binary_extraction:
-    needs: validate_DA_ID_format
     runs-on: ubicloud-standard-30
     strategy:
       matrix:
@@ -130,25 +51,8 @@ jobs:
       - name: Build Project
         env:
           SHORT_PREFIX: ${{ matrix.short_prefix }}
-          SKIP_GUEST_BUILD: 0
         run: |
           cargo build --release
-
-      - name: Check BITCOIN_DA_ID
-        id: check-id
-        run: |
-          RESULT=$(grep -R "BITCOIN_DA_ID" target/ || echo "Grep failed")
-          EXPECTED_BITCOIN_DA_ID=$(echo "${{ env.EXPECTED_BITCOIN_DA_ID }}" | tr -d '\n\r')
-          if echo "$RESULT" | grep -q "$EXPECTED_BITCOIN_DA_ID"; then
-            echo "Check passed successfully."
-            echo "Expected: BITCOIN_DA_ID ${{ env.EXPECTED_BITCOIN_DA_ID }} "
-            echo "Actual: $RESULT"
-
-          else
-            echo "Check failed. Expected: BITCOIN_DA_ID ${{ env.EXPECTED_BITCOIN_DA_ID }} "
-            echo "Actual: $RESULT"
-            exit 1
-          fi
 
       - name: Copy binary to build-push/nightly
         run: |
@@ -172,11 +76,8 @@ jobs:
         with:
           file: ./build-push/nightly/Dockerfile
           context: ./build-push/nightly
-          tags: ${{ vars.DOCKERHUB_USERNAME }}/citrea:${{ env.IMAGE_TAG }}${{ matrix.short_prefix_value }}
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/citrea-test:${{ env.IMAGE_TAG }}${{ matrix.short_prefix_value }}
           platforms: linux/amd64
           push: true
           load: false
           provenance: false
-
-
-


### PR DESCRIPTION
# Description

- Tag image explicitly as `-test`
- Clear up unneeded jobs. `SHORT_PREFIX` wasn't pass down correctly to env when using `REPR_GUEST_BUILD` as fixed in https://github.com/chainwayxyz/citrea/pull/1333. This now conflicts with `validate_DA_ID_format` jobs but this is already checked on release and regular checks so should be safe to remove here and just publish image.
- Remove unused `SKIP_GUEST_BUILD: 0` env
