### PR TITLE
Fix documentation to resolve min relay fee issue

### DIFF
--- a/docs/run-dev.md
+++ b/docs/run-dev.md
@@ -43,7 +43,7 @@ Run on local Bitcoin network.
 Run Bitcoin Regtest:
 
 ```sh
-bitcoind -regtest -txindex=1
+bitcoind -regtest -txindex=1 -addresstype=bech32m
 ```
 
 Or using docker:


### PR DESCRIPTION
Apparently the `min relay fee` error that happens with DA transactions when sequencer is run with regtest is caused as our fee estimation is expecting Taproot addressing (`bech32m`) while the default address type for `bitcoind` is `bech32`, thus resulting in a wrong estimation and causing DA transactions to not be sent as the fees are not sufficient. This was not affecting production as testnet4 nodes were configured to use Taproot addressing. 