### PR TITLE
Gas price oracle improvement

### DIFF
--- a/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
+++ b/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
@@ -269,7 +269,14 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
         // we only check a maximum of 2 * max_block_history, or the number of blocks in the chain
         let max_blocks = cmp::min(self.oracle_config.max_block_history * 2, header_number);
 
-        // use decayed cached value as a placeholder value for empty blocks
+        // Use decayed cache price as a placeholder value for empty blocks, farther the block
+        // of cached price, less effect it is going to have.
+        // This is useful especially for cases of consecutive empty blocks, which could result in
+        // high estimates. Imagine a scenario where at 100th block there is a tx with a high tip.
+        // But then there are 900 empty blocks. If we use the same estimate we had for 100th block,
+        // this would cause the estimate to be really high since all 900 blocks will be filled with
+        // this last cached value. And it would also reinforce the future estimates to return high
+        // estimates as well.
         let filler_price = if last_price.block_number == 0 {
             // if this is the first call to suggest_tip_cap, use default 0 price
             last_price.price

--- a/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
+++ b/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
@@ -304,6 +304,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
         }
 
         *last_price = GasPriceOracleResult {
+            block_number: header_number,
             block_hash: header.hash.unwrap(),
             price,
         };
@@ -399,6 +400,8 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
 /// Stores the last result that the oracle returned
 #[derive(Debug, Clone)]
 pub struct GasPriceOracleResult {
+    /// The block number that the oracle used to calculate the price
+    pub block_number: u64,
     /// The block hash that the oracle used to calculate the price
     pub block_hash: B256,
     /// The price that the oracle calculated
@@ -408,6 +411,7 @@ pub struct GasPriceOracleResult {
 impl Default for GasPriceOracleResult {
     fn default() -> Self {
         Self {
+            block_number: 0,
             block_hash: B256::ZERO,
             // Defaults to 0 so that priority fee is low when there are no txs to calculate a median tip
             price: 0_u128,

--- a/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
+++ b/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
@@ -269,13 +269,21 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
         // we only check a maximum of 2 * max_block_history, or the number of blocks in the chain
         let max_blocks = cmp::min(self.oracle_config.max_block_history * 2, header_number);
 
+        // use decayed cached value as a placeholder value for empty blocks
+        let filler_price = if last_price.block_number == 0 {
+            // if this is the first call to suggest_tip_cap, use default 0 price
+            last_price.price
+        } else {
+            let block_distance = header_number - last_price.block_number;
+            last_price.price / block_distance as u128
+        };
         for _ in 0..max_blocks {
             let (parent_hash, block_values) = self
                 .get_block_values(current_hash, SAMPLE_NUMBER as usize, working_set)?
                 .ok_or(EthApiError::UnknownBlockNumber)?;
 
             if block_values.is_empty() {
-                results.push(last_price.price);
+                results.push(filler_price);
             } else {
                 results.extend(block_values);
                 populated_blocks += 1;

--- a/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
+++ b/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
@@ -3,6 +3,8 @@
 
 // Adopted from: https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/gas_oracle.rs
 
+use std::cmp;
+
 use citrea_evm::{Evm, SYSTEM_SIGNER};
 use citrea_primitives::basefee::calculate_next_block_base_fee;
 use parking_lot::Mutex;
@@ -265,11 +267,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
         let header_number = header.number.unwrap();
 
         // we only check a maximum of 2 * max_block_history, or the number of blocks in the chain
-        let max_blocks = if self.oracle_config.max_block_history * 2 > header_number {
-            header_number
-        } else {
-            self.oracle_config.max_block_history * 2
-        };
+        let max_blocks = cmp::min(self.oracle_config.max_block_history * 2, header_number);
 
         for _ in 0..max_blocks {
             let (parent_hash, block_values) = self
@@ -302,9 +300,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
 
         // constrain to the max price
         if let Some(max_price) = self.oracle_config.max_price {
-            if price > max_price {
-                price = max_price;
-            }
+            price = cmp::min(price, max_price);
         }
 
         *last_price = GasPriceOracleResult {


### PR DESCRIPTION
# Description

It seems that the tips suggested for transactions are unnecessarily high. They can even be set to 0 with the current network conditions since no block is full, but using that is not a viable algorithm as tip is meant to be what user's are willing to pay and which of these made it into the block.

Ethereum's algorithm is simply taking the 3 lowest tip transactions from the last 20 blocks, and returning the tip at 60th percentile, which makes sense as Ethereum's blocks always has some transactions. They handle empty blocks by putting the last cached tip as placeholder into the collected tip list. It is pretty obvious that they almost never have to go into this part of their algorithm.

We also copied the same algorithm, but unlike Ethereum we do a lot of adding placeholder for empty blocks.

It seems that the tips we suggest are unnecessarily high even though almost all blocks are near empty, and this is an attempt to lower the tip estimations.

Using the exact same algorithm as Ethereum might actually cause some problems in our estimations. Imagine the scenario:
1. 100th block has a single tx with a high tip.
2. we generate 900 empty blocks.
3. even though the last 900 blocks were empty, we use the same fee as 100th block as placeholder for that 900 empty blocks, and highly likely gonna return that value as tip estimation, which doesn't make sense at all

This example is obviously exaggerated, but it is by no means impossible have this problem in smaller scale and with smaller number of blocks, but the problem aggregates over time.

This PR attempts to solve this problem by decaying the effect of last cached tip by the distance of the cached block number. So, the farther the cache tip is estimated, the smaller placeholder for empty blocks is going to be used.

Considering `block_distance = current_block_number - last_cached_block_number`, exact algorithm is:

```last_cached_price / block_distance```

I choose division because it made more sense.

If we were to use exponential algo smh like:

```last_cached_price / (2 ^ (block_distance))```

it would be decaying way too fast.

If we were to use a quadratic algorithm:

```last_cached_price * (1 - (block_distance ^ 2) / 10 ^ 2)```

This would go down to 0 at exactly 10 (which could be ok), but the main problem is that initial decay would be super slow. In contrast we want initial decay to be faster than later because if there is even 1 empty block that is a strong indication that tip could be much lower.

**TODO**
I will try to test this by running a testnet node by cherry-picking commits on top of v0.5.4, and for 1 day, I will send eth_maxPriorityFeePerGas requests to both actual testnet node, and my node with certain interval, and record the responses to see if it actually had any difference.

**IMPORTANT**
Do not merge this into nightly. Opened this PR to nightly just to see the difference. Will later open this PR into the release branch.

## Linked Issues
- Fixes #1486 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
