### PR TITLE
Silence logs in dry_run_transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,6 +2020,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -35,6 +35,7 @@ tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 reth-chainspec = { workspace = true }
 reth-db = { workspace = true }


### PR DESCRIPTION
# Description

- Run `dry_run_transactions` with custom `tracing-subscriber` set to `LevelFilter::OFF`

## Linked Issues
- Fixes #1215 

## Testing

Nightly :
```
cargo test transaction_failing_on_l1_is_removed_from_mempool  -- --nocapture 
2024-10-16T16:09:39.476209Z  WARN all_tests::test_helpers: Starting sequencer node pub key: DefaultPublicKey { pub_key: VerifyingKey(CompressedEdwardsY: [32, 64, 64, 227, 100, 193, 15, 43, 236, 156, 31, 229, 0, 161, 205, 76, 36, 124, 137, 214, 80, 160, 30, 215, 232, 44, 171, 168, 103, 135, 124, 33]), EdwardsPoint{
	X: FieldElement51([1030465738406600, 807362127825008, 1418243591771550, 1902059919033201, 866838819767884]),
	Y: FieldElement51([422315847985532, 981093698289976, 1047720882470794, 575301909777987, 1646046603810123]),
	Z: FieldElement51([1269754074730262, 197267892596642, 1770632534389860, 83005611162829, 2137343060092114]),
	T: FieldElement51([1065019337558090, 1048300965276140, 804990153805841, 665557517675114, 1768939438812686])
}) }
2024-10-16T16:09:39.509209Z  INFO Sequencer: sov_schema_db: Opened RocksDB. rocksdb_name="ledger-db"
2024-10-16T16:09:39.529844Z  INFO Sequencer: sov_schema_db: Opened RocksDB. rocksdb_name="state-db"
2024-10-16T16:09:39.534074Z  INFO Sequencer: sov_schema_db: Opened RocksDB. rocksdb_name="native"
2024-10-16T16:09:39.537049Z  INFO Sequencer: citrea::rollup: Initialize sequencer at genesis.
2024-10-16T16:09:39.537203Z  INFO Sequencer: citrea_sequencer::sequencer: No history detected. Initializing chain...
2024-10-16T16:09:39.549135Z  INFO Sequencer: citrea_sequencer::sequencer: Chain initialization is done. Genesis root: 0xdacb59b0ff5d16985a8418235133eee37758a3ac1b76ab6d1f87c6df20e4d4da
2024-10-16T16:09:39.582189Z  INFO citrea_sequencer::sequencer: Starting RPC server at 127.0.0.1:53233 
2024-10-16T16:09:39.611215Z  INFO FullNode: sov_schema_db: Opened RocksDB. rocksdb_name="ledger-db"
2024-10-16T16:09:39.621315Z  INFO FullNode: sov_schema_db: Opened RocksDB. rocksdb_name="state-db"
2024-10-16T16:09:39.625254Z  INFO FullNode: sov_schema_db: Opened RocksDB. rocksdb_name="native"
2024-10-16T16:09:39.625686Z  INFO FullNode: citrea::rollup: Initialize node at genesis.
2024-10-16T16:09:39.625751Z  INFO FullNode: citrea_fullnode::runner: No history detected. Initializing chain...
2024-10-16T16:09:39.635275Z  INFO FullNode: citrea_fullnode::runner: Chain initialization is done. Genesis root: 0xdacb59b0ff5d16985a8418235133eee37758a3ac1b76ab6d1f87c6df20e4d4da
2024-10-16T16:09:39.635286Z  INFO FullNode: citrea_fullnode::runner: Starting L2 height: 1
2024-10-16T16:09:39.635467Z  INFO citrea_fullnode::runner: Starting RPC server at 127.0.0.1:53236 
2024-10-16T16:09:39.658885Z  INFO Sequencer: citrea_sequencer::sequencer: New block #1, DA #1, Tx count: #1
2024-10-16T16:09:39.754760Z ERROR Sequencer: citrea_evm::evm::executor: Transaction failed error=Not enough funds for L1 fee: 357500000000
2024-10-16T16:09:39.754820Z ERROR Sequencer: citrea_evm::call: evm: Custom error: "Not enough funds for L1 fee: 357500000000"
2024-10-16T16:09:39.758649Z  INFO Sequencer: citrea_sequencer::sequencer: New block #2, DA #1, Tx count: #0
2024-10-16T16:09:40.643802Z  INFO citrea_fullnode::da_block_handler: Starting to sync from L1 height 1
2024-10-16T16:09:40.643816Z  INFO FullNode: citrea_fullnode::runner: Starting to sync from L2 height 1
2024-10-16T16:09:40.648220Z  INFO FullNode: citrea_fullnode::runner: Running soft confirmation batch #1 with hash: 0xa04e900d93b22ded73b98e16f4f1a742ae86e7623c6e14f996d924864fee0ee6 on DA block #1
2024-10-16T16:09:40.680783Z  INFO FullNode: citrea_fullnode::runner: New State Root after soft confirmation #1 is: RootHash("2732def96dee768b5b87ab334b7d5e7cee1c1b912c24dea4162e85f5c3096376")
2024-10-16T16:09:40.680886Z  INFO FullNode: citrea_fullnode::runner: Running soft confirmation batch #2 with hash: 0x7d624101056aaf11a661d57d0891c5e198f7f85469d5d4dec69f4479c11ecfe9 on DA block #1
2024-10-16T16:09:40.684580Z  INFO FullNode: citrea_fullnode::runner: New State Root after soft confirmation #2 is: RootHash("00cc771b42d0c41e094fedb31f36976f6084b76dfafd48fdee0551a00399cea5")
test e2e::sequencer_behaviour::transaction_failing_on_l1_is_removed_from_mempool ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 50 filtered out; finished in 1.42s


```

This PR :
```
cargo test transaction_failing_on_l1_is_removed_from_mempool  -- --nocapture 
2024-10-16T16:10:18.432221Z  WARN all_tests::test_helpers: Starting sequencer node pub key: DefaultPublicKey { pub_key: VerifyingKey(CompressedEdwardsY: [32, 64, 64, 227, 100, 193, 15, 43, 236, 156, 31, 229, 0, 161, 205, 76, 36, 124, 137, 214, 80, 160, 30, 215, 232, 44, 171, 168, 103, 135, 124, 33]), EdwardsPoint{
	X: FieldElement51([1030465738406600, 807362127825008, 1418243591771550, 1902059919033201, 866838819767884]),
	Y: FieldElement51([422315847985532, 981093698289976, 1047720882470794, 575301909777987, 1646046603810123]),
	Z: FieldElement51([1269754074730262, 197267892596642, 1770632534389860, 83005611162829, 2137343060092114]),
	T: FieldElement51([1065019337558090, 1048300965276140, 804990153805841, 665557517675114, 1768939438812686])
}) }
2024-10-16T16:10:18.465780Z  INFO Sequencer: sov_schema_db: Opened RocksDB. rocksdb_name="ledger-db"
2024-10-16T16:10:18.479732Z  INFO Sequencer: sov_schema_db: Opened RocksDB. rocksdb_name="state-db"
2024-10-16T16:10:18.484139Z  INFO Sequencer: sov_schema_db: Opened RocksDB. rocksdb_name="native"
2024-10-16T16:10:18.487516Z  INFO Sequencer: citrea::rollup: Initialize sequencer at genesis.
2024-10-16T16:10:18.487655Z  INFO Sequencer: citrea_sequencer::sequencer: No history detected. Initializing chain...
2024-10-16T16:10:18.499825Z  INFO Sequencer: citrea_sequencer::sequencer: Chain initialization is done. Genesis root: 0xdacb59b0ff5d16985a8418235133eee37758a3ac1b76ab6d1f87c6df20e4d4da
2024-10-16T16:10:18.535169Z  INFO citrea_sequencer::sequencer: Starting RPC server at 127.0.0.1:53252 
2024-10-16T16:10:18.564645Z  INFO FullNode: sov_schema_db: Opened RocksDB. rocksdb_name="ledger-db"
2024-10-16T16:10:18.575116Z  INFO FullNode: sov_schema_db: Opened RocksDB. rocksdb_name="state-db"
2024-10-16T16:10:18.579390Z  INFO FullNode: sov_schema_db: Opened RocksDB. rocksdb_name="native"
2024-10-16T16:10:18.579857Z  INFO FullNode: citrea::rollup: Initialize node at genesis.
2024-10-16T16:10:18.579921Z  INFO FullNode: citrea_fullnode::runner: No history detected. Initializing chain...
2024-10-16T16:10:18.589984Z  INFO FullNode: citrea_fullnode::runner: Chain initialization is done. Genesis root: 0xdacb59b0ff5d16985a8418235133eee37758a3ac1b76ab6d1f87c6df20e4d4da
2024-10-16T16:10:18.589997Z  INFO FullNode: citrea_fullnode::runner: Starting L2 height: 1
2024-10-16T16:10:18.590215Z  INFO citrea_fullnode::runner: Starting RPC server at 127.0.0.1:53255 
2024-10-16T16:10:18.614531Z  INFO Sequencer: citrea_sequencer::sequencer: New block #1, DA #1, Tx count: #1
2024-10-16T16:10:18.712476Z  INFO Sequencer: citrea_sequencer::sequencer: New block #2, DA #1, Tx count: #0
2024-10-16T16:10:19.596194Z  INFO citrea_fullnode::da_block_handler: Starting to sync from L1 height 1
2024-10-16T16:10:19.596202Z  INFO FullNode: citrea_fullnode::runner: Starting to sync from L2 height 1
2024-10-16T16:10:19.597551Z  INFO FullNode: citrea_fullnode::runner: Running soft confirmation batch #1 with hash: 0xc5fb3c9896419ae36c2ccb50f84118536c60fe5c4d0b02ee187971367387a264 on DA block #1
2024-10-16T16:10:19.617533Z  INFO FullNode: citrea_fullnode::runner: New State Root after soft confirmation #1 is: RootHash("26b5d9d371b59aefe3cb0daf648bb3f5ef40327bd6a575a2bafe0b15432051fc")
2024-10-16T16:10:19.617604Z  INFO FullNode: citrea_fullnode::runner: Running soft confirmation batch #2 with hash: 0x24096acdaa3a155ac216159e17d18e358e3cfb9be7923531d85bcd5d21e20fb3 on DA block #1
2024-10-16T16:10:19.620865Z  INFO FullNode: citrea_fullnode::runner: New State Root after soft confirmation #2 is: RootHash("cfc54e9faa8088ba49c6f56e9ffd793101e56e72c1109ec4c8bbf11f80bb9799")
test e2e::sequencer_behaviour::transaction_failing_on_l1_is_removed_from_mempool ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 50 filtered out; finished in 1.42s

```