### PR TITLE
Fix typos and update broken links in multiple files

### DIFF
--- a/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
+++ b/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
@@ -342,7 +342,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
         // sort the transactions by effective tip
         // but first filter those that should be ignored
 
-        // get the transactions (block.transactions is a enum but we only care about the 2nd arm)
+        // get the transactions (block.transactions is an enum but we only care about the 2nd arm)
         let txs = match &block.transactions {
             BlockTransactions::Full(txs) => txs,
             _ => return Ok(None),

--- a/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
+++ b/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
@@ -2,7 +2,7 @@
 //! previous blocks.
 #![allow(unused)]
 
-// Adopted from: https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/gas_oracle.rs
+// Adopted from: https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-eth-types/src/gas_oracle.rs
 
 use alloy_network::AnyNetwork;
 use alloy_primitives::{B256, U256};

--- a/crates/evm/src/evm/call.rs
+++ b/crates/evm/src/evm/call.rs
@@ -1,4 +1,4 @@
-// https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/revm_utils.rs
+// https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-eth-types/src/revm_utils.rs
 
 use std::cmp::min;
 

--- a/crates/evm/src/rpc_helpers/filter.rs
+++ b/crates/evm/src/rpc_helpers/filter.rs
@@ -1,4 +1,4 @@
-// https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-types/src/eth/filter.rs
+// https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/filter.rs
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::iter::StepBy;
@@ -627,7 +627,7 @@ where
     }
 }
 
-// https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/logs_utils.rs#L56
+// https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-eth-types/src/logs_utils.rs#L56
 /// Returns true if the log matches the filter and should be included
 pub fn log_matches_filter(
     log: &reth_primitives::Log,

--- a/crates/evm/src/tests/ef_tests/suite.rs
+++ b/crates/evm/src/tests/ef_tests/suite.rs
@@ -21,7 +21,7 @@ pub trait Suite {
     /// - `BlockchainTests/TransitionTests`
     fn suite_name(&self) -> String;
 
-    /// Load an run each contained test case.
+    /// Load a run each contained test case.
     ///
     /// # Note
     ///


### PR DESCRIPTION
This pull request addresses typos and outdated links in several files. Specifically, it corrects grammar issues and updates references to ensure they point to the correct, current resources.

### Changes:
- Fixed grammar errors in `suite.rs` and `gas_oracle.rs`.
- Updated broken links in `gas_oracle.rs`, `filter.rs`, and `call.rs` to point to the correct URLs.
