### PR TITLE
CI: Remove push to release-v* branches as release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "v*.*.*"
-    branches:
-      - "release-v*"
 
 jobs:
   validate_DA_ID_format:


### PR DESCRIPTION
# Description

- Remove push to release-v* branches as release trigger
- Keep it as simple tag `v*.*.*` trigger
- Follow-up of https://github.com/chainwayxyz/citrea/pull/1567