### PR TITLE
Fix tx chaining tests

### DIFF
--- a/bin/citrea/tests/bitcoin_e2e/tx_chain.rs
+++ b/bin/citrea/tests/bitcoin_e2e/tx_chain.rs
@@ -67,8 +67,8 @@ impl TestCase for TestSequencerTransactionChaining {
         );
 
         // Verify output values
-        assert_eq!(tx1.output[0].value, self.get_reveal_tx_input_value(tx2));
-        assert_eq!(tx2.output[0].value, Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
+        assert!(tx1.output[0].value >= self.get_reveal_tx_input_value(tx2));
+        assert!(tx2.output[0].value >= Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
 
         // Generate seqcommitment txs and make sure second batch is chained from first batch
         for _ in 0..min_soft_confirmations_per_commitment {
@@ -103,8 +103,8 @@ impl TestCase for TestSequencerTransactionChaining {
         );
 
         // Verify output values
-        assert_eq!(tx3.output[0].value, self.get_reveal_tx_input_value(tx4));
-        assert_eq!(tx4.output[0].value, Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
+        assert!(tx3.output[0].value >= self.get_reveal_tx_input_value(tx4));
+        assert!(tx4.output[0].value >= Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
 
         let last_tx = self
             .test_restart_with_empty_mempool(sequencer, da, tx4)
@@ -166,8 +166,8 @@ impl TestSequencerTransactionChaining {
         );
 
         // Verify output values
-        assert_eq!(tx1.output[0].value, self.get_reveal_tx_input_value(tx2));
-        assert_eq!(tx2.output[0].value, Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
+        assert!(tx1.output[0].value >= self.get_reveal_tx_input_value(tx2));
+        assert!(tx2.output[0].value >= Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
 
         Ok(tx2.clone())
     }
@@ -241,17 +241,16 @@ impl TestSequencerTransactionChaining {
         );
 
         // Verify output values
-        assert_eq!(tx1.output[0].value, self.get_reveal_tx_input_value(tx2));
-        assert_eq!(tx2.output[0].value, Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
-        assert_eq!(tx3.output[0].value, self.get_reveal_tx_input_value(tx4));
-        assert_eq!(tx4.output[0].value, Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
+        assert!(tx1.output[0].value >= self.get_reveal_tx_input_value(tx2));
+        assert!(tx2.output[0].value >= Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
+        assert!(tx3.output[0].value >= self.get_reveal_tx_input_value(tx4));
+        assert!(tx4.output[0].value >= Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
 
         Ok(())
     }
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_sequencer_transaction_chaining() -> Result<()> {
     TestCaseRunner::new(TestSequencerTransactionChaining)
         .set_citrea_path(get_citrea_path())
@@ -320,8 +319,8 @@ impl TestCase for TestProverTransactionChaining {
         );
 
         // Verify output values
-        assert_eq!(tx1.output[0].value, self.get_reveal_tx_input_value(tx2));
-        assert_eq!(tx2.output[0].value, Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
+        assert!(tx1.output[0].value >= self.get_reveal_tx_input_value(tx2));
+        assert!(tx2.output[0].value >= Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
 
         // // Do another round and make sure second batch is chained from first batch
         for _ in 0..min_soft_confirmations_per_commitment {
@@ -360,8 +359,8 @@ impl TestCase for TestProverTransactionChaining {
         );
 
         // Verify output values
-        assert_eq!(tx3.output[0].value, self.get_reveal_tx_input_value(tx4));
-        assert_eq!(tx4.output[0].value, Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
+        assert!(tx3.output[0].value >= self.get_reveal_tx_input_value(tx4));
+        assert!(tx4.output[0].value >= Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
 
         batch_prover.restart(None).await?;
 
@@ -402,15 +401,14 @@ impl TestCase for TestProverTransactionChaining {
         );
 
         // Verify output values
-        assert_eq!(tx5.output[0].value, self.get_reveal_tx_input_value(tx6));
-        assert_eq!(tx6.output[0].value, Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
+        assert!(tx5.output[0].value >= self.get_reveal_tx_input_value(tx6));
+        assert!(tx6.output[0].value >= Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
 
         Ok(())
     }
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_prover_transaction_chaining() -> Result<()> {
     TestCaseRunner::new(TestProverTransactionChaining)
         .set_citrea_path(get_citrea_path())

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -282,16 +282,14 @@ impl BitcoinService {
             .list_unspent(Some(0), None, None, Some(true), None)
             .await?;
 
-        // Make sure to retain only utxos from reveal TXs by matching on REVEAL_OUTPUT_AMOUNT
-        previous_utxos.retain(|u| {
-            u.spendable && u.solvable && u.amount == Amount::from_sat(REVEAL_OUTPUT_AMOUNT)
-        });
+        // Make sure to retain only first utxo to keep utxo chaining logic in line with `spawn_da_queue` inner loop
+        previous_utxos.retain(|u| u.spendable && u.solvable && u.vout == 0);
 
         // Sort by (confirmations - ancestor_count)
         // If any tx in mempool, confirmation would be 0 and ancestor count Some(_), giving us a negative value and prioritising in-mempool TXs
         // If no tx in mempool, confirmation would be >= 0 and ancestor count None
         previous_utxos.sort_unstable_by_key(|utxo| {
-            utxo.confirmations - (utxo.ancestor_count.unwrap_or(0) as u32)
+            utxo.confirmations as i64 - (utxo.ancestor_count.unwrap_or(0) as i64)
         });
 
         Ok(previous_utxos.into_iter().next().map(|u| u.into()))


### PR DESCRIPTION
# Description

- [Update prev utxo selection logic](https://github.com/chainwayxyz/citrea/commit/276a07e35859558388cc52469b8198cfdfa634df) in-line with new selection logic from https://github.com/chainwayxyz/citrea/pull/1329
- [Looser utxo output value assertions](https://github.com/chainwayxyz/citrea/commit/c00c77d3d457e3a5c3252c676ea6596e9ede58c1) in-line with new output values from https://github.com/chainwayxyz/citrea/pull/1329
- Fix overflow error on `get_prev_utxo` when mempool is not empty

## Testing

- Re-enable `tx_chain.rs` tests

