### PR TITLE
Restore short-prefix behind cargo flag

### DIFF
--- a/.github/workflows/nightly_build_push.yml
+++ b/.github/workflows/nightly_build_push.yml
@@ -35,11 +35,11 @@ jobs:
 
       - name: Build Project
         run: |
-          cargo build --release
+          cargo build --features short-prefix
 
       - name: Copy binary to build-push/nightly
         run: |
-          cp target/release/citrea docker/build-push/nightly/citrea
+          cp target/debug/citrea docker/build-push/nightly/citrea
           chmod +x docker/build-push/nightly/citrea
 
       - name: Set up Docker Buildx

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ EF_TESTS_URL := https://github.com/chainwayxyz/ef-tests/archive/develop.tar.gz
 EF_TESTS_DIR := crates/evm/ethereum-tests
 CITREA_E2E_TEST_BINARY := $(CURDIR)/target/debug/citrea
 PARALLEL_PROOF_LIMIT := 1
+TEST_FEATURES := --features short-prefix
 
 .PHONY: help
 
@@ -13,6 +14,10 @@ help: ## Display this help message
 build-risc0:
 	$(MAKE) -j 2 -C guests/risc0 all
 
+.PHONY: build-risc0-test
+build-risc0-test:
+	$(MAKE) -j 2 -C guests/risc0 test
+
 .PHONY: build-sp1
 build-sp1:
 	$(MAKE) -C guests/sp1 all
@@ -20,6 +25,10 @@ build-sp1:
 .PHONY: build
 build: ## Build the project
 	@cargo build
+
+.PHONY: build-test
+build-test: ## Build the project
+	@cargo build $(TEST_FEATURES)
 
 build-release: build-risc0 build-sp1 ## Build the project in release mode
 	@cargo build --release
@@ -44,7 +53,7 @@ clean-all: clean clean-node clean-txs
 test-legacy: ## Runs test suite with output from tests printed
 	@cargo test -- --nocapture -Zunstable-options --report-time
 
-test: build-risc0 build-sp1 build $(EF_TESTS_DIR) ## Runs test suite using next test
+test: build-risc0-test build-sp1-test build-test $(EF_TESTS_DIR) ## Runs test suite using next test
 	RISC0_DEV_MODE=1 cargo nextest run --workspace --all-features --no-fail-fast $(filter-out $@,$(MAKECMDGOALS))
 
 install-dev-tools:  ## Installs all necessary cargo helpers
@@ -98,7 +107,7 @@ find-unused-deps: ## Prints unused dependencies for project. Note: requires nigh
 find-flaky-tests:  ## Runs tests over and over to find if there's flaky tests
 	flaky-finder -j16 -r320 --continue "cargo test -- --nocapture"
 
-coverage: build $(EF_TESTS_DIR) ## Coverage in lcov format
+coverage: build-test $(EF_TESTS_DIR) ## Coverage in lcov format
 	cargo llvm-cov --locked --lcov --output-path lcov.info nextest --workspace --all-features
 
 coverage-html: ## Coverage in HTML format

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -32,4 +32,6 @@ native = [
 ]
 testing = [
   "native",
+  "short-prefix",
 ]
+short-prefix = []

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -1,19 +1,13 @@
-#[cfg_attr(feature = "testing", allow(dead_code))]
-const fn get_max_txbody_size() -> usize {
-    #[cfg(feature = "testing")]
-    {
-        39700
-    }
-    #[cfg(not(feature = "testing"))]
-    {
-        397000
-    }
-}
-
 /// Prefix for the reveal transaction ids - batch proof namespace.
+#[cfg(feature = "short-prefix")]
+pub const TO_BATCH_PROOF_PREFIX: &[u8] = &[1];
+#[cfg(not(feature = "short-prefix"))]
 pub const TO_BATCH_PROOF_PREFIX: &[u8] = &[1, 1];
 
 /// Prefix for the reveal transaction ids - light client namespace.
+#[cfg(feature = "short-prefix")]
+pub const TO_LIGHT_CLIENT_PREFIX: &[u8] = &[2];
+#[cfg(not(feature = "short-prefix"))]
 pub const TO_LIGHT_CLIENT_PREFIX: &[u8] = &[2, 2];
 
 pub const TEST_PRIVATE_KEY: &str =
@@ -22,4 +16,7 @@ pub const TEST_PRIVATE_KEY: &str =
 pub const MIN_BASE_FEE_PER_GAS: u128 = 10_000_000; // 0.01 gwei
 
 /// Maximum size of a bitcoin transaction body in bytes
-pub const MAX_TXBODY_SIZE: usize = get_max_txbody_size();
+#[cfg(feature = "testing")]
+pub const MAX_TXBODY_SIZE: usize = 39700;
+#[cfg(not(feature = "testing"))]
+pub const MAX_TXBODY_SIZE: usize = 397000;

--- a/guests/risc0/Cargo.toml
+++ b/guests/risc0/Cargo.toml
@@ -19,3 +19,4 @@ methods = [
 
 [features]
 bench = []
+short-prefix = []

--- a/guests/risc0/Makefile
+++ b/guests/risc0/Makefile
@@ -1,5 +1,10 @@
+TEST_FEATURES := --features short-prefix
+
 .PHONY: all
 all: batch-proof-bitcoin light-client-bitcoin
+
+.PHONY: test
+test: batch-proof-bitcoin-test light-client-bitcoin-test
 
 .PHONY: batch-proof-bitcoin
 batch-proof-bitcoin:
@@ -10,3 +15,13 @@ batch-proof-bitcoin:
 light-client-bitcoin:
 	cd ../../ && \
 	cargo risczero build --manifest-path guests/risc0/light-client-proof-bitcoin/Cargo.toml
+
+.PHONY: batch-proof-bitcoin
+batch-proof-bitcoin-test:
+	cd ../../ && \
+	cargo risczero build $(TEST_FEATURES) --manifest-path guests/risc0/batch-proof-bitcoin/Cargo.toml
+
+.PHONY: light-client-bitcoin
+light-client-bitcoin-test:
+	cd ../../ && \
+	cargo risczero build $(TEST_FEATURES) --manifest-path guests/risc0/light-client-proof-bitcoin/Cargo.toml

--- a/guests/risc0/batch-proof-bitcoin/Cargo.toml
+++ b/guests/risc0/batch-proof-bitcoin/Cargo.toml
@@ -20,6 +20,9 @@ sov-modules-stf-blueprint = { path = "../../../crates/sovereign-sdk/module-syste
 sov-rollup-interface = { path = "../../../crates/sovereign-sdk/rollup-interface" }
 sov-state = { path = "../../../crates/sovereign-sdk/module-system/sov-state" }
 
+[features]
+short-prefix = ["citrea-primitives/short-prefix"]
+
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }

--- a/guests/risc0/batch-proof-mock/Cargo.lock
+++ b/guests/risc0/batch-proof-mock/Cargo.lock
@@ -554,6 +554,7 @@ name = "batch-proof-mock"
 version = "0.5.0-rc.1"
 dependencies = [
  "anyhow",
+ "citrea-primitives",
  "citrea-risc0-adapter",
  "citrea-stf",
  "risc0-zkvm",

--- a/guests/risc0/batch-proof-mock/Cargo.toml
+++ b/guests/risc0/batch-proof-mock/Cargo.toml
@@ -11,12 +11,16 @@ risc0-zkvm = { version = "1.1.3", default-features = false }
 risc0-zkvm-platform = { version = "1.1.3" }
 
 anyhow = "1.0"
+citrea-primitives = { path = "../../../crates/primitives" }
 citrea-risc0-adapter = { path = "../../../crates/risc0" }
 citrea-stf = { path = "../../../crates/citrea-stf" }
 sov-mock-da = { path = "../../../crates/sovereign-sdk/adapters/mock-da", default-features = false }
 sov-modules-api = { path = "../../../crates/sovereign-sdk/module-system/sov-modules-api", default-features = false }
 sov-modules-stf-blueprint = { path = "../../../crates/sovereign-sdk/module-system/sov-modules-stf-blueprint" }
 sov-state = { path = "../../../crates/sovereign-sdk/module-system/sov-state" }
+
+[features]
+short-prefix = ["citrea-primitives/short-prefix"]
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }

--- a/guests/risc0/build.rs
+++ b/guests/risc0/build.rs
@@ -48,7 +48,12 @@ fn main() {
 
 fn get_guest_options() -> HashMap<&'static str, risc0_build::GuestOptions> {
     let mut guest_pkg_to_options = HashMap::new();
-    let features = vec![];
+
+    let mut features = Vec::new();
+
+    if std::env::var("CARGO_FEATURE_SHORT_PREFIX").is_ok() {
+        features.push("short-prefix".to_string());
+    }
 
     let use_docker = if std::env::var("REPR_GUEST_BUILD").is_ok() {
         let this_package_dir = std::env!("CARGO_MANIFEST_DIR");

--- a/guests/risc0/light-client-proof-bitcoin/Cargo.toml
+++ b/guests/risc0/light-client-proof-bitcoin/Cargo.toml
@@ -20,6 +20,9 @@ sov-modules-stf-blueprint = { path = "../../../crates/sovereign-sdk/module-syste
 sov-rollup-interface = { path = "../../../crates/sovereign-sdk/rollup-interface" }
 sov-state = { path = "../../../crates/sovereign-sdk/module-system/sov-state" }
 
+[features]
+short-prefix = ["citrea-primitives/short-prefix"]
+
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }

--- a/guests/risc0/light-client-proof-mock/Cargo.toml
+++ b/guests/risc0/light-client-proof-mock/Cargo.toml
@@ -21,6 +21,9 @@ sov-modules-stf-blueprint = { path = "../../../crates/sovereign-sdk/module-syste
 sov-rollup-interface = { path = "../../../crates/sovereign-sdk/rollup-interface" }
 sov-state = { path = "../../../crates/sovereign-sdk/module-system/sov-state" }
 
+[features]
+short-prefix = ["citrea-primitives/short-prefix"]
+
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }


### PR DESCRIPTION
# Description

- Restore short-prefix behind cargo `short-prefix` flag

Main rationale for the removal in https://github.com/chainwayxyz/citrea/pull/1537 was that compile time env was not properly propagated to risczero docker build. This restores it by propagating via cargo `short-prefix` flag, albeit in a convoluted way.

- Automatically derive it when in running `make test` and `make coverage`
- Remove the need to keep `CI_TEST_MODE` in line between build and test profiles.

Note that if for whatever reason, one is running via `cargo test` (not advised, `make test` is the recommended way) directly, additional `--features short-prefix` is needed in order not to have a mismatch in prefix length