### PR TITLE
Update citrea-e2e for light client starter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=d9d0e3e#d9d0e3e63d1e56091c22b5885bebbcfce9f77bca"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=0a6492ebbb7#0a6492ebbb7861a263d274bf11efa5556547247e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/citrea/Cargo.toml
+++ b/bin/citrea/Cargo.toml
@@ -88,7 +88,7 @@ rustc_version_runtime = { workspace = true }
 # bitcoin-e2e dependencies
 bitcoin.workspace = true
 bitcoincore-rpc.workspace = true
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "d9d0e3e" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "0a6492ebbb7" }
 
 [features]
 default = [] # Deviate from convention by making the "native" feature active by default. This aligns with how this package is meant to be used (as a binary first, library second).


### PR DESCRIPTION
# Description

Update citrea-e2e

```

--- TRY 2 STDERR:        citrea::all_tests bitcoin_e2e::tx_chain::test_prover_transaction_chaining ---
Error: assertion `left == right` failed: Block should contain exactly 3 transactions
  left: 5
 right: 3

   RETRY 3/3 [         ] citrea::all_tests bitcoin_e2e::tx_chain::test_prover_transaction_chaining
  TRY 1 SLOW [>900.000s] citrea::all_tests e2e::sequencer_behaviour::test_sequencer_commitment_threshold
  TRY 3 SLOW [>180.000s] citrea::all_tests bitcoin_e2e::tx_chain::test_prover_transaction_chaining
        PASS [ 926.896s] citrea::all_tests e2e::sequencer_behaviour::test_sequencer_commitment_threshold
  TRY 3 PASS [ 332.262s] citrea::all_tests bitcoin_e2e::tx_chain::test_prover_transaction_chaining
------------
     Summary [1062.661s] 420 tests run: 420 passed (6 slow, 4 flaky), 2 skipped
   FLAKY 2/3 [ 150.289s] citrea::all_tests bitcoin_e2e::batch_prover_test::basic_prover_test
   FLAKY 2/3 [ 312.824s] citrea::all_tests bitcoin_e2e::sequencer_commitments::test_sequencer_sends_commitments_to_da_layer
   FLAKY 3/3 [ 332.262s] citrea::all_tests bitcoin_e2e::tx_chain::test_prover_transaction_chaining
   FLAKY 3/3 [  65.894s] citrea::all_tests bitcoin_e2e::tx_chain::test_sequencer_transaction_chaining
```