### PR TITLE
remove TransactionReceipt::body_to_save from stf

### DIFF
--- a/crates/batch-prover/src/runner.rs
+++ b/crates/batch-prover/src/runner.rs
@@ -19,7 +19,7 @@ use sequencer_client::{GetSoftConfirmationResponse, SequencerClient};
 use sov_db::ledger_db::BatchProverLedgerOps;
 use sov_db::schema::types::{BatchNumber, SlotNumber};
 use sov_modules_api::storage::HierarchicalStorageManager;
-use sov_modules_api::{Context, SlotData};
+use sov_modules_api::{Context, SignedSoftConfirmation, SlotData};
 use sov_modules_stf_blueprint::StfBlueprintTrait;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::fork::ForkManager;
@@ -388,6 +388,7 @@ where
             .storage_manager
             .create_storage_on_l2_height(l2_height)?;
 
+        let mut signed_soft_confirmation: SignedSoftConfirmation = soft_confirmation.clone().into();
         let soft_confirmation_result = self.stf.apply_soft_confirmation(
             self.fork_manager.active_fork().spec_id,
             self.sequencer_pub_key.as_slice(),
@@ -397,8 +398,9 @@ where
             Default::default(),
             current_l1_block.header(),
             &current_l1_block.validity_condition(),
-            &mut soft_confirmation.clone().into(),
+            &mut signed_soft_confirmation,
         )?;
+        let txs_bodies = signed_soft_confirmation.txs().to_owned();
 
         let receipt = soft_confirmation_result.soft_confirmation_receipt;
 
@@ -420,8 +422,11 @@ where
 
         self.storage_manager.finalize_l2(l2_height)?;
 
-        self.ledger_db
-            .commit_soft_confirmation(next_state_root.as_ref(), receipt, true)?;
+        self.ledger_db.commit_soft_confirmation(
+            next_state_root.as_ref(),
+            receipt,
+            Some(txs_bodies),
+        )?;
 
         self.ledger_db.extend_l2_range_of_l1_slot(
             SlotNumber(current_l1_block.header().height()),

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -17,7 +17,7 @@ use jsonrpsee::RpcModule;
 use sequencer_client::{GetSoftConfirmationResponse, SequencerClient};
 use sov_db::ledger_db::NodeLedgerOps;
 use sov_db::schema::types::{BatchNumber, SlotNumber};
-use sov_modules_api::Context;
+use sov_modules_api::{Context, SignedSoftConfirmation};
 use sov_modules_stf_blueprint::StfBlueprintTrait;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::fork::ForkManager;
@@ -248,6 +248,7 @@ where
             .storage_manager
             .create_storage_on_l2_height(l2_height)?;
 
+        let mut signed_soft_confirmation: SignedSoftConfirmation = soft_confirmation.clone().into();
         let soft_confirmation_result = self.stf.apply_soft_confirmation(
             self.fork_manager.active_fork().spec_id,
             self.sequencer_pub_key.as_slice(),
@@ -257,7 +258,7 @@ where
             Default::default(),
             current_l1_block.header(),
             &current_l1_block.validity_condition(),
-            &mut soft_confirmation.clone().into(),
+            &mut signed_soft_confirmation,
         )?;
 
         let receipt = soft_confirmation_result.soft_confirmation_receipt;
@@ -273,11 +274,14 @@ where
 
         self.storage_manager.finalize_l2(l2_height)?;
 
-        self.ledger_db.commit_soft_confirmation(
-            next_state_root.as_ref(),
-            receipt,
-            self.include_tx_body,
-        )?;
+        let tx_bodies = if self.include_tx_body {
+            Some(signed_soft_confirmation.txs().to_owned())
+        } else {
+            None
+        };
+
+        self.ledger_db
+            .commit_soft_confirmation(next_state_root.as_ref(), receipt, tx_bodies)?;
 
         self.ledger_db.extend_l2_range_of_l1_slot(
             SlotNumber(current_l1_block.header().height()),

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -519,8 +519,12 @@ where
                 // however we need much better DA + finalization logic here
                 self.storage_manager.finalize_l2(l2_height)?;
 
-                self.ledger_db
-                    .commit_soft_confirmation(next_state_root.as_ref(), receipt, true)?;
+                let tx_bodies = signed_soft_confirmation.txs().to_owned();
+                self.ledger_db.commit_soft_confirmation(
+                    next_state_root.as_ref(),
+                    receipt,
+                    Some(tx_bodies),
+                )?;
 
                 // connect L1 and L2 height
                 self.ledger_db.extend_l2_range_of_l1_slot(

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -23,8 +23,8 @@ use crate::schema::tables::{
     SoftConfirmationStatus, VerifiedBatchProofsBySlotNumber, LEDGER_TABLES,
 };
 use crate::schema::types::{
-    split_tx_for_storage, BatchNumber, L2HeightRange, SlotNumber, StoredBatchProof,
-    StoredBatchProofOutput, StoredLightClientProof, StoredSlot, StoredSoftConfirmation,
+    BatchNumber, L2HeightRange, SlotNumber, StoredBatchProof, StoredBatchProofOutput,
+    StoredLightClientProof, StoredSlot, StoredSoftConfirmation, StoredTransaction,
     StoredVerifiedProof,
 };
 
@@ -189,7 +189,7 @@ impl SharedLedgerOps for LedgerDB {
         &self,
         state_root: &[u8],
         soft_confirmation_receipt: SoftConfirmationReceipt<T, DS>,
-        include_tx_body: bool,
+        tx_bodies: Option<Vec<Vec<u8>>>,
     ) -> Result<(), anyhow::Error> {
         // Create a scope to ensure that the lock is released before we commit to the db
         let mut current_item_numbers = {
@@ -202,19 +202,24 @@ impl SharedLedgerOps for LedgerDB {
 
         let mut schema_batch = SchemaBatch::new();
 
-        let mut txs = Vec::with_capacity(soft_confirmation_receipt.tx_receipts.len());
-        // Insert transactions and events from each soft confirmation before inserting the soft confirmation
-        for tx in soft_confirmation_receipt.tx_receipts.into_iter() {
-            let (mut tx_to_store, _events) = split_tx_for_storage(tx);
+        let tx_bodies = if let Some(tx_bodies) = tx_bodies {
+            tx_bodies.into_iter().map(Some).collect()
+        } else {
+            vec![None; soft_confirmation_receipt.tx_receipts.len()]
+        };
 
-            // Rollup full nodes don't need to store the tx body as they already store evm body
-            // Sequencer full nodes need to store the tx body as they are the only ones that have it
-            if !include_tx_body {
-                tx_to_store.body = None;
-            }
+        let tx_hashes = soft_confirmation_receipt
+            .tx_receipts
+            .into_iter()
+            .map(|tx| tx.tx_hash);
 
-            txs.push(tx_to_store);
-        }
+        let txs = tx_hashes
+            .zip(tx_bodies)
+            .map(|(tx_hash, tx_body)| StoredTransaction {
+                hash: tx_hash,
+                body: tx_body,
+            })
+            .collect();
 
         // Insert soft confirmation
         let soft_confirmation_to_store = StoredSoftConfirmation {

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
@@ -32,7 +32,7 @@ pub trait SharedLedgerOps {
         &self,
         state_root: &[u8],
         sc_receipt: SoftConfirmationReceipt<T, DS>,
-        include_tx_body: bool,
+        tx_bodies: Option<Vec<Vec<u8>>>,
     ) -> Result<()>;
 
     /// Records the L2 height that was created as a soft confirmaiton of an L1 height

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types.rs
@@ -9,7 +9,7 @@ use sov_rollup_interface::rpc::{
     TxResponse, VerifiedBatchProofResponse,
 };
 use sov_rollup_interface::soft_confirmation::SignedSoftConfirmation;
-use sov_rollup_interface::stf::{Event, EventKey, TransactionReceipt};
+use sov_rollup_interface::stf::EventKey;
 use sov_rollup_interface::zk::{CumulativeStateDiff, LightClientCircuitOutput, Proof};
 
 /// A cheaply cloneable bytes abstraction for use within the trust boundary of the node
@@ -278,17 +278,6 @@ impl<R: DeserializeOwned> TryFrom<StoredTransaction> for TxResponse<R> {
             phantom_data: PhantomData,
         })
     }
-}
-
-/// Split a `TransactionReceipt` into a `StoredTransaction` and a list of `Event`s for storage in the database.
-pub fn split_tx_for_storage<R: Serialize>(
-    tx: TransactionReceipt<R>,
-) -> (StoredTransaction, Vec<Event>) {
-    let tx_for_storage = StoredTransaction {
-        hash: tx.tx_hash,
-        body: tx.body_to_save,
-    };
-    (tx_for_storage, tx.events)
 }
 
 /// An identifier that specifies a single event

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
@@ -107,7 +107,6 @@ where
                     native_error!("Stateful verification error - the sequencer included an invalid transaction: {}", e);
                     let receipt = TransactionReceipt {
                         tx_hash: raw_tx_hash,
-                        body_to_save: None,
                         events: sc_workspace.take_events(),
                         receipt: TxEffect::Reverted,
                     };
@@ -140,9 +139,6 @@ where
 
             let receipt = TransactionReceipt {
                 tx_hash: raw_tx_hash,
-                // TODO: instead of re-serializing, we should just save the raw tx before decoding
-                // https://github.com/chainwayxyz/citrea/issues/1045
-                body_to_save: Some(borsh::to_vec(&tx).unwrap()),
                 events,
                 receipt: tx_effect,
             };

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
@@ -58,9 +58,6 @@ mod sealed {
 pub struct TransactionReceipt<R> {
     /// The canonical hash of this transaction
     pub tx_hash: [u8; 32],
-    /// The canonically serialized body of the transaction, if it should be persisted
-    /// in the database
-    pub body_to_save: Option<Vec<u8>>,
     /// The events output by this transaction
     pub events: Vec<Event>,
     /// Any additional structured data to be saved in the database and served over RPC

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/stf/fuzzing.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/stf/fuzzing.rs
@@ -135,7 +135,6 @@ impl<R: proptest::arbitrary::Arbitrary + 'static> proptest::arbitrary::Arbitrary
                     };
                     Self {
                         tx_hash,
-                        body_to_save,
                         events,
                         receipt,
                     }


### PR DESCRIPTION
# Description

Don't keep TransactionReceipt::body_to_save in STF, instead pass it from outside.

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/1412  https://github.com/chainwayxyz/citrea/issues/1045
