### PR TITLE
E2E Tests: Fix flakiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=6ba7230#6ba7230a137931c0d7a002092f0b38beb4d73d17"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=efde07d#efde07d66183948e1a4d6ee6ab0d364fd2b5d05c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ alloy = { version = "0.2.1", default-features = false }
 alloy-eips = { version = "0.2.1", default-features = false }
 alloy-consensus = { version = "0.2.1", default-features = false }
 
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "6ba7230" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "efde07d" }
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "ca3cfa2" }

--- a/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
@@ -33,7 +33,7 @@ pub async fn wait_for_zkproofs(
     timeout: Option<Duration>,
 ) -> Result<Vec<VerifiedBatchProofResponse>> {
     let start = Instant::now();
-    let timeout = timeout.unwrap_or(Duration::from_secs(120));
+    let timeout = timeout.unwrap_or(Duration::from_secs(240));
 
     loop {
         if start.elapsed() >= timeout {
@@ -277,7 +277,6 @@ impl TestCase for SkipPreprovenCommitmentsTest {
         da.wait_mempool_len(4, None).await?;
 
         da.generate(FINALITY_DEPTH).await?;
-
         let finalized_height = da.get_finalized_height().await?;
 
         batch_prover
@@ -290,6 +289,10 @@ impl TestCase for SkipPreprovenCommitmentsTest {
         da.generate(FINALITY_DEPTH).await?;
         let finalized_height = da.get_finalized_height().await?;
 
+        // Wait for the full node to see all process verify and store all batch proofs
+        full_node
+            .wait_for_l1_height(batch_proof_l1_height, None)
+            .await?;
         let proofs = wait_for_zkproofs(full_node, finalized_height, None)
             .await
             .unwrap();

--- a/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
@@ -33,7 +33,7 @@ pub async fn wait_for_zkproofs(
     timeout: Option<Duration>,
 ) -> Result<Vec<VerifiedBatchProofResponse>> {
     let start = Instant::now();
-    let timeout = timeout.unwrap_or(Duration::from_secs(30));
+    let timeout = timeout.unwrap_or(Duration::from_secs(120));
 
     loop {
         if start.elapsed() >= timeout {
@@ -68,32 +68,11 @@ impl TestCase for BasicProverTest {
         }
     }
 
-    fn sequencer_config() -> SequencerConfig {
-        SequencerConfig {
-            min_soft_confirmations_per_commitment: 10,
-            ..Default::default()
-        }
-    }
-
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
-        let Some(sequencer) = &f.sequencer else {
-            bail!("Sequencer not running. Set TestCaseConfig with_sequencer to true")
-        };
-
-        let Some(batch_prover) = &f.batch_prover else {
-            bail!("Batch Prover not running. Set TestCaseConfig with_batch_prover to true")
-        };
-
-        let Some(full_node) = &f.full_node else {
-            bail!("FullNode not running. Set TestCaseConfig with_full_node to true")
-        };
-
-        let Some(da) = f.bitcoin_nodes.get(0) else {
-            bail!("bitcoind not running. Test cannot run with bitcoind running as DA")
-        };
-
-        // Generate confirmed UTXOs
-        da.generate(120).await?;
+        let da = f.bitcoin_nodes.get(0).unwrap();
+        let sequencer = f.sequencer.as_ref().unwrap();
+        let batch_prover = f.batch_prover.as_ref().unwrap();
+        let full_node = f.full_node.as_ref().unwrap();
 
         let min_soft_confirmations_per_commitment =
             sequencer.min_soft_confirmations_per_commitment();
@@ -101,8 +80,6 @@ impl TestCase for BasicProverTest {
         for _ in 0..min_soft_confirmations_per_commitment {
             sequencer.client.send_publish_batch_request().await?;
         }
-
-        da.generate(FINALITY_DEPTH).await?;
 
         // Wait for blob inscribe tx to be in mempool
         da.wait_mempool_len(2, None).await?;
@@ -113,6 +90,9 @@ impl TestCase for BasicProverTest {
         batch_prover
             .wait_for_l1_height(finalized_height, None)
             .await?;
+
+        // Wait for batch proof tx to hit mempool
+        da.wait_mempool_len(2, None).await?;
 
         da.generate(FINALITY_DEPTH).await?;
         let proofs = wait_for_zkproofs(
@@ -168,23 +148,10 @@ impl TestCase for SkipPreprovenCommitmentsTest {
     }
 
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
-        let Some(sequencer) = &f.sequencer else {
-            bail!("Sequencer not running. Set TestCaseConfig with_sequencer to true")
-        };
-
-        let Some(prover) = &f.batch_prover else {
-            bail!("Batch Prover not running. Set TestCaseConfig with_batch_prover to true")
-        };
-
-        let Some(full_node) = &f.full_node else {
-            bail!("FullNode not running. Set TestCaseConfig with_full_node to true")
-        };
-
-        let Some(da) = f.bitcoin_nodes.get(0) else {
-            bail!("bitcoind not running. Test cannot run with bitcoind running as DA")
-        };
-
-        let _initial_height = f.initial_da_height;
+        let da = f.bitcoin_nodes.get(0).unwrap();
+        let sequencer = f.sequencer.as_ref().unwrap();
+        let batch_prover = f.batch_prover.as_ref().unwrap();
+        let full_node = f.full_node.as_ref().unwrap();
 
         let da_config = &f.bitcoin_nodes.get(0).unwrap().config;
         let bitcoin_da_service_config = BitcoinServiceConfig {
@@ -240,26 +207,23 @@ impl TestCase for SkipPreprovenCommitmentsTest {
             sequencer.client.send_publish_batch_request().await?;
         }
 
-        da.generate(FINALITY_DEPTH).await?;
-
         // Wait for blob inscribe tx to be in mempool
         da.wait_mempool_len(2, None).await?;
 
         da.generate(FINALITY_DEPTH).await?;
 
         let finalized_height = da.get_finalized_height().await?;
-        prover
+        batch_prover
             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
             .await?;
 
+        // Wait for batch proof tx to hit mempool
+        da.wait_mempool_len(2, None).await?;
+
         da.generate(FINALITY_DEPTH).await?;
-        let proofs = wait_for_zkproofs(
-            full_node,
-            finalized_height + FINALITY_DEPTH,
-            Some(Duration::from_secs(120)),
-        )
-        .await
-        .unwrap();
+        let proofs = wait_for_zkproofs(full_node, finalized_height + FINALITY_DEPTH, None)
+            .await
+            .unwrap();
 
         assert!(proofs
             .first()
@@ -316,19 +280,19 @@ impl TestCase for SkipPreprovenCommitmentsTest {
 
         let finalized_height = da.get_finalized_height().await?;
 
-        prover
+        batch_prover
             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
             .await?;
 
-        da.generate(FINALITY_DEPTH).await?;
+        // Wait for batch proof tx to hit mempool
+        da.wait_mempool_len(2, None).await?;
 
-        let proofs = wait_for_zkproofs(
-            full_node,
-            finalized_height + FINALITY_DEPTH,
-            Some(Duration::from_secs(120)),
-        )
-        .await
-        .unwrap();
+        da.generate(FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height().await?;
+
+        let proofs = wait_for_zkproofs(full_node, finalized_height, None)
+            .await
+            .unwrap();
 
         assert_eq!(
             proofs
@@ -519,12 +483,15 @@ impl TestCase for ParallelProvingTest {
             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(1800)))
             .await?;
 
+        // Wait for batch proof tx to hit mempool
+        da.wait_mempool_len(2, None).await?;
+
         // Write 2 batch proofs to a finalized DA block
         da.generate(FINALITY_DEPTH).await?;
         let finalized_height = da.get_finalized_height().await?;
 
         // Retrieve proofs from fullnode
-        let proofs = wait_for_zkproofs(full_node, finalized_height, Some(Duration::from_secs(120)))
+        let proofs = wait_for_zkproofs(full_node, finalized_height, None)
             .await
             .unwrap();
         dbg!(proofs.len());

--- a/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
@@ -290,9 +290,7 @@ impl TestCase for SkipPreprovenCommitmentsTest {
         let finalized_height = da.get_finalized_height().await?;
 
         // Wait for the full node to see all process verify and store all batch proofs
-        full_node
-            .wait_for_l1_height(batch_proof_l1_height, None)
-            .await?;
+        full_node.wait_for_l1_height(finalized_height, None).await?;
         let proofs = wait_for_zkproofs(full_node, finalized_height, None)
             .await
             .unwrap();

--- a/bin/citrea/tests/bitcoin_e2e/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/light_client_test.rs
@@ -254,12 +254,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         full_node
             .wait_for_l1_height(batch_proof_l1_height, Some(TEN_MINS))
             .await?;
-        let batch_proofs = wait_for_zkproofs(
-            full_node,
-            batch_proof_l1_height,
-            Some(Duration::from_secs(30)),
-        )
-        .await?;
+        let batch_proofs = wait_for_zkproofs(full_node, batch_proof_l1_height, None).await?;
         assert_eq!(batch_proofs.len(), 2);
 
         // Wait for light client prover to process batch proofs.
@@ -394,12 +389,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         full_node
             .wait_for_l1_height(batch_proof_l1_height, Some(TEN_MINS))
             .await?;
-        let batch_proofs = wait_for_zkproofs(
-            full_node,
-            batch_proof_l1_height,
-            Some(Duration::from_secs(30)),
-        )
-        .await?;
+        let batch_proofs = wait_for_zkproofs(full_node, batch_proof_l1_height, None).await?;
         assert_eq!(batch_proofs.len(), 1);
 
         // Wait for light client prover to process batch proofs.

--- a/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs
+++ b/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs
@@ -102,7 +102,10 @@ impl TestCase for LedgerGetCommitmentsProverTest {
         assert_eq!(commitments.len(), 1);
 
         assert_eq!(commitments[0].l2_start_block_number, 1);
-        assert_eq!(commitments[0].l2_end_block_number, 4);
+        assert_eq!(
+            commitments[0].l2_end_block_number,
+            min_soft_confirmations_per_commitment
+        );
 
         assert_eq!(commitments[0].found_in_l1, finalized_height);
 
@@ -172,7 +175,10 @@ impl TestCase for LedgerGetCommitmentsTest {
         assert_eq!(commitments.len(), 1);
 
         assert_eq!(commitments[0].l2_start_block_number, 1);
-        assert_eq!(commitments[0].l2_end_block_number, 4);
+        assert_eq!(
+            commitments[0].l2_end_block_number,
+            min_soft_confirmations_per_commitment
+        );
 
         assert_eq!(commitments[0].found_in_l1, finalized_height);
 

--- a/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs
+++ b/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs
@@ -30,7 +30,7 @@ pub async fn wait_for_sequencer_commitments(
     timeout: Option<Duration>,
 ) -> Result<Vec<SequencerCommitmentResponse>> {
     let start = Instant::now();
-    let timeout = timeout.unwrap_or(Duration::from_secs(30));
+    let timeout = timeout.unwrap_or(Duration::from_secs(120));
 
     loop {
         if start.elapsed() >= timeout {

--- a/bin/citrea/tests/bitcoin_e2e/tx_chain.rs
+++ b/bin/citrea/tests/bitcoin_e2e/tx_chain.rs
@@ -304,6 +304,9 @@ impl TestCase for TestProverTransactionChaining {
             .wait_for_l1_height(finalized_height, None)
             .await?;
 
+        // Wait for batch proof tx to hit mempool
+        da.wait_mempool_len(2, None).await?;
+
         da.generate(1).await?;
         let block_height = da.get_block_count().await?;
 
@@ -343,6 +346,9 @@ impl TestCase for TestProverTransactionChaining {
         batch_prover
             .wait_for_l1_height(finalized_height, None)
             .await?;
+
+        // Wait for batch proof tx to hit mempool
+        da.wait_mempool_len(2, None).await?;
 
         da.generate(1).await?;
         let block_height = da.get_block_count().await?;
@@ -385,6 +391,9 @@ impl TestCase for TestProverTransactionChaining {
         batch_prover
             .wait_for_l1_height(finalized_height, None)
             .await?;
+
+        // Wait for batch proof tx to hit mempool
+        da.wait_mempool_len(2, None).await?;
 
         da.generate(1).await?;
         let block_height = da.get_block_count().await?;

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -646,11 +646,11 @@ async fn test_offchain_contract_storage() {
     assert_eq!(code.to_vec()[..runtime_code.len()], runtime_code.to_vec());
 
     // reach the block at which the fork will be activated
-    for _ in 3..=10000 {
+    for _ in 3..=1000 {
         sequencer_client.spam_publish_batch_request().await.unwrap();
     }
 
-    wait_for_l2_block(&sequencer_client, 10000, Some(Duration::from_secs(300))).await;
+    wait_for_l2_block(&sequencer_client, 1000, Some(Duration::from_secs(300))).await;
     let seq_height = sequencer_client.eth_block_number().await;
 
     let seq_fork = fork_from_block_number(FORKS, seq_height);

--- a/crates/primitives/src/forks.rs
+++ b/crates/primitives/src/forks.rs
@@ -25,11 +25,11 @@ pub const FORKS: &[Fork] = &[
     },
     Fork {
         spec_id: SpecId::Fork1,
-        activation_height: 10000,
+        activation_height: 1000,
     },
     Fork {
         spec_id: SpecId::Fork2,
-        activation_height: 20000,
+        activation_height: 2000,
     },
 ];
 


### PR DESCRIPTION
# Description

- Reduce test FORKS values.
- Wait for batch_prover txs to hit the mempool
- Consistent default wait duration for zkproofs

## Linked Issues
- Addresses #1614 