### PR TITLE
CI: Trigger checks/release on release-v* branches

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,9 +52,9 @@ on:
   merge_group:
     types: ["checks_requested"]
   push:
-    branches: ["nightly", "devnet-freeze", "main"]
+    branches: ["nightly", "devnet-freeze", "release-v*"]
   pull_request:
-    branches: ["nightly", "devnet-freeze", "main"]
+    branches: ["nightly", "devnet-freeze", "release-v*"]
     types: [opened, synchronize, reopened, ready_for_review]
 
 run-name: ${{ inputs.custom_name || github.event.pull_request.title || github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+    branches:
+      - "release-v*"
 
 jobs:
   validate_DA_ID_format:


### PR DESCRIPTION
# Description

- [Trigger checks.yml on release-v* branches](https://github.com/chainwayxyz/citrea/commit/b555238749f5168af99ad501e28677e77d19010b)
- Remove trigger on main branch
- [Trigger release workflow on push to release-v* branch](https://github.com/chainwayxyz/citrea/pull/1567/commits/aed4172cdc9b14724fe6a0443a9779aa55502b9e)
