### PR TITLE
Bump citrea-e2e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=0a6492ebbb7#0a6492ebbb7861a263d274bf11efa5556547247e"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=bdbd991#bdbd99119dc3e0f865c9364adbd54e95908490e0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1819,7 +1819,6 @@ dependencies = [
  "futures",
  "hex",
  "jsonrpsee",
- "log-panics",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/bin/citrea/Cargo.toml
+++ b/bin/citrea/Cargo.toml
@@ -88,7 +88,7 @@ rustc_version_runtime = { workspace = true }
 # bitcoin-e2e dependencies
 bitcoin.workspace = true
 bitcoincore-rpc.workspace = true
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "0a6492ebbb7" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "bdbd991" }
 
 [features]
 default = [] # Deviate from convention by making the "native" feature active by default. This aligns with how this package is meant to be used (as a binary first, library second).


### PR DESCRIPTION
# Description

- Create required wallets for every bitcoin node https://github.com/chainwayxyz/citrea-e2e/pull/36
- Panic handling https://github.com/chainwayxyz/citrea-e2e/pull/34
- Update prover args for batch/light client prover https://github.com/chainwayxyz/citrea-e2e/pull/31
- Expose da client per node https://github.com/chainwayxyz/citrea-e2e/pull/32
