### PR TITLE
Implement FromEnv for MonitoringConfig

### DIFF
--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use anyhow::anyhow;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::Hash;
 use bitcoin::{Address, BlockHash, Transaction, Txid};
@@ -157,20 +158,27 @@ impl Default for MonitoringConfig {
 
 impl FromEnv for MonitoringConfig {
     fn from_env() -> anyhow::Result<Self> {
-        Ok(MonitoringConfig {
-            check_interval: std::env::var("DA_MONITORING_CHECK_INTERVAL").map_or_else(
-                |_| Ok(defaults::check_interval()),
-                |v| v.parse().map_err(Into::<anyhow::Error>::into),
-            )?,
-            history_limit: std::env::var("DA_MONITORING_HISTORY_LIMIT").map_or_else(
-                |_| Ok(defaults::history_limit()),
-                |v| v.parse().map_err(Into::<anyhow::Error>::into),
-            )?,
-            max_history_size: std::env::var("DA_MONITORING_MAX_HISTORY_SIZE").map_or_else(
-                |_| Ok(defaults::max_history_size()),
-                |v| v.parse().map_err(Into::<anyhow::Error>::into),
-            )?,
-        })
+        match (
+            std::env::var("DA_MONITORING_CHECK_INTERVAL"),
+            std::env::var("DA_MONITORING_HISTORY_LIMIT"),
+            std::env::var("DA_MONITORING_MAX_HISTORY_SIZE"),
+        ) {
+            (Err(_), Err(_), Err(_)) => Err(anyhow!("Missing monitoring config")),
+            (check_interval, history_limit, max_history_size) => Ok(MonitoringConfig {
+                check_interval: check_interval.map_or_else(
+                    |_| Ok(defaults::check_interval()),
+                    |v| v.parse().map_err(Into::<anyhow::Error>::into),
+                )?,
+                history_limit: history_limit.map_or_else(
+                    |_| Ok(defaults::history_limit()),
+                    |v| v.parse().map_err(Into::<anyhow::Error>::into),
+                )?,
+                max_history_size: max_history_size.map_or_else(
+                    |_| Ok(defaults::max_history_size()),
+                    |v| v.parse().map_err(Into::<anyhow::Error>::into),
+                )?,
+            }),
+        }
     }
 }
 

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -122,7 +122,7 @@ pub enum MonitorError {
     BitcoinEncodeError(#[from] bitcoin::consensus::encode::Error),
 }
 
-mod defaults {
+mod monitoring_defaults {
     pub const fn check_interval() -> u64 {
         60
     }
@@ -138,20 +138,20 @@ mod defaults {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct MonitoringConfig {
-    #[serde(default = "defaults::check_interval")]
+    #[serde(default = "monitoring_defaults::check_interval")]
     pub check_interval: u64,
-    #[serde(default = "defaults::history_limit")]
+    #[serde(default = "monitoring_defaults::history_limit")]
     pub history_limit: usize,
-    #[serde(default = "defaults::max_history_size")]
+    #[serde(default = "monitoring_defaults::max_history_size")]
     pub max_history_size: usize,
 }
 
 impl Default for MonitoringConfig {
     fn default() -> Self {
         Self {
-            check_interval: defaults::check_interval(),
-            history_limit: defaults::history_limit(),
-            max_history_size: defaults::max_history_size(),
+            check_interval: monitoring_defaults::check_interval(),
+            history_limit: monitoring_defaults::history_limit(),
+            max_history_size: monitoring_defaults::max_history_size(),
         }
     }
 }
@@ -166,15 +166,15 @@ impl FromEnv for MonitoringConfig {
             (Err(_), Err(_), Err(_)) => Err(anyhow!("Missing monitoring config")),
             (check_interval, history_limit, max_history_size) => Ok(MonitoringConfig {
                 check_interval: check_interval.map_or_else(
-                    |_| Ok(defaults::check_interval()),
+                    |_| Ok(monitoring_defaults::check_interval()),
                     |v| v.parse().map_err(Into::<anyhow::Error>::into),
                 )?,
                 history_limit: history_limit.map_or_else(
-                    |_| Ok(defaults::history_limit()),
+                    |_| Ok(monitoring_defaults::history_limit()),
                     |v| v.parse().map_err(Into::<anyhow::Error>::into),
                 )?,
                 max_history_size: max_history_size.map_or_else(
-                    |_| Ok(defaults::max_history_size()),
+                    |_| Ok(monitoring_defaults::max_history_size()),
                     |v| v.parse().map_err(Into::<anyhow::Error>::into),
                 )?,
             }),

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -8,6 +8,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::{Address, BlockHash, Transaction, Txid};
 use bitcoincore_rpc::json::GetTransactionResult;
 use bitcoincore_rpc::{Client, RpcApi};
+use citrea_common::FromEnv;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::select;
@@ -18,10 +19,6 @@ use tracing::{debug, error, info, instrument};
 
 use crate::service::FINALITY_DEPTH;
 use crate::spec::utxo::UTXO;
-
-const DEFAULT_CHECK_INTERVAL: u64 = 60;
-const DEFAULT_HISTORY_LIMIT: usize = 1_000; // Keep track of last 1k txs
-const DEFAULT_MAX_HISTORY_SIZE: usize = 200_000_000; // Default max monitored tx total size to 200mb
 
 type BlockHeight = u64;
 type Result<T> = std::result::Result<T, MonitorError>;
@@ -124,20 +121,56 @@ pub enum MonitorError {
     BitcoinEncodeError(#[from] bitcoin::consensus::encode::Error),
 }
 
+mod defaults {
+    pub const fn check_interval() -> u64 {
+        60
+    }
+
+    pub const fn history_limit() -> usize {
+        1_000 // Keep track of last 1k txs
+    }
+
+    pub const fn max_history_size() -> usize {
+        200_000_000 // Default max monitored tx total size to 200mb
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct MonitoringConfig {
+    #[serde(default = "defaults::check_interval")]
     pub check_interval: u64,
+    #[serde(default = "defaults::history_limit")]
     pub history_limit: usize,
+    #[serde(default = "defaults::max_history_size")]
     pub max_history_size: usize,
 }
 
 impl Default for MonitoringConfig {
     fn default() -> Self {
         Self {
-            check_interval: DEFAULT_CHECK_INTERVAL,
-            history_limit: DEFAULT_HISTORY_LIMIT,
-            max_history_size: DEFAULT_MAX_HISTORY_SIZE,
+            check_interval: defaults::check_interval(),
+            history_limit: defaults::history_limit(),
+            max_history_size: defaults::max_history_size(),
         }
+    }
+}
+
+impl FromEnv for MonitoringConfig {
+    fn from_env() -> anyhow::Result<Self> {
+        Ok(MonitoringConfig {
+            check_interval: std::env::var("DA_MONITORING_CHECK_INTERVAL").map_or_else(
+                |_| Ok(defaults::check_interval()),
+                |v| v.parse().map_err(Into::<anyhow::Error>::into),
+            )?,
+            history_limit: std::env::var("DA_MONITORING_HISTORY_LIMIT").map_or_else(
+                |_| Ok(defaults::history_limit()),
+                |v| v.parse().map_err(Into::<anyhow::Error>::into),
+            )?,
+            max_history_size: std::env::var("DA_MONITORING_MAX_HISTORY_SIZE").map_or_else(
+                |_| Ok(defaults::max_history_size()),
+                |v| v.parse().map_err(Into::<anyhow::Error>::into),
+            )?,
+        })
     }
 }
 

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -93,11 +93,7 @@ impl citrea_common::FromEnv for BitcoinServiceConfig {
             network: serde_json::from_str(&format!("\"{}\"", std::env::var("NETWORK")?))?,
             da_private_key: std::env::var("DA_PRIVATE_KEY").ok(),
             tx_backup_dir: std::env::var("TX_BACKUP_DIR")?,
-            monitoring: Some(MonitoringConfig {
-                check_interval: std::env::var("DA_MONITORING_CHECK_INTERVAL")?.parse()?,
-                history_limit: std::env::var("DA_MONITORING_HISTORY_LIMIT")?.parse()?,
-                max_history_size: std::env::var("DA_MONITORING_MAX_HISTORY_SIZE")?.parse()?,
-            }),
+            monitoring: MonitoringConfig::from_env().ok(),
             mempool_space_url: std::env::var("MEMPOOL_SPACE_URL").ok(),
         })
     }


### PR DESCRIPTION
# Description

- Implement `FromEnv` for `MonitoringConfig`
- Add support for partial parsing with serde defaults

Fixes #1696 