### PR TITLE
Bump citrea-e2e

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -222,7 +222,7 @@ jobs:
         run: make coverage
         env:
           RUST_BACKTRACE: 1
-          USE_DOCKER: "true"
+          TEST_BITCOIN_DOCKER: 1
           SHORT_PREFIX: 1
           CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
       - name: Upload coverage
@@ -394,7 +394,7 @@ jobs:
           RUST_BACKTRACE: 1
           BONSAI_API_URL: ${{ secrets.BONSAI_API_URL }} # TODO: remove this once we don't use the client on tests
           BONSAI_API_KEY: ${{ secrets.BONSAI_API_KEY }} # TODO: remove this once we don't use the client on tests
-          USE_DOCKER: "true"
+          TEST_BITCOIN_DOCKER: 1
           SHORT_PREFIX: 1
           CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=72a77f0#72a77f0087dd604ffa2640c432254a16bb04b591"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=cef080f#cef080f5e11bc58b848e1fc5798b55bcf62630d8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=cef080f#cef080f5e11bc58b848e1fc5798b55bcf62630d8"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=fc12cb0#fc12cb0bbf14cd55a0279014dc67db478c2ec39b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/citrea/Cargo.toml
+++ b/bin/citrea/Cargo.toml
@@ -86,7 +86,7 @@ rustc_version_runtime = { workspace = true }
 # bitcoin-e2e dependencies
 bitcoin.workspace = true
 bitcoincore-rpc.workspace = true
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "cef080f" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "fc12cb0" }
 
 [features]
 default = [] # Deviate from convention by making the "native" feature active by default. This aligns with how this package is meant to be used (as a binary first, library second).

--- a/bin/citrea/Cargo.toml
+++ b/bin/citrea/Cargo.toml
@@ -86,7 +86,7 @@ rustc_version_runtime = { workspace = true }
 # bitcoin-e2e dependencies
 bitcoin.workspace = true
 bitcoincore-rpc.workspace = true
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "72a77f0" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "cef080f" }
 
 [features]
 default = [] # Deviate from convention by making the "native" feature active by default. This aligns with how this package is meant to be used (as a binary first, library second).

--- a/bin/citrea/tests/bitcoin_e2e/bitcoin_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/bitcoin_test.rs
@@ -10,6 +10,8 @@ use citrea_e2e::test_case::{TestCase, TestCaseRunner};
 use citrea_e2e::traits::Restart;
 use citrea_e2e::Result;
 
+use super::get_citrea_path;
+
 struct BasicSyncTest;
 
 #[async_trait]
@@ -104,10 +106,16 @@ impl TestCase for RestartBitcoinTest {
 
 #[tokio::test]
 async fn test_basic_sync() -> Result<()> {
-    TestCaseRunner::new(BasicSyncTest).run().await
+    TestCaseRunner::new(BasicSyncTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
 }
 
 #[tokio::test]
 async fn test_restart_bitcoin() -> Result<()> {
-    TestCaseRunner::new(RestartBitcoinTest).run().await
+    TestCaseRunner::new(RestartBitcoinTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
 }

--- a/bin/citrea/tests/bitcoin_e2e/mempool_accept.rs
+++ b/bin/citrea/tests/bitcoin_e2e/mempool_accept.rs
@@ -52,5 +52,8 @@ impl TestCase for MempoolAcceptTest {
 
 #[tokio::test]
 async fn test_mempool_accept() -> Result<()> {
-    TestCaseRunner::new(MempoolAcceptTest).run().await
+    TestCaseRunner::new(MempoolAcceptTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
 }

--- a/bin/citrea/tests/bitcoin_e2e/mod.rs
+++ b/bin/citrea/tests/bitcoin_e2e/mod.rs
@@ -1,5 +1,23 @@
+use std::path::PathBuf;
+
 pub mod bitcoin_test;
 // pub mod mempool_accept;
 pub mod prover_test;
 pub mod sequencer_commitments;
 pub mod sequencer_test;
+
+pub(super) fn get_citrea_path() -> PathBuf {
+    std::env::var("CITREA_E2E_TEST_BINARY").map_or_else(
+        |_| {
+            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            manifest_dir
+                .ancestors()
+                .nth(2)
+                .expect("Failed to find workspace root")
+                .join("target")
+                .join("debug")
+                .join("citrea")
+        },
+        PathBuf::from,
+    )
+}

--- a/bin/citrea/tests/bitcoin_e2e/prover_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/prover_test.rs
@@ -18,6 +18,8 @@ use sov_rollup_interface::da::{DaData, SequencerCommitment};
 use sov_rollup_interface::services::da::SenderWithNotifier;
 use tokio::sync::mpsc::UnboundedSender;
 
+use super::get_citrea_path;
+
 /// This is a basic prover test showcasing spawning a bitcoin node as DA, a sequencer and a prover.
 /// It generates soft confirmations and wait until it reaches the first commitment.
 /// It asserts that the blob inscribe txs have been sent.
@@ -111,7 +113,10 @@ impl TestCase for BasicProverTest {
 
 #[tokio::test]
 async fn basic_prover_test() -> Result<()> {
-    TestCaseRunner::new(BasicProverTest).run().await
+    TestCaseRunner::new(BasicProverTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
 }
 
 #[derive(Default)]
@@ -317,6 +322,7 @@ impl TestCase for SkipPreprovenCommitmentsTest {
 #[tokio::test]
 async fn prover_skips_preproven_commitments_test() -> Result<()> {
     TestCaseRunner::new(SkipPreprovenCommitmentsTest::default())
+        .set_citrea_path(get_citrea_path())
         .run()
         .await
 }
@@ -409,5 +415,8 @@ impl TestCase for LocalProvingTest {
 #[tokio::test]
 #[ignore]
 async fn local_proving_test() -> Result<()> {
-    TestCaseRunner::new(LocalProvingTest).run().await
+    TestCaseRunner::new(LocalProvingTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
 }

--- a/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs
+++ b/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs
@@ -99,10 +99,6 @@ impl TestCase for LedgerGetCommitmentsTest {
         }
     }
 
-    fn sequencer_config() -> SequencerConfig {
-        SequencerConfig::default()
-    }
-
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
         let sequencer = f.sequencer.as_ref().unwrap();
         let da = f.bitcoin_nodes.get(0).expect("DA not running.");

--- a/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs
+++ b/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs
@@ -13,6 +13,8 @@ use citrea_primitives::REVEAL_BATCH_PROOF_PREFIX;
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
 use sov_rollup_interface::da::{BlobReaderTrait, DaData};
+
+use super::get_citrea_path;
 struct LedgerGetCommitmentsProverTest;
 
 #[async_trait]
@@ -84,6 +86,7 @@ impl TestCase for LedgerGetCommitmentsProverTest {
 #[tokio::test]
 async fn test_ledger_get_commitments_on_slot_prover() -> Result<()> {
     TestCaseRunner::new(LedgerGetCommitmentsProverTest)
+        .set_citrea_path(get_citrea_path())
         .run()
         .await
 }
@@ -153,7 +156,10 @@ impl TestCase for LedgerGetCommitmentsTest {
 
 #[tokio::test]
 async fn test_ledger_get_commitments_on_slot_full_node() -> Result<()> {
-    TestCaseRunner::new(LedgerGetCommitmentsTest).run().await
+    TestCaseRunner::new(LedgerGetCommitmentsTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
 }
 
 struct SequencerSendCommitmentsToDaTest;
@@ -309,6 +315,7 @@ impl SequencerSendCommitmentsToDaTest {
 #[tokio::test]
 async fn test_sequencer_sends_commitments_to_da_layer() -> Result<()> {
     TestCaseRunner::new(SequencerSendCommitmentsToDaTest)
+        .set_citrea_path(get_citrea_path())
         .run()
         .await
 }

--- a/bin/citrea/tests/bitcoin_e2e/sequencer_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/sequencer_test.rs
@@ -7,6 +7,8 @@ use citrea_e2e::test_case::{TestCase, TestCaseRunner};
 use citrea_e2e::traits::Restart;
 use citrea_e2e::Result;
 
+use super::get_citrea_path;
+
 struct BasicSequencerTest;
 
 #[async_trait]
@@ -47,7 +49,10 @@ impl TestCase for BasicSequencerTest {
 
 #[tokio::test]
 async fn basic_sequencer_test() -> Result<()> {
-    TestCaseRunner::new(BasicSequencerTest).run().await
+    TestCaseRunner::new(BasicSequencerTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
 }
 
 /// This test checks the sequencer behavior when missed DA blocks are detected.
@@ -130,5 +135,8 @@ impl TestCase for SequencerMissedDaBlocksTest {
 
 #[tokio::test]
 async fn test_sequencer_missed_da_blocks() -> Result<()> {
-    TestCaseRunner::new(SequencerMissedDaBlocksTest).run().await
+    TestCaseRunner::new(SequencerMissedDaBlocksTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
 }


### PR DESCRIPTION
# Description

- Bump citrea-e2e to latest rev
- Add SIGINT handling https://github.com/chainwayxyz/citrea-e2e/pull/26
- Add citrea docker support https://github.com/chainwayxyz/citrea-e2e/pull/25 && https://github.com/chainwayxyz/citrea-e2e/pull/28
- QoL improvement: Automatically resolves to `target/debug/release` if `CITREA_E2E_TEST_BINARY` is not set