### PR TITLE
CI: Create distinct e2e-test-dir upload names

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -236,7 +236,7 @@ jobs:
         if: failure() || cancelled()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-dir
+          name: e2e-test-dir-coverage
           path: ${{ runner.temp }}/coverage
 
       - name: Upload coverage
@@ -428,7 +428,7 @@ jobs:
         if: failure() || cancelled()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-dir
+          name: e2e-test-dir-test
           path: ${{ runner.temp }}/test
 
   system-contracts:


### PR DESCRIPTION
# Description

- Add suffix to coverage and test jobs
- Fixes error seen in https://github.com/chainwayxyz/citrea/actions/runs/12581654933/job/35065852713?pr=1647
`Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run`
