### PR TITLE
add missing batch proof fields to storage structs

### DIFF
--- a/bin/citrea/tests/e2e/proving.rs
+++ b/bin/citrea/tests/e2e/proving.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use citrea_batch_prover::GroupCommitments;
 use citrea_common::{BatchProverConfig, SequencerConfig};
 use citrea_stf::genesis_config::GenesisPaths;
-use sov_mock_da::{MockAddress, MockDaService};
+use sov_mock_da::{MockAddress, MockDaService, MockDaSpec};
 use sov_rollup_interface::rpc::SoftConfirmationStatus;
 use sov_rollup_interface::services::da::DaService;
 
@@ -167,6 +167,17 @@ async fn full_node_verify_proof_and_store() {
     assert_eq!(prover_proof.proof, full_node_proof[0].proof);
 
     assert_eq!(prover_proof.proof_output, full_node_proof[0].proof_output);
+
+    let proof_height = full_node_proof[0].proof_output.last_l2_height;
+    let soft_confirmation = full_node_test_client
+        .ledger_get_soft_confirmation_by_number::<MockDaSpec>(proof_height)
+        .await
+        .expect("should get soft confirmation");
+
+    assert_eq!(
+        full_node_proof[0].proof_output.final_state_root,
+        soft_confirmation.state_root
+    );
 
     full_node_test_client
         .ledger_get_soft_confirmation_status(5)

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -353,7 +353,9 @@ where
             sequencer_public_key: circuit_output.sequencer_public_key,
             sequencer_da_public_key: circuit_output.sequencer_da_public_key,
             preproven_commitments: circuit_output.preproven_commitments,
-            validity_condition: vec![],
+            prev_soft_confirmation_hash: circuit_output.prev_soft_confirmation_hash,
+            final_soft_confirmation_hash: circuit_output.final_soft_confirmation_hash,
+            last_l2_height: circuit_output.last_l2_height,
         };
         let l1_height = ledger_db
             .get_l1_height_of_l1_hash(slot_hash)?

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -324,7 +324,9 @@ where
             sequencer_public_key: batch_proof_output.sequencer_public_key,
             sequencer_da_public_key: batch_proof_output.sequencer_da_public_key,
             preproven_commitments: batch_proof_output.preproven_commitments.clone(),
-            validity_condition: vec![],
+            prev_soft_confirmation_hash: batch_proof_output.prev_soft_confirmation_hash,
+            final_soft_confirmation_hash: batch_proof_output.final_soft_confirmation_hash,
+            last_l2_height: batch_proof_output.last_l2_height,
         };
 
         let l1_hash = batch_proof_output.da_slot_hash.into();

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types.rs
@@ -149,6 +149,10 @@ pub struct StoredBatchProofOutput {
     pub initial_state_root: Vec<u8>,
     /// The state of the rollup after the transition
     pub final_state_root: Vec<u8>,
+    /// The hash of the last soft confirmation before the state transition
+    pub prev_soft_confirmation_hash: [u8; 32],
+    /// The hash of the last soft confirmation in the state transition
+    pub final_soft_confirmation_hash: [u8; 32],
     /// State diff of L2 blocks in the processed sequencer commitments.
     pub state_diff: CumulativeStateDiff,
     /// The DA slot hash that the sequencer commitments causing this state transition were found in.
@@ -162,8 +166,8 @@ pub struct StoredBatchProofOutput {
     pub sequencer_da_public_key: Vec<u8>,
     /// Pre-proven commitments L2 ranges which also exist in the current L1 `da_data`.
     pub preproven_commitments: Vec<usize>,
-    /// Validity condition. Removed in the newer version.
-    pub validity_condition: Vec<u8>,
+    /// The last processed l2 height in the processed sequencer commitments.
+    pub last_l2_height: u64,
 }
 
 /// The on-disk format for a proof. Stores the tx id of the proof sent to da, proof data and state transition
@@ -216,6 +220,9 @@ impl From<StoredBatchProofOutput> for BatchProofOutputRpcResponse {
             sequencer_public_key: value.sequencer_public_key,
             sequencer_commitments_range: value.sequencer_commitments_range,
             preproven_commitments: value.preproven_commitments,
+            prev_soft_confirmation_hash: value.prev_soft_confirmation_hash,
+            final_soft_confirmation_hash: value.final_soft_confirmation_hash,
+            last_l2_height: value.last_l2_height,
         }
     }
 }

--- a/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
@@ -296,6 +296,12 @@ pub struct BatchProofOutputRpcResponse {
     /// The state of the rollup after the transition
     #[serde(with = "hex::serde")]
     pub final_state_root: Vec<u8>,
+    /// The hash of the last soft confirmation before the state transition
+    #[serde(with = "hex::serde")]
+    pub prev_soft_confirmation_hash: [u8; 32],
+    /// The hash of the last soft confirmation in the state transition
+    #[serde(with = "hex::serde")]
+    pub final_soft_confirmation_hash: [u8; 32],
     /// State diff of L2 blocks in the processed sequencer commitments.
     #[serde(
         serialize_with = "custom_serialize_btreemap",
@@ -316,6 +322,8 @@ pub struct BatchProofOutputRpcResponse {
     pub sequencer_da_public_key: Vec<u8>,
     /// Pre-proven commitments L2 ranges which also exist in the current L1 `da_data`.
     pub preproven_commitments: Vec<usize>,
+    /// The last processed l2 height in the processed sequencer commitments.
+    pub last_l2_height: u64,
 }
 
 /// Custom serialization for BTreeMap


### PR DESCRIPTION
# Description
We forgot to update the ledger db types when we changed batch proof output types.
We'll need migration since we added last_l2_height struct. 🙈 
