### PR TITLE
Activate EF Cancun tests

### DIFF
--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -185,6 +185,7 @@ impl Case for BlockchainTestCase {
                     &EvmChainConfig {
                         chain_id: evm_config.chain_id,
                         limit_contract_code_size: evm_config.limit_contract_code_size,
+                        // TODO: Putting this todo because I am not sure what to do with this?
                         spec: vec![(0, SpecId::SHANGHAI)].into_iter().collect(),
                         coinbase: case.genesis_block_header.coinbase,
                         block_gas_limit: case.genesis_block_header.gas_limit.to(),

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -277,7 +277,7 @@ impl Case for BlockchainTestCase {
 ///
 /// The reason should be documented in a comment above the file name(s).
 pub fn should_skip(path: &Path) -> bool {
-    let path_str = path.to_str().expect("Path is not valid UTF-8");
+    // let path_str = path.to_str().expect("Path is not valid UTF-8");
     let name = path.file_name().unwrap().to_str().unwrap();
     matches!(
         name,
@@ -316,11 +316,11 @@ pub fn should_skip(path: &Path) -> bool {
         | "shiftCombinations.json"
     )
     // Ignore outdated EOF tests that haven't been updated for Cancun yet.
-    || path_contains(path_str, &["EIPTests", "stEOF"])
+    // || path_contains(path_str, &["EIPTests", "stEOF"])
 }
 
 /// `str::contains` but for a path. Takes into account the OS path separator (`/` or `\`).
-fn path_contains(path_str: &str, rhs: &[&str]) -> bool {
+fn _path_contains(path_str: &str, rhs: &[&str]) -> bool {
     let rhs = rhs.join(std::path::MAIN_SEPARATOR_STR);
     path_str.contains(&rhs)
 }

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -125,7 +125,7 @@ impl Case for BlockchainTestCase {
         // Iterate through test cases, filtering by the network type to exclude specific forks.
         self.tests
             .values()
-            .filter(|case| case.network <= ForkSpec::Cancun)
+            .filter(|case| case.network <= ForkSpec::Cancun || case.network == ForkSpec::Unknown)
             .par_bridge()
             .try_for_each(|case| {
                 let mut evm_config = EvmConfig::default();

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -187,7 +187,6 @@ impl Case for BlockchainTestCase {
                     &EvmChainConfig {
                         chain_id: evm_config.chain_id,
                         limit_contract_code_size: evm_config.limit_contract_code_size,
-                        // TODO: Putting this todo because I am not sure what to do with this?
                         spec: vec![(0, SpecId::SHANGHAI)].into_iter().collect(),
                         coinbase: case.genesis_block_header.coinbase,
                         block_gas_limit: case.genesis_block_header.gas_limit.to(),

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -53,6 +53,7 @@ pub struct BlockchainTestCase {
 }
 
 impl BlockchainTestCase {
+    #[allow(clippy::too_many_arguments)]
     fn execute_transactions(
         &self,
         evm: &mut Evm<DefaultContext>,
@@ -61,6 +62,7 @@ impl BlockchainTestCase {
         storage: ProverStorage<SnapshotManager>,
         root: &[u8; 32],
         l2_height: u64,
+        current_spec: SovSpecId,
     ) -> (
         WorkingSet<ProverStorage<SnapshotManager>>,
         ProverStorage<SnapshotManager>,
@@ -73,7 +75,7 @@ impl BlockchainTestCase {
             da_slot_height: 0,
             da_slot_txs_commitment: [0u8; 32],
             pre_state_root: root.to_vec(),
-            current_spec: SovSpecId::Genesis,
+            current_spec,
             pub_key: vec![],
             deposit_data: vec![],
             l1_fee_rate,
@@ -208,6 +210,11 @@ impl Case for BlockchainTestCase {
 
                 let root = case.genesis_block_header.state_root;
 
+                let current_spec = if case.network == ForkSpec::Cancun {
+                    SovSpecId::Fork1
+                } else {
+                    SovSpecId::Genesis
+                };
                 // Decode and insert blocks, creating a chain of blocks for the test case.
                 for block in case.blocks.iter() {
                     let decoded = SealedBlock::decode(&mut block.rlp.as_ref())?;
@@ -228,6 +235,7 @@ impl Case for BlockchainTestCase {
                         storage,
                         &root,
                         l2_height,
+                        current_spec,
                     );
 
                     l2_height += 1;

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -314,6 +314,10 @@ pub fn should_skip(path: &Path) -> bool {
         | "loopMul.json"
         | "CALLBlake2f_MaxRounds.json"
         | "shiftCombinations.json"
+
+        // VMTests/vmIOandFlowOperations does not pass the test
+        // TODO: look into it
+        | "jumpToPush.json"
     )
     // We don't support blob transactions
     || path_contains(path_str, &["Cancun", "stEIP4844-blobtransactions"])

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -125,7 +125,7 @@ impl Case for BlockchainTestCase {
         // Iterate through test cases, filtering by the network type to exclude specific forks.
         self.tests
             .values()
-            .filter(|case| case.network <= ForkSpec::Shanghai)
+            .filter(|case| case.network <= ForkSpec::Cancun)
             .par_bridge()
             .try_for_each(|case| {
                 let mut evm_config = EvmConfig::default();

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -125,7 +125,7 @@ impl Case for BlockchainTestCase {
         // Iterate through test cases, filtering by the network type to exclude specific forks.
         self.tests
             .values()
-            .filter(|case| matches!(case.network, ForkSpec::Shanghai))
+            .filter(|case| case.network <= ForkSpec::Shanghai)
             .par_bridge()
             .try_for_each(|case| {
                 let mut evm_config = EvmConfig::default();

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -323,8 +323,8 @@ pub fn should_skip(path: &Path) -> bool {
         | "CALLBlake2f_MaxRounds.json"
         | "shiftCombinations.json"
 
-        // VMTests/vmIOandFlowOperations does not pass the test
-        // TODO: look into it
+        // In VMTests/vmIOandFlowOperations, returns state root instead of latest state,
+        // hence we can't test it due to us using different tree than Ethereum
         | "jumpToPush.json"
     )
     // We don't support blob transactions

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -277,7 +277,7 @@ impl Case for BlockchainTestCase {
 ///
 /// The reason should be documented in a comment above the file name(s).
 pub fn should_skip(path: &Path) -> bool {
-    // let path_str = path.to_str().expect("Path is not valid UTF-8");
+    let path_str = path.to_str().expect("Path is not valid UTF-8");
     let name = path.file_name().unwrap().to_str().unwrap();
     matches!(
         name,
@@ -315,12 +315,12 @@ pub fn should_skip(path: &Path) -> bool {
         | "CALLBlake2f_MaxRounds.json"
         | "shiftCombinations.json"
     )
-    // Ignore outdated EOF tests that haven't been updated for Cancun yet.
-    // || path_contains(path_str, &["EIPTests", "stEOF"])
+    // We don't support blob transactions
+    || path_contains(path_str, &["Cancun", "stEIP4844-blobtransactions"])
 }
 
 /// `str::contains` but for a path. Takes into account the OS path separator (`/` or `\`).
-fn _path_contains(path_str: &str, rhs: &[&str]) -> bool {
+fn path_contains(path_str: &str, rhs: &[&str]) -> bool {
     let rhs = rhs.join(std::path::MAIN_SEPARATOR_STR);
     path_str.contains(&rhs)
 }

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -322,6 +322,8 @@ pub fn should_skip(path: &Path) -> bool {
     )
     // We don't support blob transactions
     || path_contains(path_str, &["Cancun", "stEIP4844-blobtransactions"])
+    || path_contains(path_str, &["Pyspecs", "cancun", "eip4844_blobs"])
+    || path_contains(path_str, &["Pyspecs", "cancun", "eip7516_blobgasfee"])
 }
 
 /// `str::contains` but for a path. Takes into account the OS path separator (`/` or `\`).

--- a/crates/evm/src/tests/ef_tests/mod.rs
+++ b/crates/evm/src/tests/ef_tests/mod.rs
@@ -52,7 +52,7 @@ mod general_state_tests {
     general_state_test!(st_sload, stSLoadTest);
     general_state_test!(st_zero_calls_revert, stZeroCallsRevert);
     general_state_test!(st_zero_calls, stZeroCallsTest);
-    general_state_test!(stshanghai, Shanghai);
+    general_state_test!(st_shanghai, Shanghai);
     general_state_test!(st_attack, stAttackTest);
     general_state_test!(st_bugs, stBugs);
     general_state_test!(st_call_codes, stCallCodes);

--- a/crates/evm/src/tests/ef_tests/mod.rs
+++ b/crates/evm/src/tests/ef_tests/mod.rs
@@ -92,4 +92,5 @@ mod general_state_tests {
     general_state_test!(st_zero_knowledge2, stZeroKnowledge2);
     general_state_test!(st_transition, stTransitionTest);
     general_state_test!(st_vm, VMTests);
+    general_state_test!(st_pyspecs, Pyspecs);
 }

--- a/crates/evm/src/tests/ef_tests/mod.rs
+++ b/crates/evm/src/tests/ef_tests/mod.rs
@@ -91,4 +91,5 @@ mod general_state_tests {
     general_state_test!(st_zero_knowledge, stZeroKnowledge);
     general_state_test!(st_zero_knowledge2, stZeroKnowledge2);
     general_state_test!(st_transition, stTransitionTest);
+    general_state_test!(st_vm, VMTests);
 }

--- a/crates/evm/src/tests/ef_tests/mod.rs
+++ b/crates/evm/src/tests/ef_tests/mod.rs
@@ -90,15 +90,4 @@ mod general_state_tests {
     general_state_test!(st_wallet, stWalletTest);
     general_state_test!(st_zero_knowledge, stZeroKnowledge);
     general_state_test!(st_zero_knowledge2, stZeroKnowledge2);
-
-    // Failing
-    // general_state_test!(vm_tests, VMTests);
-    // general_state_test!(st_bad_opcode, stBadOpcode);
-    // general_state_test!(st_create2, stCreate2);
-    // general_state_test!(st_create, stCreateTest);
-    // general_state_test!(st_quadratic_complexity, stQuadraticComplexityTest);
-    //general_state_test!(st_recursive_create, stRecursiveCreate);
-    // general_state_test!(st_stack, stStackTests);
 }
-
-// TODO: Add ValidBlocks and InvalidBlocks tests

--- a/crates/evm/src/tests/ef_tests/mod.rs
+++ b/crates/evm/src/tests/ef_tests/mod.rs
@@ -90,4 +90,5 @@ mod general_state_tests {
     general_state_test!(st_wallet, stWalletTest);
     general_state_test!(st_zero_knowledge, stZeroKnowledge);
     general_state_test!(st_zero_knowledge2, stZeroKnowledge2);
+    general_state_test!(st_transition, stTransitionTest);
 }

--- a/crates/evm/src/tests/ef_tests/mod.rs
+++ b/crates/evm/src/tests/ef_tests/mod.rs
@@ -53,6 +53,7 @@ mod general_state_tests {
     general_state_test!(st_zero_calls_revert, stZeroCallsRevert);
     general_state_test!(st_zero_calls, stZeroCallsTest);
     general_state_test!(st_shanghai, Shanghai);
+    general_state_test!(st_cancun, Cancun);
     general_state_test!(st_attack, stAttackTest);
     general_state_test!(st_bugs, stBugs);
     general_state_test!(st_call_codes, stCallCodes);


### PR DESCRIPTION
# Description

Now we are:
- running VMTests (except `jumpToPush.json`, it fails for some reason)
- running Pyspecs tests (which includes separated tests for each fork)
- running Cancun tests
- running tests for past forks and unknown forks (before check was `fork == Shanghai`, now it is `fork <= Cancun || fork == Unknown`). Unknowns are included because there are non-fork specific tests, which fall down to Unknown spec variant.

Excluded all the tests related to blobs as we don't support it.

## Linked Issues
- Fixes #1463 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
