### PR TITLE
Add mempool.space url to config

### DIFF
--- a/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
@@ -191,6 +191,7 @@ impl TestCase for SkipPreprovenCommitmentsTest {
                 .display()
                 .to_string(),
             monitoring: Default::default(),
+            mempool_space_url: None,
         };
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 

--- a/crates/bitcoin-da/src/fee.rs
+++ b/crates/bitcoin-da/src/fee.rs
@@ -16,7 +16,7 @@ use tracing::{debug, instrument, trace, warn};
 use crate::monitoring::{MonitoredTx, MonitoredTxKind};
 use crate::spec::utxo::UTXO;
 
-const MEMPOOL_SPACE_URL: &str = "https://mempool.space/";
+const DEFAULT_MEMPOOL_SPACE_URL: &str = "https://mempool.space/";
 const MEMPOOL_SPACE_RECOMMENDED_FEE_ENDPOINT: &str = "api/v1/fees/recommended";
 
 pub type Psbt = String;
@@ -30,11 +30,13 @@ pub enum BumpFeeMethod {
 pub struct FeeService {
     client: Arc<Client>,
     network: Network,
+    mempool_space_url: String,
 }
 
 impl FeeService {
-    pub fn new(client: Arc<Client>, network: bitcoin::Network) -> Self {
-        Self { client, network }
+    pub fn new(client: Arc<Client>, network: bitcoin::Network, mempool_space_url: Option<String>) -> Self {
+        let mempool_space_url = mempool_space_url.unwrap_or_else(|| DEFAULT_MEMPOOL_SPACE_URL.to_string());
+        Self { client, network, mempool_space_url}
     }
 
     #[instrument(level = "trace", skip_all, ret)]
@@ -56,7 +58,7 @@ impl FeeService {
     #[instrument(level = "trace", skip_all, ret)]
     pub async fn get_fee_rate_as_sat_vb(&self) -> Result<u64> {
         // If network is regtest or signet, mempool space is not available
-        let smart_fee = match get_fee_rate_from_mempool_space(self.network).await {
+        let smart_fee = match get_fee_rate_from_mempool_space(self.network, &self.mempool_space_url).await {
             Ok(fee_rate) => fee_rate,
             Err(e) => {
                 tracing::error!(?e, "Failed to get fee rate from mempool.space");
@@ -145,16 +147,17 @@ impl FeeService {
 
 pub(crate) async fn get_fee_rate_from_mempool_space(
     network: bitcoin::Network,
+    mempool_space_url: &str,
 ) -> Result<Option<Amount>> {
     let url = match network {
         bitcoin::Network::Bitcoin => format!(
             // Mainnet
             "{}{}",
-            MEMPOOL_SPACE_URL, MEMPOOL_SPACE_RECOMMENDED_FEE_ENDPOINT
+            mempool_space_url, MEMPOOL_SPACE_RECOMMENDED_FEE_ENDPOINT
         ),
         bitcoin::Network::Testnet => format!(
             "{}testnet4/{}",
-            MEMPOOL_SPACE_URL, MEMPOOL_SPACE_RECOMMENDED_FEE_ENDPOINT
+            mempool_space_url, MEMPOOL_SPACE_RECOMMENDED_FEE_ENDPOINT
         ),
         _ => {
             trace!("Unsupported network for mempool space fee estimation");
@@ -176,25 +179,27 @@ pub(crate) async fn get_fee_rate_from_mempool_space(
 #[cfg(test)]
 mod tests {
 
-    use super::get_fee_rate_from_mempool_space;
+    use super::{DEFAULT_MEMPOOL_SPACE_URL, get_fee_rate_from_mempool_space};
 
     #[tokio::test]
     async fn test_mempool_space_fee_rate() {
-        let _fee_rate = get_fee_rate_from_mempool_space(bitcoin::Network::Bitcoin)
+        let mempool_space_url = DEFAULT_MEMPOOL_SPACE_URL;
+
+        let _fee_rate = get_fee_rate_from_mempool_space(bitcoin::Network::Bitcoin, mempool_space_url)
             .await
             .unwrap();
-        let _fee_rate = get_fee_rate_from_mempool_space(bitcoin::Network::Testnet)
+        let _fee_rate = get_fee_rate_from_mempool_space(bitcoin::Network::Testnet, mempool_space_url)
             .await
             .unwrap();
         assert_eq!(
             None,
-            get_fee_rate_from_mempool_space(bitcoin::Network::Regtest)
+            get_fee_rate_from_mempool_space(bitcoin::Network::Regtest, mempool_space_url)
                 .await
                 .unwrap()
         );
         assert_eq!(
             None,
-            get_fee_rate_from_mempool_space(bitcoin::Network::Signet)
+            get_fee_rate_from_mempool_space(bitcoin::Network::Signet, mempool_space_url)
                 .await
                 .unwrap()
         );

--- a/crates/bitcoin-da/src/fee.rs
+++ b/crates/bitcoin-da/src/fee.rs
@@ -34,9 +34,18 @@ pub struct FeeService {
 }
 
 impl FeeService {
-    pub fn new(client: Arc<Client>, network: bitcoin::Network, mempool_space_url: Option<String>) -> Self {
-        let mempool_space_url = mempool_space_url.unwrap_or_else(|| DEFAULT_MEMPOOL_SPACE_URL.to_string());
-        Self { client, network, mempool_space_url}
+    pub fn new(
+        client: Arc<Client>,
+        network: bitcoin::Network,
+        mempool_space_url: Option<String>,
+    ) -> Self {
+        let mempool_space_url =
+            mempool_space_url.unwrap_or_else(|| DEFAULT_MEMPOOL_SPACE_URL.to_string());
+        Self {
+            client,
+            network,
+            mempool_space_url,
+        }
     }
 
     #[instrument(level = "trace", skip_all, ret)]
@@ -58,13 +67,14 @@ impl FeeService {
     #[instrument(level = "trace", skip_all, ret)]
     pub async fn get_fee_rate_as_sat_vb(&self) -> Result<u64> {
         // If network is regtest or signet, mempool space is not available
-        let smart_fee = match get_fee_rate_from_mempool_space(self.network, &self.mempool_space_url).await {
-            Ok(fee_rate) => fee_rate,
-            Err(e) => {
-                tracing::error!(?e, "Failed to get fee rate from mempool.space");
-                self.client.estimate_smart_fee(1, None).await?.fee_rate
-            }
-        };
+        let smart_fee =
+            match get_fee_rate_from_mempool_space(self.network, &self.mempool_space_url).await {
+                Ok(fee_rate) => fee_rate,
+                Err(e) => {
+                    tracing::error!(?e, "Failed to get fee rate from mempool.space");
+                    self.client.estimate_smart_fee(1, None).await?.fee_rate
+                }
+            };
         let sat_vkb = smart_fee.map_or(1000, |rate| rate.to_sat());
 
         tracing::debug!("Fee rate: {} sat/vb", sat_vkb / 1000);
@@ -179,18 +189,20 @@ pub(crate) async fn get_fee_rate_from_mempool_space(
 #[cfg(test)]
 mod tests {
 
-    use super::{DEFAULT_MEMPOOL_SPACE_URL, get_fee_rate_from_mempool_space};
+    use super::{get_fee_rate_from_mempool_space, DEFAULT_MEMPOOL_SPACE_URL};
 
     #[tokio::test]
     async fn test_mempool_space_fee_rate() {
         let mempool_space_url = DEFAULT_MEMPOOL_SPACE_URL;
 
-        let _fee_rate = get_fee_rate_from_mempool_space(bitcoin::Network::Bitcoin, mempool_space_url)
-            .await
-            .unwrap();
-        let _fee_rate = get_fee_rate_from_mempool_space(bitcoin::Network::Testnet, mempool_space_url)
-            .await
-            .unwrap();
+        let _fee_rate =
+            get_fee_rate_from_mempool_space(bitcoin::Network::Bitcoin, mempool_space_url)
+                .await
+                .unwrap();
+        let _fee_rate =
+            get_fee_rate_from_mempool_space(bitcoin::Network::Testnet, mempool_space_url)
+                .await
+                .unwrap();
         assert_eq!(
             None,
             get_fee_rate_from_mempool_space(bitcoin::Network::Regtest, mempool_space_url)

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -81,6 +81,7 @@ pub struct BitcoinServiceConfig {
     pub tx_backup_dir: String,
 
     pub monitoring: Option<MonitoringConfig>,
+    pub mempool_space_url: Option<String>,
 }
 
 impl citrea_common::FromEnv for BitcoinServiceConfig {
@@ -97,6 +98,7 @@ impl citrea_common::FromEnv for BitcoinServiceConfig {
                 history_limit: std::env::var("DA_MONITORING_HISTORY_LIMIT")?.parse()?,
                 max_history_size: std::env::var("DA_MONITORING_MAX_HISTORY_SIZE")?.parse()?,
             }),
+            mempool_space_url: std::env::var("MEMPOOL_SPACE_URL").ok(),
         })
     }
 }
@@ -153,7 +155,7 @@ impl BitcoinService {
         }
 
         let monitoring = Arc::new(MonitoringService::new(client.clone(), config.monitoring));
-        let fee = FeeService::new(client.clone(), config.network);
+        let fee = FeeService::new(client.clone(), config.network, config.mempool_space_url);
         Ok(Self {
             client,
             network: config.network,
@@ -195,7 +197,7 @@ impl BitcoinService {
         }
 
         let monitoring = Arc::new(MonitoringService::new(client.clone(), config.monitoring));
-        let fee = FeeService::new(client.clone(), config.network);
+        let fee = FeeService::new(client.clone(), config.network, config.mempool_space_url);
 
         Ok(Self {
             client,

--- a/crates/bitcoin-da/tests/test_utils.rs
+++ b/crates/bitcoin-da/tests/test_utils.rs
@@ -62,6 +62,7 @@ pub async fn get_service(
         da_private_key: Some(da_private_key),
         tx_backup_dir: get_tx_backup_dir(),
         monitoring: None,
+        mempool_space_url: None,
     };
 
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();


### PR DESCRIPTION
# Description

Adds an optional mempool.space url to config, defaults to "https://mempool.space/"

## Linked Issues
- Fixes #1640 