### PR TITLE
Use reference for l1 block parameters

### DIFF
--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -184,7 +184,7 @@ where
                 self.sequencer_pub_key.clone(),
                 self.sequencer_da_pub_key.clone(),
                 self.l1_block_cache.clone(),
-                l1_block.clone(),
+                l1_block,
                 Some(GroupCommitments::Normal),
             )
             .await;
@@ -250,7 +250,7 @@ where
                         self.ledger_db.clone(),
                         self.code_commitments_by_spec.clone(),
                         self.elfs_by_spec.clone(),
-                        l1_block.clone(),
+                        l1_block,
                         sequencer_commitments,
                         inputs,
                     )

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -72,11 +72,8 @@ where
         blob.full_data();
     });
 
-    let sequencer_commitments: Vec<SequencerCommitment> = extract_sequencer_commitments::<Da>(
-        da_service.clone(),
-        l1_block.clone(),
-        &sequencer_da_pub_key,
-    );
+    let sequencer_commitments: Vec<SequencerCommitment> =
+        extract_sequencer_commitments::<Da>(da_service.clone(), &l1_block, &sequencer_da_pub_key);
 
     if sequencer_commitments.is_empty() {
         return Err(L1ProcessingError::NoSeqCommitments {

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -46,7 +46,7 @@ pub(crate) async fn data_to_prove<'txs, Da, DB, StateRoot, Witness, Tx>(
     sequencer_pub_key: Vec<u8>,
     sequencer_da_pub_key: Vec<u8>,
     l1_block_cache: Arc<Mutex<L1BlockCache<Da>>>,
-    l1_block: <Da as DaService>::FilteredBlock,
+    l1_block: &<Da as DaService>::FilteredBlock,
     group_commitments: Option<GroupCommitments>,
 ) -> Result<
     (
@@ -65,7 +65,7 @@ where
     let l1_height = l1_block.header().height();
 
     let (mut da_data, inclusion_proof, completeness_proof) =
-        da_service.extract_relevant_blobs_with_proof(&l1_block, DaNamespace::ToBatchProver);
+        da_service.extract_relevant_blobs_with_proof(l1_block, DaNamespace::ToBatchProver);
 
     // if we don't do this, the zk circuit can't read the sequencer commitments
     da_data.iter_mut().for_each(|blob| {
@@ -73,7 +73,7 @@ where
     });
 
     let sequencer_commitments: Vec<SequencerCommitment> =
-        extract_sequencer_commitments::<Da>(da_service.clone(), &l1_block, &sequencer_da_pub_key);
+        extract_sequencer_commitments::<Da>(da_service.clone(), l1_block, &sequencer_da_pub_key);
 
     if sequencer_commitments.is_empty() {
         return Err(L1ProcessingError::NoSeqCommitments {
@@ -207,7 +207,7 @@ pub(crate) async fn prove_l1<Da, Ps, Vm, DB, StateRoot, Witness, Tx>(
     ledger: DB,
     code_commitments_by_spec: HashMap<SpecId, Vm::CodeCommitment>,
     elfs_by_spec: HashMap<SpecId, Vec<u8>>,
-    l1_block: Da::FilteredBlock,
+    l1_block: &Da::FilteredBlock,
     sequencer_commitments: Vec<SequencerCommitment>,
     inputs: Vec<BatchProofCircuitInput<'_, StateRoot, Witness, Da::Spec, Tx>>,
 ) -> anyhow::Result<()>

--- a/crates/batch-prover/src/rpc.rs
+++ b/crates/batch-prover/src/rpc.rs
@@ -168,7 +168,7 @@ where
             self.context.sequencer_pub_key.clone(),
             self.context.sequencer_da_pub_key.clone(),
             self.context.l1_block_cache.clone(),
-            l1_block,
+            &l1_block,
             group_commitments,
         )
         .await
@@ -223,7 +223,7 @@ where
             self.context.sequencer_pub_key.clone(),
             self.context.sequencer_da_pub_key.clone(),
             self.context.l1_block_cache.clone(),
-            l1_block.clone(),
+            &l1_block,
             group_commitments,
         )
         .await
@@ -240,7 +240,7 @@ where
             self.context.ledger.clone(),
             self.context.code_commitments_by_spec.clone(),
             self.context.elfs_by_spec.clone(),
-            l1_block,
+            &l1_block,
             sequencer_commitments,
             inputs,
         )

--- a/crates/common/src/da.rs
+++ b/crates/common/src/da.rs
@@ -42,7 +42,7 @@ pub async fn get_da_block_at_height<Da: DaService>(
 
 pub fn extract_sequencer_commitments<Da>(
     da_service: Arc<Da>,
-    l1_block: Da::FilteredBlock,
+    l1_block: &Da::FilteredBlock,
     sequencer_da_pub_key: &[u8],
 ) -> Vec<SequencerCommitment>
 where
@@ -50,7 +50,7 @@ where
 {
     let mut sequencer_commitments = da_service
         .as_ref()
-        .extract_relevant_sequencer_commitments(&l1_block, sequencer_da_pub_key)
+        .extract_relevant_sequencer_commitments(l1_block, sequencer_da_pub_key)
         .inspect_err(|e| {
             warn!("Failed to get sequencer commitments: {e}");
         })
@@ -65,10 +65,10 @@ where
 
 pub async fn extract_zk_proofs<Da: DaService>(
     da_service: Arc<Da>,
-    l1_block: Da::FilteredBlock,
+    l1_block: &Da::FilteredBlock,
     prover_da_pub_key: &[u8],
 ) -> anyhow::Result<Vec<Proof>> {
     da_service
-        .extract_relevant_zk_proofs(&l1_block, prover_da_pub_key)
+        .extract_relevant_zk_proofs(l1_block, prover_da_pub_key)
         .await
 }


### PR DESCRIPTION
# Description

Modifies `data_to_prove`, `prove_l1`, `extract_sequencer_commitments`, `extract_zk_proofs`, `process_zk_proof` to accept l1_block references, in order to avoid clones
