### PR TITLE
Guest side verification

### DIFF
--- a/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
+++ b/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
@@ -161,6 +161,10 @@ impl<ValidityCond: ValidityCondition> sov_rollup_interface::zk::ZkvmHost
         self.committed_data.push_back(data)
     }
 
+    fn add_assumption(&mut self, _receipt_buf: Vec<u8>) {
+        unimplemented!()
+    }
+
     fn simulate_with_hints(&mut self) -> Self::Guest {
         MockZkGuest {}
     }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
@@ -59,6 +59,10 @@ pub trait ZkvmHost: Zkvm + Clone {
 
     /// Host recovers pending proving sessions and returns proving results
     fn recover_proving_sessions(&self) -> Result<Vec<Proof>, anyhow::Error>;
+
+    /// Host adds an assumption to the proving session
+    /// Assumptions are used for recursive proving
+    fn add_assumption(&mut self, receipt_buf: Vec<u8>);
 }
 
 /// A Zk proof system capable of proving and verifying arbitrary Rust code


### PR DESCRIPTION
# Description
Initial pr that prepares the foundation for #1306 
After merged, for testing Risc0's `FakeReceipt`s will be used with `RISC0_DEV_MODE` enabled

## Linked Issues
- Related to #1306 
