### PR TITLE
CI: Cache docker image

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -59,6 +59,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   FOUNDRY_PROFILE: ci
+  TEST_BITCOIN_DOCKER: "bitcoin/bitcoin:28.0"
 
 # Automatically cancels a job if a new commit if pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>
@@ -178,6 +179,7 @@ jobs:
           command: check
 
   coverage:
+    needs: docker-setup
     runs-on: ubicloud-standard-16
     if: github.event.pull_request.draft == false
     steps:
@@ -198,6 +200,16 @@ jobs:
         with:
           key: "eth-tests-1c23e3c"
           path: crates/evm/ethereum-tests
+
+      - name: Restore cached Docker image
+        uses: actions/cache@v3
+        with:
+          path: /tmp/docker
+          key: ${{ runner.os }}-docker-${{ env.TEST_BITCOIN_DOCKER }}
+
+      - name: Load Docker image
+        run: docker load < /tmp/docker/bitcoin.tar
+
       - name: Run coverage
         run: make coverage
         env:
@@ -339,6 +351,7 @@ jobs:
         run: make check-no-std
 
   nextest:
+    needs: docker-setup
     name: nextest
     runs-on: ubicloud-standard-16
     timeout-minutes: 60
@@ -366,15 +379,26 @@ jobs:
         with:
           key: "eth-tests-1c23e3c"
           path: crates/evm/ethereum-tests
+
+      - name: Restore cached Docker image
+        uses: actions/cache@v3
+        with:
+          path: /tmp/docker
+          key: ${{ runner.os }}-docker-${{ env.TEST_BITCOIN_DOCKER }}
+
+      - name: Load Docker image
+        run: docker load < /tmp/docker/bitcoin.tar
+
       - name: Run nextest
         run: make test
         env:
           RUST_BACKTRACE: 1
-          RISC0_DEV_MODE: 1                             # This is needed to generate mock proofs and verify them
+          RISC0_DEV_MODE: 1 # This is needed to generate mock proofs and verify them
           TEST_BITCOIN_DOCKER: 1
           CI_TEST_MODE: 1
           CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
           PARALLEL_PROOF_LIMIT: 1
+          RUST_LOG: trace
 
   system-contracts:
     strategy:
@@ -457,3 +481,34 @@ jobs:
         with:
           expected_da_id: ${{ vars.EXPECTED_BITCOIN_DA_ID }}
           action: check_binary
+
+  docker-setup:
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache Docker images
+        id: cache-docker
+        uses: actions/cache@v3
+        with:
+          path: /tmp/docker
+          key: ${{ runner.os }}-docker-${{ env.TEST_BITCOIN_DOCKER }}
+
+      - name: Pull Docker image
+        if: steps.cache-docker.outputs.cache-hit != 'true'
+        run: |
+          docker pull ${{ env.TEST_BITCOIN_DOCKER }}
+          mkdir -p /tmp/docker
+          docker save ${{ env.TEST_BITCOIN_DOCKER }} > /tmp/docker/bitcoin.tar
+
+      - name: Load Docker image from cache
+        if: steps.cache-docker.outputs.cache-hit == 'true'
+        run: |
+          docker load < /tmp/docker/bitcoin.tar

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -398,7 +398,6 @@ jobs:
           CI_TEST_MODE: 1
           CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
           PARALLEL_PROOF_LIMIT: 1
-          RUST_LOG: trace
 
   system-contracts:
     strategy:


### PR DESCRIPTION
# Description

- Cache docker image used by e2e tests
- Fix rate limiting error as seen in https://github.com/chainwayxyz/citrea/actions/runs/11790974191/job/32877706153
- Fixes `Error: Framework not correctly initialized, result Ok(Err(Failed to pull image: Docker responded with status code 500: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading:`
- Should probably speed up e2e test a bit