### PR TITLE
Remove CI_TEST_MODE 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -223,7 +223,6 @@ jobs:
         env:
           RUST_BACKTRACE: 1
           TEST_BITCOIN_DOCKER: 1
-          CI_TEST_MODE: 1
           RISC0_DEV_MODE: 1 # This is needed to generate mock proofs and verify them
           CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
           PARALLEL_PROOF_LIMIT: 1
@@ -408,7 +407,6 @@ jobs:
           RUST_BACKTRACE: 1
           RISC0_DEV_MODE: 1 # This is needed to generate mock proofs and verify them
           TEST_BITCOIN_DOCKER: 1
-          CI_TEST_MODE: 1
           CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
           PARALLEL_PROOF_LIMIT: 1
 

--- a/.github/workflows/nightly_build_push.yml
+++ b/.github/workflows/nightly_build_push.yml
@@ -13,13 +13,6 @@ env:
 jobs:
   linux_amd64_binary_extraction:
     runs-on: ubicloud-standard-30
-    strategy:
-      matrix:
-        include:
-          - ci_test_mode: 1
-            ci_test_mode_value: "-ci"
-          - ci_test_mode: 0
-            ci_test_mode_value: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,8 +34,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Project
-        env:
-          CI_TEST_MODE: ${{ matrix.ci_test_mode }}
         run: |
           cargo build --release
 
@@ -68,7 +59,7 @@ jobs:
         with:
           file: ./docker/build-push/nightly/Dockerfile
           context: ./docker/build-push/nightly
-          tags: ${{ vars.DOCKERHUB_USERNAME }}/citrea-test:${{ env.IMAGE_TAG }}${{ matrix.ci_test_mode_value }}
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/citrea-test:${{ env.IMAGE_TAG }}
           platforms: linux/amd64
           push: true
           load: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=83ea4c3#83ea4c3617fdbf23c3a4dfaec941f546e3e1ddc3"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=c3f27fc#c3f27fcc1e3cf828f151a9d564f9b667d4b1fe18"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=5baaef3#5baaef32ac8d2c7032bca26cbb10d0f6060440dc"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=83ea4c3#83ea4c3617fdbf23c3a4dfaec941f546e3e1ddc3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ tower-http = { version = "0.5.0", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }
 hyper = { version = "1.4.0" }
 
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "5baaef3" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "83ea4c3" }
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "ca3cfa2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ tower-http = { version = "0.5.0", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }
 hyper = { version = "1.4.0" }
 
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "83ea4c3" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "79da4c4" }
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "ca3cfa2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ tower-http = { version = "0.5.0", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }
 hyper = { version = "1.4.0" }
 
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "79da4c4" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "c3f27fc" }
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "ca3cfa2" }

--- a/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
@@ -367,11 +367,7 @@ impl TestCase for LocalProvingTest {
 
     fn test_env() -> TestCaseEnv {
         TestCaseEnv {
-            test: vec![
-                ("CI_TEST_MODE", "1"),
-                ("BONSAI_API_URL", ""),
-                ("BONSAI_API_KEY", ""),
-            ],
+            test: vec![("BONSAI_API_URL", ""), ("BONSAI_API_KEY", "")],
             ..Default::default()
         }
     }

--- a/bin/citrea/tests/bitcoin_e2e/bitcoin_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/bitcoin_test.rs
@@ -69,6 +69,9 @@ impl TestCase for BitcoinReorgTest {
         let block = da0.get_block(&original_chain_hash).await?;
         assert_eq!(block.txdata.len(), 3); // Coinbase + seq commit/reveal txs
 
+        // Buffer to wait for monitoring to update status to confirmed
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
         let da1_generated_blocks = 2;
         da1.generate(da1_generated_blocks).await?;
 

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -1,36 +1,20 @@
-// Generates a prefix for REVEAL_BATCH_PROOF_PREFIX and REVEAL_LIGHT_CLIENT_PREFIX constants based on compile-time environment.
-// Returns a single-byte prefix [1] if CI_TEST_MODE env var is set, otherwise defaults to [1, 1].
-// This greatly reduces the time required to find a nonce when generating batch proving txs and LightClientTxs
-// We have to make these prefixes constants due to zk proving.
-// But two bytes takes too long to generate nonce, making tests very flaky and slow.
-// So in CI we define an env var CI_TEST_MODE to use less bytes.
-// This doesn't change any method ids, just the prefixes.
-const fn get_reveal_batch_proof_prefix() -> &'static [u8] {
-    match option_env!("CI_TEST_MODE") {
-        Some(v) if matches!(v.as_bytes(), b"1" | b"true") => &[1],
-        _ => &[1, 1],
-    }
-}
-
-const fn get_reveal_light_client_prefix() -> &'static [u8] {
-    match option_env!("CI_TEST_MODE") {
-        Some(v) if matches!(v.as_bytes(), b"1" | b"true") => &[2],
-        _ => &[2, 2],
-    }
-}
-
+#[cfg_attr(feature = "testing", allow(dead_code))]
 const fn get_max_txbody_size() -> usize {
-    match option_env!("CI_TEST_MODE") {
-        Some(v) if matches!(v.as_bytes(), b"1" | b"true") => 39700,
-        _ => 397000,
+    #[cfg(feature = "testing")]
+    {
+        39700
+    }
+    #[cfg(not(feature = "testing"))]
+    {
+        397000
     }
 }
 
 /// Prefix for the reveal transaction ids - batch proof namespace.
-pub const TO_BATCH_PROOF_PREFIX: &[u8] = get_reveal_batch_proof_prefix();
+pub const TO_BATCH_PROOF_PREFIX: &[u8] = &[1, 1];
 
 /// Prefix for the reveal transaction ids - light client namespace.
-pub const TO_LIGHT_CLIENT_PREFIX: &[u8] = get_reveal_light_client_prefix();
+pub const TO_LIGHT_CLIENT_PREFIX: &[u8] = &[2, 2];
 
 pub const TEST_PRIVATE_KEY: &str =
     "1212121212121212121212121212121212121212121212121212121212121212";


### PR DESCRIPTION
# Description

- Remove `CI_TEST_MODE`  and replace with recently introduced testing flag
- Remove prefix length reduction in test.
- The initial rationale was a single `SHORT_PREFIX` env which isn't relevant since https://github.com/chainwayxyz/citrea/pull/1329 (negligeable time reduction in test).
- Keeps `get_max_txbody_size` behind `testing` flag
- Remove the need for `CI_TEST_MODE` matrix in CI
