### PR TITLE
Fix docs - pass network

### DIFF
--- a/docs/run-dev.md
+++ b/docs/run-dev.md
@@ -21,7 +21,7 @@ Run on a local da layer, sharable between nodes that run on your computer.
 Run sequencer on Mock DA:
 
 ```sh
-./target/debug/citrea --da-layer mock --rollup-config-path resources/configs/mock/sequencer_rollup_config.toml --sequencer resources/configs/mock/sequencer_config.toml --genesis-paths resources/genesis/mock/
+./target/debug/citrea --dev --da-layer mock --rollup-config-path resources/configs/mock/sequencer_rollup_config.toml --sequencer resources/configs/mock/sequencer_config.toml --genesis-paths resources/genesis/mock/
 ```
 
 Sequencer RPC is accessible at `127.0.0.1:12345`
@@ -29,7 +29,7 @@ Sequencer RPC is accessible at `127.0.0.1:12345`
 _Optional_: Run full node on Mock DA:
 
 ```sh
-./target/debug/citrea --rollup-config-path resources/configs/mock/rollup_config.toml --genesis-paths resources/genesis/mock/
+./target/debug/citrea --dev --rollup-config-path resources/configs/mock/rollup_config.toml --genesis-paths resources/genesis/mock/
 ```
 
 Full node RPC is accessible at `127.0.0.1:12346`
@@ -84,7 +84,7 @@ node_password = ""
 Run sequencer:
 
 ```sh
-./target/debug/citrea --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/sequencer_rollup_config.toml --sequencer resources/configs/bitcoin-regtest/sequencer_config.toml --genesis-paths resources/genesis/bitcoin-regtest/
+./target/debug/citrea --dev --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/sequencer_rollup_config.toml --sequencer resources/configs/bitcoin-regtest/sequencer_config.toml --genesis-paths resources/genesis/bitcoin-regtest/
 ```
 
 Sequencer RPC is accessible at `127.0.0.1:12345`
@@ -94,7 +94,7 @@ _Optional_: Run full node
 Run full node:
 
 ```sh
-./target/debug/citrea --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/rollup_config.toml --genesis-paths resources/genesis/bitcoin-regtest/
+./target/debug/citrea --dev --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/rollup_config.toml --genesis-paths resources/genesis/bitcoin-regtest/
 ```
 
 Full node RPC is accessible at `127.0.0.1:12346`
@@ -102,7 +102,7 @@ Full node RPC is accessible at `127.0.0.1:12346`
 _Optional_: Run batch prover:
 
 ```sh
-./target/debug/citrea --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/batch_prover_rollup_config.toml --batch-prover resources/configs/bitcoin-regtest/batch_prover_config.toml --genesis-paths resources/genesis/bitcoin-regtest
+./target/debug/citrea --dev --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/batch_prover_rollup_config.toml --batch-prover resources/configs/bitcoin-regtest/batch_prover_config.toml --genesis-paths resources/genesis/bitcoin-regtest
 ```
 
 If you want to test proofs, make sure to set `proof_sampling_number` in `resources/configs/bitcoin-regtest/batch_prover_config.toml` to 0, and you can lower the `min_soft_confirmations_per_commitment` to a number between 5-50, as higher numbers than that takes too long even if you run the prover in execute mode.
@@ -112,7 +112,7 @@ To publish blocks on Bitcoin Regtest, run the sequencer with `test_mode` in sequ
 _Optional_: Run light client prover:
 
 ```sh
-./target/debug/citrea --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/light_client_prover_rollup_config.toml --light-client-prover resources/configs/bitcoin-regtest/light_client_prover_config.toml --genesis-paths resources/genesis/bitcoin-regtest
+./target/debug/citrea --dev --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/light_client_prover_rollup_config.toml --light-client-prover resources/configs/bitcoin-regtest/light_client_prover_config.toml --genesis-paths resources/genesis/bitcoin-regtest
 ```
 
 To delete sequencer or full nodes databases run:

--- a/docs/run-testnet.md
+++ b/docs/run-testnet.md
@@ -169,7 +169,7 @@ Look through the `rollup_config.toml` and apply changes as you wish, if you modi
 And then run the full node by executing this command
 
 ```sh
-./target/release/citrea --da-layer bitcoin --rollup-config-path ./resources/configs/testnet/rollup_config.toml --genesis-paths ./resources/genesis/testnet
+./target/release/citrea --network devnet --da-layer bitcoin --rollup-config-path ./resources/configs/testnet/rollup_config.toml --genesis-paths ./resources/genesis/testnet
 ```
 
 ### Option 3: Using Docker

--- a/docs/run-testnet.md
+++ b/docs/run-testnet.md
@@ -169,7 +169,7 @@ Look through the `rollup_config.toml` and apply changes as you wish, if you modi
 And then run the full node by executing this command
 
 ```sh
-./target/release/citrea --network devnet --da-layer bitcoin --rollup-config-path ./resources/configs/testnet/rollup_config.toml --genesis-paths ./resources/genesis/testnet
+./target/release/citrea --network testnet --da-layer bitcoin --rollup-config-path ./resources/configs/testnet/rollup_config.toml --genesis-paths ./resources/genesis/testnet
 ```
 
 ### Option 3: Using Docker


### PR DESCRIPTION
# Description

For running the development version, pass `--dev`.
For running testnet, pass `--network testnet`

# Note

This would be merged AFTER releasing latest nightly changes since the `--network` flag changes are not released yet.