### PR TITLE
Blob with sender versioned serialized

### DIFF
--- a/crates/bitcoin-da/src/spec/blob.rs
+++ b/crates/bitcoin-da/src/spec/blob.rs
@@ -82,13 +82,13 @@ impl BlobReaderTrait for BlobWithSender {
         self.verified_data()
     }
 
-    fn serialize_v1(&self) -> anyhow::Result<Vec<u8>> {
+    fn serialize_v1(&self) -> borsh::io::Result<Vec<u8>> {
         let v1 = BlobWithSenderV1 {
             hash: self.hash,
             sender: self.sender.clone(),
             blob: &self.blob,
         };
-        Ok(borsh::to_vec(&v1)?)
+        borsh::to_vec(&v1)
     }
 }
 

--- a/crates/bitcoin-da/src/spec/blob.rs
+++ b/crates/bitcoin-da/src/spec/blob.rs
@@ -81,4 +81,21 @@ impl BlobReaderTrait for BlobWithSender {
         self.blob.advance(num_bytes);
         self.verified_data()
     }
+
+    fn serialize_v1(&self) -> anyhow::Result<Vec<u8>> {
+        let v1 = BlobWithSenderV1 {
+            hash: self.hash,
+            sender: self.sender.clone(),
+            blob: &self.blob,
+        };
+        Ok(borsh::to_vec(&v1)?)
+    }
+}
+
+#[derive(BorshSerialize)]
+/// Internal type to ease serialization process
+struct BlobWithSenderV1<'a> {
+    hash: [u8; 32],
+    sender: AddressWrapper,
+    blob: &'a CountedBufReader<BlobBuf>,
 }

--- a/crates/sovereign-sdk/adapters/mock-da/src/verifier.rs
+++ b/crates/sovereign-sdk/adapters/mock-da/src/verifier.rs
@@ -34,6 +34,10 @@ impl BlobReaderTrait for MockBlob {
         self.data.advance(num_bytes);
         self.verified_data()
     }
+
+    fn serialize_v1(&self) -> anyhow::Result<Vec<u8>> {
+        Ok(borsh::to_vec(self)?)
+    }
 }
 
 /// A [`sov_rollup_interface::da::DaSpec`] suitable for testing.

--- a/crates/sovereign-sdk/adapters/mock-da/src/verifier.rs
+++ b/crates/sovereign-sdk/adapters/mock-da/src/verifier.rs
@@ -35,8 +35,8 @@ impl BlobReaderTrait for MockBlob {
         self.verified_data()
     }
 
-    fn serialize_v1(&self) -> anyhow::Result<Vec<u8>> {
-        Ok(borsh::to_vec(self)?)
+    fn serialize_v1(&self) -> borsh::io::Result<Vec<u8>> {
+        borsh::to_vec(self)
     }
 }
 

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/reexport_macros.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/reexport_macros.rs
@@ -88,6 +88,10 @@ pub use sov_modules_macros::ModuleCallJsonSchema;
 #[cfg(feature = "macros")]
 pub use sov_modules_macros::ModuleInfo;
 
+/// Implements ForkCodec trait. Requires the type to be enum.
+#[cfg(feature = "macros")]
+pub use sov_modules_macros::ForkCodec;
+
 /// Procedural macros to assist with creating new modules.
 #[cfg(feature = "macros")]
 pub mod macros {

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/reexport_macros.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/reexport_macros.rs
@@ -2,6 +2,9 @@
 /// type.
 #[cfg(feature = "macros")]
 pub use sov_modules_macros::DispatchCall;
+/// Implements ForkCodec trait. Requires the type to be enum.
+#[cfg(feature = "macros")]
+pub use sov_modules_macros::ForkCodec;
 /// Derives the [`Genesis`](trait.Genesis.html) trait for the underlying runtime
 /// `struct`.
 #[cfg(feature = "macros")]
@@ -87,10 +90,6 @@ pub use sov_modules_macros::ModuleCallJsonSchema;
 /// ```
 #[cfg(feature = "macros")]
 pub use sov_modules_macros::ModuleInfo;
-
-/// Implements ForkCodec trait. Requires the type to be enum.
-#[cfg(feature = "macros")]
-pub use sov_modules_macros::ForkCodec;
 
 /// Procedural macros to assist with creating new modules.
 #[cfg(feature = "macros")]

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/src/fork_codec.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/src/fork_codec.rs
@@ -1,0 +1,67 @@
+use proc_macro2::Span;
+use quote::quote;
+use syn::{Data, DeriveInput, Error};
+
+pub fn derive_fork_codec(input: DeriveInput) -> Result<proc_macro::TokenStream, Error> {
+    // Extract the name of the enum
+    let name = &input.ident;
+
+    // Ensure it's an enum
+    let Data::Enum(data_enum) = &input.data else {
+        return Err(Error::new(
+            Span::call_site(),
+            "ForkCodec can only be derived for enums. Use borsh derive directly instead.",
+        ));
+    };
+
+    // Extract variants
+    let variants = &data_enum.variants;
+
+    // Generate match arms for encode and decode
+    let encode_arms = variants.iter().map(|variant| {
+        let variant_name = &variant.ident;
+        quote! {
+            Self::#variant_name(inner) => borsh::to_vec(inner).map_err(|e| e.into()),
+        }
+    });
+
+    let decode_arms = variants.iter().enumerate().map(|(index, variant)| {
+        let variant_name = &variant.ident;
+        quote! {
+            #index => {
+                let inner = borsh::from_slice(slice)?;
+                Ok(Self::#variant_name(inner))
+            }
+        }
+    });
+
+    // Fallback for remaining SpecId variants
+    let fallback_variant = &variants.last().unwrap().ident;
+    let fallback_arm = quote! {
+        _ => {
+            let inner = borsh::from_slice(slice)?;
+            Ok(Self::#fallback_variant(inner))
+        }
+    };
+
+    // Generate the implementation
+    let expanded = quote! {
+        impl sov_rollup_interface::fork::ForkCodec for #name {
+            fn encode(&self) -> anyhow::Result<Vec<u8>> {
+                match self {
+                    #(#encode_arms)*
+                }
+            }
+
+            fn decode(bytes: impl AsRef<[u8]>, spec: sov_rollup_interface::spec::SpecId) -> anyhow::Result<Self> {
+                let slice = bytes.as_ref();
+                match spec as u8 as usize {
+                    #(#decode_arms)*
+                    #fallback_arm
+                }
+            }
+        }
+    };
+
+    Ok(proc_macro::TokenStream::from(expanded))
+}

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/src/lib.rs
@@ -212,6 +212,7 @@ pub fn cli_parser(input: TokenStream) -> TokenStream {
     let cli_parser = CliParserMacro::new("Cmd");
     handle_macro_error(cli_parser.cli_macro(input))
 }
+
 #[cfg(feature = "native")]
 #[proc_macro_derive(CliWalletArg)]
 pub fn custom_enum_clap(input: TokenStream) -> TokenStream {

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/src/lib.rs
@@ -14,6 +14,7 @@ mod cli_parser;
 mod common;
 mod default_runtime;
 mod dispatch;
+mod fork_codec;
 mod make_constants;
 mod manifest;
 mod module_call_json_schema;
@@ -27,6 +28,7 @@ use default_runtime::DefaultRuntimeMacro;
 use dispatch::dispatch_call::DispatchCallMacro;
 use dispatch::genesis::GenesisMacro;
 use dispatch::message_codec::MessageCodec;
+use fork_codec::derive_fork_codec;
 use make_constants::{make_const, PartialItemConst};
 use module_call_json_schema::derive_module_call_json_schema;
 use module_info::ModuleType;
@@ -218,4 +220,10 @@ pub fn cli_parser(input: TokenStream) -> TokenStream {
 pub fn custom_enum_clap(input: TokenStream) -> TokenStream {
     let input: syn::DeriveInput = parse_macro_input!(input);
     handle_macro_error(derive_cli_wallet_arg(input))
+}
+
+#[proc_macro_derive(ForkCodec)]
+pub fn fork_codec_derive(input: TokenStream) -> TokenStream {
+    let input: syn::DeriveInput = parse_macro_input!(input);
+    handle_macro_error(derive_fork_codec(input))
 }

--- a/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
@@ -79,3 +79,55 @@ pub fn fork_pos_from_block_number(forks: &[Fork], block_number: u64) -> usize {
         Err(idx) => idx.saturating_sub(1),
     }
 }
+
+/// ForkCodec is the serialization trait for types that require forking when changed.
+/// Optimal usecase would be the type to be versioned enum, and do untagged enum ser/de.
+///
+/// Example:
+///
+/// ```
+/// use sov_rollup_interface::fork::ForkCodec;
+/// use sov_rollup_interface::spec::SpecId;
+///
+/// #[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
+/// struct InputV1 {}
+///
+/// #[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
+/// struct InputV2 {}
+///
+/// enum Input {
+///     V1(InputV1),
+///     V2(InputV2),
+/// }
+///
+/// impl Input {
+///     pub fn new_v1(v1: InputV1) -> Self {
+///         Self::V1(v1)
+///     }
+///
+///     pub fn new_v2(v2: InputV2) -> Self {
+///         Self::V2(v2)
+///     }
+/// }
+///
+/// impl ForkCodec for Input {
+///     fn encode(&self) -> anyhow::Result<Vec<u8>> {
+///         match self {
+///             Self::V1(v1) => Ok(borsh::to_vec(v1)?),
+///             Self::V2(v2) => Ok(borsh::to_vec(v2)?),
+///         }
+///     }
+///
+///     fn decode(bytes: impl AsRef<[u8]>, spec: SpecId) -> anyhow::Result<Self> {
+///         let slice = bytes.as_ref();
+///         match spec {
+///             SpecId::Genesis => Ok(Self::new_v1(borsh::from_slice(slice)?)),
+///             SpecId::Fork1 => Ok(Self::new_v2(borsh::from_slice(slice)?)),
+///         }
+///     }
+/// }
+/// ```
+pub trait ForkCodec: Sized {
+    fn encode(&self) -> anyhow::Result<Vec<u8>>;
+    fn decode(bytes: impl AsRef<[u8]>, spec: SpecId) -> anyhow::Result<Self>;
+}

--- a/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
@@ -5,6 +5,8 @@ mod migration;
 #[cfg(test)]
 mod tests;
 
+use alloc::vec::Vec;
+
 pub use manager::*;
 pub use migration::*;
 

--- a/crates/sovereign-sdk/rollup-interface/src/spec.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/spec.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
     Deserialize,
     Hash,
 )]
+#[repr(u8)]
 #[borsh(use_discriminant = true)]
 pub enum SpecId {
     /// Genesis spec

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
@@ -295,7 +295,7 @@ pub trait BlobReaderTrait:
     }
 
     /// Weird method to serialize blob as v1. Should be removed when a better way is introduced in the future.
-    fn serialize_v1(&self) -> anyhow::Result<Vec<u8>>;
+    fn serialize_v1(&self) -> borsh::io::Result<Vec<u8>>;
 }
 
 /// Trait with collection of trait bounds for a block hash.

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
@@ -293,6 +293,9 @@ pub trait BlobReaderTrait:
     fn full_data(&mut self) -> &[u8] {
         self.advance(self.total_len())
     }
+
+    /// Weird method to serialize blob as v1. Should be removed when a better way is introduced in the future.
+    fn serialize_v1(&self) -> anyhow::Result<Vec<u8>>;
 }
 
 /// Trait with collection of trait bounds for a block hash.

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
@@ -18,6 +18,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
+use super::da::BlobReaderTrait;
 use super::soft_confirmation::SignedSoftConfirmationV1;
 use crate::da::{DaSpec, LatestDaState};
 use crate::mmr::{MMRChunk, MMRGuest, MMRInclusionProof};
@@ -288,7 +289,14 @@ impl<StateRoot: borsh::BorshSerialize, Witness: borsh::BorshSerialize, Da: DaSpe
         BorshSerialize::serialize(&self.initial_state_root, writer)?;
         BorshSerialize::serialize(&self.final_state_root, writer)?;
         BorshSerialize::serialize(&self.initial_batch_hash, writer)?;
-        BorshSerialize::serialize(&self.da_data, writer)?;
+
+        // We write each blob tx as serialized into v1
+        BorshSerialize::serialize(&(self.da_data.len() as u32), writer)?;
+        for blob in &self.da_data {
+            let bytes = blob.serialize_v1()?;
+            writer.write_all(&bytes)?;
+        }
+
         // remove last 32 bytes
         let original = borsh::to_vec(&self.da_block_header_of_commitments)?;
         writer.write_all(&original[..original.len() - 32])?;


### PR DESCRIPTION
# Description

adds temporary serialize_v1 method to blobs to be able to ignore wtxids.

Also added a suggestion for how to handle forked types in the version to make compatibility as smooth as possible. Implemented ForkCodec trait. It is not used anywhere at the moment and will require more work, still wanted to add it to this pr.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
