### PR TITLE
[WIP] PoW stateful statediff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=4a65005#4a650050325a8c5d2b02fb5c1f6c3ec55e7fbe7d"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=5baaef3#5baaef32ac8d2c7032bca26cbb10d0f6060440dc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7542,6 +7542,7 @@ dependencies = [
 name = "sov-state"
 version = "0.5.0-rc.1"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "arbitrary",
  "bcs",

--- a/crates/sovereign-sdk/fuzz/Cargo.lock
+++ b/crates/sovereign-sdk/fuzz/Cargo.lock
@@ -39,6 +39,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-primitives"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "hex-literal",
+ "itoa",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +320,9 @@ name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2-sys"
@@ -421,6 +441,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487981fa1af147182687064d0a2c336586d337a606595ced9ffb0c685c250c73"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +495,12 @@ checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -812,6 +851,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "http"
@@ -1737,6 +1782,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "ruint"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+dependencies = [
+ "proptest",
+ "rand",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,6 +2327,7 @@ dependencies = [
 name = "sov-state"
 version = "0.5.0-rc.1"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "arbitrary",
  "bcs",
@@ -2384,6 +2450,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.75",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2605,6 +2680,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/crates/sovereign-sdk/module-system/sov-state/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-state/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 resolver = "2"
 
 [dependencies]
+alloy-primitives = { workspace = true, features = ["serde"] }
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
 borsh = { workspace = true, features = ["rc", "bytes"] }

--- a/crates/sovereign-sdk/module-system/sov-state/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/lib.rs
@@ -7,6 +7,8 @@ pub mod codec;
 #[cfg(feature = "native")]
 mod prover_storage;
 
+mod stateful_statediff;
+
 mod witness;
 mod zk_storage;
 

--- a/crates/sovereign-sdk/module-system/sov-state/src/stateful_statediff/compression.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/stateful_statediff/compression.rs
@@ -1,0 +1,239 @@
+// Originally written in 2019 by Matter Labs. Lisence: MIT/APACHE.
+
+use alloy_primitives::U256;
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Debug)]
+pub struct CompressionAdd {
+    pub diff: U256,
+    pub size: usize,
+}
+
+impl CompressionAdd {
+    fn new(prev_value: U256, new_value: U256) -> Option<Self> {
+        let (diff, _overflowed) = new_value.overflowing_sub(prev_value);
+        let size = diff.byte_len();
+
+        if size <= 30 {
+            Some(Self { diff, size })
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CompressionSub {
+    pub diff: U256,
+    pub size: usize,
+}
+
+impl CompressionSub {
+    fn new(prev_value: U256, new_value: U256) -> Option<Self> {
+        let (diff, _overflowed) = prev_value.overflowing_sub(new_value);
+        let size = diff.byte_len();
+
+        if size <= 30 {
+            Some(Self { diff, size })
+        } else {
+            None
+        }
+    }
+}
+
+/// Only try to remove leading zeroes.
+#[derive(Debug)]
+pub struct CompressionTransform {
+    pub diff: U256,
+    pub size: usize,
+}
+
+impl CompressionTransform {
+    fn new(new_value: U256) -> Option<Self> {
+        let diff = new_value;
+        let size = diff.byte_len();
+
+        if size <= 30 {
+            Some(Self { diff, size })
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CompressionAbsent {
+    pub diff: U256,
+    pub size: usize,
+}
+
+impl CompressionAbsent {
+    fn new(new_value: U256) -> Self {
+        let diff = new_value;
+        let size = 32;
+
+        Self { diff, size }
+    }
+}
+
+#[derive(Debug)]
+pub enum SlotChange {
+    Add(CompressionAdd),
+    Sub(CompressionSub),
+    Transform(CompressionTransform),
+    NoCompression(CompressionAbsent),
+}
+
+impl SlotChange {
+    fn output_size(&self) -> usize {
+        match self {
+            SlotChange::Add(add) => add.size,
+            SlotChange::Sub(sub) => sub.size,
+            SlotChange::Transform(transform) => transform.size,
+            SlotChange::NoCompression(no) => no.size,
+        }
+    }
+    fn compressed(&self) -> &[u8] {
+        let (bytes, size) = match self {
+            SlotChange::Add(add) => (add.diff.as_le_slice(), add.size),
+            SlotChange::Sub(sub) => (sub.diff.as_le_slice(), sub.size),
+            SlotChange::Transform(transform) => (transform.diff.as_le_slice(), transform.size),
+            SlotChange::NoCompression(no) => (no.diff.as_le_slice(), no.size),
+        };
+        &bytes[..size]
+    }
+}
+
+/// Generates the metadata byte for a given compression strategy.
+/// The metadata byte is structured as:
+/// First 5 bits: length of the compressed value
+/// Last 3 bits: operation id corresponding to the given compression used.
+fn metadata_byte(output_size: usize, operation_id: usize) -> u8 {
+    ((output_size << 3) | operation_id) as u8
+}
+
+impl BorshSerialize for SlotChange {
+    fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        let operation_id = match self {
+            SlotChange::Add(_) => 1,
+            SlotChange::Sub(_) => 2,
+            SlotChange::Transform(_) => 3,
+            SlotChange::NoCompression(_) => 0,
+        };
+        let metadata = metadata_byte(self.output_size(), operation_id);
+        writer.write_all(&[metadata])?;
+        writer.write_all(self.compressed())
+    }
+}
+
+impl BorshDeserialize for SlotChange {
+    fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+        let mut m_buf = [0u8];
+        reader.read_exact(&mut m_buf)?;
+        let metadata = m_buf[0];
+        let id = metadata & 7;
+        let size = (metadata >> 3) as usize;
+
+        if !(id == 0 || id == 1 || id == 2 || id == 3) {
+            return Err(borsh::io::Error::new(
+                borsh::io::ErrorKind::InvalidData,
+                "Unexpected type of operation",
+            ));
+        }
+
+        if size > 32 {
+            return Err(borsh::io::Error::new(
+                borsh::io::ErrorKind::InvalidData,
+                "Unexpected size of operation",
+            ));
+        }
+
+        let mut d_buff = [0u8; 32];
+        let bytes = &mut d_buff[..size];
+        reader.read_exact(bytes)?;
+
+        let diff = U256::from_le_slice(bytes);
+
+        let slot_change = match id {
+            0 => SlotChange::NoCompression(CompressionAbsent { diff, size }),
+            1 => SlotChange::Add(CompressionAdd { diff, size }),
+            2 => SlotChange::Sub(CompressionSub { diff, size }),
+            3 => SlotChange::Transform(CompressionTransform { diff, size }),
+            _ => {
+                unreachable!("Only Add,Sub,Transform,NoCompression");
+            }
+        };
+
+        Ok(slot_change)
+    }
+}
+
+// Find a strategy with the least bytes to write.
+fn select_best_strategy(
+    compressors: impl Iterator<Item = Option<SlotChange>>,
+    default: SlotChange,
+) -> SlotChange {
+    compressors
+        .into_iter()
+        .flatten()
+        .min_by_key(|comp| comp.output_size())
+        .unwrap_or(default)
+}
+
+/// For a given previous value and new value, try each compression strategy selecting the most
+/// efficient one.
+pub fn compress_two_best_strategy(prev_value: U256, new_value: U256) -> SlotChange {
+    let add = CompressionAdd::new(prev_value, new_value);
+    let sub = CompressionSub::new(prev_value, new_value);
+    let transform = CompressionTransform::new(new_value);
+    let no_compression = CompressionAbsent::new(new_value);
+
+    let compressors = [
+        add.map(SlotChange::Add),
+        sub.map(SlotChange::Sub),
+        transform.map(SlotChange::Transform),
+    ];
+
+    select_best_strategy(
+        compressors.into_iter(),
+        SlotChange::NoCompression(no_compression),
+    )
+}
+
+/// For a given one value, try each compression strategy selecting the most
+/// efficient one.
+pub fn compress_one_best_strategy(new_value: U256) -> SlotChange {
+    let transform = CompressionTransform::new(new_value);
+    let no_compression = CompressionAbsent::new(new_value);
+
+    let compressors = [transform.map(SlotChange::Transform)];
+
+    select_best_strategy(
+        compressors.into_iter(),
+        SlotChange::NoCompression(no_compression),
+    )
+}
+
+/*
+fn main() {
+    // let x = U256::MAX - U256::from(1);
+    // let y = U256::from(0);
+    // let y = U256::from_limbs([98989898989, 4594895849584, 34546456, 4556756756]);
+
+    let x = U256::from(0);
+    let y = U256::from(257);
+    let z = compress_two_best_strategy(x, y);
+    dbg!(x, y, &z);
+
+    let serialized = borsh::to_vec(&z).unwrap();
+    dbg!(&serialized, serialized.len());
+
+    let deserialized: SlotChange = borsh::from_slice(&serialized).unwrap();
+    dbg!(deserialized);
+
+    // let b = U256::from(1);
+
+    // dbg!(x - b);
+    // dbg!(U256::MAX);
+}
+*/

--- a/crates/sovereign-sdk/module-system/sov-state/src/stateful_statediff/mod.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/stateful_statediff/mod.rs
@@ -1,0 +1,285 @@
+pub mod compression;
+
+use std::collections::BTreeMap;
+use std::io::{Error, ErrorKind, Write};
+
+use alloy_primitives::{Address, B256, U256};
+// use alloy_primitives::{address, keccak256, Address, BlockNumber, Bloom, Bytes, B256, U256};
+// use borsh::io::{Error, Write};
+use borsh::BorshSerialize;
+use compression::SlotChange;
+use serde::{Deserialize, Serialize};
+use sov_modules_core::{CacheKey, CacheValue};
+
+pub(crate) struct PreState {
+    evm_accounts: BTreeMap<Address, Option<DbAccountInfo>>,
+    evm_storage: BTreeMap<Address, BTreeMap<U256, Option<U256>>>,
+}
+
+pub(crate) fn build_pre_state(ordered_reads: Vec<(CacheKey, Option<CacheValue>)>) -> PreState {
+    // We need the first values we read. So we traverse from the beginning.
+    // We are only interested in keys -> values only when we see them the first time.
+    // And we need only Evm accounts and storage, because that's the only
+    // thing we need to compress with zksync algorithms.
+    let mut evm_accounts: BTreeMap<Address, Option<DbAccountInfo>> = BTreeMap::new();
+    let mut evm_storage: BTreeMap<Address, _> = BTreeMap::new();
+
+    for (k, v) in ordered_reads {
+        let (key, value) = (k.key, v.map(|v| v.value));
+        match &key[..6] {
+            _account @ b"Evm/a/" => {
+                let address: Address = bcs::from_bytes(&key[6..]).unwrap();
+                evm_accounts.entry(address).or_insert_with(|| {
+                    let info: Option<DbAccountInfo> =
+                        value.as_ref().map(|v| bcs::from_bytes(v).unwrap());
+                    info
+                });
+            }
+            _storage @ b"Evm/s/" => {
+                let address = Address::from_slice(&key[6..(6 + 20)]);
+                let storage_key: U256 = bcs::from_bytes(&key[26..]).unwrap();
+
+                let account_storage: &mut BTreeMap<U256, Option<U256>> =
+                    evm_storage.entry(address).or_default();
+
+                account_storage.entry(storage_key).or_insert_with(|| {
+                    let storage_value: Option<U256> =
+                        value.as_ref().map(|v| bcs::from_bytes(v).unwrap());
+                    storage_value
+                });
+            }
+            _ => {}
+        }
+    }
+    PreState {
+        evm_accounts,
+        evm_storage,
+    }
+}
+
+pub(crate) struct PostState {
+    evm_accounts: BTreeMap<Address, Option<DbAccountInfo>>,
+    evm_storage: BTreeMap<Address, BTreeMap<U256, Option<U256>>>,
+    // TODO other typed key->values
+    untyped: Vec<(Vec<u8>, Option<Vec<u8>>)>,
+}
+
+pub(crate) fn build_post_state(ordered_writes: &[(CacheKey, Option<CacheValue>)]) -> PostState {
+    // We need the last values we write. So we traverse from the end.
+    let mut evm_accounts: BTreeMap<Address, Option<DbAccountInfo>> = BTreeMap::new();
+    let mut evm_storage: BTreeMap<Address, _> = BTreeMap::new();
+    let mut untyped = Vec::new();
+
+    for (k, v) in ordered_writes.iter().rev() {
+        let (key, value) = (k.key.clone(), v.clone().map(|v| v.value));
+        match &key[..6] {
+            _account @ b"Evm/a/" => {
+                // Only the first key -> value
+                let address: Address = bcs::from_bytes(&key[6..]).unwrap();
+                evm_accounts.entry(address).or_insert_with(|| {
+                    let info: Option<DbAccountInfo> =
+                        value.as_ref().map(|v| bcs::from_bytes(v).unwrap());
+                    info
+                });
+            }
+            _storage @ b"Evm/s/" => {
+                // Only the first key -> value
+                let address = Address::from_slice(&key[6..(6 + 20)]);
+                let storage_key: U256 = bcs::from_bytes(&key[26..]).unwrap();
+
+                let account_storage: &mut BTreeMap<U256, Option<U256>> =
+                    evm_storage.entry(address).or_default();
+
+                account_storage.entry(storage_key).or_insert_with(|| {
+                    let storage_value: Option<U256> =
+                        value.as_ref().map(|v| bcs::from_bytes(v).unwrap());
+                    storage_value
+                });
+            }
+            _ => {
+                let key_bytes = (*key).clone();
+                let value_bytes = value.map(|v| (*v).clone());
+
+                untyped.push((key_bytes, value_bytes));
+            }
+        }
+    }
+    PostState {
+        evm_accounts,
+        evm_storage,
+        untyped,
+    }
+}
+
+#[derive(BorshSerialize, Debug)]
+pub struct AccountChange {
+    pub balance: SlotChange,
+    pub nonce: SlotChange,
+    #[borsh(serialize_with = "borsh_ser_option_b256")]
+    pub code_hash: Option<B256>,
+}
+
+#[derive(BorshSerialize, Debug)]
+pub struct StorageChange {
+    #[borsh(serialize_with = "borsh_ser_btree_u256")]
+    pub storage: BTreeMap<U256, Option<SlotChange>>,
+}
+
+#[derive(BorshSerialize, Debug)]
+pub struct StatefulStateDiff {
+    #[borsh(serialize_with = "borsh_ser_btree_address")]
+    evm_accounts: BTreeMap<Address, AccountChange>,
+    #[borsh(serialize_with = "borsh_ser_btree_address")]
+    evm_storage: BTreeMap<Address, StorageChange>,
+    // TODO other typed key->values
+    untyped: Vec<(Vec<u8>, Option<Vec<u8>>)>,
+}
+
+pub(crate) fn compress_state(pre_state: PreState, post_state: PostState) -> StatefulStateDiff {
+    use compression::{compress_one_best_strategy, compress_two_best_strategy};
+
+    //  Compute diff for all evm::account(address): balance, nonce, code_hash
+    let mut changed_evm_accounts = BTreeMap::new();
+    for (address, new_info) in post_state.evm_accounts {
+        let Some(new_info) = new_info else {
+            // TODO if acc info was deleted
+            continue;
+        };
+
+        let prev_info = pre_state.evm_accounts.get(&address);
+        let acc_change = if let Some(Some(prev_info)) = prev_info {
+            AccountChange {
+                balance: compress_two_best_strategy(prev_info.balance, new_info.balance),
+                nonce: compress_two_best_strategy(prev_info.balance, U256::from(new_info.nonce)),
+                code_hash: new_info.code_hash,
+            }
+        } else {
+            AccountChange {
+                balance: compress_one_best_strategy(new_info.balance),
+                nonce: compress_one_best_strategy(U256::from(new_info.nonce)),
+                code_hash: new_info.code_hash,
+            }
+        };
+        changed_evm_accounts.insert(address, acc_change);
+    }
+
+    // Compute diff for all evm::storage(address, key, value)
+    let mut changed_evm_storage = BTreeMap::new();
+    for (address, new_storage) in post_state.evm_storage {
+        let old_storage = pre_state.evm_storage.get(&address);
+        let mut storage_change = StorageChange {
+            storage: Default::default(),
+        };
+        if let Some(old_storage) = old_storage {
+            for (key, new_value) in new_storage {
+                let Some(new_value) = new_value else {
+                    // if storage(address, key, value) was deleted
+                    storage_change.storage.insert(key, None);
+                    continue;
+                };
+                let prev_value = old_storage.get(&key);
+                let slot_change = if let Some(&Some(prev_value)) = prev_value {
+                    compress_two_best_strategy(prev_value, new_value)
+                } else {
+                    compress_one_best_strategy(new_value)
+                };
+                storage_change.storage.insert(key, Some(slot_change));
+            }
+        } else {
+            for (key, new_value) in new_storage {
+                let Some(new_value) = new_value else {
+                    // if storage(address, key, value) was deleted
+                    storage_change.storage.insert(key, None);
+                    continue;
+                };
+                let slot_change = compress_one_best_strategy(new_value);
+                storage_change.storage.insert(key, Some(slot_change));
+            }
+        }
+
+        changed_evm_storage.insert(address, storage_change);
+    }
+
+    StatefulStateDiff {
+        evm_accounts: changed_evm_accounts,
+        evm_storage: changed_evm_storage,
+        untyped: post_state.untyped,
+    }
+}
+
+#[derive(Default, BorshSerialize, Deserialize, Serialize, Debug, Clone)]
+struct DbAccountInfo {
+    #[borsh(serialize_with = "borsh_ser_u256")]
+    balance: U256,
+    nonce: u64,
+    #[borsh(serialize_with = "borsh_ser_option_b256")]
+    code_hash: Option<B256>,
+}
+
+// borsh serializers:
+
+// fn borsh_ser_address<W: Write>(x: &Address, writer: &mut W) -> Result<(), Error> {
+//     let t = x.0 .0;
+//     BorshSerialize::serialize(&t, writer)
+// }
+
+fn borsh_ser_u256<W: Write>(x: &U256, writer: &mut W) -> Result<(), Error> {
+    let t = x.to_be_bytes::<32>();
+    BorshSerialize::serialize(&t, writer)
+}
+
+// fn borsh_ser_option_u256<W: Write>(x: &Option<U256>, writer: &mut W) -> Result<(), Error> {
+//     let t = x.map(|x| x.to_be_bytes::<32>());
+//     BorshSerialize::serialize(&t, writer)
+// }
+
+// fn borsh_ser_b256<W: Write>(x: &B256, writer: &mut W) -> Result<(), Error> {
+//     let t = x.0;
+//     BorshSerialize::serialize(&t, writer)
+// }
+
+// fn borsh_ser_vec_b256<W: Write>(x: &Vec<B256>, writer: &mut W) -> Result<(), Error> {
+//     let t: Vec<_> = x.into_iter().map(|x| x.0).collect();
+//     BorshSerialize::serialize(&t, writer)
+// }
+
+fn borsh_ser_option_b256<W: Write>(x: &Option<B256>, writer: &mut W) -> Result<(), Error> {
+    let t = x.map(|x| x.0);
+    BorshSerialize::serialize(&t, writer)
+}
+
+// fn borsh_ser_bytes<W: Write>(x: &Bytes, writer: &mut W) -> Result<(), Error> {
+//     let t = &x.0;
+//     BorshSerialize::serialize(&t, writer)
+// }
+
+// fn borsh_ser_bloom<W: Write>(x: &Bloom, writer: &mut W) -> Result<(), Error> {
+//     let t = x.0 .0;
+//     BorshSerialize::serialize(&t, writer)
+// }
+
+fn borsh_ser_btree_address<V: BorshSerialize, W: Write>(
+    x: &BTreeMap<Address, V>,
+    writer: &mut W,
+) -> Result<(), Error> {
+    let len = u32::try_from(x.len()).map_err(|_| ErrorKind::InvalidData)?;
+    BorshSerialize::serialize(&len, writer)?;
+    for (key, value) in x {
+        BorshSerialize::serialize(&(key.0 .0), writer)?;
+        BorshSerialize::serialize(value, writer)?;
+    }
+    Ok(())
+}
+
+fn borsh_ser_btree_u256<V: BorshSerialize, W: Write>(
+    x: &BTreeMap<U256, V>,
+    writer: &mut W,
+) -> Result<(), Error> {
+    let len = u32::try_from(x.len()).map_err(|_| ErrorKind::InvalidData)?;
+    BorshSerialize::serialize(&len, writer)?;
+    for (key, value) in x {
+        BorshSerialize::serialize(key.as_le_slice(), writer)?;
+        BorshSerialize::serialize(value, writer)?;
+    }
+    Ok(())
+}

--- a/crates/sovereign-sdk/module-system/sov-state/src/zk_storage.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/zk_storage.rs
@@ -87,7 +87,7 @@ where
         let prev_state_root = witness.get_hint();
 
         // For each value that's been read from the tree, verify the provided smt proof
-        for (key, read_value) in state_accesses.ordered_reads {
+        for (key, read_value) in &state_accesses.ordered_reads {
             let key_hash = KeyHash::with::<H>(key.key.as_ref());
             // TODO: Switch to the batch read API once it becomes available
             let proof: jmt::proof::SparseMerkleProof<H> = witness.get_hint();
@@ -100,6 +100,12 @@ where
                 None => proof.verify_nonexistence(jmt::RootHash(prev_state_root), key_hash)?,
             }
         }
+
+        let pre_state = crate::stateful_statediff::build_pre_state(state_accesses.ordered_reads);
+        let post_state =
+            crate::stateful_statediff::build_post_state(&state_accesses.ordered_writes);
+
+        let _st_statediff = crate::stateful_statediff::compress_state(pre_state, post_state);
 
         let mut diff = vec![];
 

--- a/guests/risc0/batch-proof-bitcoin/Cargo.lock
+++ b/guests/risc0/batch-proof-bitcoin/Cargo.lock
@@ -3031,6 +3031,7 @@ dependencies = [
 name = "sov-state"
 version = "0.5.0-rc.1"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "bcs",
  "borsh",

--- a/guests/risc0/batch-proof-mock/Cargo.lock
+++ b/guests/risc0/batch-proof-mock/Cargo.lock
@@ -2832,6 +2832,7 @@ dependencies = [
 name = "sov-state"
 version = "0.5.0-rc.1"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "bcs",
  "borsh",

--- a/guests/risc0/light-client-proof-bitcoin/Cargo.lock
+++ b/guests/risc0/light-client-proof-bitcoin/Cargo.lock
@@ -2796,6 +2796,7 @@ dependencies = [
 name = "sov-state"
 version = "0.5.0-rc.1"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "bcs",
  "borsh",

--- a/guests/risc0/light-client-proof-mock/Cargo.lock
+++ b/guests/risc0/light-client-proof-mock/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
 name = "sov-state"
 version = "0.5.0-rc.1"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "bcs",
  "borsh",


### PR DESCRIPTION
# Description

Now instead of storing [address balance nonce code_hash] we store [address diff(balance) diff(nonce) diff(code_hash)]. When nonce/code_hash are not changed, they take 1 byte. And some heuristics to find a diff are implemented.So for a transfer tx we went from [20 + 32 + 8 + 33] + [20 + 32 + 8 + 33] bytes to [20 diff 2 1] + [20 diff 1 1], where diff for balance e.g. (before 4283200000, after 1232308282) is packed into 5 bytes. So 93+93 bytes went to 28+27.

- [x] Compress evm::Account { balance, nonce }
- [ ] Compress evm::Account { code_hash }
- [x] Compress evm::Account::storage { value } 
- [ ] Implement InitialWrite / RepeatedWrite (hard)

Easy to implement (see https://github.com/chainwayxyz/citrea/issues/1132):
- [ ] parse into typed: SetL1Hash
- [ ] parse into typed: SetLatestBlockHash
- [ ] parse into typed: RemoveLatestBlockHashRange
- [ ] parse into typed: SetHead(Block)
- [ ] parse into typed: SetScreData(RuleEnforcerData)
- [ ] parse into typed: SetSovAccountPublicKey([u8; 32], [u8; 32])
- [ ] parse into typed: RemoveSovAccountPublicKey([u8; 32])
- [ ] parse into typed: SetSovAccount([u8; 32], SovAcc)
- [ ] parse into typed: RemoveSovAccount([u8; 32])

To implement RepeatedWrites we need to scan writes, if:
- there is no write in Db -> assign unique u32 id and store it in db
- there was a write and it has a u32 id -> provide that id into compute_state_update

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/1499 https://github.com/chainwayxyz/citrea/issues/1132
- Related to https://github.com/chainwayxyz/citrea/issues/1237
