### PR TITLE
Use global secp256k1 context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "pin-project",
  "rand",
  "reqwest",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/bitcoin-da/Cargo.toml
+++ b/crates/bitcoin-da/Cargo.toml
@@ -30,6 +30,7 @@ metrics = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true, features = [] }
 rand = { workspace = true }
 reqwest = { workspace = true, optional = true }
+secp256k1 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }

--- a/crates/bitcoin-da/src/helpers/builders/mod.rs
+++ b/crates/bitcoin-da/src/helpers/builders/mod.rs
@@ -21,6 +21,7 @@ use bitcoin::{
     Address, Amount, OutPoint, ScriptBuf, Sequence, TapLeafHash, TapNodeHash, Transaction, TxIn,
     TxOut, Txid, Witness, XOnlyPublicKey,
 };
+use secp256k1::SECP256K1;
 use serde::Serialize;
 use tracing::{instrument, trace, warn};
 
@@ -464,10 +465,9 @@ fn choose_utxos(
 /// Returns (signature, public_key)
 pub fn sign_blob_with_private_key(blob: &[u8], private_key: &SecretKey) -> (Vec<u8>, Vec<u8>) {
     let message = calculate_sha256(blob);
-    let secp = Secp256k1::new();
-    let public_key = secp256k1::PublicKey::from_secret_key(&secp, private_key);
+    let public_key = secp256k1::PublicKey::from_secret_key(SECP256K1, private_key);
     let msg = secp256k1::Message::from_digest(message);
-    let sig = secp.sign_ecdsa(&msg, private_key);
+    let sig = SECP256K1.sign_ecdsa(&msg, private_key);
     (
         sig.serialize_compact().to_vec(),
         public_key.serialize().to_vec(),

--- a/crates/bitcoin-da/src/helpers/parsers.rs
+++ b/crates/bitcoin-da/src/helpers/parsers.rs
@@ -4,8 +4,8 @@ use bitcoin::blockdata::script::Instruction;
 use bitcoin::opcodes::all::OP_CHECKSIGVERIFY;
 use bitcoin::script::Instruction::{Op, PushBytes};
 use bitcoin::script::{Error as ScriptError, PushBytes as StructPushBytes};
-use bitcoin::secp256k1::{ecdsa, Message, Secp256k1};
-use bitcoin::{secp256k1, Opcode, Script, Transaction};
+use bitcoin::{Opcode, Script, Transaction};
+use secp256k1::{self, ecdsa, Message, SECP256K1};
 use thiserror::Error;
 
 use super::calculate_sha256;
@@ -76,11 +76,9 @@ pub trait VerifyParsed {
         let hash = calculate_sha256(self.body());
         let message = Message::from_digest_slice(&hash).unwrap(); // cannot fail
 
-        let secp = Secp256k1::new();
-
         if public_key.is_ok()
             && signature.is_ok()
-            && secp
+            && SECP256K1
                 .verify_ecdsa(&message, &signature.unwrap(), &public_key.unwrap())
                 .is_ok()
         {

--- a/guests/risc0/batch-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "rand",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha2",

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "rand",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha2",


### PR DESCRIPTION
# Description

Creating Secp256k1 context everytime causes precomputed values to be calculated for each signature verification, causing big memory allocations and unnecessary elliptic curve arithmetic.

Used global context provided by the secp256k1 library instead.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
