### PR TITLE
Suggest 100 wei constant as tip in transactions

### DIFF
--- a/crates/ethereum-rpc/src/ethereum.rs
+++ b/crates/ethereum-rpc/src/ethereum.rs
@@ -87,8 +87,6 @@ impl<C: sov_modules_api::Context, Da: DaService> Ethereum<C, Da> {
 
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn max_fee_per_gas(&self, working_set: &mut WorkingSet<C>) -> (U256, U256) {
-        // let suggested_tip = self.gas_price_oracle.suggest_tip_cap(working_set).unwrap();
-
         let evm = Evm::<C>::default();
         let base_fee = evm
             .get_block_by_number(None, None, working_set)

--- a/crates/ethereum-rpc/src/ethereum.rs
+++ b/crates/ethereum-rpc/src/ethereum.rs
@@ -20,6 +20,7 @@ use crate::gas_price::gas_oracle::{GasPriceOracle, GasPriceOracleConfig};
 use crate::subscription::SubscriptionManager;
 
 const MAX_TRACE_BLOCK: u32 = 1000;
+const DEFAULT_PRIORITY_FEE: U256 = U256::from_limbs([100, 0, 0, 0]);
 
 #[derive(Clone)]
 pub struct EthRpcConfig {
@@ -86,7 +87,7 @@ impl<C: sov_modules_api::Context, Da: DaService> Ethereum<C, Da> {
 
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn max_fee_per_gas(&self, working_set: &mut WorkingSet<C>) -> (U256, U256) {
-        let suggested_tip = self.gas_price_oracle.suggest_tip_cap(working_set).unwrap();
+        // let suggested_tip = self.gas_price_oracle.suggest_tip_cap(working_set).unwrap();
 
         let evm = Evm::<C>::default();
         let base_fee = evm
@@ -97,7 +98,10 @@ impl<C: sov_modules_api::Context, Da: DaService> Ethereum<C, Da> {
             .base_fee_per_gas
             .unwrap_or_default();
 
-        (U256::from(base_fee), U256::from(suggested_tip))
+        // We return a default priority of 100 wei. Small enough to
+        // not make a difference to price, but also allows bumping tip
+        // of EIP-1559 transactions in times of congestion.
+        (U256::from(base_fee), DEFAULT_PRIORITY_FEE)
     }
 
     //     fn make_raw_tx(

--- a/crates/ethereum-rpc/src/gas_price/cache.rs
+++ b/crates/ethereum-rpc/src/gas_price/cache.rs
@@ -21,6 +21,7 @@ impl<C: sov_modules_api::Context> BlockCache<C> {
     }
 
     /// Gets block from cache or from provider
+    #[allow(unused)]
     pub fn get_block(
         &mut self,
         block_hash: B256,

--- a/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
+++ b/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
@@ -1,5 +1,6 @@
 //! An implementation of the eth gas price oracle, used for providing gas price estimates based on
 //! previous blocks.
+#![allow(unused)]
 
 // Adopted from: https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/gas_oracle.rs
 


### PR DESCRIPTION
# Description

As a rollup, tips do not make much sense for us, as we will have congestions very rarely, and we already have dynamic basefee algorithm in place. After discussions with @eyusufatik , we decided to suggest 100 wei as tip always.

First we thought about returning 0, but then we would lose the ability to order EIP-1559 transactions completely since there won't be any chance to speed up in rare times of congestion. Hence, we settled on 100 wei, which should almost make no difference to price in regular times, but also should allow people to bump the tips by 10% in case of congestion.

## Linked Issues
- Fixes #1486 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
