### PR TITLE
Don't hash da headers more than once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test-legacy: ## Runs test suite with output from tests printed
 	@cargo test -- --nocapture -Zunstable-options --report-time
 
 test: build $(EF_TESTS_DIR) ## Runs test suite using next test
-	@cargo nextest run --workspace --all-features --no-fail-fast $(filter-out $@,$(MAKECMDGOALS))
+	RISC0_DEV_MODE=1 cargo nextest run --workspace --all-features --no-fail-fast $(filter-out $@,$(MAKECMDGOALS))
 
 install-dev-tools:  ## Installs all necessary cargo helpers
 	cargo install --locked dprint

--- a/crates/bitcoin-da/src/spec/header.rs
+++ b/crates/bitcoin-da/src/spec/header.rs
@@ -18,6 +18,7 @@ pub struct HeaderWrapper {
     pub tx_count: u32,
     pub height: u64,
     txs_commitment: [u8; 32],
+    precomputed_hash: BlockHashWrapper,
 }
 
 impl BlockHeaderTrait for HeaderWrapper {
@@ -28,7 +29,11 @@ impl BlockHeaderTrait for HeaderWrapper {
     }
 
     fn hash(&self) -> Self::Hash {
-        BlockHashWrapper::from(self.header.block_hash().to_byte_array())
+        self.precomputed_hash.clone()
+    }
+
+    fn verify_hash(&self) -> bool {
+        self.hash() == BlockHashWrapper::from(self.header.block_hash().to_byte_array())
     }
 
     fn txs_commitment(&self) -> Self::Hash {
@@ -56,6 +61,7 @@ impl HeaderWrapper {
             tx_count,
             height,
             txs_commitment,
+            precomputed_hash: BlockHashWrapper::from(header.block_hash().to_byte_array()),
         }
     }
 

--- a/crates/citrea-stf/src/verifier.rs
+++ b/crates/citrea-stf/src/verifier.rs
@@ -40,6 +40,11 @@ where
     ) -> Result<(), Da::Error> {
         println!("Running sequencer commitments in DA slot");
         let data: StateTransitionData<Stf::StateRoot, _, Da::Spec> = zkvm.read_from_host();
+
+        if !data.da_block_header_of_commitments.verify_hash() {
+            panic!("Invalid hash of DA block header of commitments");
+        }
+
         let validity_condition = self.da_verifier.verify_relevant_tx_list(
             &data.da_block_header_of_commitments,
             &data.da_data,

--- a/crates/sovereign-sdk/adapters/mock-da/src/types/mod.rs
+++ b/crates/sovereign-sdk/adapters/mock-da/src/types/mod.rs
@@ -139,6 +139,10 @@ impl BlockHeaderTrait for MockBlockHeader {
     fn time(&self) -> Time {
         self.time.clone()
     }
+
+    fn verify_hash(&self) -> bool {
+        true
+    }
 }
 
 /// The configuration for mock da

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -721,6 +721,12 @@ where
                 "All DA headers must be checked"
             );
 
+            // also it's hash wasn't verified
+            assert!(
+                da_block_headers[index_headers].verify_hash(),
+                "Invalid DA block header hash"
+            );
+
             // now verify the claimed merkle root of soft confirmation hashes
             let mut soft_confirmation_hashes = vec![];
 

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -441,6 +441,8 @@ where
         pre_state_root: &Self::StateRoot,
         pre_state: Self::PreState,
         witness: Self::Witness,
+        // the header hash does not need to be verified here because the full
+        // nodes construct the header on their own
         slot_header: &<Da as DaSpec>::BlockHeader,
         _validity_condition: &<Da as DaSpec>::ValidityCondition,
         soft_confirmation: &mut SignedSoftConfirmation,
@@ -664,6 +666,13 @@ where
                     previous_batch_hash = soft_confirmations[index_soft_confirmation].hash();
                     index_soft_confirmation += 1;
                 } else {
+                    // before going to the next DA block header, we must check if it's hash was supplied
+                    // correctly
+                    assert!(
+                        da_block_headers[index_headers].verify_hash(),
+                        "Invalid DA block header hash"
+                    );
+
                     index_headers += 1;
 
                     // this can also be done in soft confirmation rule enforcer?

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
@@ -273,7 +273,12 @@ pub trait BlockHeaderTrait:
     fn prev_hash(&self) -> Self::Hash;
 
     /// Hash the type to get the digest.
+    /// This is pre computed so can't be trusted in zk
+    /// until `verify_hash` is called
     fn hash(&self) -> Self::Hash;
+
+    /// Verify the hash of the block.
+    fn verify_hash(&self) -> bool;
 
     /// Transactions commitment of the block.
     fn txs_commitment(&self) -> Self::Hash;


### PR DESCRIPTION
# Description

I realized whenever we called `BlockHeaderTrait::hash`, we computed bitcoin header hash again and again.

Added capability to supply a precomputed hash, which can be verified once and used from the precomputation

## Results

*Nightly*: SessionStats { segments: 5292, total_cycles: 5548277760, user_cycles: 3819206639 }
*This branch*: SessionStats { segments: 5211, total_cycles: 5464129536, user_cycles: 3774273877 }

This is against Bitcoin testnet4 block #52685 's first sequencer commitment group, it has very few DA blocks and very high evm gas consumption, so look at the raw reduction not in percentage wise :)

