### PR TITLE
FORKS are always sorted, use binary_search to find current fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7465,6 +7465,7 @@ version = "0.5.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
+ "citrea-primitives",
  "hex",
  "itertools 0.13.0",
  "jmt",

--- a/bin/citrea/src/rollup/mod.rs
+++ b/bin/citrea/src/rollup/mod.rs
@@ -118,7 +118,7 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
             .map(|(l2_height, _)| l2_height)
             .unwrap_or(BatchNumber(0));
 
-        let mut fork_manager = ForkManager::new(FORKS.to_vec(), current_l2_height.0);
+        let mut fork_manager = ForkManager::new(FORKS, current_l2_height.0);
         fork_manager.register_handler(Box::new(ledger_db.clone()));
 
         let seq = CitreaSequencer::new(
@@ -232,7 +232,7 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
             .map(|(l2_height, _)| l2_height)
             .unwrap_or(BatchNumber(0));
 
-        let mut fork_manager = ForkManager::new(FORKS.to_vec(), current_l2_height.0);
+        let mut fork_manager = ForkManager::new(FORKS, current_l2_height.0);
         fork_manager.register_handler(Box::new(ledger_db.clone()));
 
         let runner = CitreaFullnode::new(
@@ -356,7 +356,7 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
             .map(|(l2_height, _)| l2_height)
             .unwrap_or(BatchNumber(0));
 
-        let mut fork_manager = ForkManager::new(FORKS.to_vec(), current_l2_height.0);
+        let mut fork_manager = ForkManager::new(FORKS, current_l2_height.0);
         fork_manager.register_handler(Box::new(ledger_db.clone()));
 
         let runner = CitreaBatchProver::new(
@@ -446,7 +446,7 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
             .map(|(l2_height, _)| l2_height)
             .unwrap_or(BatchNumber(0));
 
-        let mut fork_manager = ForkManager::new(FORKS.to_vec(), current_l2_height.0);
+        let mut fork_manager = ForkManager::new(FORKS, current_l2_height.0);
         fork_manager.register_handler(Box::new(ledger_db.clone()));
 
         let runner = CitreaLightClientProver::new(

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -283,7 +283,7 @@ where
         info!("Verifying proof!");
 
         let last_active_spec_id =
-            fork_from_block_number(FORKS.to_vec(), circuit_output.last_l2_height).spec_id;
+            fork_from_block_number(FORKS, circuit_output.last_l2_height).spec_id;
         let code_commitment = code_commitments_by_spec
             .get(&last_active_spec_id)
             .expect("Proof public input must contain valid spec id");

--- a/crates/citrea-stf/src/verifier.rs
+++ b/crates/citrea-stf/src/verifier.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use citrea_primitives::forks::FORKS;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaNamespace, DaVerifier};
 use sov_rollup_interface::stf::{ApplySequencerCommitmentsOutput, StateTransitionFunction};
 use sov_rollup_interface::zk::{
@@ -86,7 +85,6 @@ where
                 data.da_block_headers_of_soft_confirmations,
                 data.soft_confirmations,
                 data.preproven_commitments.clone(),
-                FORKS.to_vec(),
             );
 
         println!("out of apply_soft_confirmations_from_sequencer_commitments");

--- a/crates/evm/src/evm/conversions.rs
+++ b/crates/evm/src/evm/conversions.rs
@@ -148,7 +148,7 @@ pub(crate) fn sealed_block_to_block_env(
             .excess_blob_gas
             .or_else(|| {
                 if citrea_spec_id_to_evm_spec_id(
-                    fork_from_block_number(FORKS.to_vec(), sealed_header.number).spec_id,
+                    fork_from_block_number(FORKS, sealed_header.number).spec_id,
                 ) >= SpecId::CANCUN
                 {
                     Some(0)

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -366,9 +366,8 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         let block_number = self.block_number_for_id(&block_number, working_set)?;
 
-        let current_spec = citrea_spec_id_to_evm_spec_id(
-            fork_from_block_number(FORKS.to_vec(), block_number).spec_id,
-        );
+        let current_spec =
+            citrea_spec_id_to_evm_spec_id(fork_from_block_number(FORKS, block_number).spec_id);
 
         self.set_state_to_end_of_evm_block_by_block_id(block_id, working_set)?;
 
@@ -563,7 +562,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 .get(working_set)
                 .expect("EVM chain config should be set");
 
-            let citrea_spec_id = fork_from_block_number(FORKS.to_vec(), block_num).spec_id;
+            let citrea_spec_id = fork_from_block_number(FORKS, block_num).spec_id;
             let evm_spec_id = citrea_spec_id_to_evm_spec_id(citrea_spec_id);
 
             let cfg_env = get_cfg_env(cfg, evm_spec_id);
@@ -658,7 +657,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 .get(working_set)
                 .expect("EVM chain config should be set");
 
-            let citrea_spec_id = fork_from_block_number(FORKS.to_vec(), block_num).spec_id;
+            let citrea_spec_id = fork_from_block_number(FORKS, block_num).spec_id;
             let evm_spec_id = citrea_spec_id_to_evm_spec_id(citrea_spec_id);
 
             let cfg_env = get_cfg_env(cfg, evm_spec_id);
@@ -770,7 +769,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 .expect("EVM chain config should be set");
 
             let citrea_spec_id =
-                fork_from_block_number(FORKS.to_vec(), block_env.number.saturating_to()).spec_id;
+                fork_from_block_number(FORKS, block_env.number.saturating_to()).spec_id;
             let evm_spec_id = citrea_spec_id_to_evm_spec_id(citrea_spec_id);
 
             let cfg_env = get_cfg_env(cfg, evm_spec_id);
@@ -1197,7 +1196,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         // set state to end of the previous block
         set_state_to_end_of_evm_block(block_number - 1, working_set);
 
-        let citrea_spec_id = fork_from_block_number(FORKS.to_vec(), block_number).spec_id;
+        let citrea_spec_id = fork_from_block_number(FORKS, block_number).spec_id;
         let evm_spec_id = citrea_spec_id_to_evm_spec_id(citrea_spec_id);
 
         let block_env = sealed_block_to_block_env(&sealed_block.header);
@@ -1837,7 +1836,7 @@ fn get_pending_block_env<C: sov_modules_api::Context>(
         .next_block_excess_blob_gas()
         .or_else(|| {
             if citrea_spec_id_to_evm_spec_id(
-                fork_from_block_number(FORKS.to_vec(), block_env.number.saturating_to()).spec_id,
+                fork_from_block_number(FORKS, block_env.number.saturating_to()).spec_id,
             ) >= SpecId::CANCUN
             {
                 Some(0)

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -313,7 +313,7 @@ where
         }
 
         let last_active_spec_id =
-            fork_from_block_number(FORKS.to_vec(), batch_proof_output.last_l2_height).spec_id;
+            fork_from_block_number(FORKS, batch_proof_output.last_l2_height).spec_id;
         let code_commitment = self
             .code_commitments_by_spec
             .get(&last_active_spec_id)

--- a/crates/fullnode/tests/hash_stf.rs
+++ b/crates/fullnode/tests/hash_stf.rs
@@ -5,7 +5,6 @@ use sov_modules_api::Context;
 use sov_modules_stf_blueprint::StfBlueprintTrait;
 use sov_prover_storage_manager::{new_orphan_storage, SnapshotManager};
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec};
-use sov_rollup_interface::fork::Fork;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::stf::{
     ApplySequencerCommitmentsOutput, SlotResult, SoftConfirmationReceipt, SoftConfirmationResult,
@@ -242,7 +241,6 @@ impl<Da: DaSpec> StateTransitionFunction<Da> for HashStf {
             Vec<sov_modules_api::SignedSoftConfirmation>,
         >,
         _preproven_commitment_indicies: Vec<usize>,
-        _forks: Vec<Fork>,
     ) -> ApplySequencerCommitmentsOutput<Self::StateRoot> {
         todo!()
     }

--- a/crates/fullnode/tests/runner_initialization_tests.rs
+++ b/crates/fullnode/tests/runner_initialization_tests.rs
@@ -53,7 +53,7 @@ fn initialize_runner(
     sov_modules_api::default_context::DefaultContext,
     LedgerDB,
 > {
-    let forks = vec![Fork::new(SpecId::Genesis, 0)];
+    static T_FORKS: &[Fork] = &[Fork::new(SpecId::Genesis, 0)];
     let da_storage_path = storage_path.join("da").to_path_buf();
     let rollup_storage_path = storage_path.join("rollup").to_path_buf();
 
@@ -113,7 +113,7 @@ fn initialize_runner(
     // let vm = MockZkvm::new(MockValidityCond::default());
     // let verifier = MockDaVerifier::default();
 
-    let fork_manager = ForkManager::new(forks, 0);
+    let fork_manager = ForkManager::new(T_FORKS, 0);
 
     let mut code_commitments_by_spec = HashMap::new();
     code_commitments_by_spec.insert(SpecId::Genesis, MockCodeCommitment([1u8; 32]));

--- a/crates/primitives/src/forks.rs
+++ b/crates/primitives/src/forks.rs
@@ -4,7 +4,7 @@ use sov_rollup_interface::spec::SpecId;
 /// This defines the list of forks which will be activated
 /// at specific heights.
 #[cfg(not(feature = "testing"))]
-pub const FORKS: [Fork; 2] = [
+pub static FORKS: &[Fork] = &[
     Fork {
         spec_id: SpecId::Genesis,
         activation_height: 0,
@@ -18,7 +18,7 @@ pub const FORKS: [Fork; 2] = [
 ];
 
 #[cfg(feature = "testing")]
-pub const FORKS: [Fork; 3] = [
+pub static FORKS: &[Fork] = &[
     Fork {
         spec_id: SpecId::Genesis,
         activation_height: 0,

--- a/crates/primitives/src/forks.rs
+++ b/crates/primitives/src/forks.rs
@@ -4,7 +4,7 @@ use sov_rollup_interface::spec::SpecId;
 /// This defines the list of forks which will be activated
 /// at specific heights.
 #[cfg(not(feature = "testing"))]
-pub static FORKS: &[Fork] = &[
+pub const FORKS: &[Fork] = &[
     Fork {
         spec_id: SpecId::Genesis,
         activation_height: 0,
@@ -18,7 +18,7 @@ pub static FORKS: &[Fork] = &[
 ];
 
 #[cfg(feature = "testing")]
-pub static FORKS: &[Fork] = &[
+pub const FORKS: &[Fork] = &[
     Fork {
         spec_id: SpecId::Genesis,
         activation_height: 0,
@@ -32,3 +32,18 @@ pub static FORKS: &[Fork] = &[
         activation_height: 2000,
     },
 ];
+
+const _CHECK_FORKS_ARE_SORTED: () = {
+    const fn check_forks_are_sorted() {
+        let mut height = FORKS[0].activation_height;
+        let mut i = 1;
+        while i < FORKS.len() {
+            let fork = FORKS[i];
+            let fork_height = fork.activation_height;
+            assert!(fork_height > height, "FORKS are not sorted!");
+            height = fork_height;
+            i += 1;
+        }
+    }
+    check_forks_are_sorted()
+};

--- a/crates/sovereign-sdk/full-node/sov-stf-runner/src/mock/mod.rs
+++ b/crates/sovereign-sdk/full-node/sov-stf-runner/src/mock/mod.rs
@@ -2,7 +2,6 @@ use std::marker::PhantomData;
 
 use sov_modules_api::hooks::SoftConfirmationError;
 use sov_rollup_interface::da::DaSpec;
-use sov_rollup_interface::fork::Fork;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::stf::{
     ApplySequencerCommitmentsOutput, BatchReceipt, SlotResult, SoftConfirmationResult,
@@ -100,7 +99,6 @@ impl<Da: DaSpec> StateTransitionFunction<Da> for MockStf {
             Vec<sov_modules_api::SignedSoftConfirmation>,
         >,
         _preproven_commitment_indicies: Vec<usize>,
-        _forks: Vec<Fork>,
     ) -> ApplySequencerCommitmentsOutput<Self::StateRoot> {
         todo!()
     }

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true, optional = true }
 
 # Sovereign-SDK deps
+citrea-primitives = { path = "../../../primitives", default-features = false }
 sov-modules-api = { path = "../sov-modules-api", default-features = false }
 sov-rollup-interface = { path = "../../rollup-interface" }
 sov-state = { path = "../sov-state" }

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -2,6 +2,7 @@
 #![doc = include_str!("../README.md")]
 
 use borsh::BorshDeserialize;
+use citrea_primitives::forks::FORKS;
 use itertools::Itertools;
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
@@ -15,7 +16,7 @@ use sov_modules_api::{
     Genesis, Signature, Spec, StateCheckpoint, UnsignedSoftConfirmation, WorkingSet,
 };
 use sov_rollup_interface::da::DaDataBatchProof;
-use sov_rollup_interface::fork::{Fork, ForkManager};
+use sov_rollup_interface::fork::ForkManager;
 use sov_rollup_interface::soft_confirmation::SignedSoftConfirmation;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::stf::{
@@ -554,7 +555,6 @@ where
         slot_headers: std::collections::VecDeque<Vec<<Da as DaSpec>::BlockHeader>>,
         soft_confirmations: std::collections::VecDeque<Vec<SignedSoftConfirmation>>,
         preproven_commitment_indices: Vec<usize>,
-        forks: Vec<Fork>,
     ) -> ApplySequencerCommitmentsOutput<Self::StateRoot> {
         let mut state_diff = CumulativeStateDiff::default();
 
@@ -625,7 +625,7 @@ where
         let mut previous_batch_hash = soft_confirmations[0][0].prev_hash();
         let mut last_commitment_end_height: Option<u64> = None;
 
-        let mut fork_manager = ForkManager::new(forks, sequencer_commitments_range.0 as u64);
+        let mut fork_manager = ForkManager::new(FORKS, sequencer_commitments_range.0 as u64);
 
         // should panic if number of sequencer commitments, soft confirmations, slot headers and witnesses don't match
         for (((sequencer_commitment, soft_confirmations), da_block_headers), witnesses) in

--- a/crates/sovereign-sdk/rollup-interface/src/fork/manager.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/fork/manager.rs
@@ -5,18 +5,18 @@ use alloc::vec::Vec;
 use super::{Fork, ForkMigration};
 
 pub struct ForkManager {
-    forks: Vec<Fork>,
+    forks: &'static [Fork],
     active_fork_idx: usize,
     migration_handlers: Vec<Box<dyn ForkMigration + Sync + Send>>,
 }
 
 impl ForkManager {
-    pub fn new(forks: Vec<Fork>, current_l2_height: u64) -> Self {
+    pub fn new(forks: &'static [Fork], current_l2_height: u64) -> Self {
         // Make sure the list of specs is sorted by the block number at which they activate.
         #[cfg(debug_assertions)]
         {
             // FIXME replace it with is_sorted() when we move to rust 1.82.0
-            let mut forks_sorted = forks.clone();
+            let mut forks_sorted = forks.to_owned();
             forks_sorted.sort_by_key(|fork| fork.activation_height);
             assert_eq!(forks, forks_sorted);
         }
@@ -74,6 +74,6 @@ impl ForkManager {
 
 /// Simple search for the fork to which a specific block number blongs.
 /// This assumes that the list of forks is sorted by block number in ascending fashion.
-pub fn fork_from_block_number(forks: Vec<Fork>, block_number: u64) -> Fork {
+pub fn fork_from_block_number(forks: &'static [Fork], block_number: u64) -> Fork {
     ForkManager::new(forks, block_number).active_fork()
 }

--- a/crates/sovereign-sdk/rollup-interface/src/fork/manager.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/fork/manager.rs
@@ -11,19 +11,22 @@ pub struct ForkManager {
 }
 
 impl ForkManager {
-    pub fn new(mut forks: Vec<Fork>, current_l2_height: u64) -> Self {
+    pub fn new(forks: Vec<Fork>, current_l2_height: u64) -> Self {
         // Make sure the list of specs is sorted by the block number at which they activate.
-        forks.sort_by_key(|fork| fork.activation_height);
-
-        // TODO: binary search here and assume forks is always sorted
-        let mut active_fork_idx = 0;
-        for (idx, fork) in forks.iter().enumerate() {
-            if current_l2_height >= fork.activation_height {
-                active_fork_idx = idx;
-            } else {
-                break;
-            }
+        #[cfg(debug_assertions)]
+        {
+            // FIXME replace it with is_sorted() when we move to rust 1.82.0
+            let mut forks_sorted = forks.clone();
+            forks_sorted.sort_by_key(|fork| fork.activation_height);
+            assert_eq!(forks, forks_sorted);
         }
+
+        let pos = forks.binary_search_by(|fork| fork.activation_height.cmp(&current_l2_height));
+
+        let active_fork_idx = match pos {
+            Ok(idx) => idx,
+            Err(idx) => idx.saturating_sub(1),
+        };
 
         Self {
             forks,
@@ -36,8 +39,8 @@ impl ForkManager {
         self.migration_handlers.push(handler);
     }
 
-    pub fn active_fork(&self) -> &Fork {
-        &self.forks[self.active_fork_idx]
+    pub fn active_fork(&self) -> Fork {
+        self.forks[self.active_fork_idx]
     }
 
     pub fn register_block(&mut self, height: u64) -> anyhow::Result<()> {
@@ -72,5 +75,5 @@ impl ForkManager {
 /// Simple search for the fork to which a specific block number blongs.
 /// This assumes that the list of forks is sorted by block number in ascending fashion.
 pub fn fork_from_block_number(forks: Vec<Fork>, block_number: u64) -> Fork {
-    ForkManager::new(forks, block_number).active_fork().clone()
+    ForkManager::new(forks, block_number).active_fork()
 }

--- a/crates/sovereign-sdk/rollup-interface/src/fork/manager.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/fork/manager.rs
@@ -12,17 +12,9 @@ pub struct ForkManager {
 
 impl ForkManager {
     pub fn new(forks: &'static [Fork], current_l2_height: u64) -> Self {
-        // Make sure the list of specs is sorted by the block number at which they activate.
-        #[cfg(debug_assertions)]
-        {
-            // FIXME replace it with is_sorted() when we move to rust 1.82.0
-            let mut forks_sorted = forks.to_owned();
-            forks_sorted.sort_by_key(|fork| fork.activation_height);
-            assert_eq!(forks, forks_sorted);
-        }
+        // FORKS from citrea-primitives are checked at compile time to be sorted.
 
         let pos = forks.binary_search_by(|fork| fork.activation_height.cmp(&current_l2_height));
-
         let active_fork_idx = match pos {
             Ok(idx) => idx,
             Err(idx) => idx.saturating_sub(1),

--- a/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
@@ -11,7 +11,7 @@ pub use migration::*;
 use crate::spec::SpecId;
 
 /// Fork is a wrapper struct that contains spec id and it's activation height
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 pub struct Fork {
     /// Spec id for this fork
     pub spec_id: SpecId,

--- a/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
@@ -11,7 +11,7 @@ pub use migration::*;
 use crate::spec::SpecId;
 
 /// Fork is a wrapper struct that contains spec id and it's activation height
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Fork {
     /// Spec id for this fork
     pub spec_id: SpecId,

--- a/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
@@ -21,7 +21,7 @@ pub struct Fork {
 
 impl Fork {
     /// Creates new Fork instance
-    pub fn new(spec_id: SpecId, activation_height: u64) -> Self {
+    pub const fn new(spec_id: SpecId, activation_height: u64) -> Self {
         Self {
             spec_id,
             activation_height,

--- a/crates/sovereign-sdk/rollup-interface/src/fork/tests.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/fork/tests.rs
@@ -6,35 +6,26 @@ use crate::spec::SpecId;
 
 #[test]
 fn test_fork_from_block_number() {
-    let forks = vec![
+    static T_FORKS: &[Fork] = &[
         Fork::new(SpecId::Genesis, 0),
         Fork::new(SpecId::Fork1, 100),
         Fork::new(SpecId::Fork2, 500),
     ];
 
-    assert_eq!(
-        fork_from_block_number(forks.clone(), 5).spec_id,
-        SpecId::Genesis
-    );
-    assert_eq!(
-        fork_from_block_number(forks.clone(), 105).spec_id,
-        SpecId::Fork1
-    );
-    assert_eq!(
-        fork_from_block_number(forks.clone(), 350).spec_id,
-        SpecId::Fork1
-    );
-    assert_eq!(fork_from_block_number(forks, 505).spec_id, SpecId::Fork2);
+    assert_eq!(fork_from_block_number(T_FORKS, 5).spec_id, SpecId::Genesis);
+    assert_eq!(fork_from_block_number(T_FORKS, 105).spec_id, SpecId::Fork1);
+    assert_eq!(fork_from_block_number(T_FORKS, 350).spec_id, SpecId::Fork1);
+    assert_eq!(fork_from_block_number(T_FORKS, 505).spec_id, SpecId::Fork2);
 }
 
 #[test]
 fn test_fork_manager() {
-    let forks = vec![
+    static T_FORKS: &[Fork] = &[
         Fork::new(SpecId::Genesis, 0),
         Fork::new(SpecId::Fork1, 100),
         Fork::new(SpecId::Fork2, 500),
     ];
-    let mut fork_manager = ForkManager::new(forks, 0);
+    let mut fork_manager = ForkManager::new(T_FORKS, 0);
     fork_manager.register_block(5).unwrap();
     assert_eq!(fork_manager.active_fork().spec_id, SpecId::Genesis);
     fork_manager.register_block(100).unwrap();
@@ -47,7 +38,7 @@ fn test_fork_manager() {
 
 #[test]
 fn test_fork_manager_callbacks() {
-    let forks = vec![
+    static T_FORKS: &[Fork] = &[
         Fork::new(SpecId::Genesis, 0),
         Fork::new(SpecId::Fork1, 100),
         Fork::new(SpecId::Fork2, 500),
@@ -63,7 +54,7 @@ fn test_fork_manager_callbacks() {
         }
     }
     let handler = Box::new(Handler {});
-    let mut fork_manager = ForkManager::new(forks, 0);
+    let mut fork_manager = ForkManager::new(T_FORKS, 0);
     fork_manager.register_handler(handler);
     let result = fork_manager.register_block(100);
     assert!(result.is_err());

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
@@ -17,7 +17,6 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use crate::da::DaSpec;
-use crate::fork::Fork;
 use crate::soft_confirmation::SignedSoftConfirmation;
 use crate::spec::SpecId;
 use crate::zk::CumulativeStateDiff;
@@ -313,7 +312,6 @@ pub trait StateTransitionFunction<Da: DaSpec> {
         slot_headers: VecDeque<Vec<Da::BlockHeader>>,
         soft_confirmations: VecDeque<Vec<SignedSoftConfirmation>>,
         preproven_commitment_indicies: Vec<usize>,
-        forks: Vec<Fork>,
     ) -> ApplySequencerCommitmentsOutput<Self::StateRoot>;
 }
 


### PR DESCRIPTION
# Description

- Check if FORKS are sorted at compile time
- Use binary search in fork_from_block_number
- Don't cast FORKS to vec
- Don't pass forks as arg to .apply_soft_confirmations_from_sequencer_commitments

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/1460
