### PR TITLE
Optimize DA verify_transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,6 +1229,7 @@ dependencies = [
  "crypto-bigint",
  "futures",
  "hex",
+ "itertools 0.13.0",
  "jsonrpsee",
  "pin-project",
  "rand 0.8.5",

--- a/bin/citrea/provers/risc0/batch-proof-bitcoin/Cargo.lock
+++ b/bin/citrea/provers/risc0/batch-proof-bitcoin/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "crypto-bigint",
  "futures",
  "hex",
+ "itertools 0.13.0",
  "rand",
  "serde",
  "serde_json",

--- a/bin/citrea/provers/risc0/light-client-proof-bitcoin/Cargo.lock
+++ b/bin/citrea/provers/risc0/light-client-proof-bitcoin/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "crypto-bigint",
  "futures",
  "hex",
+ "itertools 0.13.0",
  "rand",
  "serde",
  "serde_json",

--- a/crates/bitcoin-da/Cargo.toml
+++ b/crates/bitcoin-da/Cargo.toml
@@ -24,6 +24,7 @@ backoff = { workspace = true, optional = true }
 borsh = { workspace = true }
 crypto-bigint = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
+itertools = { workspace = true }
 jsonrpsee = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true, features = [] }
 rand = { workspace = true }

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -90,8 +90,7 @@ impl DaVerifier for BitcoinVerifier {
             .wtxids
             .iter()
             .filter(|wtxid| wtxid.starts_with(prefix));
-        let completeness_iter = completeness_proof.iter();
-        for (wtxid, tx) in relevant_wtxid_iter.zip_eq(completeness_iter) {
+for (wtxid, tx) in relevant_wtxid_iter.zip_eq(&completeness_proof) {
             // ensure completeness proof tx matches the inclusion tx
             if tx.compute_wtxid().as_byte_array() != wtxid {
                 return Err(ValidationError::RelevantTxNotInProof);

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -1044,10 +1044,33 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, mut completeness_proof, mut txs) = get_mock_data();
+        let (block_header, inclusion_proof, mut completeness_proof, txs) = get_mock_data();
 
         completeness_proof.swap(2, 3);
-        txs.swap(2, 3);
+
+        assert_eq!(
+            verifier.verify_transactions(
+                &block_header,
+                txs.as_slice(),
+                inclusion_proof,
+                completeness_proof,
+                DaNamespace::ToBatchProver,
+            ),
+            Err(ValidationError::RelevantTxNotInProof)
+        );
+    }
+
+    #[test]
+    fn break_rel_tx_order() {
+        let verifier = BitcoinVerifier::new(RollupParams {
+            to_batch_proof_prefix: vec![1, 1],
+            to_light_client_prefix: vec![2, 2],
+        });
+
+        let (block_header, inclusion_proof, mut completeness_proof, mut txs) = get_mock_data();
+
+        txs.swap(0, 1);
+        completeness_proof.swap(0, 1);
 
         assert_eq!(
             verifier.verify_transactions(

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -511,6 +511,7 @@ mod tests {
             )
             .is_ok());
     }
+
     #[test]
     fn test_non_segwit_block() {
         let verifier = BitcoinVerifier::new(RollupParams {

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use bitcoin::hashes::Hash;
 use citrea_primitives::compression::decompress_blob;
 use crypto_bigint::{Encoding, U256};
@@ -82,29 +80,26 @@ impl DaVerifier for BitcoinVerifier {
         // create hash set of blobs
         let mut blobs_iter = blobs.iter();
 
-        let mut inclusion_iter = inclusion_proof.wtxids.iter();
-
         let prefix = match namespace {
             DaNamespace::ToBatchProver => self.to_batch_proof_prefix.as_slice(),
             DaNamespace::ToLightClientProver => self.to_light_client_prefix.as_slice(),
         };
-        // Check starting bytes tx that parsed correctly is in blobs
-        let mut completeness_tx_hashes = BTreeSet::new();
 
-        for tx in completeness_proof.iter() {
-            let wtxid = tx.compute_wtxid();
-            // make sure it starts with the correct prefix
-            if !wtxid.as_byte_array().starts_with(prefix) {
-                return Err(ValidationError::NonRelevantTxInProof);
+        let mut completeness_iter = completeness_proof.iter();
+        for inclusion_wtxid in inclusion_proof.wtxids.iter() {
+            // skip nonrelevant transactions
+            if !inclusion_wtxid.starts_with(prefix) {
+                continue;
             }
 
-            // make sure completeness txs are ordered same in inclusion proof
-            // this logic always start seaching from the last found index
-            // ordering should be preserved naturally
-            let is_found_in_block =
-                inclusion_iter.any(|wtxid_inc| wtxid_inc == wtxid.as_byte_array());
-            if !is_found_in_block {
-                return Err(ValidationError::RelevantTxNotFoundInBlock);
+            // completeness proof tx for the relevant tx must exist
+            let Some(tx) = completeness_iter.next() else {
+                return Err(ValidationError::RelevantTxNotInProof);
+            };
+
+            // ensure the next completeness proof tx matches the inclusion tx
+            if tx.compute_wtxid().as_byte_array() != inclusion_wtxid {
+                return Err(ValidationError::RelevantTxNotInProof);
             }
 
             // it must be parsed correctly
@@ -162,29 +157,15 @@ impl DaVerifier for BitcoinVerifier {
                     }
                 }
             }
-
-            completeness_tx_hashes.insert(wtxid.to_byte_array());
         }
 
+        // ensure no extra completeness proof is left
+        if completeness_iter.next().is_some() {
+            return Err(ValidationError::NonRelevantTxInProof);
+        }
         // assert no extra txs than the ones in the completeness proof are left
         if blobs_iter.next().is_some() {
             return Err(ValidationError::IncorrectCompletenessProof);
-        }
-
-        // no prefix bytes left behind completeness proof
-        inclusion_proof.wtxids.iter().try_for_each(|wtxid| {
-            if wtxid.starts_with(prefix) {
-                // assert all prefixed transactions are included in completeness proof
-                if !completeness_tx_hashes.remove(wtxid) {
-                    return Err(ValidationError::RelevantTxNotInProof);
-                }
-            }
-            Ok(())
-        })?;
-
-        // assert no other (irrelevant) tx is in completeness proof
-        if !completeness_tx_hashes.is_empty() {
-            return Err(ValidationError::NonRelevantTxInProof);
         }
 
         // verify that one of the outputs of the coinbase transaction has script pub key starting with 0x6a24aa21a9ed,
@@ -857,7 +838,7 @@ mod tests {
                 completeness_proof,
                 DaNamespace::ToBatchProver,
             ),
-            Err(ValidationError::NonRelevantTxInProof)
+            Err(ValidationError::RelevantTxNotInProof)
         );
     }
 
@@ -951,7 +932,7 @@ mod tests {
                 completeness_proof,
                 DaNamespace::ToBatchProver,
             ),
-            Err(ValidationError::RelevantTxNotFoundInBlock)
+            Err(ValidationError::NonRelevantTxInProof)
         );
     }
 
@@ -974,7 +955,7 @@ mod tests {
                 completeness_proof,
                 DaNamespace::ToBatchProver,
             ),
-            Err(ValidationError::RelevantTxNotFoundInBlock)
+            Err(ValidationError::NonRelevantTxInProof)
         );
     }
 
@@ -1020,7 +1001,7 @@ mod tests {
                 completeness_proof,
                 DaNamespace::ToBatchProver,
             ),
-            Err(ValidationError::IncorrectCompletenessProof)
+            Err(ValidationError::RelevantTxNotInProof)
         );
     }
 
@@ -1043,7 +1024,7 @@ mod tests {
                 completeness_proof,
                 DaNamespace::ToBatchProver,
             ),
-            Err(ValidationError::IncorrectCompletenessProof)
+            Err(ValidationError::RelevantTxNotInProof)
         );
     }
 
@@ -1090,12 +1071,12 @@ mod tests {
                 completeness_proof,
                 DaNamespace::ToBatchProver,
             ),
-            Err(ValidationError::RelevantTxNotFoundInBlock)
+            Err(ValidationError::RelevantTxNotInProof)
         );
     }
 
     #[test]
-    fn break_rel_tx_order() {
+    fn break_rel_tx_and_completeness_proof_order() {
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
             to_light_client_prefix: vec![2, 2],
@@ -1114,30 +1095,6 @@ mod tests {
                 DaNamespace::ToBatchProver,
             ),
             Err(ValidationError::BlobWasTamperedWith)
-        );
-    }
-
-    #[test]
-    fn break_rel_tx_and_completeness_proof_order() {
-        let verifier = BitcoinVerifier::new(RollupParams {
-            to_batch_proof_prefix: vec![1, 1],
-            to_light_client_prefix: vec![2, 2],
-        });
-
-        let (block_header, inclusion_proof, mut completeness_proof, mut txs) = get_mock_data();
-
-        txs.swap(0, 1);
-        completeness_proof.swap(0, 1);
-
-        assert_eq!(
-            verifier.verify_transactions(
-                &block_header,
-                txs.as_slice(),
-                inclusion_proof,
-                completeness_proof,
-                DaNamespace::ToBatchProver,
-            ),
-            Err(ValidationError::RelevantTxNotFoundInBlock)
         );
     }
 

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -90,7 +90,7 @@ impl DaVerifier for BitcoinVerifier {
             .wtxids
             .iter()
             .filter(|wtxid| wtxid.starts_with(prefix));
-for (wtxid, tx) in relevant_wtxid_iter.zip_eq(&completeness_proof) {
+        for (wtxid, tx) in relevant_wtxid_iter.zip_eq(&completeness_proof) {
             // ensure completeness proof tx matches the inclusion tx
             if tx.compute_wtxid().as_byte_array() != wtxid {
                 return Err(ValidationError::RelevantTxNotInProof);

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -1,6 +1,7 @@
 use bitcoin::hashes::Hash;
 use citrea_primitives::compression::decompress_blob;
 use crypto_bigint::{Encoding, U256};
+use itertools::Itertools;
 use sov_rollup_interface::da::{
     BlockHeaderTrait, CountedBufReader, DaNamespace, DaSpec, DaVerifier, UpdatedDaState,
 };
@@ -85,20 +86,14 @@ impl DaVerifier for BitcoinVerifier {
             DaNamespace::ToLightClientProver => self.to_light_client_prefix.as_slice(),
         };
 
-        let mut completeness_iter = completeness_proof.iter();
-        for inclusion_wtxid in inclusion_proof.wtxids.iter() {
-            // skip nonrelevant transactions
-            if !inclusion_wtxid.starts_with(prefix) {
-                continue;
-            }
-
-            // completeness proof tx for the relevant tx must exist
-            let Some(tx) = completeness_iter.next() else {
-                return Err(ValidationError::RelevantTxNotInProof);
-            };
-
-            // ensure the next completeness proof tx matches the inclusion tx
-            if tx.compute_wtxid().as_byte_array() != inclusion_wtxid {
+        let relevant_wtxid_iter = inclusion_proof
+            .wtxids
+            .iter()
+            .filter(|wtxid| wtxid.starts_with(prefix));
+        let completeness_iter = completeness_proof.iter();
+        for (wtxid, tx) in relevant_wtxid_iter.zip_eq(completeness_iter) {
+            // ensure completeness proof tx matches the inclusion tx
+            if tx.compute_wtxid().as_byte_array() != wtxid {
                 return Err(ValidationError::RelevantTxNotInProof);
             }
 
@@ -159,10 +154,6 @@ impl DaVerifier for BitcoinVerifier {
             }
         }
 
-        // ensure no extra completeness proof is left
-        if completeness_iter.next().is_some() {
-            return Err(ValidationError::NonRelevantTxInProof);
-        }
         // assert no extra txs than the ones in the completeness proof are left
         if blobs_iter.next().is_some() {
             return Err(ValidationError::IncorrectCompletenessProof);
@@ -914,6 +905,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "itertools: .zip_eq() reached end of one iterator before the other")]
     fn missing_tx_in_inclusion() {
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
@@ -924,19 +916,18 @@ mod tests {
 
         inclusion_proof.wtxids.pop();
 
-        assert_eq!(
-            verifier.verify_transactions(
-                &block_header,
-                txs.as_slice(),
-                inclusion_proof,
-                completeness_proof,
-                DaNamespace::ToBatchProver,
-            ),
-            Err(ValidationError::NonRelevantTxInProof)
+        // should panic
+        let _ = verifier.verify_transactions(
+            &block_header,
+            txs.as_slice(),
+            inclusion_proof,
+            completeness_proof,
+            DaNamespace::ToBatchProver,
         );
     }
 
     #[test]
+    #[should_panic(expected = "itertools: .zip_eq() reached end of one iterator before the other")]
     fn empty_inclusion() {
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
@@ -947,15 +938,13 @@ mod tests {
 
         inclusion_proof.wtxids.clear();
 
-        assert_eq!(
-            verifier.verify_transactions(
-                &block_header,
-                txs.as_slice(),
-                inclusion_proof,
-                completeness_proof,
-                DaNamespace::ToBatchProver,
-            ),
-            Err(ValidationError::NonRelevantTxInProof)
+        // should panic
+        let _ = verifier.verify_transactions(
+            &block_header,
+            txs.as_slice(),
+            inclusion_proof,
+            completeness_proof,
+            DaNamespace::ToBatchProver,
         );
     }
 
@@ -983,6 +972,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "itertools: .zip_eq() reached end of one iterator before the other")]
     fn missing_tx_in_completeness_proof() {
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
@@ -993,19 +983,18 @@ mod tests {
 
         completeness_proof.pop();
 
-        assert_eq!(
-            verifier.verify_transactions(
-                &block_header,
-                txs.as_slice(),
-                inclusion_proof,
-                completeness_proof,
-                DaNamespace::ToBatchProver,
-            ),
-            Err(ValidationError::RelevantTxNotInProof)
+        // should panic
+        let _ = verifier.verify_transactions(
+            &block_header,
+            txs.as_slice(),
+            inclusion_proof,
+            completeness_proof,
+            DaNamespace::ToBatchProver,
         );
     }
 
     #[test]
+    #[should_panic(expected = "itertools: .zip_eq() reached end of one iterator before the other")]
     fn empty_completeness_proof() {
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
@@ -1016,19 +1005,18 @@ mod tests {
 
         completeness_proof.clear();
 
-        assert_eq!(
-            verifier.verify_transactions(
-                &block_header,
-                txs.as_slice(),
-                inclusion_proof,
-                completeness_proof,
-                DaNamespace::ToBatchProver,
-            ),
-            Err(ValidationError::RelevantTxNotInProof)
+        // should panic
+        let _ = verifier.verify_transactions(
+            &block_header,
+            txs.as_slice(),
+            inclusion_proof,
+            completeness_proof,
+            DaNamespace::ToBatchProver,
         );
     }
 
     #[test]
+    #[should_panic(expected = "itertools: .zip_eq() reached end of one iterator before the other")]
     fn non_relevant_tx_in_completeness_proof() {
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
@@ -1039,15 +1027,13 @@ mod tests {
 
         completeness_proof.push(get_mock_txs().get(1).unwrap().clone().into());
 
-        assert_eq!(
-            verifier.verify_transactions(
-                &block_header,
-                txs.as_slice(),
-                inclusion_proof,
-                completeness_proof,
-                DaNamespace::ToBatchProver,
-            ),
-            Err(ValidationError::NonRelevantTxInProof)
+        // should panic
+        let _ = verifier.verify_transactions(
+            &block_header,
+            txs.as_slice(),
+            inclusion_proof,
+            completeness_proof,
+            DaNamespace::ToBatchProver,
         );
     }
 

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -1067,6 +1067,29 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
+        let (block_header, inclusion_proof, completeness_proof, mut txs) = get_mock_data();
+
+        txs.swap(0, 1);
+
+        assert_eq!(
+            verifier.verify_transactions(
+                &block_header,
+                txs.as_slice(),
+                inclusion_proof,
+                completeness_proof,
+                DaNamespace::ToBatchProver,
+            ),
+            Err(ValidationError::BlobWasTamperedWith)
+        );
+    }
+
+    #[test]
+    fn break_rel_tx_and_completeness_order() {
+        let verifier = BitcoinVerifier::new(RollupParams {
+            to_batch_proof_prefix: vec![1, 1],
+            to_light_client_prefix: vec![2, 2],
+        });
+
         let (block_header, inclusion_proof, mut completeness_proof, mut txs) = get_mock_data();
 
         txs.swap(0, 1);
@@ -1081,29 +1104,6 @@ mod tests {
                 DaNamespace::ToBatchProver,
             ),
             Err(ValidationError::RelevantTxNotInProof)
-        );
-    }
-
-    #[test]
-    fn break_rel_tx_and_completeness_proof_order() {
-        let verifier = BitcoinVerifier::new(RollupParams {
-            to_batch_proof_prefix: vec![1, 1],
-            to_light_client_prefix: vec![2, 2],
-        });
-
-        let (block_header, inclusion_proof, completeness_proof, mut txs) = get_mock_data();
-
-        txs.swap(0, 1);
-
-        assert_eq!(
-            verifier.verify_transactions(
-                &block_header,
-                txs.as_slice(),
-                inclusion_proof,
-                completeness_proof,
-                DaNamespace::ToBatchProver,
-            ),
-            Err(ValidationError::BlobWasTamperedWith)
         );
     }
 


### PR DESCRIPTION
# Description

Optimizes verify_transactions method of DA verifier.

Previously:
1. Iterate over completeness proof (Verifying each tx in completeness also exist in inclusion)
  1.1. Validate wtxid
  1.2. Ensure corresponding tx exists in inclusion proof
  1.3. Collect completeness proof wtxids into a BTreeSet
2. Iterate over inclusion proof (Verifying each relevant tx in inclusion also exist in completeness)
  2.1 If prefix matches, verify it also exists in collected completeness proof wtxids BTreeSet and remove it
3. If completeness proof wtxids BTreeSet not empty, there is extra tx in completeness, hence invalid

New:
1. Filter out nonrelevant transactions from inclusion proof
2. ZipEq filtered out inclusion and completeness, they must be of same length
  1.1 Verify wtxids match

With the new version, collecting and later removing wtxids into an BTreeSet is removed, and there is now only 1 iteration over proofs.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
