### PR TITLE
Fix regtest docker to resolve min relay fee issue

### DIFF
--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -15,6 +15,7 @@ services:
       -printtoconsole
       -regtest=1
       -rest
+      -addresstype=bech32m
       -rpcbind=0.0.0.0
       -rpcallowip=0.0.0.0/0
       -rpcport=18443


### PR DESCRIPTION
# Description
Fixes the same issue as the pr #1393 in the `docker-compose.regtest.yml` file.