### PR TITLE
Ignore regtest in get_fee_rate_from_mempool_space

### DIFF
--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -1707,11 +1707,17 @@ mod tests {
         let _fee_rate = get_fee_rate_from_mempool_space(bitcoin::Network::Testnet)
             .await
             .unwrap();
-        assert!(get_fee_rate_from_mempool_space(bitcoin::Network::Regtest)
-            .await
-            .is_err());
-        assert!(get_fee_rate_from_mempool_space(bitcoin::Network::Signet)
-            .await
-            .is_err());
+        assert_eq!(
+            None,
+            get_fee_rate_from_mempool_space(bitcoin::Network::Regtest)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            None,
+            get_fee_rate_from_mempool_space(bitcoin::Network::Signet)
+                .await
+                .unwrap()
+        );
     }
 }

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -569,7 +569,7 @@ impl BitcoinService {
     pub async fn get_fee_rate_as_sat_vb(&self) -> Result<u64, anyhow::Error> {
         // If network is regtest or signet, mempool space is not available
         let smart_fee = match get_fee_rate_from_mempool_space(self.network).await {
-            Ok(fee_rate) => Some(fee_rate),
+            Ok(fee_rate) => fee_rate,
             Err(e) => {
                 tracing::warn!(?e, "Failed to get fee rate from mempool.space");
                 self.client.estimate_smart_fee(1, None).await?.fee_rate
@@ -1152,7 +1152,9 @@ fn calculate_witness_root(txdata: &[TransactionWrapper]) -> [u8; 32] {
     BitcoinMerkleTree::new(hashes).root()
 }
 
-pub(crate) async fn get_fee_rate_from_mempool_space(network: bitcoin::Network) -> Result<Amount> {
+pub(crate) async fn get_fee_rate_from_mempool_space(
+    network: bitcoin::Network,
+) -> Result<Option<Amount>> {
     let url = match network {
         bitcoin::Network::Bitcoin => format!(
             // Mainnet
@@ -1164,9 +1166,8 @@ pub(crate) async fn get_fee_rate_from_mempool_space(network: bitcoin::Network) -
             MEMPOOL_SPACE_URL, MEMPOOL_SPACE_RECOMMENDED_FEE_ENDPOINT
         ),
         _ => {
-            return Err(anyhow!(
-                "Unsupported network for mempool space fee estimation"
-            ))
+            trace!("Unsupported network for mempool space fee estimation");
+            return Ok(None);
         }
     };
     let fee_rate = reqwest::get(url)
@@ -1178,7 +1179,7 @@ pub(crate) async fn get_fee_rate_from_mempool_space(network: bitcoin::Network) -
         .map(|fee| Amount::from_sat(fee * 1000)) // multiply by 1000 to convert to sat/vkb
         .ok_or(anyhow!("Failed to get fee rate from mempool space"))?;
 
-    Ok(fee_rate)
+    Ok(Some(fee_rate))
 }
 
 pub fn get_relevant_blobs_from_txs_light_client(

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -571,7 +571,7 @@ impl BitcoinService {
         let smart_fee = match get_fee_rate_from_mempool_space(self.network).await {
             Ok(fee_rate) => fee_rate,
             Err(e) => {
-                tracing::warn!(?e, "Failed to get fee rate from mempool.space");
+                tracing::error!(?e, "Failed to get fee rate from mempool.space");
                 self.client.estimate_smart_fee(1, None).await?.fee_rate
             }
         };


### PR DESCRIPTION
# Description

So that e2e tests are not spammed when RUST_BACKTRACE=1. 

```
WARN bitcoin_da::service: Failed to get fee rate from mempool.space e=Unsupported network for mempool space fee estimation

Stack backtrace:
   0: anyhow::error::<impl anyhow::Error>::msg
```
