### PR TITLE
Use unwrap() in e2e tests instead of operator ?

### DIFF
--- a/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
@@ -61,28 +61,29 @@ impl TestCase for BasicProverTest {
         };
 
         // Generate confirmed UTXOs
-        da.generate(120, None).await?;
+        da.generate(120, None).await.unwrap();
 
         let min_soft_confirmations_per_commitment =
             sequencer.min_soft_confirmations_per_commitment();
 
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
         // Wait for blob inscribe tx to be in mempool
-        da.wait_mempool_len(1, None).await?;
+        da.wait_mempool_len(1, None).await.unwrap();
 
-        da.generate(FINALITY_DEPTH, None).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
+        let finalized_height = da.get_finalized_height().await.unwrap();
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)
-            .await?;
+            .await
+            .unwrap();
 
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
         let proofs = full_node
             .wait_for_zkproofs(
                 finalized_height + FINALITY_DEPTH,
@@ -198,28 +199,29 @@ impl TestCase for SkipPreprovenCommitmentsTest {
         bitcoin_da_service.clone().spawn_da_queue(rx);
 
         // Generate 1 FINALIZED DA block.
-        da.generate(1 + FINALITY_DEPTH, None).await?;
+        da.generate(1 + FINALITY_DEPTH, None).await.unwrap();
 
         let min_soft_confirmations_per_commitment =
             sequencer.min_soft_confirmations_per_commitment();
 
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
         // Wait for blob inscribe tx to be in mempool
-        da.wait_mempool_len(1, None).await?;
+        da.wait_mempool_len(1, None).await.unwrap();
 
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height().await.unwrap();
         prover
             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
-            .await?;
+            .await
+            .unwrap();
 
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
         let proofs = full_node
             .wait_for_zkproofs(
                 finalized_height + FINALITY_DEPTH,
@@ -236,7 +238,7 @@ impl TestCase for SkipPreprovenCommitmentsTest {
             .is_empty());
 
         // Make sure the mempool is mined.
-        da.wait_mempool_len(0, None).await?;
+        da.wait_mempool_len(0, None).await.unwrap();
 
         // Fetch the commitment created from the previous L1 range
         let commitments: Vec<SequencerCommitment> = full_node
@@ -270,25 +272,26 @@ impl TestCase for SkipPreprovenCommitmentsTest {
             .unwrap();
 
         // Wait for the duplicate commitment transaction to be accepted.
-        da.wait_mempool_len(2, None).await?;
+        da.wait_mempool_len(2, None).await.unwrap();
 
         // Trigger a new commitment.
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
         // Wait for the sequencer commitment to be submitted & accepted.
-        da.wait_mempool_len(4, None).await?;
+        da.wait_mempool_len(4, None).await.unwrap();
 
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height().await.unwrap();
 
         prover
             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
-            .await?;
+            .await
+            .unwrap();
 
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
         let proofs = full_node
             .wait_for_zkproofs(
@@ -379,28 +382,29 @@ impl TestCase for LocalProvingTest {
             sequencer.min_soft_confirmations_per_commitment();
         // Generate soft confirmations to invoke commitment creation
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
         // Wait for commitment tx to hit mempool
-        da.wait_mempool_len(1, None).await?;
+        da.wait_mempool_len(1, None).await.unwrap();
 
         // Make commitment tx into a finalized block
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height().await.unwrap();
         // Wait for batch prover to process the proof
         batch_prover
             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(7200)))
-            .await?;
+            .await
+            .unwrap();
 
         // Wait for batch proof tx to hit mempool
-        da.wait_mempool_len(1, None).await?;
+        da.wait_mempool_len(1, None).await.unwrap();
 
         // Make batch proof tx into a finalized block
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height().await.unwrap();
         // Wait for full node to see zkproofs
         let proofs = full_node
             .wait_for_zkproofs(finalized_height, Some(Duration::from_secs(7200)))

--- a/bin/citrea/tests/bitcoin_e2e/bitcoin_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/bitcoin_test.rs
@@ -32,10 +32,10 @@ impl TestCase for BasicSyncTest {
         let initial_height = f.initial_da_height;
 
         // Generate some blocks on node0
-        da0.generate(5, None).await?;
+        da0.generate(5, None).await.unwrap();
 
-        let height0 = da0.get_block_count().await?;
-        let height1 = da1.get_block_count().await?;
+        let height0 = da0.get_block_count().await.unwrap();
+        let height1 = da1.get_block_count().await.unwrap();
 
         // Nodes are now out of sync
         assert_eq!(height0, initial_height + 5);
@@ -44,10 +44,11 @@ impl TestCase for BasicSyncTest {
         // Sync both nodes
         f.bitcoin_nodes
             .wait_for_sync(Duration::from_secs(30))
-            .await?;
+            .await
+            .unwrap();
 
-        let height0 = da0.get_block_count().await?;
-        let height1 = da1.get_block_count().await?;
+        let height0 = da0.get_block_count().await.unwrap();
+        let height1 = da1.get_block_count().await.unwrap();
 
         // Assert that nodes are in sync
         assert_eq!(height0, height1, "Block heights don't match");
@@ -82,16 +83,16 @@ impl TestCase for RestartBitcoinTest {
             ..da.config.clone()
         };
 
-        let block_before = da.get_block_count().await?;
-        let info = da.get_index_info().await?;
+        let block_before = da.get_block_count().await.unwrap();
+        let info = da.get_index_info().await.unwrap();
 
         assert_eq!(info.txindex, None);
 
         // Restart node with txindex
-        da.restart(Some(new_conf)).await?;
+        da.restart(Some(new_conf)).await.unwrap();
 
-        let block_after = da.get_block_count().await?;
-        let info = da.get_index_info().await?;
+        let block_after = da.get_block_count().await.unwrap();
+        let info = da.get_index_info().await.unwrap();
 
         assert!(matches!(
             info.txindex,

--- a/bin/citrea/tests/bitcoin_e2e/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/light_client_test.rs
@@ -57,11 +57,12 @@ impl TestCase for LightClientProvingTest {
 
         // publish min_soft_confirmations_per_commitment confirmations
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
         sequencer
             .wait_for_l2_height(min_soft_confirmations_per_commitment, None)
-            .await?;
+            .await
+            .unwrap();
 
         // Wait for commitment tx to be submitted to DA
         da.wait_mempool_len(1, Some(TEN_MINS)).await.unwrap();

--- a/bin/citrea/tests/bitcoin_e2e/mempool_accept.rs
+++ b/bin/citrea/tests/bitcoin_e2e/mempool_accept.rs
@@ -31,20 +31,20 @@ impl TestCase for MempoolAcceptTest {
 
         // publish min_soft_conf_per_commitment - 1 confirmations, no commitments should be sent
         for _ in 0..min_soft_conf_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
         sequencer
             .wait_for_l2_height(min_soft_conf_per_commitment, None)
             .await;
 
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
         // TODO find the right assertions here
         // Should be either 2 or 0
         // Before this PR and the addition of testmempoolaccept, first tx would go in and second would be rejected due to mempool policy set above
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(2, None).await?;
+        da.wait_mempool_len(2, None).await.unwrap();
 
         Ok(())
     }

--- a/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs
+++ b/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs
@@ -39,22 +39,26 @@ impl TestCase for LedgerGetCommitmentsProverTest {
             sequencer.min_soft_confirmations_per_commitment();
 
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
         sequencer
             .wait_for_l2_height(min_soft_confirmations_per_commitment, None)
-            .await?;
+            .await
+            .unwrap();
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(1, None).await?;
+        da.wait_mempool_len(1, None).await.unwrap();
 
         // Include commitment in block and finalize it
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height().await.unwrap();
 
         // wait here until we see from prover's rpc that it finished proving
-        prover.wait_for_l1_height(finalized_height, None).await?;
+        prover
+            .wait_for_l1_height(finalized_height, None)
+            .await
+            .unwrap();
 
         let commitments = prover
             .client
@@ -70,7 +74,7 @@ impl TestCase for LedgerGetCommitmentsProverTest {
 
         assert_eq!(commitments[0].found_in_l1, finalized_height);
 
-        let hash = da.get_block_hash(finalized_height).await?;
+        let hash = da.get_block_hash(finalized_height).await.unwrap();
 
         let commitments_hash = prover
             .client
@@ -110,29 +114,31 @@ impl TestCase for LedgerGetCommitmentsTest {
             sequencer.min_soft_confirmations_per_commitment();
 
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
-        // disable this since it's the only difference from other tests??
-        // da.generate(1, None).await?;
+        // disable this since it's the only difference from other tests.unwrap().unwrap()
+        // da.generate(1, None).await.unwrap();
 
-        // sequencer.client.send_publish_batch_request().await?;
+        // sequencer.client.send_publish_batch_request().await.unwrap();
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(1, None).await?;
+        da.wait_mempool_len(1, None).await.unwrap();
 
         // Generate enough block to finalize
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
         full_node
             .wait_for_l2_height(min_soft_confirmations_per_commitment, None)
-            .await?;
+            .await
+            .unwrap();
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height().await.unwrap();
 
         let commitments = full_node
             .wait_for_sequencer_commitments(finalized_height, None)
-            .await?;
+            .await
+            .unwrap();
 
         assert_eq!(commitments.len(), 1);
 
@@ -141,7 +147,7 @@ impl TestCase for LedgerGetCommitmentsTest {
 
         assert_eq!(commitments[0].found_in_l1, finalized_height);
 
-        let hash = da.get_block_hash(finalized_height).await?;
+        let hash = da.get_block_hash(finalized_height).await.unwrap();
 
         let commitments_node = full_node
             .client
@@ -183,20 +189,21 @@ impl TestCase for SequencerSendCommitmentsToDaTest {
 
         // publish min_soft_confirmations_per_commitment - 1 confirmations, no commitments should be sent
         for _ in 0..min_soft_confirmations_per_commitment - 1 {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
         sequencer
             .wait_for_l2_height(min_soft_confirmations_per_commitment - 1, None)
-            .await?;
+            .await
+            .unwrap();
 
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height().await.unwrap();
 
         for height in initial_height..finalized_height {
-            let hash = da.get_block_hash(height).await?;
-            let block = da.get_block(&hash).await?;
+            let hash = da.get_block_hash(height).await.unwrap();
+            let block = da.get_block(&hash).await.unwrap();
 
             let mut blobs = get_relevant_blobs_from_txs(block.txdata, REVEAL_BATCH_PROOF_PREFIX);
 
@@ -208,48 +215,52 @@ impl TestCase for SequencerSendCommitmentsToDaTest {
         }
 
         // Publish one more L2 block and send commitment
-        sequencer.client.send_publish_batch_request().await?;
+        sequencer.client.send_publish_batch_request().await.unwrap();
 
         sequencer
             .wait_for_l2_height(
                 min_soft_confirmations_per_commitment + FINALITY_DEPTH - 1,
                 None,
             )
-            .await?;
+            .await
+            .unwrap();
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(1, None).await?;
+        da.wait_mempool_len(1, None).await.unwrap();
 
         // Include commitment in block and finalize it
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
         let start_l2_block = 1;
         let end_l2_block = 19;
 
         self.check_sequencer_commitment(sequencer, da, start_l2_block, end_l2_block)
-            .await?;
+            .await
+            .unwrap();
 
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
         sequencer
             .wait_for_l2_height(
                 end_l2_block + min_soft_confirmations_per_commitment + FINALITY_DEPTH - 2,
                 None,
             )
-            .await?;
+            .await
+            .unwrap();
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(1, None).await?;
+        da.wait_mempool_len(1, None).await.unwrap();
         // Include commitment in block and finalize it
-        da.generate(FINALITY_DEPTH, None).await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
 
         let start_l2_block = end_l2_block + 1;
         let end_l2_block = end_l2_block + 12;
 
         self.check_sequencer_commitment(sequencer, da, start_l2_block, end_l2_block)
-            .await?;
+            .await
+            .unwrap();
 
         Ok(())
     }
@@ -263,11 +274,11 @@ impl SequencerSendCommitmentsToDaTest {
         start_l2_block: u64,
         end_l2_block: u64,
     ) -> Result<()> {
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height().await.unwrap();
 
         // Extract and verify the commitment from the block
-        let hash = da.get_block_hash(finalized_height).await?;
-        let block = da.get_block(&hash).await?;
+        let hash = da.get_block_hash(finalized_height).await.unwrap();
+        let block = da.get_block(&hash).await.unwrap();
 
         let mut blobs = get_relevant_blobs_from_txs(block.txdata, REVEAL_BATCH_PROOF_PREFIX);
 
@@ -292,7 +303,8 @@ impl SequencerSendCommitmentsToDaTest {
                 sequencer
                     .client
                     .ledger_get_soft_confirmation_by_number(i)
-                    .await?
+                    .await
+                    .unwrap()
                     .unwrap(),
             );
         }

--- a/bin/citrea/tests/bitcoin_e2e/sequencer_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/sequencer_test.rs
@@ -22,24 +22,26 @@ impl TestCase for BasicSequencerTest {
             bail!("bitcoind not running. Test cannot run with bitcoind runnign as DA")
         };
 
-        sequencer.client.send_publish_batch_request().await?;
+        sequencer.client.send_publish_batch_request().await.unwrap();
 
         let head_batch0 = sequencer
             .client
             .ledger_get_head_soft_confirmation()
-            .await?
+            .await
+            .unwrap()
             .unwrap();
         assert_eq!(head_batch0.l2_height, 1);
 
-        sequencer.client.send_publish_batch_request().await?;
+        sequencer.client.send_publish_batch_request().await.unwrap();
 
-        da.generate(1, None).await?;
+        da.generate(1, None).await.unwrap();
 
-        sequencer.client.wait_for_l2_block(1, None).await?;
+        sequencer.client.wait_for_l2_block(1, None).await.unwrap();
         let head_batch1 = sequencer
             .client
             .ledger_get_head_soft_confirmation()
-            .await?
+            .await
+            .unwrap()
             .unwrap();
         assert_eq!(head_batch1.l2_height, 2);
 
@@ -77,29 +79,30 @@ impl TestCase for SequencerMissedDaBlocksTest {
         let sequencer = f.sequencer.as_mut().unwrap();
         let da = f.bitcoin_nodes.get(0).unwrap();
 
-        let initial_l1_height = da.get_finalized_height().await?;
+        let initial_l1_height = da.get_finalized_height().await.unwrap();
 
         // Create initial DA blocks
-        da.generate(3, None).await?;
+        da.generate(3, None).await.unwrap();
 
-        sequencer.client.send_publish_batch_request().await?;
+        sequencer.client.send_publish_batch_request().await.unwrap();
 
-        sequencer.wait_until_stopped().await?;
+        sequencer.wait_until_stopped().await.unwrap();
 
         // Create 10 more DA blocks while the sequencer is down
-        da.generate(10, None).await?;
+        da.generate(10, None).await.unwrap();
 
         // Restart the sequencer
-        sequencer.start(None).await?;
+        sequencer.start(None).await.unwrap();
 
         for _ in 0..10 {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
         let head_soft_confirmation_height = sequencer
             .client
             .ledger_get_head_soft_confirmation_height()
-            .await?;
+            .await
+            .unwrap();
 
         let mut last_used_l1_height = initial_l1_height;
 
@@ -111,7 +114,8 @@ impl TestCase for SequencerMissedDaBlocksTest {
             let soft_confirmation = sequencer
                 .client
                 .ledger_get_soft_confirmation_by_number(i)
-                .await?
+                .await
+                .unwrap()
                 .unwrap();
 
             if i == 1 {
@@ -126,7 +130,7 @@ impl TestCase for SequencerMissedDaBlocksTest {
             last_used_l1_height = soft_confirmation.da_slot_height;
         }
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height().await.unwrap();
         assert_eq!(last_used_l1_height, finalized_height);
 
         Ok(())

--- a/bin/citrea/tests/bitcoin_e2e/tx_chain.rs
+++ b/bin/citrea/tests/bitcoin_e2e/tx_chain.rs
@@ -42,16 +42,19 @@ impl TestCase for TestSequencerTransactionChaining {
             sequencer.min_soft_confirmations_per_commitment();
 
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(2, None).await?;
+        da.wait_mempool_len(2, None).await.unwrap();
 
-        da.generate(1, None).await?;
+        da.generate(1, None).await.unwrap();
 
         // Get latest block
-        let block = da.get_block(&da.get_best_block_hash().await?).await?;
+        let block = da
+            .get_block(&da.get_best_block_hash().await.unwrap())
+            .await
+            .unwrap();
         let txs = &block.txdata;
 
         assert_eq!(txs.len(), 3, "Block should contain exactly 3 transactions");
@@ -72,16 +75,19 @@ impl TestCase for TestSequencerTransactionChaining {
 
         // Generate seqcommitment txs and make sure second batch is chained from first batch
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(2, None).await?;
+        da.wait_mempool_len(2, None).await.unwrap();
 
-        da.generate(1, None).await?;
+        da.generate(1, None).await.unwrap();
 
         // Get latest block
-        let block = da.get_block(&da.get_best_block_hash().await?).await?;
+        let block = da
+            .get_block(&da.get_best_block_hash().await.unwrap())
+            .await
+            .unwrap();
         let txs = &block.txdata;
 
         assert_eq!(txs.len(), 3, "Block should contain exactly 3 transactions");
@@ -108,10 +114,12 @@ impl TestCase for TestSequencerTransactionChaining {
 
         let last_tx = self
             .test_restart_with_empty_mempool(sequencer, da, tx4)
-            .await?;
+            .await
+            .unwrap();
 
         self.test_restart_with_tx_in_mempool(sequencer, da, &last_tx)
-            .await?;
+            .await
+            .unwrap();
 
         Ok(())
     }
@@ -125,26 +133,29 @@ impl TestSequencerTransactionChaining {
         prev_tx: &Transaction,
     ) -> Result<Transaction> {
         // Start with empty mempool
-        let mempool = da.get_raw_mempool().await?;
+        let mempool = da.get_raw_mempool().await.unwrap();
         assert_eq!(mempool.len(), 0);
 
-        sequencer.restart(None).await?;
+        sequencer.restart(None).await.unwrap();
 
         let min_soft_confirmations_per_commitment =
             sequencer.min_soft_confirmations_per_commitment();
 
         // Generate seqcommitment txs restart and make sure third batch is chained from prev_tx
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(2, None).await?;
+        da.wait_mempool_len(2, None).await.unwrap();
 
-        da.generate(1, None).await?;
+        da.generate(1, None).await.unwrap();
 
         // Get latest block
-        let block = da.get_block(&da.get_best_block_hash().await?).await?;
+        let block = da
+            .get_block(&da.get_best_block_hash().await.unwrap())
+            .await
+            .unwrap();
         let txs = &block.txdata;
 
         assert_eq!(txs.len(), 3, "Block should contain exactly 3 transactions");
@@ -179,7 +190,7 @@ impl TestSequencerTransactionChaining {
         prev_tx: &Transaction,
     ) -> Result<()> {
         // Start with empty mempool
-        let mempool = da.get_raw_mempool().await?;
+        let mempool = da.get_raw_mempool().await.unwrap();
         assert_eq!(mempool.len(), 0);
 
         let min_soft_confirmations_per_commitment =
@@ -187,26 +198,29 @@ impl TestSequencerTransactionChaining {
 
         // Generate seqcommitment txs and check that they are chained from prev_tx
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(2, None).await?;
+        da.wait_mempool_len(2, None).await.unwrap();
 
         // Restart before generating a block to check `get_prev_utxo` prioritisting UTXO from mempool
-        sequencer.restart(None).await?;
+        sequencer.restart(None).await.unwrap();
 
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
-        da.wait_mempool_len(4, None).await?;
+        da.wait_mempool_len(4, None).await.unwrap();
 
         // Generate two round of commit/reveal tx pair
-        da.generate(1, None).await?;
+        da.generate(1, None).await.unwrap();
 
         // Get latest block
-        let block = da.get_block(&da.get_best_block_hash().await?).await?;
+        let block = da
+            .get_block(&da.get_best_block_hash().await.unwrap())
+            .await
+            .unwrap();
         let txs = &block.txdata;
 
         assert_eq!(txs.len(), 5, "Block should contain exactly 5 transactions");
@@ -284,26 +298,28 @@ impl TestCase for TestProverTransactionChaining {
             sequencer.min_soft_confirmations_per_commitment();
 
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(2, None).await?;
+        da.wait_mempool_len(2, None).await.unwrap();
 
-        da.generate(FINALITY_DEPTH, None).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
+        let finalized_height = da.get_finalized_height().await.unwrap();
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)
-            .await?;
+            .await
+            .unwrap();
 
-        da.generate(1, None).await?;
-        let block_height = da.get_block_count().await?;
+        da.generate(1, None).await.unwrap();
+        let block_height = da.get_block_count().await.unwrap();
 
         // Get block holding prover txs
         let block = da
-            .get_block(&da.get_block_hash(block_height).await?)
-            .await?;
+            .get_block(&da.get_block_hash(block_height).await.unwrap())
+            .await
+            .unwrap();
         let txs = &block.txdata;
 
         assert_eq!(txs.len(), 3, "Block should contain exactly 3 transactions");
@@ -324,26 +340,28 @@ impl TestCase for TestProverTransactionChaining {
 
         // // Do another round and make sure second batch is chained from first batch
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(2, None).await?;
+        da.wait_mempool_len(2, None).await.unwrap();
 
-        da.generate(FINALITY_DEPTH, None).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
+        let finalized_height = da.get_finalized_height().await.unwrap();
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)
-            .await?;
+            .await
+            .unwrap();
 
-        da.generate(1, None).await?;
-        let block_height = da.get_block_count().await?;
+        da.generate(1, None).await.unwrap();
+        let block_height = da.get_block_count().await.unwrap();
 
         // Get block holding prover txs
         let block = da
-            .get_block(&da.get_block_hash(block_height).await?)
-            .await?;
+            .get_block(&da.get_block_hash(block_height).await.unwrap())
+            .await
+            .unwrap();
         let txs = &block.txdata;
 
         assert_eq!(txs.len(), 3, "Block should contain exactly 3 transactions");
@@ -362,30 +380,32 @@ impl TestCase for TestProverTransactionChaining {
         assert!(tx3.output[0].value >= self.get_reveal_tx_input_value(tx4));
         assert!(tx4.output[0].value >= Amount::from_sat(REVEAL_OUTPUT_AMOUNT));
 
-        batch_prover.restart(None).await?;
+        batch_prover.restart(None).await.unwrap();
 
         // // Do another round post restart and make sure third batch is chained from second batch
         for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
+            sequencer.client.send_publish_batch_request().await.unwrap();
         }
 
         // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(2, None).await?;
+        da.wait_mempool_len(2, None).await.unwrap();
 
-        da.generate(FINALITY_DEPTH, None).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        da.generate(FINALITY_DEPTH, None).await.unwrap();
+        let finalized_height = da.get_finalized_height().await.unwrap();
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)
-            .await?;
+            .await
+            .unwrap();
 
-        da.generate(1, None).await?;
-        let block_height = da.get_block_count().await?;
+        da.generate(1, None).await.unwrap();
+        let block_height = da.get_block_count().await.unwrap();
 
         // Get block holding prover txs
         let block = da
-            .get_block(&da.get_block_hash(block_height).await?)
-            .await?;
+            .get_block(&da.get_block_hash(block_height).await.unwrap())
+            .await
+            .unwrap();
         let txs = &block.txdata;
 
         assert_eq!(txs.len(), 3, "Block should contain exactly 3 transactions");


### PR DESCRIPTION
# Description

We don't need to propagate error. We need an early panic & stop.