### PR TITLE
Remove use_latest_elf config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,7 +1907,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=f75fe92#f75fe92b0594724b9785eff857bb6aff861a2a55"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=df45afe#df45afe8e36ae0c51cfea1b5fab5ec9370e5274a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ alloy-eips = { version = "0.4.2", default-features = false }
 alloy-consensus = { version = "0.4.2", default-features = false, features = ["serde", "serde-bincode-compat"] }
 alloy-network = { version = "0.4.2", default-features = false }
 
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "f75fe92" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "df45afe" }
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "ca3cfa2" }

--- a/bin/citrea/src/guests.rs
+++ b/bin/citrea/src/guests.rs
@@ -48,8 +48,9 @@ lazy_static! {
         );
         m
     };
-    /// The following 2 are used as latest guest builds for tests that use Bitcoin DA.
-    pub(crate) static ref BATCH_PROOF_LATEST_BITCOIN_GUESTS: HashMap<SpecId, (Digest, Vec<u8>)> = {
+
+    #[feature("testing")]
+    pub(crate) static ref BATCH_PROOF_REGTEST_BITCOIN_GUESTS: HashMap<SpecId, (Digest, Vec<u8>)> = {
         HashMap::from(
             [
                 // this is ELF of genesis fork except for da namespace [1, 1] -> [1] and [2,2] -> [2]
@@ -61,6 +62,19 @@ lazy_static! {
             ]
         )
     };
+
+    /// The following 2 are used as latest guest builds for tests that use Bitcoin DA.
+    pub(crate) static ref BATCH_PROOF_LATEST_BITCOIN_GUESTS: HashMap<SpecId, (Digest, Vec<u8>)> = {
+        HashMap::from(
+            [
+                (SpecId::Fork1,
+                    (Digest::new(citrea_risc0_batch_proof::BATCH_PROOF_BITCOIN_ID),
+                    citrea_risc0_batch_proof::BATCH_PROOF_BITCOIN_ELF.to_vec())
+                )
+            ]
+        )
+    };
+
     pub(crate) static ref LIGHT_CLIENT_LATEST_BITCOIN_GUESTS: HashMap<SpecId, (Digest, Vec<u8>)> = {
         let mut m = HashMap::new();
 

--- a/bin/citrea/src/lib.rs
+++ b/bin/citrea/src/lib.rs
@@ -29,7 +29,6 @@ pub enum NetworkArg {
     Devnet,
     /// Nightly
     Nightly,
-    #[cfg(feature = "testing")]
     /// Regtest
     Regtest,
 }
@@ -41,7 +40,6 @@ impl From<NetworkArg> for Network {
             NetworkArg::Testnet => Network::Testnet,
             NetworkArg::Devnet => Network::Devnet,
             NetworkArg::Nightly => Network::Nightly,
-            #[cfg(feature = "testing")]
             NetworkArg::Regtest => Network::Regtest,
         }
     }

--- a/bin/citrea/src/lib.rs
+++ b/bin/citrea/src/lib.rs
@@ -18,7 +18,7 @@ pub use rollup::*;
 
 /// The network currently running.
 #[derive(clap::ValueEnum, Copy, Clone, Default, Debug, Serialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "lowercase")]
 pub enum NetworkArg {
     /// Mainnet
     #[default]
@@ -27,6 +27,11 @@ pub enum NetworkArg {
     Testnet,
     /// Devnet
     Devnet,
+    /// Nightly
+    Nightly,
+    #[cfg(feature = "testing")]
+    /// Regtest
+    Regtest,
 }
 
 impl From<NetworkArg> for Network {
@@ -35,6 +40,9 @@ impl From<NetworkArg> for Network {
             NetworkArg::Mainnet => Network::Mainnet,
             NetworkArg::Testnet => Network::Testnet,
             NetworkArg::Devnet => Network::Devnet,
+            NetworkArg::Nightly => Network::Nightly,
+            #[cfg(feature = "testing")]
+            NetworkArg::Regtest => Network::Regtest,
         }
     }
 }

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -150,7 +150,11 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let mut network = args.network.into();
     if args.dev {
-        network = Network::Nightly;
+        network = if cfg!(feature = "testing") && network == Network::Regtest {
+            Network::Regtest
+        } else {
+            Network::Nightly
+        };
     }
 
     info!("Starting node on {network}");

--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -180,7 +180,6 @@ impl RollupBlueprint for BitcoinRollup {
                 .iter()
                 .map(|(k, (_, code))| (*k, code.clone()))
                 .collect(),
-            #[cfg(feature = "testing")]
             Network::Regtest => BATCH_PROOF_REGTEST_BITCOIN_GUESTS
                 .iter()
                 .map(|(k, (_, code))| (*k, code.clone()))
@@ -206,7 +205,6 @@ impl RollupBlueprint for BitcoinRollup {
                 .iter()
                 .map(|(k, (_, code))| (*k, code.clone()))
                 .collect(),
-            #[cfg(feature = "testing")]
             Network::Regtest => LIGHT_CLIENT_LATEST_BITCOIN_GUESTS
                 .iter()
                 .map(|(k, (_, code))| (*k, code.clone()))
@@ -234,7 +232,6 @@ impl RollupBlueprint for BitcoinRollup {
                 .iter()
                 .map(|(k, (id, _))| (*k, *id))
                 .collect(),
-            #[cfg(feature = "testing")]
             Network::Regtest => BATCH_PROOF_REGTEST_BITCOIN_GUESTS
                 .iter()
                 .map(|(k, (id, _))| (*k, *id))
@@ -262,7 +259,6 @@ impl RollupBlueprint for BitcoinRollup {
                 .iter()
                 .map(|(k, (id, _))| (*k, *id))
                 .collect(),
-            #[cfg(feature = "testing")]
             Network::Regtest => LIGHT_CLIENT_LATEST_BITCOIN_GUESTS
                 .iter()
                 .map(|(k, (id, _))| (*k, *id))

--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -31,8 +31,8 @@ use tracing::instrument;
 
 use crate::guests::{
     BATCH_PROOF_DEVNET_GUESTS, BATCH_PROOF_LATEST_BITCOIN_GUESTS, BATCH_PROOF_MAINNET_GUESTS,
-    BATCH_PROOF_TESTNET_GUESTS, LIGHT_CLIENT_DEVNET_GUESTS, LIGHT_CLIENT_LATEST_BITCOIN_GUESTS,
-    LIGHT_CLIENT_MAINNET_GUESTS, LIGHT_CLIENT_TESTNET_GUESTS,
+    BATCH_PROOF_REGTEST_BITCOIN_GUESTS, BATCH_PROOF_TESTNET_GUESTS, LIGHT_CLIENT_DEVNET_GUESTS,
+    LIGHT_CLIENT_LATEST_BITCOIN_GUESTS, LIGHT_CLIENT_MAINNET_GUESTS, LIGHT_CLIENT_TESTNET_GUESTS,
 };
 use crate::{CitreaRollupBlueprint, Network};
 
@@ -180,6 +180,11 @@ impl RollupBlueprint for BitcoinRollup {
                 .iter()
                 .map(|(k, (_, code))| (*k, code.clone()))
                 .collect(),
+            #[cfg(feature = "testing")]
+            Network::Regtest => BATCH_PROOF_REGTEST_BITCOIN_GUESTS
+                .iter()
+                .map(|(k, (_, code))| (*k, code.clone()))
+                .collect(),
         }
     }
 
@@ -198,6 +203,11 @@ impl RollupBlueprint for BitcoinRollup {
                 .map(|(k, (_, code))| (*k, code.clone()))
                 .collect(),
             Network::Nightly => LIGHT_CLIENT_LATEST_BITCOIN_GUESTS
+                .iter()
+                .map(|(k, (_, code))| (*k, code.clone()))
+                .collect(),
+            #[cfg(feature = "testing")]
+            Network::Regtest => LIGHT_CLIENT_LATEST_BITCOIN_GUESTS
                 .iter()
                 .map(|(k, (_, code))| (*k, code.clone()))
                 .collect(),
@@ -224,6 +234,11 @@ impl RollupBlueprint for BitcoinRollup {
                 .iter()
                 .map(|(k, (id, _))| (*k, *id))
                 .collect(),
+            #[cfg(feature = "testing")]
+            Network::Regtest => BATCH_PROOF_REGTEST_BITCOIN_GUESTS
+                .iter()
+                .map(|(k, (id, _))| (*k, *id))
+                .collect(),
         }
     }
 
@@ -244,6 +259,11 @@ impl RollupBlueprint for BitcoinRollup {
                 .map(|(k, (id, _))| (*k, *id))
                 .collect(),
             Network::Nightly => LIGHT_CLIENT_LATEST_BITCOIN_GUESTS
+                .iter()
+                .map(|(k, (id, _))| (*k, *id))
+                .collect(),
+            #[cfg(feature = "testing")]
+            Network::Regtest => LIGHT_CLIENT_LATEST_BITCOIN_GUESTS
                 .iter()
                 .map(|(k, (id, _))| (*k, *id))
                 .collect(),

--- a/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/batch_prover_test.rs
@@ -72,13 +72,6 @@ impl TestCase for BasicProverTest {
         }
     }
 
-    fn batch_prover_config() -> BatchProverConfig {
-        BatchProverConfig {
-            use_latest_elf: false,
-            ..Default::default()
-        }
-    }
-
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
         let da = f.bitcoin_nodes.get(0).unwrap();
         let sequencer = f.sequencer.as_ref().unwrap();
@@ -161,13 +154,6 @@ impl TestCase for SkipPreprovenCommitmentsTest {
     fn sequencer_config() -> SequencerConfig {
         SequencerConfig {
             min_soft_confirmations_per_commitment: 1,
-            ..Default::default()
-        }
-    }
-
-    fn batch_prover_config() -> BatchProverConfig {
-        BatchProverConfig {
-            use_latest_elf: false,
             ..Default::default()
         }
     }
@@ -555,6 +541,21 @@ impl TestCase for ForkElfSwitchingTest {
         }
     }
 
+    fn light_client_prover_config() -> LightClientProverConfig {
+        LightClientProverConfig {
+            initial_da_height: 171,
+            enable_recovery: false,
+            ..Default::default()
+        }
+    }
+
+    fn test_env() -> TestCaseEnv {
+        TestCaseEnv {
+            test: vec![("CITREA_NETWORK", "regtest")],
+            ..Default::default()
+        }
+    }
+
     fn sequencer_config() -> SequencerConfig {
         let fork_1_height = ForkManager::new(get_forks(), 0)
             .next_fork()
@@ -565,21 +566,6 @@ impl TestCase for ForkElfSwitchingTest {
         // and second batch above fork1
         SequencerConfig {
             min_soft_confirmations_per_commitment: fork_1_height - 5,
-            ..Default::default()
-        }
-    }
-
-    fn batch_prover_config() -> BatchProverConfig {
-        BatchProverConfig {
-            use_latest_elf: false,
-            ..Default::default()
-        }
-    }
-
-    fn light_client_prover_config() -> LightClientProverConfig {
-        LightClientProverConfig {
-            initial_da_height: 171,
-            enable_recovery: false,
             ..Default::default()
         }
     }
@@ -636,6 +622,7 @@ impl TestCase for ForkElfSwitchingTest {
         assert_eq!(fork_from_block_number(height).spec_id, SpecId::Fork1);
 
         da.wait_mempool_len(4, None).await?;
+        println!("got 4 seq txs");
 
         da.generate(FINALITY_DEPTH).await?;
 
@@ -693,6 +680,8 @@ impl TestCase for ForkElfSwitchingTest {
 
 #[tokio::test]
 async fn test_fork_elf_switching() -> Result<()> {
+    std::env::set_var("CITREA_NETWORK", "regtest");
+
     TestCaseRunner::new(ForkElfSwitchingTest)
         .set_citrea_path(get_citrea_path())
         .run()

--- a/bin/citrea/tests/bitcoin_e2e/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin_e2e/light_client_test.rs
@@ -52,7 +52,6 @@ impl TestCase for LightClientProvingTest {
     fn batch_prover_config() -> BatchProverConfig {
         BatchProverConfig {
             enable_recovery: false,
-            use_latest_elf: false,
             ..Default::default()
         }
     }
@@ -188,7 +187,6 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         BatchProverConfig {
             enable_recovery: false,
             proof_sampling_number: 99999999,
-            use_latest_elf: false,
             ..Default::default()
         }
     }
@@ -240,11 +238,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         batch_prover
             .client
             .http_client()
-            .prove(
-                commitment_l1_height,
-                false,
-                Some(GroupCommitments::OneByOne),
-            )
+            .prove(commitment_l1_height, Some(GroupCommitments::OneByOne))
             .await
             .unwrap();
 
@@ -369,11 +363,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         batch_prover
             .client
             .http_client()
-            .prove(
-                commitment_l1_height,
-                false,
-                Some(GroupCommitments::OneByOne),
-            )
+            .prove(commitment_l1_height, Some(GroupCommitments::OneByOne))
             .await
             .unwrap();
 
@@ -477,7 +467,6 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
     fn batch_prover_config() -> BatchProverConfig {
         BatchProverConfig {
             enable_recovery: false,
-            use_latest_elf: false,
             ..Default::default()
         }
     }

--- a/bin/citrea/tests/e2e/mod.rs
+++ b/bin/citrea/tests/e2e/mod.rs
@@ -96,7 +96,6 @@ async fn test_all_flow() {
                 proving_mode: sov_stf_runner::ProverGuestRunConfig::Execute,
                 proof_sampling_number: 0,
                 enable_recovery: true,
-                use_latest_elf: true,
             }),
             None,
             rollup_config,

--- a/bin/citrea/tests/e2e/proving.rs
+++ b/bin/citrea/tests/e2e/proving.rs
@@ -64,7 +64,6 @@ async fn full_node_verify_proof_and_store() {
                 proving_mode: sov_stf_runner::ProverGuestRunConfig::Execute,
                 proof_sampling_number: 0,
                 enable_recovery: true,
-                use_latest_elf: true,
             }),
             None,
             rollup_config,
@@ -247,7 +246,6 @@ async fn test_batch_prover_prove_rpc() {
                 // Make it impossible for proving to happen
                 proof_sampling_number: 1_000_000,
                 enable_recovery: true,
-                use_latest_elf: true,
             }),
             None,
             rollup_config,
@@ -301,7 +299,7 @@ async fn test_batch_prover_prove_rpc() {
 
     // Trigger proving via the RPC endpoint
     prover_node_test_client
-        .batch_prover_prove(3, true, Some(GroupCommitments::Normal))
+        .batch_prover_prove(3, Some(GroupCommitments::Normal))
         .await;
 
     // wait here until we see from prover's rpc that it finished proving

--- a/bin/citrea/tests/e2e/reopen.rs
+++ b/bin/citrea/tests/e2e/reopen.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use alloy_primitives::Address;
-use citrea_common::{BatchProverConfig, SequencerConfig};
+use citrea_common::SequencerConfig;
 use citrea_stf::genesis_config::GenesisPaths;
 use reth_primitives::BlockNumberOrTag;
 use sov_db::ledger_db::migrations::copy_db_dir_recursive;
@@ -330,10 +330,7 @@ async fn test_reopen_prover() -> Result<(), anyhow::Error> {
                 start_rollup(
                     prover_node_port_tx,
                     GenesisPaths::from_dir(TEST_DATA_GENESIS_PATH),
-                    Some(BatchProverConfig {
-                        use_latest_elf: true,
-                        ..Default::default()
-                    }),
+                    None,
                     None,
                     rollup_config,
                     None,
@@ -402,10 +399,7 @@ async fn test_reopen_prover() -> Result<(), anyhow::Error> {
                 start_rollup(
                     prover_node_port_tx,
                     GenesisPaths::from_dir(TEST_DATA_GENESIS_PATH),
-                    Some(BatchProverConfig {
-                        use_latest_elf: true,
-                        ..Default::default()
-                    }),
+                    None,
                     None,
                     rollup_config,
                     None,
@@ -458,10 +452,7 @@ async fn test_reopen_prover() -> Result<(), anyhow::Error> {
                 start_rollup(
                     prover_node_port_tx,
                     GenesisPaths::from_dir(TEST_DATA_GENESIS_PATH),
-                    Some(BatchProverConfig {
-                        use_latest_elf: true,
-                        ..Default::default()
-                    }),
+                    None,
                     None,
                     rollup_config,
                     None,

--- a/bin/citrea/tests/e2e/syncing.rs
+++ b/bin/citrea/tests/e2e/syncing.rs
@@ -299,7 +299,6 @@ async fn test_prover_sync_with_commitments() -> Result<(), anyhow::Error> {
                 proving_mode: sov_stf_runner::ProverGuestRunConfig::Execute,
                 proof_sampling_number: 0,
                 enable_recovery: true,
-                use_latest_elf: true,
             }),
             None,
             rollup_config,

--- a/bin/citrea/tests/test_client/mod.rs
+++ b/bin/citrea/tests/test_client/mod.rs
@@ -728,13 +728,12 @@ impl TestClient {
     pub(crate) async fn batch_prover_prove(
         &self,
         l1_height: u64,
-        use_latest_elf: bool,
         group_commitments: Option<GroupCommitments>,
     ) {
         self.http_client
             .request(
                 "batchProver_prove",
-                rpc_params![l1_height, use_latest_elf, group_commitments],
+                rpc_params![l1_height, group_commitments],
             )
             .await
             .unwrap()

--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -260,7 +260,6 @@ where
                         l1_block,
                         sequencer_commitments,
                         inputs,
-                        self.prover_config.use_latest_elf,
                     )
                     .await?;
                 } else {
@@ -293,7 +292,6 @@ where
             self.ledger_db.clone(),
             txs_and_proofs,
             self.code_commitments_by_spec.clone(),
-            self.prover_config.use_latest_elf,
         )
         .await?;
 

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -211,7 +211,6 @@ where
     Ok((sequencer_commitments, batch_proof_circuit_inputs))
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn prove_l1<Da, Ps, Vm, DB, StateRoot, Witness, Tx>(
     prover_service: Arc<Ps>,
     ledger: DB,
@@ -220,7 +219,6 @@ pub(crate) async fn prove_l1<Da, Ps, Vm, DB, StateRoot, Witness, Tx>(
     l1_block: &Da::FilteredBlock,
     sequencer_commitments: Vec<SequencerCommitment>,
     inputs: Vec<BatchProofCircuitInput<'_, StateRoot, Witness, Da::Spec, Tx>>,
-    use_latest_elf: bool,
 ) -> anyhow::Result<()>
 where
     Da: DaService,
@@ -248,11 +246,7 @@ where
             let seq_com = sequencer_commitments.get(i).expect("Commitment exists");
             let last_l2_height = seq_com.l2_end_block_number;
 
-            let mut current_spec = fork_from_block_number(last_l2_height).spec_id;
-
-            if use_latest_elf {
-                current_spec = SpecId::Fork1;
-            }
+            let current_spec = fork_from_block_number(last_l2_height).spec_id;
 
             let elf = elfs_by_spec
                 .get(&current_spec)
@@ -288,7 +282,6 @@ where
         ledger.clone(),
         txs_and_proofs,
         code_commitments_by_spec.clone(),
-        use_latest_elf,
     )
     .await?;
 
@@ -331,7 +324,6 @@ pub(crate) async fn extract_and_store_proof<DB, Da, Vm, StateRoot>(
     ledger_db: DB,
     txs_and_proofs: Vec<(<Da as DaService>::TransactionId, Proof)>,
     code_commitments_by_spec: HashMap<SpecId, Vm::CodeCommitment>,
-    use_latest_elf: bool,
 ) -> Result<(), anyhow::Error>
 where
     Da: DaService,
@@ -351,7 +343,7 @@ where
         // l1_height => (tx_id, proof, circuit_output)
         // save proof along with tx id to db, should be queryable by slot number or slot hash
         // TODO: select output version based on spec
-        let (mut last_active_spec_id, circuit_output) = match Vm::extract_output::<
+        let (last_active_spec_id, circuit_output) = match Vm::extract_output::<
             BatchProofCircuitOutput<<Da as DaService>::Spec, StateRoot>,
         >(&proof)
         {
@@ -384,10 +376,6 @@ where
                 (SpecId::Genesis, batch_proof_output)
             }
         };
-
-        if use_latest_elf {
-            last_active_spec_id = SpecId::Fork1;
-        }
 
         let code_commitment = code_commitments_by_spec
             .get(&last_active_spec_id)

--- a/crates/batch-prover/src/rpc.rs
+++ b/crates/batch-prover/src/rpc.rs
@@ -75,7 +75,6 @@ pub trait BatchProverRpc {
     async fn prove(
         &self,
         l1_height: u64,
-        use_latest_elf: bool,
         group_commitments: Option<GroupCommitments>,
     ) -> RpcResult<()>;
 }
@@ -203,7 +202,6 @@ where
     async fn prove(
         &self,
         l1_height: u64,
-        use_latest_elf: bool,
         group_commitments: Option<GroupCommitments>,
     ) -> RpcResult<()> {
         let l1_block: <Da as DaService>::FilteredBlock = self
@@ -245,7 +243,6 @@ where
             &l1_block,
             sequencer_commitments,
             inputs,
-            use_latest_elf,
         )
         .await
         .map_err(|e| {

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -250,7 +250,7 @@ impl DaVerifier for BitcoinVerifier {
                 latest_da_state.unwrap_or(&INITIAL_SIGNET_STATE),
                 block_header,
             ),
-            Network::Nightly => {
+            Network::Nightly | Network::Regtest => {
                 // For regtest, if this is the first light client proof, we always
                 // consider the block valid with respect to its parent block, so
                 // it can start from anywhere.

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -239,8 +239,6 @@ pub struct BatchProverConfig {
     pub proof_sampling_number: usize,
     /// If true prover will try to recover ongoing proving sessions
     pub enable_recovery: bool,
-    /// Whether to always use latest ELF or not
-    pub use_latest_elf: bool,
 }
 
 /// Prover configuration
@@ -265,9 +263,6 @@ impl Default for BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
             enable_recovery: true,
-            // defaults to false. beacuse in production we don't want to accedentially set this to true.
-            // true actually applies to testing mostly.
-            use_latest_elf: false,
         }
     }
 }
@@ -289,10 +284,6 @@ impl FromEnv for BatchProverConfig {
             proving_mode: serde_json::from_str(&format!("\"{}\"", std::env::var("PROVING_MODE")?))?,
             proof_sampling_number: std::env::var("PROOF_SAMPLING_NUMBER")?.parse()?,
             enable_recovery: std::env::var("ENABLE_RECOVERY")?.parse()?,
-            use_latest_elf: std::env::var("USE_LATEST_ELF")?
-                .parse()
-                .ok()
-                .unwrap_or(false),
         })
     }
 }
@@ -464,7 +455,7 @@ mod tests {
             sequencer_public_key = "0000000000000000000000000000000000000000000000000000000000000000"
             sequencer_da_pub_key = "7777777777777777777777777777777777777777777777777777777777777777"
             prover_da_pub_key = ""
-            
+
             [rpc]
             bind_host = "127.0.0.1"
             bind_port = 12345
@@ -475,11 +466,11 @@ mod tests {
             [da]
             sender_address = "0000000000000000000000000000000000000000000000000000000000000000"
             db_path = "/tmp/da"
-            
+
             [storage]
             path = "/tmp/rollup"
             db_max_open_files = 123
-            
+
             [runner]
             include_tx_body = true
             sequencer_client_url = "http://0.0.0.0:12346"
@@ -538,7 +529,6 @@ mod tests {
             proving_mode = "skip"
             proof_sampling_number = 500
             enable_recovery = true
-            use_latest_elf = false
         "#;
 
         let config_file = create_config_from(config);
@@ -548,7 +538,6 @@ mod tests {
             proving_mode: ProverGuestRunConfig::Skip,
             proof_sampling_number: 500,
             enable_recovery: true,
-            use_latest_elf: false,
         };
         assert_eq!(config, expected);
     }
@@ -601,7 +590,6 @@ mod tests {
         std::env::set_var("PROVING_MODE", "skip");
         std::env::set_var("PROOF_SAMPLING_NUMBER", "500");
         std::env::set_var("ENABLE_RECOVERY", "true");
-        std::env::set_var("USE_LATEST_ELF", "false");
 
         let prover_config = BatchProverConfig::from_env().unwrap();
 
@@ -609,7 +597,6 @@ mod tests {
             proving_mode: ProverGuestRunConfig::Skip,
             proof_sampling_number: 500,
             enable_recovery: true,
-            use_latest_elf: false,
         };
         assert_eq!(prover_config, expected);
     }

--- a/crates/primitives/src/forks.rs
+++ b/crates/primitives/src/forks.rs
@@ -16,7 +16,7 @@ pub fn use_network_forks(network: Network) {
         Network::Mainnet => &MAINNET_FORKS,
         Network::Testnet => &TESTNET_FORKS,
         Network::Devnet => &DEVNET_FORKS,
-        Network::Nightly => &NIGHTLY_FORKS,
+        Network::Nightly | Network::Regtest => &NIGHTLY_FORKS,
     };
 
     #[cfg(not(feature = "testing"))]
@@ -56,12 +56,12 @@ pub const MAINNET_FORKS: [Fork; 1] = [Fork::new(SpecId::Fork1, 0)];
 
 pub const TESTNET_FORKS: [Fork; 2] = [
     Fork::new(SpecId::Genesis, 0),
-    Fork::new(SpecId::Fork1, 999_999_999),
+    Fork::new(SpecId::Fork1, u64::MAX),
 ];
 
 pub const DEVNET_FORKS: [Fork; 2] = [
     Fork::new(SpecId::Genesis, 0),
-    Fork::new(SpecId::Fork1, 999_999_999),
+    Fork::new(SpecId::Fork1, u64::MAX),
 ];
 
 #[cfg(feature = "testing")]

--- a/crates/primitives/src/forks.rs
+++ b/crates/primitives/src/forks.rs
@@ -16,7 +16,9 @@ pub fn use_network_forks(network: Network) {
         Network::Mainnet => &MAINNET_FORKS,
         Network::Testnet => &TESTNET_FORKS,
         Network::Devnet => &DEVNET_FORKS,
-        Network::Nightly | Network::Regtest => &NIGHTLY_FORKS,
+        Network::Nightly => &NIGHTLY_FORKS,
+        #[cfg(feature = "testing")]
+        Network::Regtest => &NIGHTLY_FORKS,
     };
 
     #[cfg(not(feature = "testing"))]

--- a/crates/primitives/src/forks.rs
+++ b/crates/primitives/src/forks.rs
@@ -16,9 +16,7 @@ pub fn use_network_forks(network: Network) {
         Network::Mainnet => &MAINNET_FORKS,
         Network::Testnet => &TESTNET_FORKS,
         Network::Devnet => &DEVNET_FORKS,
-        Network::Nightly => &NIGHTLY_FORKS,
-        #[cfg(feature = "testing")]
-        Network::Regtest => &NIGHTLY_FORKS,
+        Network::Nightly | Network::Regtest => &NIGHTLY_FORKS,
     };
 
     #[cfg(not(feature = "testing"))]

--- a/crates/sovereign-sdk/rollup-interface/src/network.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/network.rs
@@ -12,7 +12,6 @@ pub enum Network {
     Devnet,
     /// Nightly
     Nightly,
-    #[cfg(feature = "testing")]
     /// Regtest
     Regtest,
 }

--- a/crates/sovereign-sdk/rollup-interface/src/network.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/network.rs
@@ -1,7 +1,7 @@
 use core::fmt::Display;
 
 /// The network currently running.
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
 pub enum Network {
     /// Mainnet
     #[default]
@@ -12,6 +12,9 @@ pub enum Network {
     Devnet,
     /// Nightly
     Nightly,
+    #[cfg(feature = "testing")]
+    /// Regtest
+    Regtest,
 }
 
 impl Display for Network {
@@ -28,6 +31,8 @@ impl Network {
             b"testnet" => Some(Network::Testnet),
             b"devnet" => Some(Network::Devnet),
             b"nightly" => Some(Network::Nightly),
+            #[cfg(feature = "testing")]
+            b"regtest" => Some(Network::Regtest),
             _ => None,
         }
     }

--- a/guests/risc0/batch-proof/bitcoin/src/bin/batch_proof_bitcoin.rs
+++ b/guests/risc0/batch-proof/bitcoin/src/bin/batch_proof_bitcoin.rs
@@ -17,12 +17,10 @@ use sov_state::ZkStorage;
 risc0_zkvm::guest::entry!(main);
 
 const NETWORK: Network = match option_env!("CITREA_NETWORK") {
-    Some(network) => {
-        match Network::const_from_str(network) {
-            Some(network) => network,
-            None => panic!("Invalid CITREA_NETWORK value"),
-        } 
-    }
+    Some(network) => match Network::const_from_str(network) {
+        Some(network) => network,
+        None => panic!("Invalid CITREA_NETWORK value"),
+    },
     None => Network::Nightly,
 };
 
@@ -31,12 +29,10 @@ const SEQUENCER_PUBLIC_KEY: [u8; 32] = {
         Network::Mainnet => "0000000000000000000000000000000000000000000000000000000000000000",
         Network::Testnet => "4682a70af1d3fae53a5a26b682e2e75f7a1de21ad5fc8d61794ca889880d39d1",
         Network::Devnet => "52f41a5076498d1ae8bdfa57d19e91e3c2c94b6de21985d099cd48cfa7aef174",
-        Network::Nightly => {
-            match option_env!("SEQUENCER_PUBLIC_KEY") {
-                Some(hex_pub_key) => hex_pub_key,
-                None => "204040e364c10f2bec9c1fe500a1cd4c247c89d650a01ed7e82caba867877c21",
-            }
-        }
+        Network::Nightly | Network::Regtest => match option_env!("SEQUENCER_PUBLIC_KEY") {
+            Some(hex_pub_key) => hex_pub_key,
+            None => "204040e364c10f2bec9c1fe500a1cd4c247c89d650a01ed7e82caba867877c21",
+        },
     };
 
     match const_hex::const_decode_to_array(hex_pub_key.as_bytes()) {
@@ -50,12 +46,10 @@ const SEQUENCER_DA_PUBLIC_KEY: [u8; 33] = {
         Network::Mainnet => "030000000000000000000000000000000000000000000000000000000000000000",
         Network::Testnet => "03015a7c4d2cc1c771198686e2ebef6fe7004f4136d61f6225b061d1bb9b821b9b",
         Network::Devnet => "039cd55f9b3dcf306c4d54f66cd7c4b27cc788632cd6fb73d80c99d303c6536486",
-        Network::Nightly => {
-            match option_env!("SEQUENCER_DA_PUB_KEY") {
-                Some(hex_pub_key) => hex_pub_key,
-                None => "02588d202afcc1ee4ab5254c7847ec25b9a135bbda0f2bc69ee1a714749fd77dc9",
-            }
-        }
+        Network::Nightly | Network::Regtest => match option_env!("SEQUENCER_DA_PUB_KEY") {
+            Some(hex_pub_key) => hex_pub_key,
+            None => "02588d202afcc1ee4ab5254c7847ec25b9a135bbda0f2bc69ee1a714749fd77dc9",
+        },
     };
 
     match const_hex::const_decode_to_array(hex_pub_key.as_bytes()) {
@@ -68,7 +62,7 @@ const FORKS: &[Fork] = match NETWORK {
     Network::Mainnet => &MAINNET_FORKS,
     Network::Testnet => &TESTNET_FORKS,
     Network::Devnet => &DEVNET_FORKS,
-    Network::Nightly => &NIGHTLY_FORKS,
+    Network::Nightly | Network::Regtest => &NIGHTLY_FORKS,
 };
 
 pub fn main() {
@@ -87,7 +81,13 @@ pub fn main() {
     let data = guest.read_from_host();
 
     let out = stf_verifier
-        .run_sequencer_commitments_in_da_slot(data, storage, &SEQUENCER_PUBLIC_KEY, &SEQUENCER_DA_PUBLIC_KEY, FORKS)
+        .run_sequencer_commitments_in_da_slot(
+            data,
+            storage,
+            &SEQUENCER_PUBLIC_KEY,
+            &SEQUENCER_DA_PUBLIC_KEY,
+            FORKS,
+        )
         .expect("Prover must be honest");
 
     guest.commit(&out);

--- a/guests/risc0/light-client-proof/bitcoin/src/bin/light_client_proof_bitcoin.rs
+++ b/guests/risc0/light-client-proof/bitcoin/src/bin/light_client_proof_bitcoin.rs
@@ -24,7 +24,7 @@ const L2_GENESIS_ROOT: [u8; 32] = {
         // TODO: Update this after finding out the first batch prover output of the next release
         Network::Testnet => "05183faf24857f0fa6d4a7738fe5ef14b7ebe88be0f66e6f87f461485554d531",
         Network::Devnet => "c23eb4eec08765750400f6e98567ef1977dc86334318f5424b7783c4080c0a36",
-        Network::Nightly => match option_env!("L2_GENESIS_ROOT") {
+        Network::Nightly | Network::Regtest => match option_env!("L2_GENESIS_ROOT") {
             Some(hex_root) => hex_root,
             None => "dacb59b0ff5d16985a8418235133eee37758a3ac1b76ab6d1f87c6df20e4d4da",
         },
@@ -64,7 +64,7 @@ const INITIAL_BATCH_PROOF_METHOD_IDS: &[(u64, [u32; 8])] = {
         ],
         // TODO: Update
         Network::Devnet => &[(0, [0; 8])],
-        Network::Nightly => match option_env!("BATCH_PROOF_METHOD_ID") {
+        Network::Nightly | Network::Regtest => match option_env!("BATCH_PROOF_METHOD_ID") {
             Some(hex_method_id) => &[(0, decode_to_u32_array(hex_method_id))],
             None => &[
                 (
@@ -84,7 +84,7 @@ const BATCH_PROVER_DA_PUBLIC_KEY: [u8; 33] = {
         Network::Mainnet => "030000000000000000000000000000000000000000000000000000000000000000",
         Network::Testnet => "0357d255ab93638a2d880787ebaadfefdfc9bb51a26b4a37e5d588e04e54c60a42",
         Network::Devnet => "03fc6fb2ef68368009c895d2d4351dcca4109ec2f5f327291a0553570ce769f5e5",
-        Network::Nightly => match option_env!("PROVER_DA_PUB_KEY") {
+        Network::Nightly | Network::Regtest => match option_env!("PROVER_DA_PUB_KEY") {
             Some(hex_pub_key) => hex_pub_key,
             None => "03eedab888e45f3bdc3ec9918c491c11e5cf7af0a91f38b97fbc1e135ae4056601",
         },
@@ -101,10 +101,12 @@ pub const METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEY: [u8; 33] = {
         Network::Mainnet => "000000000000000000000000000000000000000000000000000000000000000000",
         Network::Testnet => "000000000000000000000000000000000000000000000000000000000000000000",
         Network::Devnet => "000000000000000000000000000000000000000000000000000000000000000000",
-        Network::Nightly => match option_env!("METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEY") {
-            Some(hex_pub_key) => hex_pub_key,
-            None => "0313c4ff65eb94999e0ac41cfe21592baa52910f5a5ada9074b816de4f560189db",
-        },
+        Network::Nightly | Network::Regtest => {
+            match option_env!("METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEY") {
+                Some(hex_pub_key) => hex_pub_key,
+                None => "0313c4ff65eb94999e0ac41cfe21592baa52910f5a5ada9074b816de4f560189db",
+            }
+        }
     };
 
     match const_hex::const_decode_to_array(hex_pub_key.as_bytes()) {


### PR DESCRIPTION
# Description

- Remove `use_latest_elf` config.
- Replaces it with a new `Regtest` network behind "testing" flag. Keep previous ELF available only on this newly introduced network and remove the conflict with other tests depending on latest elf.

