### PR TITLE
Set codeowner and random assignment for PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Esad is always requested for review
+*       @eyusufatik

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -18,4 +18,4 @@ skipKeywords:
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)
-numberOfReviewers: 2
+numberOfReviewers: 1

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -6,7 +6,6 @@ addAssignees: author
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
-  - eyusufatik
   - kpp
   - rakanalh
   - yaziciahmet
@@ -19,4 +18,4 @@ skipKeywords:
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)
-numberOfReviewers: 0
+numberOfReviewers: 2


### PR DESCRIPTION
# Description

This is a suggested new way of assigning people to review PRs.

1. @eyusufatik is always requested to review / approve every PR.
2. One random person is assigned to review the PR as well instead the whole team.

This enables PR author to wait for PRs from two people which should distribute the load of reviewing PRs on different people on the team.

@eyusufatik, this means that you have to setup repo settings to require your approval on the PR as code owner before merging.