### PR TITLE
Remove MerkleProofSpec

### DIFF
--- a/bin/citrea/src/eth.rs
+++ b/bin/citrea/src/eth.rs
@@ -13,7 +13,7 @@ use tokio::sync::broadcast;
 // register ethereum methods.
 pub(crate) fn register_ethereum<Da: DaService>(
     da_service: Arc<Da>,
-    storage: ProverStorage<sov_state::DefaultWitness, sov_state::DefaultHasher, SnapshotManager>,
+    storage: ProverStorage<SnapshotManager>,
     ledger_db: LedgerDB,
     methods: &mut jsonrpsee::RpcModule<()>,
     sequencer_client_url: Option<String>,

--- a/bin/citrea/src/eth.rs
+++ b/bin/citrea/src/eth.rs
@@ -13,7 +13,7 @@ use tokio::sync::broadcast;
 // register ethereum methods.
 pub(crate) fn register_ethereum<Da: DaService>(
     da_service: Arc<Da>,
-    storage: ProverStorage<sov_state::DefaultStorageSpec, SnapshotManager>,
+    storage: ProverStorage<sov_state::DefaultWitness, sov_state::DefaultHasher, SnapshotManager>,
     ledger_db: LedgerDB,
     methods: &mut jsonrpsee::RpcModule<()>,
     sequencer_client_url: Option<String>,

--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -23,7 +23,7 @@ use sov_rollup_interface::da::DaVerifier;
 use sov_rollup_interface::services::da::SenderWithNotifier;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::zk::{Zkvm, ZkvmHost};
-use sov_state::{DefaultHasher, DefaultWitness, Storage, ZkStorage};
+use sov_state::{Storage, ZkStorage};
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::unbounded_channel;
 use tracing::instrument;
@@ -45,7 +45,7 @@ impl RollupBlueprint for BitcoinRollup {
     type ZkContext = ZkDefaultContext;
     type NativeContext = DefaultContext;
 
-    type StorageManager = ProverStorageManager<BitcoinSpec, DefaultWitness, DefaultHasher>;
+    type StorageManager = ProverStorageManager<BitcoinSpec>;
 
     type ZkRuntime = Runtime<Self::ZkContext, Self::DaSpec>;
     type NativeRuntime = Runtime<Self::NativeContext, Self::DaSpec>;

--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -23,7 +23,7 @@ use sov_rollup_interface::da::DaVerifier;
 use sov_rollup_interface::services::da::SenderWithNotifier;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::zk::{Zkvm, ZkvmHost};
-use sov_state::{DefaultStorageSpec, Storage, ZkStorage};
+use sov_state::{DefaultHasher, DefaultWitness, Storage, ZkStorage};
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::unbounded_channel;
 use tracing::instrument;
@@ -45,7 +45,7 @@ impl RollupBlueprint for BitcoinRollup {
     type ZkContext = ZkDefaultContext;
     type NativeContext = DefaultContext;
 
-    type StorageManager = ProverStorageManager<BitcoinSpec, DefaultStorageSpec>;
+    type StorageManager = ProverStorageManager<BitcoinSpec, DefaultWitness, DefaultHasher>;
 
     type ZkRuntime = Runtime<Self::ZkContext, Self::DaSpec>;
     type NativeRuntime = Runtime<Self::NativeContext, Self::DaSpec>;

--- a/bin/citrea/src/rollup/mock.rs
+++ b/bin/citrea/src/rollup/mock.rs
@@ -18,7 +18,7 @@ use sov_modules_stf_blueprint::StfBlueprint;
 use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::zk::{Zkvm, ZkvmHost};
-use sov_state::{DefaultStorageSpec, Storage, ZkStorage};
+use sov_state::{DefaultHasher, DefaultWitness, Storage, ZkStorage};
 use tokio::sync::broadcast;
 
 use crate::CitreaRollupBlueprint;
@@ -38,7 +38,7 @@ impl RollupBlueprint for MockDemoRollup {
     type ZkContext = ZkDefaultContext;
     type NativeContext = DefaultContext;
 
-    type StorageManager = ProverStorageManager<MockDaSpec, DefaultStorageSpec>;
+    type StorageManager = ProverStorageManager<MockDaSpec, DefaultWitness, DefaultHasher>;
 
     type ZkRuntime = Runtime<Self::ZkContext, Self::DaSpec>;
     type NativeRuntime = Runtime<Self::NativeContext, Self::DaSpec>;

--- a/bin/citrea/src/rollup/mock.rs
+++ b/bin/citrea/src/rollup/mock.rs
@@ -18,7 +18,7 @@ use sov_modules_stf_blueprint::StfBlueprint;
 use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::zk::{Zkvm, ZkvmHost};
-use sov_state::{DefaultHasher, DefaultWitness, Storage, ZkStorage};
+use sov_state::{Storage, ZkStorage};
 use tokio::sync::broadcast;
 
 use crate::CitreaRollupBlueprint;
@@ -38,7 +38,7 @@ impl RollupBlueprint for MockDemoRollup {
     type ZkContext = ZkDefaultContext;
     type NativeContext = DefaultContext;
 
-    type StorageManager = ProverStorageManager<MockDaSpec, DefaultWitness, DefaultHasher>;
+    type StorageManager = ProverStorageManager<MockDaSpec>;
 
     type ZkRuntime = Runtime<Self::ZkContext, Self::DaSpec>;
     type NativeRuntime = Runtime<Self::NativeContext, Self::DaSpec>;

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -15,7 +15,7 @@ use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Context, StateMapAccessor, StateValueAccessor, WorkingSet};
 use sov_prover_storage_manager::SnapshotManager;
 use sov_rollup_interface::spec::SpecId as SovSpecId;
-use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
+use sov_state::ProverStorage;
 
 use crate::evm::DbAccount;
 use crate::primitive_types::Block;
@@ -58,13 +58,10 @@ impl BlockchainTestCase {
         evm: &mut Evm<DefaultContext>,
         txs: Vec<RlpEvmTransaction>,
         mut working_set: WorkingSet<DefaultContext>,
-        storage: ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>,
+        storage: ProverStorage<SnapshotManager>,
         root: &[u8; 32],
         l2_height: u64,
-    ) -> (
-        WorkingSet<DefaultContext>,
-        ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>,
-    ) {
+    ) -> (WorkingSet<DefaultContext>, ProverStorage<SnapshotManager>) {
         let l1_fee_rate = 0;
         // Call begin_soft_confirmation_hook
         let soft_confirmation_info = HookSoftConfirmationInfo {

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -15,7 +15,7 @@ use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Context, StateMapAccessor, StateValueAccessor, WorkingSet};
 use sov_prover_storage_manager::SnapshotManager;
 use sov_rollup_interface::spec::SpecId as SovSpecId;
-use sov_state::{DefaultStorageSpec, ProverStorage};
+use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
 
 use crate::evm::DbAccount;
 use crate::primitive_types::Block;
@@ -58,12 +58,12 @@ impl BlockchainTestCase {
         evm: &mut Evm<DefaultContext>,
         txs: Vec<RlpEvmTransaction>,
         mut working_set: WorkingSet<DefaultContext>,
-        storage: ProverStorage<DefaultStorageSpec, SnapshotManager>,
+        storage: ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>,
         root: &[u8; 32],
         l2_height: u64,
     ) -> (
         WorkingSet<DefaultContext>,
-        ProverStorage<DefaultStorageSpec, SnapshotManager>,
+        ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>,
     ) {
         let l1_fee_rate = 0;
         // Call begin_soft_confirmation_hook

--- a/crates/evm/src/tests/queries/mod.rs
+++ b/crates/evm/src/tests/queries/mod.rs
@@ -13,7 +13,7 @@ use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Context, Module, WorkingSet};
 use sov_prover_storage_manager::SnapshotManager;
 use sov_rollup_interface::spec::SpecId as SovSpecId;
-use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
+use sov_state::ProverStorage;
 
 use crate::call::CallMessage;
 use crate::smart_contracts::{
@@ -27,7 +27,7 @@ use crate::tests::utils::{
 use crate::{AccountData, Evm, EvmConfig, RlpEvmTransaction};
 
 type C = DefaultContext;
-type Storage = ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>;
+type Storage = ProverStorage<SnapshotManager>;
 
 /// Creates evm instance with 4 blocks (including genesis)
 /// Block 1 has 3 transactions

--- a/crates/evm/src/tests/queries/mod.rs
+++ b/crates/evm/src/tests/queries/mod.rs
@@ -13,7 +13,7 @@ use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Context, Module, WorkingSet};
 use sov_prover_storage_manager::SnapshotManager;
 use sov_rollup_interface::spec::SpecId as SovSpecId;
-use sov_state::{DefaultStorageSpec, ProverStorage};
+use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
 
 use crate::call::CallMessage;
 use crate::smart_contracts::{
@@ -27,18 +27,13 @@ use crate::tests::utils::{
 use crate::{AccountData, Evm, EvmConfig, RlpEvmTransaction};
 
 type C = DefaultContext;
+type Storage = ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>;
 
 /// Creates evm instance with 4 blocks (including genesis)
 /// Block 1 has 3 transactions
 /// Block 2 has 4 transactions
 /// Block 3 has 2 transactions
-fn init_evm() -> (
-    Evm<C>,
-    WorkingSet<C>,
-    ProverStorage<DefaultStorageSpec, SnapshotManager>,
-    TestSigner,
-    u64,
-) {
+fn init_evm() -> (Evm<C>, WorkingSet<C>, Storage, TestSigner, u64) {
     let dev_signer: TestSigner = TestSigner::new_random();
 
     let mut config = EvmConfig {

--- a/crates/evm/src/tests/utils.rs
+++ b/crates/evm/src/tests/utils.rs
@@ -12,7 +12,7 @@ use sov_modules_api::hooks::HookSoftConfirmationInfo;
 use sov_modules_api::{Module, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
 use sov_rollup_interface::spec::SpecId as SovSpecId;
-use sov_state::{DefaultStorageSpec, ProverStorage, Storage};
+use sov_state::{DefaultHasher, DefaultWitness, ProverStorage, Storage};
 use sov_stf_runner::read_json_file;
 
 use crate::smart_contracts::{LogsContract, SimpleStorageContract, TestContract};
@@ -35,7 +35,7 @@ pub(crate) fn get_evm_with_storage(
 ) -> (
     Evm<C>,
     WorkingSet<DefaultContext>,
-    ProverStorage<DefaultStorageSpec, SnapshotManager>,
+    ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>,
 ) {
     let tmpdir = tempfile::tempdir().unwrap();
     let prover_storage = new_orphan_storage(tmpdir.path()).unwrap();
@@ -93,7 +93,7 @@ pub(crate) fn get_evm(config: &EvmConfig) -> (Evm<C>, WorkingSet<C>) {
 
 pub(crate) fn commit(
     working_set: WorkingSet<C>,
-    storage: ProverStorage<DefaultStorageSpec, SnapshotManager>,
+    storage: ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>,
 ) -> [u8; 32] {
     // Save checkpoint
     let mut checkpoint = working_set.checkpoint();

--- a/crates/evm/src/tests/utils.rs
+++ b/crates/evm/src/tests/utils.rs
@@ -12,7 +12,7 @@ use sov_modules_api::hooks::HookSoftConfirmationInfo;
 use sov_modules_api::{Module, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
 use sov_rollup_interface::spec::SpecId as SovSpecId;
-use sov_state::{DefaultHasher, DefaultWitness, ProverStorage, Storage};
+use sov_state::{ProverStorage, Storage};
 use sov_stf_runner::read_json_file;
 
 use crate::smart_contracts::{LogsContract, SimpleStorageContract, TestContract};
@@ -35,7 +35,7 @@ pub(crate) fn get_evm_with_storage(
 ) -> (
     Evm<C>,
     WorkingSet<DefaultContext>,
-    ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>,
+    ProverStorage<SnapshotManager>,
 ) {
     let tmpdir = tempfile::tempdir().unwrap();
     let prover_storage = new_orphan_storage(tmpdir.path()).unwrap();
@@ -93,7 +93,7 @@ pub(crate) fn get_evm(config: &EvmConfig) -> (Evm<C>, WorkingSet<C>) {
 
 pub(crate) fn commit(
     working_set: WorkingSet<C>,
-    storage: ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>,
+    storage: ProverStorage<SnapshotManager>,
 ) -> [u8; 32] {
     // Save checkpoint
     let mut checkpoint = working_set.checkpoint();

--- a/crates/fullnode/tests/hash_stf.rs
+++ b/crates/fullnode/tests/hash_stf.rs
@@ -301,7 +301,6 @@ fn compare_output() {
     assert_eq!(recorded_state_root, state_root);
 }
 
-#[allow(clippy::type_complexity)]
 // Returns final data hash and root hash
 pub fn get_result_from_blocks(
     genesis_params: &[u8],

--- a/crates/fullnode/tests/hash_stf.rs
+++ b/crates/fullnode/tests/hash_stf.rs
@@ -15,13 +15,7 @@ use sov_rollup_interface::stf::{
 };
 use sov_rollup_interface::zk::{CumulativeStateDiff, ValidityCondition, Zkvm};
 use sov_state::storage::{NativeStorage, StorageKey, StorageValue};
-use sov_state::{
-    ArrayWitness, DefaultHasher, DefaultWitness, OrderedReadsAndWrites, Prefix, ProverStorage,
-    Storage,
-};
-
-pub type W = DefaultWitness;
-pub type H = DefaultHasher;
+use sov_state::{ArrayWitness, OrderedReadsAndWrites, Prefix, ProverStorage, Storage};
 pub type Q = SnapshotManager;
 
 #[derive(Default, Clone)]
@@ -43,9 +37,9 @@ impl<Cond> HashStf<Cond> {
 
     fn save_from_hasher(
         hasher: sha2::Sha256,
-        storage: ProverStorage<W, H, Q>,
+        storage: ProverStorage<Q>,
         witness: &mut ArrayWitness,
-    ) -> ([u8; 32], ProverStorage<W, H, Q>) {
+    ) -> ([u8; 32], ProverStorage<Q>) {
         let result = hasher.finalize();
 
         let hash_key = HashStf::<Cond>::hash_key();
@@ -144,8 +138,8 @@ impl<Vm: Zkvm, Cond: ValidityCondition, Da: DaSpec> StateTransitionFunction<Vm, 
 {
     type StateRoot = [u8; 32];
     type GenesisParams = Vec<u8>;
-    type PreState = ProverStorage<W, H, Q>;
-    type ChangeSet = ProverStorage<W, H, Q>;
+    type PreState = ProverStorage<Q>;
+    type ChangeSet = ProverStorage<Q>;
     type TxReceiptContents = ();
     type BatchReceiptContents = [u8; 32];
     type Witness = ArrayWitness;
@@ -312,7 +306,7 @@ fn compare_output() {
 pub fn get_result_from_blocks(
     genesis_params: &[u8],
     blocks: &[MockBlock],
-) -> ([u8; 32], Option<<ProverStorage<W, H, Q> as Storage>::Root>) {
+) -> ([u8; 32], Option<<ProverStorage<Q> as Storage>::Root>) {
     let tmpdir = tempfile::tempdir().unwrap();
 
     let storage = new_orphan_storage(tmpdir.path()).unwrap();

--- a/crates/fullnode/tests/runner_initialization_tests.rs
+++ b/crates/fullnode/tests/runner_initialization_tests.rs
@@ -10,7 +10,6 @@ use sov_mock_zkvm::{MockCodeCommitment, MockZkvm};
 use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::fork::{Fork, ForkManager};
 use sov_rollup_interface::spec::SpecId;
-use sov_state::{DefaultHasher, DefaultWitness};
 use sov_stf_runner::InitVariant;
 mod hash_stf;
 
@@ -20,9 +19,7 @@ use tokio::sync::broadcast;
 type MockInitVariant =
     InitVariant<HashStf<MockValidityCond>, MockZkvm<MockValidityCond>, MockDaSpec>;
 
-type W = DefaultWitness;
-type H = DefaultHasher;
-type StorageManager = ProverStorageManager<MockDaSpec, W, H>;
+type StorageManager = ProverStorageManager<MockDaSpec>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn init_and_restart() {

--- a/crates/fullnode/tests/runner_initialization_tests.rs
+++ b/crates/fullnode/tests/runner_initialization_tests.rs
@@ -10,7 +10,7 @@ use sov_mock_zkvm::{MockCodeCommitment, MockZkvm};
 use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::fork::{Fork, ForkManager};
 use sov_rollup_interface::spec::SpecId;
-use sov_state::DefaultStorageSpec;
+use sov_state::{DefaultHasher, DefaultWitness};
 use sov_stf_runner::InitVariant;
 mod hash_stf;
 
@@ -20,8 +20,9 @@ use tokio::sync::broadcast;
 type MockInitVariant =
     InitVariant<HashStf<MockValidityCond>, MockZkvm<MockValidityCond>, MockDaSpec>;
 
-type S = DefaultStorageSpec;
-type StorageManager = ProverStorageManager<MockDaSpec, S>;
+type W = DefaultWitness;
+type H = DefaultHasher;
+type StorageManager = ProverStorageManager<MockDaSpec, W, H>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn init_and_restart() {

--- a/crates/sovereign-sdk/examples/demo-stf/src/tests/mod.rs
+++ b/crates/sovereign-sdk/examples/demo-stf/src/tests/mod.rs
@@ -6,7 +6,7 @@
 // use sov_modules_stf_blueprint::kernels::basic::{BasicKernel, BasicKernelGenesisConfig};
 // use sov_modules_stf_blueprint::{GenesisParams, StfBlueprint};
 // use sov_prover_storage_manager::ProverStorageManager;
-// use sov_state::DefaultStorageSpec;
+//use sov_state::{DefaultHasher, DefaultWitness};
 // use sov_stf_runner::read_json_file;
 
 // use crate::genesis_config::{get_genesis_config, GenesisPaths};
@@ -29,7 +29,7 @@
 
 // pub(crate) fn create_storage_manager_for_tests(
 //     path: impl AsRef<Path>,
-// ) -> ProverStorageManager<MockDaSpec, DefaultStorageSpec> {
+// ) -> ProverStorageManager<MockDaSpec, DefaultWitness, DefaultHasher> {
 //     let config = sov_state::config::Config {
 //         path: path.as_ref().to_path_buf(),
 //     };

--- a/crates/sovereign-sdk/examples/demo-stf/src/tests/mod.rs
+++ b/crates/sovereign-sdk/examples/demo-stf/src/tests/mod.rs
@@ -6,7 +6,6 @@
 // use sov_modules_stf_blueprint::kernels::basic::{BasicKernel, BasicKernelGenesisConfig};
 // use sov_modules_stf_blueprint::{GenesisParams, StfBlueprint};
 // use sov_prover_storage_manager::ProverStorageManager;
-//use sov_state::{DefaultHasher, DefaultWitness};
 // use sov_stf_runner::read_json_file;
 
 // use crate::genesis_config::{get_genesis_config, GenesisPaths};
@@ -29,7 +28,7 @@
 
 // pub(crate) fn create_storage_manager_for_tests(
 //     path: impl AsRef<Path>,
-// ) -> ProverStorageManager<MockDaSpec, DefaultWitness, DefaultHasher> {
+// ) -> ProverStorageManager<MockDaSpec> {
 //     let config = sov_state::config::Config {
 //         path: path.as_ref().to_path_buf(),
 //     };

--- a/crates/sovereign-sdk/full-node/sov-prover-storage-manager/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/sov-prover-storage-manager/Cargo.toml
@@ -18,6 +18,7 @@ sov-db = { path = "../db/sov-db" }
 sov-schema-db = { path = "../db/sov-schema-db" }
 sov-state = { path = "../../module-system/sov-state", features = ["native"] }
 tracing = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }

--- a/crates/sovereign-sdk/full-node/sov-prover-storage-manager/benches/single_thread_progression.rs
+++ b/crates/sovereign-sdk/full-node/sov-prover-storage-manager/benches/single_thread_progression.rs
@@ -16,7 +16,8 @@ use sov_state::storage::{CacheKey, CacheValue, StorageKey};
 use sov_state::{ArrayWitness, OrderedReadsAndWrites, Storage};
 
 type Da = sov_mock_da::MockDaSpec;
-type S = sov_state::DefaultStorageSpec;
+type W = ArrayWitness;
+type H = sha2::Sha256;
 
 fn generate_random_bytes<R: Rng>(
     rng: &mut R,
@@ -38,7 +39,7 @@ fn generate_random_bytes<R: Rng>(
 struct TestData {
     random_key: Vec<u8>,
     non_existing_key: Vec<u8>,
-    storage_manager: ProverStorageManager<Da, S>,
+    storage_manager: ProverStorageManager<Da, W, H>,
 }
 
 //TODO: Extend with auxiliary data
@@ -54,7 +55,7 @@ fn setup_storage(
         db_max_open_files: None,
     };
 
-    let mut storage_manager = ProverStorageManager::<Da, S>::new(config).unwrap();
+    let mut storage_manager = ProverStorageManager::<Da, W, H>::new(config).unwrap();
 
     let mut old_writes: Vec<Vec<u8>> = Vec::with_capacity(rollup_height as usize * num_old_writes);
 

--- a/crates/sovereign-sdk/full-node/sov-prover-storage-manager/benches/single_thread_progression.rs
+++ b/crates/sovereign-sdk/full-node/sov-prover-storage-manager/benches/single_thread_progression.rs
@@ -16,8 +16,6 @@ use sov_state::storage::{CacheKey, CacheValue, StorageKey};
 use sov_state::{ArrayWitness, OrderedReadsAndWrites, Storage};
 
 type Da = sov_mock_da::MockDaSpec;
-type W = ArrayWitness;
-type H = sha2::Sha256;
 
 fn generate_random_bytes<R: Rng>(
     rng: &mut R,
@@ -39,7 +37,7 @@ fn generate_random_bytes<R: Rng>(
 struct TestData {
     random_key: Vec<u8>,
     non_existing_key: Vec<u8>,
-    storage_manager: ProverStorageManager<Da, W, H>,
+    storage_manager: ProverStorageManager<Da>,
 }
 
 //TODO: Extend with auxiliary data
@@ -55,7 +53,7 @@ fn setup_storage(
         db_max_open_files: None,
     };
 
-    let mut storage_manager = ProverStorageManager::<Da, W, H>::new(config).unwrap();
+    let mut storage_manager = ProverStorageManager::<Da>::new(config).unwrap();
 
     let mut old_writes: Vec<Vec<u8>> = Vec::with_capacity(rollup_height as usize * num_old_writes);
 

--- a/crates/sovereign-sdk/full-node/sov-prover-storage-manager/src/lib.rs
+++ b/crates/sovereign-sdk/full-node/sov-prover-storage-manager/src/lib.rs
@@ -3,22 +3,26 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 use std::sync::{Arc, RwLock};
 
+use sha2::Digest;
 use sov_db::native_db::NativeDB;
 use sov_db::rocks_db_config::RocksdbConfig;
 use sov_db::state_db::StateDB;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_schema_db::snapshot::{DbSnapshot, ReadOnlyLock, SnapshotId};
-use sov_state::{MerkleProofSpec, ProverStorage};
+use sov_state::{ProverStorage, Witness};
 use tracing::{debug, trace};
 
 pub use crate::snapshot_manager::SnapshotManager;
-
 mod snapshot_manager;
 
 /// Implementation of [`HierarchicalStorageManager`] that handles relation between snapshots
 /// And reorgs on Data Availability layer.
-pub struct ProverStorageManager<Da: DaSpec, S: MerkleProofSpec> {
+pub struct ProverStorageManager<Da: DaSpec, W, H>
+where
+    W: Witness + Send + Sync,
+    H: Digest<OutputSize = sha2::digest::typenum::U32>,
+{
     // L1 forks representation
     // Chain: prev_block -> child_blocks
     chain_forks: HashMap<Da::SlotHash, Vec<Da::SlotHash>>,
@@ -41,12 +45,14 @@ pub struct ProverStorageManager<Da: DaSpec, S: MerkleProofSpec> {
     state_snapshot_manager: Arc<RwLock<SnapshotManager>>,
     accessory_snapshot_manager: Arc<RwLock<SnapshotManager>>,
 
-    phantom_mp_spec: PhantomData<S>,
+    phantom_mp_spec: PhantomData<(W, H)>,
 }
 
-impl<Da: DaSpec, S: MerkleProofSpec> ProverStorageManager<Da, S>
+impl<Da: DaSpec, W, H> ProverStorageManager<Da, W, H>
 where
     Da::SlotHash: Hash,
+    W: Witness + Send + Sync,
+    H: Digest<OutputSize = sha2::digest::typenum::U32>,
 {
     fn with_db_handles(state_db: sov_schema_db::DB, native_db: sov_schema_db::DB) -> Self {
         let snapshot_id_to_parent = Arc::new(RwLock::new(HashMap::new()));
@@ -90,7 +96,7 @@ where
     fn get_storage_with_snapshot_id(
         &self,
         snapshot_id: SnapshotId,
-    ) -> anyhow::Result<ProverStorage<S, SnapshotManager>> {
+    ) -> anyhow::Result<ProverStorage<W, H, SnapshotManager>> {
         let state_db_snapshot = DbSnapshot::new(
             snapshot_id,
             ReadOnlyLock::new(self.state_snapshot_manager.clone()),
@@ -196,12 +202,14 @@ where
     }
 }
 
-impl<Da: DaSpec, S: MerkleProofSpec> HierarchicalStorageManager<Da> for ProverStorageManager<Da, S>
+impl<Da: DaSpec, W, H> HierarchicalStorageManager<Da> for ProverStorageManager<Da, W, H>
 where
     Da::SlotHash: Hash,
+    W: Witness + Send + Sync,
+    H: Digest<OutputSize = sha2::digest::typenum::U32>,
 {
-    type NativeStorage = ProverStorage<S, SnapshotManager>;
-    type NativeChangeSet = ProverStorage<S, SnapshotManager>;
+    type NativeStorage = ProverStorage<W, H, SnapshotManager>;
+    type NativeChangeSet = ProverStorage<W, H, SnapshotManager>;
 
     fn create_storage_on_l2_height(
         &mut self,
@@ -424,9 +432,13 @@ where
 /// Creates orphan [`ProverStorage`] which just points directly to the underlying database for previous data
 /// Should be used only in tests
 #[cfg(feature = "test-utils")]
-pub fn new_orphan_storage<S: MerkleProofSpec>(
+pub fn new_orphan_storage<W, H>(
     path: impl AsRef<std::path::Path>,
-) -> anyhow::Result<ProverStorage<S, SnapshotManager>> {
+) -> anyhow::Result<ProverStorage<W, H, SnapshotManager>>
+where
+    W: Witness + Send + Sync,
+    H: Digest<OutputSize = sha2::digest::typenum::U32>,
+{
     let state_db_raw =
         StateDB::<SnapshotManager>::setup_schema_db(&RocksdbConfig::new(path.as_ref(), None))?;
     let state_db_sm = Arc::new(RwLock::new(SnapshotManager::orphan(state_db_raw)));
@@ -445,14 +457,15 @@ mod tests {
     use sov_mock_da::{MockBlockHeader, MockHash};
     use sov_rollup_interface::da::Time;
     use sov_state::storage::{CacheKey, CacheValue};
-    use sov_state::{ArrayWitness, OrderedReadsAndWrites, Storage};
+    use sov_state::{ArrayWitness, DefaultHasher, DefaultWitness, OrderedReadsAndWrites, Storage};
 
     use super::*;
 
     type Da = sov_mock_da::MockDaSpec;
-    type S = sov_state::DefaultStorageSpec;
+    type W = DefaultWitness;
+    type H = DefaultHasher;
 
-    fn validate_internal_consistency(storage_manager: &ProverStorageManager<Da, S>) {
+    fn validate_internal_consistency(storage_manager: &ProverStorageManager<Da, W, H>) {
         let snapshot_id_to_parent = storage_manager.snapshot_id_to_parent.read().unwrap();
         let state_snapshot_manager = storage_manager.state_snapshot_manager.read().unwrap();
         let native_snapshot_manager = storage_manager.state_snapshot_manager.read().unwrap();
@@ -524,7 +537,8 @@ mod tests {
 
         let (state_db, native_db) = build_dbs(tmpdir.path());
 
-        let storage_manager = ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+        let storage_manager =
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
         assert!(storage_manager.is_empty());
         validate_internal_consistency(&storage_manager);
     }
@@ -536,7 +550,7 @@ mod tests {
         let (state_db, native_db) = build_dbs(tmpdir.path());
 
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
         assert!(storage_manager.is_empty());
 
         let block_header = MockBlockHeader {
@@ -576,7 +590,7 @@ mod tests {
         let (state_db, native_db) = build_dbs(tmpdir.path());
 
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
         assert!(storage_manager.is_empty());
 
         let block_header = MockBlockHeader {
@@ -619,7 +633,7 @@ mod tests {
         let (state_db, native_db) = build_dbs(tmpdir.path());
 
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
         assert!(storage_manager.is_empty());
 
         let block_header = MockBlockHeader {
@@ -644,7 +658,7 @@ mod tests {
         let (state_db, native_db) = build_dbs(tmpdir.path());
 
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
         assert!(storage_manager.is_empty());
 
         let block_a = MockBlockHeader {
@@ -680,7 +694,7 @@ mod tests {
         let (state_db, native_db) = build_dbs(tmpdir.path());
 
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
         assert!(storage_manager.is_empty());
 
         let block_header = MockBlockHeader {
@@ -720,13 +734,13 @@ mod tests {
         let snapshot_1 = {
             let (state_db, native_db) = build_dbs(tmpdir_1.path());
             let mut storage_manager_temp =
-                ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+                ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
             storage_manager_temp.create_storage_on(&block_a).unwrap()
         };
 
         let (state_db, native_db) = build_dbs(tmpdir_2.path());
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
 
         let result = storage_manager.save_change_set(&block_a, snapshot_1);
         assert!(result.is_err());
@@ -766,7 +780,7 @@ mod tests {
         let (snapshot_alien_1, snapshot_alien_2) = {
             let (state_db, native_db) = build_dbs(tmpdir_1.path());
             let mut storage_manager_temp =
-                ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+                ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
             // ID = 1
             let snapshot_a = storage_manager_temp.create_storage_on(&block_a).unwrap();
             // ID = 2
@@ -776,7 +790,7 @@ mod tests {
 
         let (state_db, native_db) = build_dbs(tmpdir_2.path());
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
 
         let snapshot_own_a = storage_manager.create_storage_on(&block_a).unwrap();
         let _snapshot_own_b = storage_manager.create_storage_on(&block_b).unwrap();
@@ -823,7 +837,7 @@ mod tests {
         let (state_db, native_db) = build_dbs(tmpdir.path());
 
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
         assert!(storage_manager.is_empty());
 
         let block_from_i = |i: u8| MockBlockHeader {
@@ -855,7 +869,7 @@ mod tests {
         let (state_db, native_db) = build_dbs(tmpdir.path());
 
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
         assert!(storage_manager.is_empty());
 
         // 1    2    3
@@ -908,7 +922,7 @@ mod tests {
         let (state_db, native_db) = build_dbs(tmpdir.path());
 
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
         assert!(storage_manager.is_empty());
 
         // Blocks A -> B -> C
@@ -983,7 +997,7 @@ mod tests {
         let (state_db, native_db) = build_dbs(tmpdir.path());
 
         let mut storage_manager =
-            ProverStorageManager::<Da, S>::with_db_handles(state_db, native_db);
+            ProverStorageManager::<Da, W, H>::with_db_handles(state_db, native_db);
         assert!(storage_manager.is_empty());
 
         // Chains:

--- a/crates/sovereign-sdk/fuzz/Cargo.lock
+++ b/crates/sovereign-sdk/fuzz/Cargo.lock
@@ -2206,6 +2206,7 @@ name = "sov-prover-storage-manager"
 version = "0.5.0-rc.1"
 dependencies = [
  "anyhow",
+ "sha2",
  "sov-db",
  "sov-rollup-interface",
  "sov-schema-db",

--- a/crates/sovereign-sdk/module-system/module-implementations/module-template/tests/value_setter.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/module-template/tests/value_setter.rs
@@ -2,13 +2,13 @@ use module_template::{CallMessage, ExampleModule, ExampleModuleConfig, Response}
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
 use sov_modules_api::{Address, Context, Event, Module, SpecId, WorkingSet};
 use sov_prover_storage_manager::new_orphan_storage;
-use sov_state::{DefaultStorageSpec, ZkStorage};
+use sov_state::{DefaultHasher, DefaultWitness, ZkStorage};
 
 #[test]
 fn test_value_setter() {
     let tmpdir = tempfile::tempdir().unwrap();
 
-    let storage = new_orphan_storage::<DefaultStorageSpec>(tmpdir.path()).unwrap();
+    let storage = new_orphan_storage::<DefaultWitness, DefaultHasher>(tmpdir.path()).unwrap();
     let mut working_set = WorkingSet::new(storage);
 
     let admin = Address::from([1; 32]);

--- a/crates/sovereign-sdk/module-system/module-implementations/module-template/tests/value_setter.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/module-template/tests/value_setter.rs
@@ -2,13 +2,13 @@ use module_template::{CallMessage, ExampleModule, ExampleModuleConfig, Response}
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
 use sov_modules_api::{Address, Context, Event, Module, SpecId, WorkingSet};
 use sov_prover_storage_manager::new_orphan_storage;
-use sov_state::{DefaultHasher, DefaultWitness, ZkStorage};
+use sov_state::ZkStorage;
 
 #[test]
 fn test_value_setter() {
     let tmpdir = tempfile::tempdir().unwrap();
 
-    let storage = new_orphan_storage::<DefaultWitness, DefaultHasher>(tmpdir.path()).unwrap();
+    let storage = new_orphan_storage(tmpdir.path()).unwrap();
     let mut working_set = WorkingSet::new(storage);
 
     let admin = Address::from([1; 32]);

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/archival_query_test.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/archival_query_test.rs
@@ -6,7 +6,7 @@ use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::{Address, Context, Module, SpecId, StateReaderAndWriter, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
 use sov_state::storage::{StorageKey, StorageValue};
-use sov_state::{DefaultHasher, DefaultWitness, ProverStorage, Storage};
+use sov_state::{ProverStorage, Storage};
 
 #[test]
 fn transfer_initial_token() {
@@ -270,10 +270,7 @@ fn transfer(
         .expect("Transfer call failed");
 }
 
-fn commit(
-    working_set: WorkingSet<DefaultContext>,
-    storage: ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>,
-) {
+fn commit(working_set: WorkingSet<DefaultContext>, storage: ProverStorage<SnapshotManager>) {
     // Save checkpoint
     let mut checkpoint = working_set.checkpoint();
 

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/archival_query_test.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/archival_query_test.rs
@@ -6,7 +6,7 @@ use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::{Address, Context, Module, SpecId, StateReaderAndWriter, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
 use sov_state::storage::{StorageKey, StorageValue};
-use sov_state::{DefaultStorageSpec, ProverStorage, Storage};
+use sov_state::{DefaultHasher, DefaultWitness, ProverStorage, Storage};
 
 #[test]
 fn transfer_initial_token() {
@@ -272,7 +272,7 @@ fn transfer(
 
 fn commit(
     working_set: WorkingSet<DefaultContext>,
-    storage: ProverStorage<DefaultStorageSpec, SnapshotManager>,
+    storage: ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>,
 ) {
     // Save checkpoint
     let mut checkpoint = working_set.checkpoint();

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/burn_test.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/burn_test.rs
@@ -4,13 +4,13 @@ use sov_bank::{
 };
 use sov_modules_api::{Context, Error, Module, SpecId, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
-use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
+use sov_state::ProverStorage;
 
 use crate::helpers::create_bank_config_with_token;
 
 mod helpers;
 
-pub type Storage = ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>;
+pub type Storage = ProverStorage<SnapshotManager>;
 
 #[test]
 fn burn_deployed_tokens() {

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/burn_test.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/burn_test.rs
@@ -4,13 +4,13 @@ use sov_bank::{
 };
 use sov_modules_api::{Context, Error, Module, SpecId, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
-use sov_state::{DefaultStorageSpec, ProverStorage};
+use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
 
 use crate::helpers::create_bank_config_with_token;
 
 mod helpers;
 
-pub type Storage = ProverStorage<DefaultStorageSpec, SnapshotManager>;
+pub type Storage = ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>;
 
 #[test]
 fn burn_deployed_tokens() {

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -4,11 +4,11 @@ use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Context, Error, Module, SpecId, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
-use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
+use sov_state::ProverStorage;
 
 mod helpers;
 
-pub type Storage = ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>;
+pub type Storage = ProverStorage<SnapshotManager>;
 
 #[test]
 fn freeze_token() {

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -4,11 +4,11 @@ use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Context, Error, Module, SpecId, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
-use sov_state::{DefaultStorageSpec, ProverStorage};
+use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
 
 mod helpers;
 
-pub type Storage = ProverStorage<DefaultStorageSpec, SnapshotManager>;
+pub type Storage = ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>;
 
 #[test]
 fn freeze_token() {

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -3,11 +3,11 @@ use sov_bank::{get_token_address, Bank, BankConfig, CallMessage, Coins};
 use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Context, Error, Module, SpecId, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
-use sov_state::{DefaultStorageSpec, ProverStorage};
+use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
 
 mod helpers;
 
-pub type Storage = ProverStorage<DefaultStorageSpec, SnapshotManager>;
+pub type Storage = ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>;
 
 #[test]
 fn mint_token() {

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -3,11 +3,11 @@ use sov_bank::{get_token_address, Bank, BankConfig, CallMessage, Coins};
 use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Context, Error, Module, SpecId, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
-use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
+use sov_state::ProverStorage;
 
 mod helpers;
 
-pub type Storage = ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>;
+pub type Storage = ProverStorage<SnapshotManager>;
 
 #[test]
 fn mint_token() {

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/transfer_test.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/transfer_test.rs
@@ -7,9 +7,9 @@ use sov_bank::{
 use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Context, Error, Module, SpecId, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
-use sov_state::{DefaultStorageSpec, ProverStorage};
+use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
 
-pub type Storage = ProverStorage<DefaultStorageSpec, SnapshotManager>;
+pub type Storage = ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>;
 
 #[test]
 fn transfer_initial_token() {

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/transfer_test.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-bank/tests/transfer_test.rs
@@ -7,9 +7,9 @@ use sov_bank::{
 use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Context, Error, Module, SpecId, WorkingSet};
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
-use sov_state::{DefaultHasher, DefaultWitness, ProverStorage};
+use sov_state::ProverStorage;
 
-pub type Storage = ProverStorage<DefaultWitness, DefaultHasher, SnapshotManager>;
+pub type Storage = ProverStorage<SnapshotManager>;
 
 #[test]
 fn transfer_initial_token() {

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/containers/mod.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/containers/mod.rs
@@ -30,7 +30,6 @@ mod test {
     use sov_modules_core::{StateReaderAndWriter, Storage, StorageKey, StorageValue, WorkingSet};
     use sov_prover_storage_manager::ProverStorageManager;
     use sov_rollup_interface::storage::HierarchicalStorageManager;
-    use sov_state::{DefaultHasher, DefaultWitness};
 
     use crate::default_context::DefaultContext;
 
@@ -76,10 +75,7 @@ mod test {
         };
         {
             let mut storage_manager =
-                ProverStorageManager::<MockDaSpec, DefaultWitness, DefaultHasher>::new(
-                    storage_config.clone(),
-                )
-                .unwrap();
+                ProverStorageManager::<MockDaSpec>::new(storage_config.clone()).unwrap();
             let header = MockBlockHeader::default();
             let prover_storage = storage_manager.create_storage_on(&header).unwrap();
             for test in tests.clone() {
@@ -106,10 +102,7 @@ mod test {
 
         {
             let mut storage_manager =
-                ProverStorageManager::<MockDaSpec, DefaultWitness, DefaultHasher>::new(
-                    storage_config,
-                )
-                .unwrap();
+                ProverStorageManager::<MockDaSpec>::new(storage_config).unwrap();
             let header = MockBlockHeader::default();
             let storage = storage_manager.create_storage_on(&header).unwrap();
             for test in tests {
@@ -132,10 +125,7 @@ mod test {
         };
         {
             let mut storage_manager =
-                ProverStorageManager::<MockDaSpec, DefaultWitness, DefaultHasher>::new(
-                    storage_config.clone(),
-                )
-                .unwrap();
+                ProverStorageManager::<MockDaSpec>::new(storage_config.clone()).unwrap();
             let header = MockBlockHeader::default();
             let prover_storage = storage_manager.create_storage_on(&header).unwrap();
             assert!(prover_storage.is_empty());
@@ -146,10 +136,7 @@ mod test {
         // First restart
         {
             let mut storage_manager =
-                ProverStorageManager::<MockDaSpec, DefaultWitness, DefaultHasher>::new(
-                    storage_config.clone(),
-                )
-                .unwrap();
+                ProverStorageManager::<MockDaSpec>::new(storage_config.clone()).unwrap();
             let header = MockBlockHeader::default();
             let prover_storage = storage_manager.create_storage_on(&header).unwrap();
             assert!(prover_storage.is_empty());
@@ -168,10 +155,7 @@ mod test {
         // Correctly restart from disk
         {
             let mut storage_manager =
-                ProverStorageManager::<MockDaSpec, DefaultWitness, DefaultHasher>::new(
-                    storage_config.clone(),
-                )
-                .unwrap();
+                ProverStorageManager::<MockDaSpec>::new(storage_config.clone()).unwrap();
             let prover_storage = storage_manager.create_finalized_storage().unwrap();
             assert!(!prover_storage.is_empty());
             assert_eq!(

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/containers/mod.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/containers/mod.rs
@@ -30,7 +30,7 @@ mod test {
     use sov_modules_core::{StateReaderAndWriter, Storage, StorageKey, StorageValue, WorkingSet};
     use sov_prover_storage_manager::ProverStorageManager;
     use sov_rollup_interface::storage::HierarchicalStorageManager;
-    use sov_state::DefaultStorageSpec;
+    use sov_state::{DefaultHasher, DefaultWitness};
 
     use crate::default_context::DefaultContext;
 
@@ -76,8 +76,10 @@ mod test {
         };
         {
             let mut storage_manager =
-                ProverStorageManager::<MockDaSpec, DefaultStorageSpec>::new(storage_config.clone())
-                    .unwrap();
+                ProverStorageManager::<MockDaSpec, DefaultWitness, DefaultHasher>::new(
+                    storage_config.clone(),
+                )
+                .unwrap();
             let header = MockBlockHeader::default();
             let prover_storage = storage_manager.create_storage_on(&header).unwrap();
             for test in tests.clone() {
@@ -104,8 +106,10 @@ mod test {
 
         {
             let mut storage_manager =
-                ProverStorageManager::<MockDaSpec, DefaultStorageSpec>::new(storage_config)
-                    .unwrap();
+                ProverStorageManager::<MockDaSpec, DefaultWitness, DefaultHasher>::new(
+                    storage_config,
+                )
+                .unwrap();
             let header = MockBlockHeader::default();
             let storage = storage_manager.create_storage_on(&header).unwrap();
             for test in tests {
@@ -128,8 +132,10 @@ mod test {
         };
         {
             let mut storage_manager =
-                ProverStorageManager::<MockDaSpec, DefaultStorageSpec>::new(storage_config.clone())
-                    .unwrap();
+                ProverStorageManager::<MockDaSpec, DefaultWitness, DefaultHasher>::new(
+                    storage_config.clone(),
+                )
+                .unwrap();
             let header = MockBlockHeader::default();
             let prover_storage = storage_manager.create_storage_on(&header).unwrap();
             assert!(prover_storage.is_empty());
@@ -140,8 +146,10 @@ mod test {
         // First restart
         {
             let mut storage_manager =
-                ProverStorageManager::<MockDaSpec, DefaultStorageSpec>::new(storage_config.clone())
-                    .unwrap();
+                ProverStorageManager::<MockDaSpec, DefaultWitness, DefaultHasher>::new(
+                    storage_config.clone(),
+                )
+                .unwrap();
             let header = MockBlockHeader::default();
             let prover_storage = storage_manager.create_storage_on(&header).unwrap();
             assert!(prover_storage.is_empty());
@@ -160,8 +168,10 @@ mod test {
         // Correctly restart from disk
         {
             let mut storage_manager =
-                ProverStorageManager::<MockDaSpec, DefaultStorageSpec>::new(storage_config.clone())
-                    .unwrap();
+                ProverStorageManager::<MockDaSpec, DefaultWitness, DefaultHasher>::new(
+                    storage_config.clone(),
+                )
+                .unwrap();
             let prover_storage = storage_manager.create_finalized_storage().unwrap();
             assert!(!prover_storage.is_empty());
             assert_eq!(

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/default_context.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/default_context.rs
@@ -30,8 +30,7 @@ pub struct DefaultContext {
 #[cfg(feature = "native")]
 impl Spec for DefaultContext {
     type Address = Address;
-    type Storage =
-        ProverStorage<DefaultWitness, DefaultHasher, sov_prover_storage_manager::SnapshotManager>;
+    type Storage = ProverStorage<sov_prover_storage_manager::SnapshotManager>;
     type PrivateKey = DefaultPrivateKey;
     type PublicKey = DefaultPublicKey;
     type Hasher = sha2::Sha256;

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/default_context.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/default_context.rs
@@ -9,7 +9,7 @@ use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::RollupAddress;
 #[cfg(feature = "native")]
 use sov_state::ProverStorage;
-use sov_state::{ArrayWitness, DefaultStorageSpec, ZkStorage};
+use sov_state::{ArrayWitness, DefaultHasher, DefaultWitness, ZkStorage};
 
 #[cfg(feature = "native")]
 use crate::default_signature::private_key::DefaultPrivateKey;
@@ -30,7 +30,8 @@ pub struct DefaultContext {
 #[cfg(feature = "native")]
 impl Spec for DefaultContext {
     type Address = Address;
-    type Storage = ProverStorage<DefaultStorageSpec, sov_prover_storage_manager::SnapshotManager>;
+    type Storage =
+        ProverStorage<DefaultWitness, DefaultHasher, sov_prover_storage_manager::SnapshotManager>;
     type PrivateKey = DefaultPrivateKey;
     type PublicKey = DefaultPublicKey;
     type Hasher = sha2::Sha256;
@@ -90,7 +91,7 @@ pub struct ZkDefaultContext {
 
 impl Spec for ZkDefaultContext {
     type Address = Address;
-    type Storage = ZkStorage<DefaultStorageSpec>;
+    type Storage = ZkStorage<DefaultWitness, DefaultHasher>;
     #[cfg(feature = "native")]
     type PrivateKey = DefaultPrivateKey;
     type PublicKey = DefaultPublicKey;

--- a/crates/sovereign-sdk/module-system/sov-modules-api/tests/state_tests.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/tests/state_tests.rs
@@ -171,7 +171,7 @@ fn test_witness_round_trip() {
 
     // Native execution
     let witness: ArrayWitness = {
-        let storage = new_orphan_storage::<DefaultWitness, DefaultHasher>(tempdir.path()).unwrap();
+        let storage = new_orphan_storage(tempdir.path()).unwrap();
         // let storage = ProverStorage::<DefaultWitness, DefaultHasher>::with_path(path).unwrap();
         let mut working_set: WorkingSet<DefaultContext> = WorkingSet::new(storage.clone());
         state_value.set(&11, &mut working_set);

--- a/crates/sovereign-sdk/module-system/sov-modules-api/tests/state_tests.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/tests/state_tests.rs
@@ -2,7 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
 use sov_modules_api::*;
 use sov_prover_storage_manager::new_orphan_storage;
-use sov_state::{ArrayWitness, DefaultStorageSpec, Prefix, Storage, ZkStorage};
+use sov_state::{ArrayWitness, DefaultHasher, DefaultWitness, Prefix, Storage, ZkStorage};
 
 enum Operation {
     Merge,
@@ -171,8 +171,8 @@ fn test_witness_round_trip() {
 
     // Native execution
     let witness: ArrayWitness = {
-        let storage = new_orphan_storage::<DefaultStorageSpec>(tempdir.path()).unwrap();
-        // let storage = ProverStorage::<DefaultStorageSpec>::with_path(path).unwrap();
+        let storage = new_orphan_storage::<DefaultWitness, DefaultHasher>(tempdir.path()).unwrap();
+        // let storage = ProverStorage::<DefaultWitness, DefaultHasher>::with_path(path).unwrap();
         let mut working_set: WorkingSet<DefaultContext> = WorkingSet::new(storage.clone());
         state_value.set(&11, &mut working_set);
         let _ = state_value.get(&mut working_set);
@@ -186,7 +186,7 @@ fn test_witness_round_trip() {
     };
 
     {
-        let storage = ZkStorage::<DefaultStorageSpec>::new();
+        let storage = ZkStorage::<DefaultWitness, DefaultHasher>::new();
         let mut working_set: WorkingSet<ZkDefaultContext> =
             WorkingSet::with_witness(storage.clone(), witness);
         state_value.set(&11, &mut working_set);

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/tests/custom_codec_must_be_used.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/tests/custom_codec_must_be_used.rs
@@ -4,7 +4,7 @@ use sov_modules_api::default_context::ZkDefaultContext;
 use sov_modules_api::prelude::*;
 use sov_modules_api::{Context, ModuleInfo, StateValue, WorkingSet};
 use sov_modules_core::{StateCodec, StateKeyCodec, StateValueCodec};
-use sov_state::{DefaultStorageSpec, ZkStorage};
+use sov_state::{DefaultHasher, DefaultWitness, ZkStorage};
 
 #[derive(ModuleInfo)]
 struct TestModule<C>
@@ -57,7 +57,7 @@ impl<V> StateValueCodec<V> for CustomCodec {
 }
 
 fn main() {
-    let storage: ZkStorage<DefaultStorageSpec> = ZkStorage::new();
+    let storage: ZkStorage<DefaultWitness, DefaultHasher> = ZkStorage::new();
     let module: TestModule<ZkDefaultContext> = TestModule::default();
 
     catch_unwind(|| {

--- a/crates/sovereign-sdk/module-system/sov-state/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/lib.rs
@@ -20,29 +20,10 @@ pub use sov_modules_core::{
     storage, AlignedVec, CacheLog, OrderedReadsAndWrites, Prefix, Storage, StorageInternalCache,
     Witness,
 };
-use sov_rollup_interface::digest::Digest;
 
 pub use crate::witness::ArrayWitness;
 
-/// A trait specifying the hash function and format of the witness used in
-/// merkle proofs for storage access
-pub trait MerkleProofSpec {
-    /// The structure that accumulates the witness data
-    type Witness: Witness + Send + Sync;
-    /// The hash function used to compute the merkle root
-    type Hasher: Digest<OutputSize = sha2::digest::typenum::U32>;
-}
-
-use sha2::Sha256;
-
-/// The default [`MerkleProofSpec`] implementation.
-///
-/// This type is typically found as a type parameter for [`ProverStorage`].
-#[derive(Clone)]
-pub struct DefaultStorageSpec;
-
-impl MerkleProofSpec for DefaultStorageSpec {
-    type Witness = ArrayWitness;
-
-    type Hasher = Sha256;
-}
+/// The default Witness type used in merkle proofs for storage access, typically found as a type parameter for [`ProverStorage`].
+pub type DefaultWitness = ArrayWitness;
+/// The default Hasher type used in merkle proofs for storage access, typically found as a type parameter for [`ProverStorage`].
+pub type DefaultHasher = sha2::Sha256;

--- a/crates/sovereign-sdk/module-system/sov-state/src/prover_storage.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/prover_storage.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use jmt::storage::{NodeBatch, TreeWriter};
 use jmt::{JellyfishMerkleTree, KeyHash, Version};
+use sha2::Digest;
 use sov_db::native_db::NativeDB;
 use sov_db::schema::{QueryManager, ReadOnlyDbSnapshot};
 use sov_db::state_db::StateDB;
@@ -13,17 +14,23 @@ use sov_modules_core::{
 use sov_rollup_interface::stf::StateDiff;
 
 use crate::config::Config;
-use crate::MerkleProofSpec;
-
 /// A [`Storage`] implementation to be used by the prover in a native execution
 /// environment (outside of the zkVM).
-pub struct ProverStorage<S: MerkleProofSpec, Q> {
+pub struct ProverStorage<W, H, Q>
+where
+    W: Witness + Send + Sync,
+    H: Digest<OutputSize = sha2::digest::typenum::U32>,
+{
     db: StateDB<Q>,
     native_db: NativeDB<Q>,
-    _phantom_hasher: PhantomData<S::Hasher>,
+    _phantom_hasher: PhantomData<(W, H)>,
 }
 
-impl<S: MerkleProofSpec, Q> Clone for ProverStorage<S, Q> {
+impl<W, H, Q> Clone for ProverStorage<W, H, Q>
+where
+    W: Witness + Send + Sync,
+    H: Digest<OutputSize = sha2::digest::typenum::U32>,
+{
     fn clone(&self) -> Self {
         Self {
             db: self.db.clone(),
@@ -33,7 +40,11 @@ impl<S: MerkleProofSpec, Q> Clone for ProverStorage<S, Q> {
     }
 }
 
-impl<S: MerkleProofSpec, Q> ProverStorage<S, Q> {
+impl<W, H, Q> ProverStorage<W, H, Q>
+where
+    W: Witness + Send + Sync,
+    H: Digest<OutputSize = sha2::digest::typenum::U32>,
+{
     /// Creates a new [`ProverStorage`] instance from specified db handles
     pub fn with_db_handles(db: StateDB<Q>, native_db: NativeDB<Q>) -> Self {
         Self {
@@ -54,7 +65,12 @@ impl<S: MerkleProofSpec, Q> ProverStorage<S, Q> {
     }
 }
 
-impl<S: MerkleProofSpec, Q: QueryManager> ProverStorage<S, Q> {
+impl<W, H, Q> ProverStorage<W, H, Q>
+where
+    W: Witness + Send + Sync,
+    H: Digest<OutputSize = sha2::digest::typenum::U32>,
+    Q: QueryManager,
+{
     fn read_value(&self, key: &StorageKey, version: Option<Version>) -> Option<StorageValue> {
         let version_to_use = version.unwrap_or_else(|| self.db.get_next_version());
         match self
@@ -73,10 +89,15 @@ pub struct ProverStateUpdate {
     pub key_preimages: Vec<(KeyHash, CacheKey)>,
 }
 
-impl<S: MerkleProofSpec, Q: QueryManager> Storage for ProverStorage<S, Q> {
-    type Witness = S::Witness;
+impl<W, H, Q> Storage for ProverStorage<W, H, Q>
+where
+    W: Witness + Send + Sync,
+    H: Digest<OutputSize = sha2::digest::typenum::U32>,
+    Q: QueryManager,
+{
+    type Witness = W;
     type RuntimeConfig = Config;
-    type Proof = jmt::proof::SparseMerkleProof<S::Hasher>;
+    type Proof = jmt::proof::SparseMerkleProof<H>;
     type Root = jmt::RootHash;
     type StateUpdate = ProverStateUpdate;
 
@@ -106,7 +127,7 @@ impl<S: MerkleProofSpec, Q: QueryManager> Storage for ProverStorage<S, Q> {
         witness: &mut Self::Witness,
     ) -> Result<(Self::Root, Self::StateUpdate, StateDiff), anyhow::Error> {
         let latest_version = self.db.get_next_version() - 1;
-        let jmt = JellyfishMerkleTree::<_, S::Hasher>::new(&self.db);
+        let jmt = JellyfishMerkleTree::<_, H>::new(&self.db);
 
         // Handle empty jmt
         // TODO: Fix this before introducing snapshots!
@@ -128,7 +149,7 @@ impl<S: MerkleProofSpec, Q: QueryManager> Storage for ProverStorage<S, Q> {
 
         // For each value that's been read from the tree, read it from the logged JMT to populate hints
         for (key, read_value) in state_accesses.ordered_reads {
-            let key_hash = KeyHash::with::<S::Hasher>(key.key.as_ref());
+            let key_hash = KeyHash::with::<H>(key.key.as_ref());
             // TODO: Switch to the batch read API once it becomes available
             let (result, proof) = jmt.get_with_proof(key_hash, latest_version)?;
             if result.as_ref() != read_value.as_ref().map(|f| f.value.as_ref()) {
@@ -146,7 +167,7 @@ impl<S: MerkleProofSpec, Q: QueryManager> Storage for ProverStorage<S, Q> {
             .ordered_writes
             .into_iter()
             .map(|(key, value)| {
-                let key_hash = KeyHash::with::<S::Hasher>(key.key.as_ref());
+                let key_hash = KeyHash::with::<H>(key.key.as_ref());
 
                 let key_bytes =
                     Arc::try_unwrap(key.key.clone()).unwrap_or_else(|arc| (*arc).clone());
@@ -216,7 +237,7 @@ impl<S: MerkleProofSpec, Q: QueryManager> Storage for ProverStorage<S, Q> {
         state_proof: StorageProof<Self::Proof>,
     ) -> Result<(StorageKey, Option<StorageValue>), anyhow::Error> {
         let StorageProof { key, value, proof } = state_proof;
-        let key_hash = KeyHash::with::<S::Hasher>(key.as_ref());
+        let key_hash = KeyHash::with::<H>(key.as_ref());
 
         proof.verify(state_root, key_hash, value.as_ref().map(|v| v.value()))?;
         Ok((key, value))
@@ -228,12 +249,17 @@ impl<S: MerkleProofSpec, Q: QueryManager> Storage for ProverStorage<S, Q> {
     }
 }
 
-impl<S: MerkleProofSpec, Q: QueryManager> NativeStorage for ProverStorage<S, Q> {
+impl<W, H, Q> NativeStorage for ProverStorage<W, H, Q>
+where
+    W: Witness + Send + Sync,
+    H: Digest<OutputSize = sha2::digest::typenum::U32>,
+    Q: QueryManager,
+{
     fn get_with_proof(&self, key: StorageKey) -> StorageProof<Self::Proof> {
-        let merkle = JellyfishMerkleTree::<StateDB<Q>, S::Hasher>::new(&self.db);
+        let merkle = JellyfishMerkleTree::<StateDB<Q>, H>::new(&self.db);
         let (val_opt, proof) = merkle
             .get_with_proof(
-                KeyHash::with::<S::Hasher>(key.as_ref()),
+                KeyHash::with::<H>(key.as_ref()),
                 self.db.get_next_version() - 1,
             )
             .unwrap();
@@ -245,7 +271,7 @@ impl<S: MerkleProofSpec, Q: QueryManager> NativeStorage for ProverStorage<S, Q> 
     }
 
     fn get_root_hash(&self, version: Version) -> anyhow::Result<jmt::RootHash> {
-        let temp_merkle: JellyfishMerkleTree<'_, StateDB<Q>, S::Hasher> =
+        let temp_merkle: JellyfishMerkleTree<'_, StateDB<Q>, H> =
             JellyfishMerkleTree::new(&self.db);
         temp_merkle.get_root_hash(version)
     }


### PR DESCRIPTION
# Description

Removes the trait `MerkleProofSpec`, and instead of generic parameters, uses `DefaultWitness` and `DefaultHasher` in `ProverStorage`.

## Linked Issues
- Fixes #1005 
