### PR TITLE
DA Verifier light client proof tests

### DIFF
--- a/crates/bitcoin-da/src/helpers/test_utils.rs
+++ b/crates/bitcoin-da/src/helpers/test_utils.rs
@@ -4,11 +4,12 @@ use bitcoin::block::{Header, Version};
 use bitcoin::hash_types::{TxMerkleNode, WitnessMerkleNode};
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, CompactTarget, Transaction};
+use citrea_primitives::compression::decompress_blob;
 use sov_rollup_interface::da::{DaSpec, DaVerifier};
 
+use super::merkle_tree;
 use super::parsers::{parse_batch_proof_transaction, parse_light_client_transaction, ParserError};
-use super::{calculate_sha256, merkle_tree};
-use crate::helpers::parsers::parse_hex_transaction;
+use crate::helpers::parsers::{parse_hex_transaction, VerifyParsed};
 use crate::spec::blob::BlobWithSender;
 use crate::spec::header::HeaderWrapper;
 use crate::spec::proof::InclusionMultiProof;
@@ -33,12 +34,15 @@ pub(crate) fn get_blob_with_sender(
     tx: &Transaction,
     ty: MockData,
 ) -> Result<BlobWithSender, ParserError> {
-    let (blob, public_key) = match ty {
+    let (blob, public_key, hash) = match ty {
         MockData::BatchProof => {
             let parsed_tx = parse_batch_proof_transaction(tx)?;
             match parsed_tx {
                 super::parsers::ParsedBatchProofTransaction::SequencerCommitment(seq_com) => {
-                    (seq_com.body, seq_com.public_key)
+                    let hash = seq_com
+                        .get_sig_verified_hash()
+                        .expect("Invalid sighash on commitment");
+                    (seq_com.body, seq_com.public_key, hash)
                 }
             }
         }
@@ -46,18 +50,26 @@ pub(crate) fn get_blob_with_sender(
             let parsed_tx = parse_light_client_transaction(tx)?;
             match parsed_tx {
                 super::parsers::ParsedLightClientTransaction::Complete(complete) => {
-                    (complete.body, complete.public_key)
+                    println!("is complete");
+                    let hash = complete
+                        .get_sig_verified_hash()
+                        .expect("Invalid sighash on complete zk proof");
+                    let blob = decompress_blob(&complete.body);
+                    (blob, complete.public_key, hash)
+                }
+                super::parsers::ParsedLightClientTransaction::Aggregate(aggregate) => {
+                    println!("is aggregate");
+                    let hash = aggregate
+                        .get_sig_verified_hash()
+                        .expect("Invalid sighash on aggregate zk proof");
+                    (aggregate.body, aggregate.public_key, hash)
                 }
                 _ => unimplemented!(),
             }
         }
     };
 
-    Ok(BlobWithSender::new(
-        blob.clone(),
-        public_key,
-        calculate_sha256(&blob),
-    ))
+    Ok(BlobWithSender::new(blob.clone(), public_key, hash))
 }
 
 #[allow(clippy::type_complexity)]
@@ -96,9 +108,17 @@ pub(crate) fn get_mock_data(
 
     let block_txs = get_mock_txs();
 
+    block_txs
+        .iter()
+        .enumerate()
+        .filter(|(_, tx)| tx.compute_wtxid().as_byte_array().starts_with(&[2, 2]))
+        .for_each(|(idx, _)| {
+            println!("{}", idx);
+        });
+
     let relevant_txs_indices: &[usize] = match ty {
         MockData::BatchProof => &[4, 6, 18, 28, 34],
-        MockData::LightClientProof => &[], // TODO: add lc mock_txs
+        MockData::LightClientProof => &[8, 14, 16, 32], // TODO: add lc mock_txs
     };
 
     let completeness_proof = relevant_txs_indices

--- a/crates/bitcoin-da/src/helpers/test_utils.rs
+++ b/crates/bitcoin-da/src/helpers/test_utils.rs
@@ -50,7 +50,6 @@ pub(crate) fn get_blob_with_sender(
             let parsed_tx = parse_light_client_transaction(tx)?;
             match parsed_tx {
                 super::parsers::ParsedLightClientTransaction::Complete(complete) => {
-                    println!("is complete");
                     let hash = complete
                         .get_sig_verified_hash()
                         .expect("Invalid sighash on complete zk proof");
@@ -58,7 +57,6 @@ pub(crate) fn get_blob_with_sender(
                     (blob, complete.public_key, hash)
                 }
                 super::parsers::ParsedLightClientTransaction::Aggregate(aggregate) => {
-                    println!("is aggregate");
                     let hash = aggregate
                         .get_sig_verified_hash()
                         .expect("Invalid sighash on aggregate zk proof");
@@ -107,14 +105,6 @@ pub(crate) fn get_mock_data(
     );
 
     let block_txs = get_mock_txs();
-
-    block_txs
-        .iter()
-        .enumerate()
-        .filter(|(_, tx)| tx.compute_wtxid().as_byte_array().starts_with(&[2, 2]))
-        .for_each(|(idx, _)| {
-            println!("{}", idx);
-        });
 
     let relevant_txs_indices: &[usize] = match ty {
         MockData::BatchProof => &[4, 6, 18, 28, 34],

--- a/crates/bitcoin-da/src/helpers/test_utils.rs
+++ b/crates/bitcoin-da/src/helpers/test_utils.rs
@@ -6,13 +6,19 @@ use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, CompactTarget, Transaction};
 use sov_rollup_interface::da::{DaSpec, DaVerifier};
 
-use super::parsers::{parse_batch_proof_transaction, ParserError};
+use super::parsers::{parse_batch_proof_transaction, parse_light_client_transaction, ParserError};
 use super::{calculate_sha256, merkle_tree};
 use crate::helpers::parsers::parse_hex_transaction;
 use crate::spec::blob::BlobWithSender;
 use crate::spec::header::HeaderWrapper;
 use crate::spec::proof::InclusionMultiProof;
 use crate::verifier::BitcoinVerifier;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum MockData {
+    BatchProof,
+    LightClientProof,
+}
 
 pub(crate) fn get_mock_txs() -> Vec<Transaction> {
     // relevant txs are on 6, 8, 10, 12 indices
@@ -23,14 +29,27 @@ pub(crate) fn get_mock_txs() -> Vec<Transaction> {
         .collect()
 }
 
-pub(crate) fn get_blob_with_sender(tx: &Transaction) -> Result<BlobWithSender, ParserError> {
-    let tx = tx.clone();
-
-    let parsed_transaction = parse_batch_proof_transaction(&tx)?;
-
-    let (blob, public_key) = match parsed_transaction {
-        super::parsers::ParsedBatchProofTransaction::SequencerCommitment(seq_com) => {
-            (seq_com.body, seq_com.public_key)
+pub(crate) fn get_blob_with_sender(
+    tx: &Transaction,
+    ty: MockData,
+) -> Result<BlobWithSender, ParserError> {
+    let (blob, public_key) = match ty {
+        MockData::BatchProof => {
+            let parsed_tx = parse_batch_proof_transaction(tx)?;
+            match parsed_tx {
+                super::parsers::ParsedBatchProofTransaction::SequencerCommitment(seq_com) => {
+                    (seq_com.body, seq_com.public_key)
+                }
+            }
+        }
+        MockData::LightClientProof => {
+            let parsed_tx = parse_light_client_transaction(tx)?;
+            match parsed_tx {
+                super::parsers::ParsedLightClientTransaction::Complete(complete) => {
+                    (complete.body, complete.public_key)
+                }
+                _ => unimplemented!(),
+            }
         }
     };
 
@@ -42,7 +61,9 @@ pub(crate) fn get_blob_with_sender(tx: &Transaction) -> Result<BlobWithSender, P
 }
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn get_mock_data() -> (
+pub(crate) fn get_mock_data(
+    ty: MockData,
+) -> (
     <<BitcoinVerifier as DaVerifier>::Spec as DaSpec>::BlockHeader, // block header
     <<BitcoinVerifier as DaVerifier>::Spec as DaSpec>::InclusionMultiProof, // inclusion proof
     <<BitcoinVerifier as DaVerifier>::Spec as DaSpec>::CompletenessProof, // completeness proof
@@ -75,11 +96,14 @@ pub(crate) fn get_mock_data() -> (
 
     let block_txs = get_mock_txs();
 
-    let relevant_txs_indices = [4, 6, 18, 28, 34];
+    let relevant_txs_indices: &[usize] = match ty {
+        MockData::BatchProof => &[4, 6, 18, 28, 34],
+        MockData::LightClientProof => &[], // TODO: add lc mock_txs
+    };
 
     let completeness_proof = relevant_txs_indices
-        .into_iter()
-        .map(|i| block_txs[i].clone())
+        .iter()
+        .map(|i| block_txs[*i].clone())
         .map(Into::into)
         .collect();
 
@@ -103,8 +127,8 @@ pub(crate) fn get_mock_data() -> (
     inclusion_proof.wtxids[0] = [0; 32];
 
     let txs: Vec<BlobWithSender> = relevant_txs_indices
-        .into_iter()
-        .filter_map(|i| get_blob_with_sender(&block_txs[i]).ok())
+        .iter()
+        .filter_map(|i| get_blob_with_sender(&block_txs[*i], ty).ok())
         .collect();
 
     (header, inclusion_proof, completeness_proof, txs)

--- a/crates/bitcoin-da/src/helpers/test_utils.rs
+++ b/crates/bitcoin-da/src/helpers/test_utils.rs
@@ -108,7 +108,7 @@ pub(crate) fn get_mock_data(
 
     let relevant_txs_indices: &[usize] = match ty {
         MockData::BatchProof => &[4, 6, 18, 28, 34],
-        MockData::LightClientProof => &[8, 14, 16, 32], // TODO: add lc mock_txs
+        MockData::LightClientProof => &[8, 14, 16, 32],
     };
 
     let completeness_proof = relevant_txs_indices

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -1156,7 +1156,7 @@ mod tests {
 
     use super::{get_relevant_blobs_from_txs, BitcoinService};
     use crate::helpers::parsers::parse_hex_transaction;
-    use crate::helpers::test_utils::{get_mock_data, get_mock_txs};
+    use crate::helpers::test_utils::{get_mock_data, get_mock_txs, MockData};
     use crate::service::BitcoinServiceConfig;
     use crate::spec::block::BitcoinBlock;
     use crate::spec::header::HeaderWrapper;
@@ -1391,7 +1391,8 @@ mod tests {
     #[tokio::test]
     async fn extract_relevant_blobs() {
         let da_service = get_service().await;
-        let (header, _inclusion_proof, _completeness_proof, relevant_txs) = get_mock_data();
+        let (header, _inclusion_proof, _completeness_proof, relevant_txs) =
+            get_mock_data(MockData::BatchProof);
 
         let block_txs = get_mock_txs();
         let block_txs = block_txs.into_iter().map(Into::into).collect();
@@ -1415,7 +1416,8 @@ mod tests {
         });
 
         let da_service = get_service().await;
-        let (header, _inclusion_proof, _completeness_proof, _relevant_txs) = get_mock_data();
+        let (header, _inclusion_proof, _completeness_proof, _relevant_txs) =
+            get_mock_data(MockData::BatchProof);
         let block_txs = get_mock_txs();
         let block_txs = block_txs.into_iter().map(Into::into).collect();
 

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -1179,7 +1179,7 @@ mod tests {
         path.to_str().unwrap().to_string()
     }
 
-    async fn get_service() -> Arc<BitcoinService> {
+    async fn get_service(task_manager: &mut TaskManager<()>) -> Arc<BitcoinService> {
         let runtime_config = BitcoinServiceConfig {
             node_url: "http://localhost:38332/wallet/test".to_string(),
             node_username: "chainway".to_string(),
@@ -1192,7 +1192,7 @@ mod tests {
             monitoring: None,
         };
 
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
         let da_service = BitcoinService::new_without_wallet_check(
             runtime_config,
@@ -1206,7 +1206,8 @@ mod tests {
         .expect("Error initialazing BitcoinService");
 
         let da_service = Arc::new(da_service);
-        // da_service.clone().spawn_da_queue(_rx);
+        task_manager.spawn(|tk| da_service.clone().run_da_queue(rx, tk));
+
         #[allow(clippy::let_and_return)]
         da_service
     }
@@ -1281,13 +1282,13 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    // #[ignore]
     /// A test we use to generate some data for the other tests
     async fn send_transaction() {
         use sov_rollup_interface::da::DaData;
 
         let mut task_manager = TaskManager::default();
-        let da_service = get_service().await;
+        let da_service = get_service(&mut task_manager).await;
 
         da_service
             .send_transaction(DaData::SequencerCommitment(SequencerCommitment {
@@ -1386,11 +1387,13 @@ mod tests {
             }))
             .await
             .expect("Failed to send transaction");
+        task_manager.abort();
     }
 
     #[tokio::test]
     async fn extract_relevant_blobs_bp() {
-        let da_service = get_service().await;
+        let da_service = get_service(&mut task_manager).await;
+
         let (header, _inclusion_proof, _completeness_proof, relevant_txs) =
             get_mock_data(MockData::BatchProof);
 
@@ -1406,11 +1409,14 @@ mod tests {
             da_service.extract_relevant_blobs_with_proof(&block, DaNamespace::ToBatchProver);
 
         assert_eq!(txs, relevant_txs);
+        task_manager.abort();
     }
 
     #[tokio::test]
     async fn extract_relevant_blobs_lcp() {
-        let da_service = get_service().await;
+        let mut task_manager = TaskManager::default();
+
+        let da_service = get_service(task_manager).await;
         let (header, _inclusion_proof, _completeness_proof, relevant_txs) =
             get_mock_data(MockData::LightClientProof);
 
@@ -1430,12 +1436,14 @@ mod tests {
 
     #[tokio::test]
     async fn extract_relevant_blobs_with_proof_bp() {
+        let mut task_manager = TaskManager::default();
+
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
             to_light_client_prefix: vec![2, 2],
         });
 
-        let da_service = get_service().await;
+        let da_service = get_service(&mut task_manager).await;
         let (header, _inclusion_proof, _completeness_proof, _relevant_txs) =
             get_mock_data(MockData::BatchProof);
         let block_txs = get_mock_txs();
@@ -1458,6 +1466,7 @@ mod tests {
                 DaNamespace::ToBatchProver
             )
             .is_ok());
+        task_manager.abort();
     }
 
     #[tokio::test]
@@ -1482,8 +1491,10 @@ mod tests {
 
     #[tokio::test]
     async fn incorrect_private_key_signature_should_fail() {
+        let mut task_manager = TaskManager::default();
+
         // The transaction was sent with this service and the tx data is stored in false_signature_txs.txt
-        let da_service = get_service().await;
+        let da_service = get_service(&mut task_manager).await;
         let secp = bitcoin::secp256k1::Secp256k1::new();
         let da_pubkey = Keypair::from_secret_key(&secp, &da_service.da_private_key.unwrap())
             .public_key()
@@ -1570,11 +1581,14 @@ mod tests {
             incorrect_pub_key,
             "Publickey recovered incorrectly!"
         );
+        task_manager.abort();
     }
 
     #[tokio::test]
     async fn check_signature() {
-        let da_service = get_service().await;
+        let mut task_manager = TaskManager::default();
+
+        let da_service = get_service(&mut task_manager).await;
         let secp = bitcoin::secp256k1::Secp256k1::new();
         let da_pubkey = Keypair::from_secret_key(&secp, &da_service.da_private_key.unwrap())
             .public_key()
@@ -1624,5 +1638,7 @@ mod tests {
             da_pubkey,
             "Publickey recovered incorrectly!"
         );
+
+        task_manager.abort();
     }
 }

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -1282,7 +1282,7 @@ mod tests {
     }
 
     #[tokio::test]
-    // #[ignore]
+    #[ignore]
     /// A test we use to generate some data for the other tests
     async fn send_transaction() {
         use sov_rollup_interface::da::DaData;
@@ -1387,11 +1387,14 @@ mod tests {
             }))
             .await
             .expect("Failed to send transaction");
-        task_manager.abort();
+
+        task_manager.abort().await;
     }
 
     #[tokio::test]
     async fn extract_relevant_blobs_bp() {
+        let mut task_manager = TaskManager::default();
+
         let da_service = get_service(&mut task_manager).await;
 
         let (header, _inclusion_proof, _completeness_proof, relevant_txs) =
@@ -1409,14 +1412,15 @@ mod tests {
             da_service.extract_relevant_blobs_with_proof(&block, DaNamespace::ToBatchProver);
 
         assert_eq!(txs, relevant_txs);
-        task_manager.abort();
+
+        task_manager.abort().await;
     }
 
     #[tokio::test]
     async fn extract_relevant_blobs_lcp() {
         let mut task_manager = TaskManager::default();
 
-        let da_service = get_service(task_manager).await;
+        let da_service = get_service(&mut task_manager).await;
         let (header, _inclusion_proof, _completeness_proof, relevant_txs) =
             get_mock_data(MockData::LightClientProof);
 
@@ -1432,6 +1436,8 @@ mod tests {
             da_service.extract_relevant_blobs_with_proof(&block, DaNamespace::ToLightClientProver);
 
         assert_eq!(txs, relevant_txs);
+
+        task_manager.abort().await;
     }
 
     #[tokio::test]
@@ -1466,12 +1472,15 @@ mod tests {
                 DaNamespace::ToBatchProver
             )
             .is_ok());
-        task_manager.abort();
+
+        task_manager.abort().await;
     }
 
     #[tokio::test]
     async fn extract_relevant_blobs_with_proof_lcp() {
-        let da_service = get_service().await;
+        let mut task_manager = TaskManager::default();
+
+        let da_service = get_service(&mut task_manager).await;
         let (header, _inclusion_proof, _completeness_proof, relevant_txs) =
             get_mock_data(MockData::LightClientProof);
 
@@ -1487,13 +1496,17 @@ mod tests {
             da_service.extract_relevant_blobs_with_proof(&block, DaNamespace::ToLightClientProver);
 
         assert_eq!(txs, relevant_txs);
+
+        task_manager.abort().await;
     }
 
     #[tokio::test]
     // Ignore for now as it is not working due to mock_txs.txt being outdated
     #[ignore]
     async fn extract_relevant_zk_proofs() {
-        let da_service = get_service().await;
+        let mut task_manager = TaskManager::default();
+
+        let da_service = get_service(&mut task_manager).await;
 
         let secp = bitcoin::secp256k1::Secp256k1::new();
         let da_pubkey = Keypair::from_secret_key(&secp, &da_service.da_private_key.unwrap())
@@ -1518,6 +1531,8 @@ mod tests {
             .unwrap();
 
         dbg!(proofs.len());
+
+        task_manager.abort().await;
     }
 
     #[tokio::test]
@@ -1612,7 +1627,8 @@ mod tests {
             incorrect_pub_key,
             "Publickey recovered incorrectly!"
         );
-        task_manager.abort();
+
+        task_manager.abort().await;
     }
 
     #[tokio::test]
@@ -1670,6 +1686,6 @@ mod tests {
             "Publickey recovered incorrectly!"
         );
 
-        task_manager.abort();
+        task_manager.abort().await;
     }
 }

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -1389,7 +1389,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn extract_relevant_blobs() {
+    async fn extract_relevant_blobs_bp() {
         let da_service = get_service().await;
         let (header, _inclusion_proof, _completeness_proof, relevant_txs) =
             get_mock_data(MockData::BatchProof);
@@ -1409,7 +1409,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn extract_relevant_blobs_with_proof() {
+    async fn extract_relevant_blobs_lcp() {
+        let da_service = get_service().await;
+        let (header, _inclusion_proof, _completeness_proof, relevant_txs) =
+            get_mock_data(MockData::LightClientProof);
+
+        let block_txs = get_mock_txs();
+        let block_txs = block_txs.into_iter().map(Into::into).collect();
+
+        let block = BitcoinBlock {
+            header,
+            txdata: block_txs,
+        };
+
+        let (txs, _, _) =
+            da_service.extract_relevant_blobs_with_proof(&block, DaNamespace::ToLightClientProver);
+
+        assert_eq!(txs, relevant_txs);
+    }
+
+    #[tokio::test]
+    async fn extract_relevant_blobs_with_proof_bp() {
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
             to_light_client_prefix: vec![2, 2],
@@ -1438,6 +1458,26 @@ mod tests {
                 DaNamespace::ToBatchProver
             )
             .is_ok());
+    }
+
+    #[tokio::test]
+    async fn extract_relevant_blobs_with_proof_lcp() {
+        let da_service = get_service().await;
+        let (header, _inclusion_proof, _completeness_proof, relevant_txs) =
+            get_mock_data(MockData::LightClientProof);
+
+        let block_txs = get_mock_txs();
+        let block_txs = block_txs.into_iter().map(Into::into).collect();
+
+        let block = BitcoinBlock {
+            header,
+            txdata: block_txs,
+        };
+
+        let (txs, _, _) =
+            da_service.extract_relevant_blobs_with_proof(&block, DaNamespace::ToLightClientProver);
+
+        assert_eq!(txs, relevant_txs);
     }
 
     #[tokio::test]

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -434,7 +434,7 @@ impl BitcoinService {
         let all_tx_map = commit_chunks
             .iter()
             .chain(reveal_chunks.iter())
-            .chain([commit.clone(), reveal.tx.clone()].iter())
+            .chain([&commit, &reveal.tx].into_iter())
             .map(|tx| (tx.compute_txid(), tx.clone()))
             .collect::<HashMap<_, _>>();
 

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -1490,6 +1490,37 @@ mod tests {
     }
 
     #[tokio::test]
+    // Ignore for now as it is not working due to mock_txs.txt being outdated
+    #[ignore]
+    async fn extract_relevant_zk_proofs() {
+        let da_service = get_service().await;
+
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let da_pubkey = Keypair::from_secret_key(&secp, &da_service.da_private_key.unwrap())
+            .public_key()
+            .serialize()
+            .to_vec();
+
+        let (header, _inclusion_proof, _completeness_proof, _relevant_txs) =
+            get_mock_data(MockData::LightClientProof);
+
+        let block_txs = get_mock_txs();
+        let block_txs = block_txs.into_iter().map(Into::into).collect();
+
+        let block = BitcoinBlock {
+            header,
+            txdata: block_txs,
+        };
+
+        let proofs = da_service
+            .extract_relevant_zk_proofs(&block, &da_pubkey)
+            .await
+            .unwrap();
+
+        dbg!(proofs.len());
+    }
+
+    #[tokio::test]
     async fn incorrect_private_key_signature_should_fail() {
         let mut task_manager = TaskManager::default();
 

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -4,6 +4,7 @@
 use core::result::Result::Ok;
 use core::str::FromStr;
 use core::time::Duration;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -16,7 +17,7 @@ use bitcoin::consensus::{encode, Decodable};
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::SecretKey;
 use bitcoin::{Amount, BlockHash, CompactTarget, Transaction, Txid, Wtxid};
-use bitcoincore_rpc::json::TestMempoolAcceptResult;
+use bitcoincore_rpc::json::{SignRawTransactionInput, TestMempoolAcceptResult};
 use bitcoincore_rpc::{Auth, Client, Error, RpcApi, RpcError};
 use borsh::BorshDeserialize;
 use citrea_primitives::compression::{compress_blob, decompress_blob};
@@ -422,32 +423,80 @@ impl BitcoinService {
         commit: Transaction,
         reveal: TxWithId,
     ) -> Result<Vec<Txid>> {
+        assert_eq!(
+            commit_chunks.len(),
+            reveal_chunks.len(),
+            "Chunks commit and reveal length mismatch"
+        );
+
         debug!("Sending chunked transaction");
-        let mut raw_txs = Vec::with_capacity(commit_chunks.len() * 2 + 2);
+
+        let all_tx_map = commit_chunks
+            .iter()
+            .chain(reveal_chunks.iter())
+            .chain([commit.clone(), reveal.tx.clone()].iter())
+            .map(|tx| (tx.compute_txid(), tx.clone()))
+            .collect::<HashMap<_, _>>();
+
+        let mut raw_txs = Vec::with_capacity(all_tx_map.len());
 
         for (commit, reveal) in commit_chunks.into_iter().zip(reveal_chunks) {
+            let mut inputs = vec![];
+
+            for input in commit.input.iter() {
+                if let Some(entry) = all_tx_map.get(&input.previous_output.txid) {
+                    inputs.push(SignRawTransactionInput {
+                        txid: input.previous_output.txid,
+                        vout: input.previous_output.vout,
+                        script_pub_key: entry.output[input.previous_output.vout as usize]
+                            .script_pubkey
+                            .clone(),
+                        redeem_script: None,
+                        amount: Some(entry.output[input.previous_output.vout as usize].value),
+                    });
+                }
+            }
+
             let signed_raw_commit_tx = self
                 .client
-                .sign_raw_transaction_with_wallet(&commit, None, None)
+                .sign_raw_transaction_with_wallet(&commit, Some(inputs.as_slice()), None)
                 .await?;
             raw_txs.push(signed_raw_commit_tx.hex);
+
             let serialized_reveal_tx = encode::serialize(&reveal);
             raw_txs.push(serialized_reveal_tx);
         }
 
+        let mut inputs = vec![];
+
+        for input in commit.input.iter() {
+            if let Some(entry) = all_tx_map.get(&input.previous_output.txid) {
+                inputs.push(SignRawTransactionInput {
+                    txid: input.previous_output.txid,
+                    vout: input.previous_output.vout,
+                    script_pub_key: entry.output[input.previous_output.vout as usize]
+                        .script_pubkey
+                        .clone(),
+                    redeem_script: None,
+                    amount: Some(entry.output[input.previous_output.vout as usize].value),
+                });
+            }
+        }
         let signed_raw_commit_tx = self
             .client
-            .sign_raw_transaction_with_wallet(&commit, None, None)
+            .sign_raw_transaction_with_wallet(&commit, Some(inputs.as_slice()), None)
             .await?;
+
         raw_txs.push(signed_raw_commit_tx.hex);
 
         let serialized_reveal_tx = encode::serialize(&reveal.tx);
         raw_txs.push(serialized_reveal_tx);
 
         self.test_mempool_accept(&raw_txs).await?;
+
         let txids = self.send_raw_transactions(&raw_txs).await?;
 
-        for txid in txids[1..txids.len() - 1].iter().step_by(2) {
+        for txid in txids[1..].iter().step_by(2) {
             info!("Blob chunk inscribe tx sent. Hash: {txid}");
         }
 
@@ -781,7 +830,7 @@ impl DaService for BitcoinService {
                     }
                 }
             }
-            let zk_proof: Proof = borsh::from_slice(&body)
+            let zk_proof: Proof = borsh::from_slice(decompress_blob(&body).as_slice())
                 .map_err(|e| anyhow!("{}: Failed to parse Proof from Aggregate: {e}", tx_id))?;
             aggregates.push((i, zk_proof));
         }

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -448,11 +448,15 @@ mod tests {
     use bitcoin::hash_types::{TxMerkleNode, WitnessMerkleNode};
     use bitcoin::hashes::Hash;
     use bitcoin::{BlockHash, CompactTarget, ScriptBuf, Witness};
+    use citrea_primitives::compression::decompress_blob;
     use sov_rollup_interface::da::{DaNamespace, DaVerifier};
 
     use super::BitcoinVerifier;
     use crate::helpers::merkle_tree::BitcoinMerkleTree;
-    use crate::helpers::parsers::{parse_batch_proof_transaction, ParsedBatchProofTransaction};
+    use crate::helpers::parsers::{
+        parse_batch_proof_transaction, parse_light_client_transaction, ParsedBatchProofTransaction,
+        ParsedLightClientTransaction,
+    };
     use crate::helpers::test_utils::{
         get_blob_with_sender, get_mock_data, get_mock_txs, get_non_segwit_mock_txs, MockData,
     };
@@ -464,7 +468,7 @@ mod tests {
     use crate::verifier::{ValidationError, WITNESS_COMMITMENT_PREFIX};
 
     #[test]
-    fn correct() {
+    fn correct_bp() {
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
             to_light_client_prefix: vec![2, 2],
@@ -482,6 +486,71 @@ mod tests {
                 DaNamespace::ToBatchProver,
             )
             .is_ok());
+    }
+
+    #[test]
+    fn correct_lcp() {
+        let verifier = BitcoinVerifier::new(RollupParams {
+            to_batch_proof_prefix: vec![1, 1],
+            to_light_client_prefix: vec![2, 2],
+        });
+
+        let (block_header, inclusion_proof, completeness_proof, txs) =
+            get_mock_data(MockData::LightClientProof);
+
+        assert!(verifier
+            .verify_transactions(
+                &block_header,
+                txs.as_slice(),
+                inclusion_proof,
+                completeness_proof,
+                DaNamespace::ToLightClientProver,
+            )
+            .is_ok());
+    }
+
+    #[test]
+    fn batch_in_light_client_should_fail() {
+        let verifier = BitcoinVerifier::new(RollupParams {
+            to_batch_proof_prefix: vec![1, 1],
+            to_light_client_prefix: vec![2, 2],
+        });
+
+        let (block_header, inclusion_proof, completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
+
+        assert_eq!(
+            verifier.verify_transactions(
+                &block_header,
+                txs.as_slice(),
+                inclusion_proof,
+                completeness_proof,
+                DaNamespace::ToLightClientProver,
+            ),
+            Err(ValidationError::RelevantTxNotInProof),
+        );
+    }
+
+    #[test]
+    fn light_client_in_batch_should_fail() {
+        let verifier = BitcoinVerifier::new(RollupParams {
+            to_batch_proof_prefix: vec![1, 1],
+            to_light_client_prefix: vec![2, 2],
+        });
+
+        let (block_header, inclusion_proof, completeness_proof, txs) =
+            get_mock_data(MockData::LightClientProof);
+
+        assert_eq!(
+            verifier.verify_transactions(
+                &block_header,
+                txs.as_slice(),
+                inclusion_proof,
+                completeness_proof,
+                DaNamespace::ToBatchProver,
+            ),
+            Err(ValidationError::RelevantTxNotInProof),
+        );
     }
 
     #[test]
@@ -1119,7 +1188,7 @@ mod tests {
     }
 
     #[test]
-    fn tamper_rel_tx_content() {
+    fn tamper_rel_tx_content_bp() {
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
             to_light_client_prefix: vec![2, 2],
@@ -1144,7 +1213,32 @@ mod tests {
     }
 
     #[test]
-    fn tamper_senders() {
+    fn tamper_rel_tx_content_lcp() {
+        let verifier = BitcoinVerifier::new(RollupParams {
+            to_batch_proof_prefix: vec![1, 1],
+            to_light_client_prefix: vec![2, 2],
+        });
+
+        let (block_header, inclusion_proof, completeness_proof, mut txs) =
+            get_mock_data(MockData::LightClientProof);
+
+        let new_blob = vec![2; 152];
+
+        txs[1] = BlobWithSender::new(new_blob, txs[1].sender.0.clone(), txs[1].hash);
+        assert_eq!(
+            verifier.verify_transactions(
+                &block_header,
+                txs.as_slice(),
+                inclusion_proof,
+                completeness_proof,
+                DaNamespace::ToLightClientProver,
+            ),
+            Err(ValidationError::BlobContentWasModified)
+        );
+    }
+
+    #[test]
+    fn tamper_senders_bp() {
         let verifier = BitcoinVerifier::new(RollupParams {
             to_batch_proof_prefix: vec![1, 1],
             to_light_client_prefix: vec![2, 2],
@@ -1169,6 +1263,69 @@ mod tests {
                 DaNamespace::ToBatchProver,
             ),
             Err(ValidationError::IncorrectSenderInBlob)
+        );
+    }
+
+    #[test]
+    fn tamper_senders_lcp() {
+        let verifier = BitcoinVerifier::new(RollupParams {
+            to_batch_proof_prefix: vec![1, 1],
+            to_light_client_prefix: vec![2, 2],
+        });
+
+        let (block_header, inclusion_proof, completeness_proof, mut txs) =
+            get_mock_data(MockData::LightClientProof);
+        let tx1 = &completeness_proof[1];
+        let body = {
+            let parsed = parse_light_client_transaction(tx1).unwrap();
+            match parsed {
+                ParsedLightClientTransaction::Complete(complete) => decompress_blob(&complete.body),
+                ParsedLightClientTransaction::Aggregate(aggregate) => aggregate.body,
+                _ => unimplemented!(),
+            }
+        };
+        txs[1] = BlobWithSender::new(body, vec![2; 33], txs[1].hash);
+
+        assert_eq!(
+            verifier.verify_transactions(
+                &block_header,
+                txs.as_slice(),
+                inclusion_proof,
+                completeness_proof,
+                DaNamespace::ToLightClientProver,
+            ),
+            Err(ValidationError::IncorrectSenderInBlob)
+        );
+    }
+
+    #[test]
+    fn compressed_lcp_blob_tx_should_fail() {
+        let verifier = BitcoinVerifier::new(RollupParams {
+            to_batch_proof_prefix: vec![1, 1],
+            to_light_client_prefix: vec![2, 2],
+        });
+
+        let (block_header, inclusion_proof, completeness_proof, mut txs) =
+            get_mock_data(MockData::LightClientProof);
+        let tx0 = &completeness_proof[0];
+        let body = {
+            let parsed = parse_light_client_transaction(tx0).unwrap();
+            match parsed {
+                ParsedLightClientTransaction::Complete(complete) => complete.body, // normally we should decompress the tx body here
+                _ => panic!("Should not select zk proof tx other than complete"),
+            }
+        };
+        txs[1] = BlobWithSender::new(body, txs[1].sender.0.clone(), txs[1].hash);
+
+        assert_eq!(
+            verifier.verify_transactions(
+                &block_header,
+                txs.as_slice(),
+                inclusion_proof,
+                completeness_proof,
+                DaNamespace::ToLightClientProver,
+            ),
+            Err(ValidationError::BlobContentWasModified)
         );
     }
 

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -454,7 +454,7 @@ mod tests {
     use crate::helpers::merkle_tree::BitcoinMerkleTree;
     use crate::helpers::parsers::{parse_batch_proof_transaction, ParsedBatchProofTransaction};
     use crate::helpers::test_utils::{
-        get_blob_with_sender, get_mock_data, get_mock_txs, get_non_segwit_mock_txs,
+        get_blob_with_sender, get_mock_data, get_mock_txs, get_non_segwit_mock_txs, MockData,
     };
     use crate::spec::blob::BlobWithSender;
     use crate::spec::header::HeaderWrapper;
@@ -470,7 +470,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, completeness_proof, txs) = get_mock_data();
+        let (block_header, inclusion_proof, completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
 
         assert!(verifier
             .verify_transactions(
@@ -629,7 +630,7 @@ mod tests {
 
         let txs: Vec<BlobWithSender> = relevant_txs_indices
             .into_iter()
-            .filter_map(|i| get_blob_with_sender(&block_txs[i]).ok())
+            .filter_map(|i| get_blob_with_sender(&block_txs[i], MockData::BatchProof).ok())
             .collect();
 
         assert_eq!(
@@ -727,7 +728,7 @@ mod tests {
 
         let txs: Vec<BlobWithSender> = relevant_txs_indices
             .into_iter()
-            .filter_map(|i| get_blob_with_sender(&block_txs[i]).ok())
+            .filter_map(|i| get_blob_with_sender(&block_txs[i], MockData::BatchProof).ok())
             .collect();
 
         assert_eq!(
@@ -817,7 +818,7 @@ mod tests {
 
         let txs: Vec<BlobWithSender> = relevant_txs_indices
             .into_iter()
-            .filter_map(|i| get_blob_with_sender(&block_txs[i]).ok())
+            .filter_map(|i| get_blob_with_sender(&block_txs[i], MockData::BatchProof).ok())
             .collect();
 
         assert_eq!(
@@ -840,7 +841,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, mut inclusion_proof, completeness_proof, txs) = get_mock_data();
+        let (block_header, mut inclusion_proof, completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
 
         assert!(verifier
             .verify_transactions(
@@ -887,7 +889,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, mut inclusion_proof, completeness_proof, txs) = get_mock_data();
+        let (block_header, mut inclusion_proof, completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
 
         inclusion_proof.wtxids.push([5; 32]);
 
@@ -911,7 +914,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, mut inclusion_proof, completeness_proof, txs) = get_mock_data();
+        let (block_header, mut inclusion_proof, completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
 
         inclusion_proof.wtxids.pop();
 
@@ -933,7 +937,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, mut inclusion_proof, completeness_proof, txs) = get_mock_data();
+        let (block_header, mut inclusion_proof, completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
 
         inclusion_proof.wtxids.clear();
 
@@ -954,7 +959,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, mut inclusion_proof, completeness_proof, txs) = get_mock_data();
+        let (block_header, mut inclusion_proof, completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
 
         inclusion_proof.wtxids.swap(0, 1);
 
@@ -978,7 +984,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, mut completeness_proof, txs) = get_mock_data();
+        let (block_header, inclusion_proof, mut completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
 
         completeness_proof.pop();
 
@@ -1000,7 +1007,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, mut completeness_proof, txs) = get_mock_data();
+        let (block_header, inclusion_proof, mut completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
 
         completeness_proof.clear();
 
@@ -1022,7 +1030,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, mut completeness_proof, txs) = get_mock_data();
+        let (block_header, inclusion_proof, mut completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
 
         completeness_proof.push(get_mock_txs().get(1).unwrap().clone().into());
 
@@ -1043,7 +1052,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, mut completeness_proof, txs) = get_mock_data();
+        let (block_header, inclusion_proof, mut completeness_proof, txs) =
+            get_mock_data(MockData::BatchProof);
 
         completeness_proof.swap(2, 3);
 
@@ -1066,7 +1076,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, completeness_proof, mut txs) = get_mock_data();
+        let (block_header, inclusion_proof, completeness_proof, mut txs) =
+            get_mock_data(MockData::BatchProof);
 
         txs.swap(0, 1);
 
@@ -1089,7 +1100,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, mut completeness_proof, mut txs) = get_mock_data();
+        let (block_header, inclusion_proof, mut completeness_proof, mut txs) =
+            get_mock_data(MockData::BatchProof);
 
         txs.swap(0, 1);
         completeness_proof.swap(0, 1);
@@ -1113,7 +1125,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, completeness_proof, mut txs) = get_mock_data();
+        let (block_header, inclusion_proof, completeness_proof, mut txs) =
+            get_mock_data(MockData::BatchProof);
 
         let new_blob = vec![2; 152];
 
@@ -1137,7 +1150,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, completeness_proof, mut txs) = get_mock_data();
+        let (block_header, inclusion_proof, completeness_proof, mut txs) =
+            get_mock_data(MockData::BatchProof);
         let tx1 = &completeness_proof[1];
         let body = {
             let parsed = parse_batch_proof_transaction(tx1).unwrap();
@@ -1165,7 +1179,8 @@ mod tests {
             to_light_client_prefix: vec![2, 2],
         });
 
-        let (block_header, inclusion_proof, completeness_proof, mut txs) = get_mock_data();
+        let (block_header, inclusion_proof, completeness_proof, mut txs) =
+            get_mock_data(MockData::BatchProof);
 
         txs = vec![txs[0].clone(), txs[1].clone(), txs[2].clone()];
 


### PR DESCRIPTION
# Description

Added light client proof namespace tests to DAVerifier. I only added tests that are exclusive to light client proofs. For instance, I didn't add a new `missing_tx_in_completeness_proof_lcp` test, as the purpose of this test is ensure the inclusion and completeness proof txs match, irrelevant of their content.

## Linked Issues
- Fixes #1020 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
