### PR TITLE
first l2 block copy blocks, transactions, receipts to rlp acessory state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,6 +1949,7 @@ dependencies = [
  "bytes",
  "citrea-primitives",
  "clap",
+ "derive_more",
  "hex",
  "itertools 0.13.0",
  "jsonrpsee",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -21,6 +21,7 @@ citrea-primitives = { path = "../primitives" }
 
 borsh = { workspace = true, features = ["rc"] }
 clap = { workspace = true, optional = true }
+derive_more = { workspace = true, optional = true }
 hex = { workspace = true }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 schemars = { workspace = true, optional = true }
@@ -102,5 +103,6 @@ native = [
   "serde_json",
   "secp256k1",
   "dep:tracing",
+  "derive_more",
 ]
 serde = []

--- a/crates/evm/src/evm/compat.rs
+++ b/crates/evm/src/evm/compat.rs
@@ -1,0 +1,587 @@
+use alloy_consensus::{TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy};
+use alloy_eips::eip7702::{Authorization, SignedAuthorization};
+use alloy_primitives::{Address, Bytes, ChainId, Parity, Signature, TxHash, TxKind, B256, U256};
+use alloy_rpc_types::AccessList;
+use reth_primitives::{Transaction, TransactionSigned};
+use serde::{Deserialize, Serialize};
+
+/// To be used with `Option<CompactPlaceholder>` to place or replace one bit on the bitflag struct.
+pub(crate) type CompactPlaceholder = ();
+
+// Legacy transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct DoNotUseTxLegacy {
+    /// Added as EIP-155: Simple replay attack protection
+    pub chain_id: Option<ChainId>,
+    /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
+    pub nonce: u64,
+    /// A scalar value equal to the number of
+    /// Wei to be paid per unit of gas for all computation
+    /// costs incurred as a result of the execution of this transaction; formally Tp.
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    pub gas_price: u128,
+    /// A scalar value equal to the maximum
+    /// amount of gas that should be used in executing
+    /// this transaction. This is paid up-front, before any
+    /// computation is done and may not be increased
+    /// later; formally Tg.
+    pub gas_limit: u64,
+    /// The 160-bit address of the message call’s recipient or, for a contract creation
+    /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
+    pub to: TxKind,
+    /// A scalar value equal to the number of Wei to
+    /// be transferred to the message call’s recipient or,
+    /// in the case of contract creation, as an endowment
+    /// to the newly created account; formally Tv.
+    pub value: U256,
+    /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
+    /// Some). pub init: An unlimited size byte array specifying the
+    /// EVM-code for the account initialisation procedure CREATE,
+    /// data: An unlimited size byte array specifying the
+    /// input data of the message call, formally Td.
+    pub input: Bytes,
+}
+
+impl From<DoNotUseTxLegacy> for TxLegacy {
+    fn from(tx: DoNotUseTxLegacy) -> Self {
+        let DoNotUseTxLegacy {
+            chain_id,
+            nonce,
+            gas_price,
+            gas_limit,
+            to,
+            value,
+            input,
+        } = tx;
+
+        TxLegacy {
+            chain_id,
+            nonce,
+            gas_price,
+            gas_limit,
+            to,
+            value,
+            input,
+        }
+    }
+}
+
+/// Transaction with an [`AccessList`] ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct DoNotUseTxEip2930 {
+    /// Added as EIP-155: Simple replay attack protection
+    pub chain_id: ChainId,
+
+    /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
+    pub nonce: u64,
+
+    /// A scalar value equal to the number of
+    /// Wei to be paid per unit of gas for all computation
+    /// costs incurred as a result of the execution of this transaction; formally Tp.
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    pub gas_price: u128,
+
+    /// A scalar value equal to the maximum
+    /// amount of gas that should be used in executing
+    /// this transaction. This is paid up-front, before any
+    /// computation is done and may not be increased
+    /// later; formally Tg.
+    pub gas_limit: u64,
+
+    /// The 160-bit address of the message call’s recipient or, for a contract creation
+    /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
+    pub to: TxKind,
+
+    /// A scalar value equal to the number of Wei to
+    /// be transferred to the message call’s recipient or,
+    /// in the case of contract creation, as an endowment
+    /// to the newly created account; formally Tv.
+    pub value: U256,
+
+    /// The accessList specifies a list of addresses and storage keys;
+    /// these addresses and storage keys are added into the `accessed_addresses`
+    /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
+    /// A gas cost is charged, though at a discount relative to the cost of
+    /// accessing outside the list.
+    pub access_list: AccessList,
+
+    /// Input has two uses depending if the transaction `to` field is [`TxKind::Create`] or
+    /// [`TxKind::Call`].
+    ///
+    /// Input as init code, or if `to` is [`TxKind::Create`]: An unlimited size byte array
+    /// specifying the EVM-code for the account initialisation procedure `CREATE`
+    ///
+    /// Input as data, or if `to` is [`TxKind::Call`]: An unlimited size byte array specifying the
+    /// input data of the message call, formally Td.
+    pub input: Bytes,
+}
+
+impl From<DoNotUseTxEip2930> for TxEip2930 {
+    fn from(tx: DoNotUseTxEip2930) -> Self {
+        let DoNotUseTxEip2930 {
+            chain_id,
+            nonce,
+            gas_price,
+            gas_limit,
+            to,
+            value,
+            access_list,
+            input,
+        } = tx;
+
+        TxEip2930 {
+            chain_id,
+            nonce,
+            gas_price,
+            gas_limit,
+            to,
+            value,
+            access_list,
+            input,
+        }
+    }
+}
+
+/// A transaction with a priority fee ([EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct DoNotUseTxEip1559 {
+    /// Added as EIP-155: Simple replay attack protection
+    pub chain_id: ChainId,
+
+    /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
+    pub nonce: u64,
+
+    /// A scalar value equal to the maximum
+    /// amount of gas that should be used in executing
+    /// this transaction. This is paid up-front, before any
+    /// computation is done and may not be increased
+    /// later; formally Tg.
+    pub gas_limit: u64,
+
+    /// A scalar value equal to the maximum
+    /// amount of gas that should be used in executing
+    /// this transaction. This is paid up-front, before any
+    /// computation is done and may not be increased
+    /// later; formally Tg.
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    ///
+    /// This is also known as `GasFeeCap`
+    pub max_fee_per_gas: u128,
+
+    /// Max Priority fee that transaction is paying
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    ///
+    /// This is also known as `GasTipCap`
+    pub max_priority_fee_per_gas: u128,
+
+    /// The 160-bit address of the message call’s recipient or, for a contract creation
+    /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
+    pub to: TxKind,
+
+    /// A scalar value equal to the number of Wei to
+    /// be transferred to the message call’s recipient or,
+    /// in the case of contract creation, as an endowment
+    /// to the newly created account; formally Tv.
+    pub value: U256,
+
+    /// The accessList specifies a list of addresses and storage keys;
+    /// these addresses and storage keys are added into the `accessed_addresses`
+    /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
+    /// A gas cost is charged, though at a discount relative to the cost of
+    /// accessing outside the list.
+    pub access_list: AccessList,
+
+    /// Input has two uses depending if the transaction `to` field is [`TxKind::Create`] or
+    /// [`TxKind::Call`].
+    ///
+    /// Input as init code, or if `to` is [`TxKind::Create`]: An unlimited size byte array
+    /// specifying the EVM-code for the account initialisation procedure `CREATE`
+    ///
+    /// Input as data, or if `to` is [`TxKind::Call`]: An unlimited size byte array specifying the
+    /// input data of the message call, formally Td.
+    pub input: Bytes,
+}
+
+impl From<DoNotUseTxEip1559> for TxEip1559 {
+    fn from(tx: DoNotUseTxEip1559) -> Self {
+        let DoNotUseTxEip1559 {
+            chain_id,
+            nonce,
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            to,
+            value,
+            access_list,
+            input,
+        } = tx;
+
+        TxEip1559 {
+            chain_id,
+            nonce,
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            to,
+            value,
+            access_list,
+            input,
+        }
+    }
+}
+
+/// [EIP-4844 Blob Transaction](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction)
+///
+/// A transaction with blob hashes and max blob fee
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct DoNotUseTxEip4844 {
+    /// Added as EIP-155: Simple replay attack protection
+    pub chain_id: ChainId,
+
+    /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
+    pub nonce: u64,
+
+    /// A scalar value equal to the maximum
+    /// amount of gas that should be used in executing
+    /// this transaction. This is paid up-front, before any
+    /// computation is done and may not be increased
+    /// later; formally Tg.
+    pub gas_limit: u64,
+
+    /// A scalar value equal to the maximum
+    /// amount of gas that should be used in executing
+    /// this transaction. This is paid up-front, before any
+    /// computation is done and may not be increased
+    /// later; formally Tg.
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    ///
+    /// This is also known as `GasFeeCap`
+    pub max_fee_per_gas: u128,
+
+    /// Max Priority fee that transaction is paying
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    ///
+    /// This is also known as `GasTipCap`
+    pub max_priority_fee_per_gas: u128,
+
+    /// TODO(debt): this should be removed if we break the DB.
+    /// Makes sure that the Compact bitflag struct has one bit after the above field:
+    /// <https://github.com/paradigmxyz/reth/pull/8291#issuecomment-2117545016>
+    pub placeholder: Option<CompactPlaceholder>,
+
+    /// The 160-bit address of the message call’s recipient.
+    pub to: Address,
+
+    /// A scalar value equal to the number of Wei to
+    /// be transferred to the message call’s recipient or,
+    /// in the case of contract creation, as an endowment
+    /// to the newly created account; formally Tv.
+    pub value: U256,
+
+    /// The accessList specifies a list of addresses and storage keys;
+    /// these addresses and storage keys are added into the `accessed_addresses`
+    /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
+    /// A gas cost is charged, though at a discount relative to the cost of
+    /// accessing outside the list.
+    pub access_list: AccessList,
+
+    /// It contains a vector of fixed size hash(32 bytes)
+    pub blob_versioned_hashes: Vec<B256>,
+
+    /// Max fee per data gas
+    ///
+    /// aka BlobFeeCap or blobGasFeeCap
+    pub max_fee_per_blob_gas: u128,
+
+    /// Unlike other transaction types, where the `input` field has two uses depending on whether
+    /// or not the `to` field is [`Create`](crate::TxKind::Create) or
+    /// [`Call`](crate::TxKind::Call), EIP-4844 transactions cannot be
+    /// [`Create`](crate::TxKind::Create) transactions.
+    ///
+    /// This means the `input` field has a single use, as data: An unlimited size byte array
+    /// specifying the input data of the message call, formally Td.
+    pub input: Bytes,
+}
+
+impl From<DoNotUseTxEip4844> for TxEip4844 {
+    fn from(value: DoNotUseTxEip4844) -> Self {
+        TxEip4844 {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_limit: value.gas_limit,
+            max_fee_per_gas: value.max_fee_per_gas,
+            max_priority_fee_per_gas: value.max_priority_fee_per_gas,
+            to: value.to,
+            value: value.value,
+            access_list: value.access_list,
+            blob_versioned_hashes: value.blob_versioned_hashes,
+            max_fee_per_blob_gas: value.max_fee_per_blob_gas,
+            input: value.input,
+        }
+    }
+}
+
+/// r, s: Values corresponding to the signature of the
+/// transaction and used to determine the sender of
+/// the transaction; formally Tr and Ts. This is expanded in Appendix F of yellow paper.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct DoNotUseSignature {
+    /// The R field of the signature; the point on the curve.
+    pub r: U256,
+    /// The S field of the signature; the point on the curve.
+    pub s: U256,
+    /// yParity: Signature Y parity; formally Ty
+    ///
+    /// WARNING: if it's deprecated in favor of `alloy_primitives::Signature` be sure that parity
+    /// storage deser matches.
+    pub odd_y_parity: bool,
+}
+
+impl From<DoNotUseSignature> for Signature {
+    fn from(value: DoNotUseSignature) -> Self {
+        Signature::new(value.r, value.s, Parity::Parity(value.odd_y_parity))
+    }
+}
+
+/// An internal wrapper around an `Option<u64>` for optional nonces.
+///
+/// In EIP-7702 the nonce is encoded as a list of either 0 or 1 items, where 0 items means that no
+/// nonce was specified (i.e. `None`). If there is 1 item, this is the same as `Some`.
+///
+/// The wrapper type is used for RLP encoding and decoding.
+#[derive(Default, Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DoNotUseOptionalNonce(Option<u64>);
+
+/// An unsigned EIP-7702 authorization.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DoNotUseAuthorization {
+    /// The chain ID of the authorization.
+    pub chain_id: ChainId,
+    /// The address of the authorization.
+    pub address: Address,
+    /// The nonce for the authorization.
+    pub nonce: DoNotUseOptionalNonce,
+}
+
+impl From<DoNotUseAuthorization> for Authorization {
+    fn from(value: DoNotUseAuthorization) -> Self {
+        Authorization {
+            chain_id: U256::from(value.chain_id),
+            address: value.address,
+            nonce: value.nonce.0.unwrap_or_default(),
+        }
+    }
+}
+
+/// A signed EIP-7702 authorization.
+/// Signature struct is different
+/// Authorization struct ChainID field used to be u64, now U256
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct DoNotUseSignedAuthorization {
+    inner: DoNotUseAuthorization,
+    signature: DoNotUseSignature,
+}
+
+impl From<DoNotUseSignedAuthorization> for SignedAuthorization {
+    fn from(value: DoNotUseSignedAuthorization) -> Self {
+        Authorization {
+            chain_id: U256::from(value.inner.chain_id),
+            address: value.inner.address,
+            nonce: value.inner.nonce.0.unwrap_or_default(),
+        }
+        .into_signed(value.signature.into())
+    }
+}
+
+/// [EIP-7702 Set Code Transaction](https://eips.ethereum.org/EIPS/eip-7702)
+///
+/// Set EOA account code for one transaction
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct DoNotUseTxEip7702 {
+    /// Added as EIP-155: Simple replay attack protection
+    pub chain_id: ChainId,
+    /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
+    pub nonce: u64,
+    /// A scalar value equal to the number of
+    /// Wei to be paid per unit of gas for all computation
+    /// costs incurred as a result of the execution of this transaction; formally Tp.
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    pub gas_limit: u64,
+    /// A scalar value equal to the maximum
+    /// amount of gas that should be used in executing
+    /// this transaction. This is paid up-front, before any
+    /// computation is done and may not be increased
+    /// later; formally Tg.
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    ///
+    /// This is also known as `GasFeeCap`
+    pub max_fee_per_gas: u128,
+    /// Max Priority fee that transaction is paying
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    ///
+    /// This is also known as `GasTipCap`
+    pub max_priority_fee_per_gas: u128,
+    /// The 160-bit address of the message call’s recipient or, for a contract creation
+    /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
+    pub to: TxKind,
+    /// A scalar value equal to the number of Wei to
+    /// be transferred to the message call’s recipient or,
+    /// in the case of contract creation, as an endowment
+    /// to the newly created account; formally Tv.
+    pub value: U256,
+    /// The accessList specifies a list of addresses and storage keys;
+    /// these addresses and storage keys are added into the `accessed_addresses`
+    /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
+    /// A gas cost is charged, though at a discount relative to the cost of
+    /// accessing outside the list.
+    pub access_list: AccessList,
+    /// Authorizations are used to temporarily set the code of its signer to
+    /// the code referenced by `address`. These also include a `chain_id` (which
+    /// can be set to zero and not evaluated) as well as an optional `nonce`.
+    pub authorization_list: Vec<DoNotUseSignedAuthorization>,
+    /// Input has two uses depending if the transaction `to` field is [`TxKind::Create`] or
+    /// [`TxKind::Call`].
+    ///
+    /// Input as init code, or if `to` is [`TxKind::Create`]: An unlimited size byte array
+    /// specifying the EVM-code for the account initialisation procedure `CREATE`
+    ///
+    /// Input as data, or if `to` is [`TxKind::Call`]: An unlimited size byte array specifying the
+    /// input data of the message call, formally Td.
+    pub input: Bytes,
+}
+
+impl From<DoNotUseTxEip7702> for TxEip7702 {
+    fn from(value: DoNotUseTxEip7702) -> Self {
+        let addr: Option<Address> = value.to.into();
+        let list = value
+            .authorization_list
+            .iter()
+            .map(|v| v.clone().into())
+            .collect::<Vec<SignedAuthorization>>();
+
+        TxEip7702 {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_limit: value.gas_limit,
+            max_fee_per_gas: value.max_fee_per_gas,
+            max_priority_fee_per_gas: value.max_priority_fee_per_gas,
+            to: addr.unwrap(),
+            value: value.value,
+            access_list: value.access_list,
+            authorization_list: list,
+            input: value.input,
+        }
+    }
+}
+
+/// A raw transaction.
+///
+/// Transaction types were introduced in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum DoNotUseTransaction {
+    /// Legacy transaction (type `0x0`).
+    ///
+    /// Traditional Ethereum transactions, containing parameters `nonce`, `gasPrice`, `gasLimit`,
+    /// `to`, `value`, `data`, `v`, `r`, and `s`.
+    ///
+    /// These transactions do not utilize access lists nor do they incorporate EIP-1559 fee market
+    /// changes.
+    Legacy(DoNotUseTxLegacy),
+    /// Transaction with an [`AccessList`] ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)), type `0x1`.
+    ///
+    /// The `accessList` specifies an array of addresses and storage keys that the transaction
+    /// plans to access, enabling gas savings on cross-contract calls by pre-declaring the accessed
+    /// contract and storage slots.
+    Eip2930(DoNotUseTxEip2930),
+    /// A transaction with a priority fee ([EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), type `0x2`.
+    ///
+    /// Unlike traditional transactions, EIP-1559 transactions use an in-protocol, dynamically
+    /// changing base fee per gas, adjusted at each block to manage network congestion.
+    ///
+    /// - `maxPriorityFeePerGas`, specifying the maximum fee above the base fee the sender is
+    ///   willing to pay
+    /// - `maxFeePerGas`, setting the maximum total fee the sender is willing to pay.
+    ///
+    /// The base fee is burned, while the priority fee is paid to the miner who includes the
+    /// transaction, incentivizing miners to include transactions with higher priority fees per
+    /// gas.
+    Eip1559(DoNotUseTxEip1559),
+    /// Shard Blob Transactions ([EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)), type `0x3`.
+    ///
+    /// Shard Blob Transactions introduce a new transaction type called a blob-carrying transaction
+    /// to reduce gas costs. These transactions are similar to regular Ethereum transactions but
+    /// include additional data called a blob.
+    ///
+    /// Blobs are larger (~125 kB) and cheaper than the current calldata, providing an immutable
+    /// and read-only memory for storing transaction data.
+    ///
+    /// EIP-4844, also known as proto-danksharding, implements the framework and logic of
+    /// danksharding, introducing new transaction formats and verification rules.
+    Eip4844(DoNotUseTxEip4844),
+    /// EOA Set Code Transactions ([EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)), type `0x4`.
+    ///
+    /// EOA Set Code Transactions give the ability to temporarily set contract code for an
+    /// EOA for a single transaction. This allows for temporarily adding smart contract
+    /// functionality to the EOA.
+    Eip7702(DoNotUseTxEip7702),
+}
+
+impl From<DoNotUseTransaction> for Transaction {
+    fn from(value: DoNotUseTransaction) -> Self {
+        match value {
+            DoNotUseTransaction::Legacy(tx) => Transaction::Legacy(tx.into()),
+            DoNotUseTransaction::Eip2930(tx) => Transaction::Eip2930(tx.into()),
+            DoNotUseTransaction::Eip1559(tx) => Transaction::Eip1559(tx.into()),
+            DoNotUseTransaction::Eip4844(tx) => Transaction::Eip4844(tx.into()),
+            DoNotUseTransaction::Eip7702(tx) => Transaction::Eip7702(tx.into()),
+        }
+    }
+}
+
+/// Signed transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DoNotUseTransactionSigned {
+    /// Transaction hash
+    pub hash: TxHash,
+    /// The transaction signature values
+    pub signature: DoNotUseSignature,
+    /// Raw transaction info
+    pub transaction: DoNotUseTransaction,
+}
+
+impl From<DoNotUseTransactionSigned> for TransactionSigned {
+    fn from(value: DoNotUseTransactionSigned) -> Self {
+        TransactionSigned {
+            hash: value.hash,
+            signature: value.signature.into(),
+            transaction: value.transaction.into(),
+        }
+    }
+}

--- a/crates/evm/src/evm/mod.rs
+++ b/crates/evm/src/evm/mod.rs
@@ -19,6 +19,8 @@ pub(crate) mod system_events;
 
 #[cfg(feature = "native")]
 pub(crate) mod call;
+#[cfg(feature = "native")]
+pub(crate) mod compat;
 
 #[cfg(all(test, feature = "native"))]
 mod tests;

--- a/crates/evm/src/hooks.rs
+++ b/crates/evm/src/hooks.rs
@@ -7,8 +7,6 @@ use sov_modules_api::prelude::*;
 use sov_modules_api::{AccessoryWorkingSet, WorkingSet};
 use sov_rollup_interface::spec::SpecId as CitreaSpecId;
 use sov_rollup_interface::zk::StorageRootHash;
-use sov_state::codec::{BcsCodec, RlpCodec};
-use sov_state::storage::StateValueCodec;
 #[cfg(feature = "native")]
 use tracing::instrument;
 
@@ -292,7 +290,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 for i in 0..len {
                     tracing::info!("Migrating transaction {}", i);
                     let tx = self.transactions.get(i, &mut accessory_state).unwrap();
-                    self.transactions_rlp.push(&tx, &mut accessory_state);
+                    self.transactions_rlp.push(&tx.into(), &mut accessory_state);
                 }
             }
 

--- a/crates/evm/src/hooks.rs
+++ b/crates/evm/src/hooks.rs
@@ -7,6 +7,8 @@ use sov_modules_api::prelude::*;
 use sov_modules_api::{AccessoryWorkingSet, WorkingSet};
 use sov_rollup_interface::spec::SpecId as CitreaSpecId;
 use sov_rollup_interface::zk::StorageRootHash;
+use sov_state::codec::{BcsCodec, RlpCodec};
+use sov_state::storage::StateValueCodec;
 #[cfg(feature = "native")]
 use tracing::instrument;
 
@@ -283,14 +285,37 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
             self.pending_head.set(&block, &mut accessory_state);
 
+            // migration start
+            if self.transactions_rlp.len(&mut accessory_state) == 0 {
+                let len = self.transactions.len(&mut accessory_state);
+                tracing::info!("Migrating {} transactions from storage to RLP", len);
+                for i in 0..len {
+                    tracing::info!("Migrating transaction {}", i);
+                    let tx = self.transactions.get(i, &mut accessory_state).unwrap();
+                    self.transactions_rlp.push(&tx, &mut accessory_state);
+                }
+            }
+
+            if self.receipts_rlp.len(&mut accessory_state) == 0 {
+                let len = self.receipts.len(&mut accessory_state);
+                tracing::info!("Migrating {} receipts from storage to RLP", len);
+                for i in 0..len {
+                    tracing::info!("Migrating receipt {}", i);
+                    let receipt = self.receipts.get(i, &mut accessory_state).unwrap();
+                    self.receipts_rlp.push(&receipt, &mut accessory_state);
+                }
+            }
+            // migration end
+
             let mut tx_index = start_tx_index;
             for PendingTransaction {
                 transaction,
                 receipt,
             } in pending_transactions
             {
-                self.transactions.push(transaction, &mut accessory_state);
-                self.receipts.push(receipt, &mut accessory_state);
+                self.transactions_rlp
+                    .push(transaction, &mut accessory_state);
+                self.receipts_rlp.push(receipt, &mut accessory_state);
 
                 self.transaction_hashes.set(
                     &transaction.signed_transaction.hash,
@@ -321,7 +346,18 @@ impl<C: sov_modules_api::Context> Evm<C> {
     ) {
         #[cfg(feature = "native")]
         {
-            let expected_block_number = self.blocks.len(accessory_working_set) as u64;
+            // migration start
+            if self.blocks_rlp.len(accessory_working_set) == 0 {
+                let len = self.blocks.len(accessory_working_set);
+                tracing::info!("Migrating {} blocks from storage to RLP", len);
+                for i in 0..len {
+                    let block = self.blocks.get(i, accessory_working_set).unwrap();
+                    self.blocks_rlp.push(&block.into(), accessory_working_set);
+                }
+            }
+            // migration end
+
+            let expected_block_number = self.blocks_rlp.len(accessory_working_set) as u64;
 
             let mut block = self
                 .pending_head
@@ -343,7 +379,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
             let sealed_block = block.seal();
 
-            self.blocks.push(&sealed_block, accessory_working_set);
+            self.blocks_rlp.push(&sealed_block, accessory_working_set);
             self.block_hashes.set(
                 &sealed_block.header.hash(),
                 &sealed_block.header.number,

--- a/crates/evm/src/hooks.rs
+++ b/crates/evm/src/hooks.rs
@@ -288,7 +288,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 let len = self.transactions.len(&mut accessory_state);
                 tracing::info!("Migrating {} transactions from storage to RLP", len);
                 for i in 0..len {
-                    tracing::info!("Migrating transaction {}", i);
                     let tx = self.transactions.get(i, &mut accessory_state).unwrap();
                     self.transactions_rlp.push(&tx.into(), &mut accessory_state);
                 }
@@ -298,7 +297,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 let len = self.receipts.len(&mut accessory_state);
                 tracing::info!("Migrating {} receipts from storage to RLP", len);
                 for i in 0..len {
-                    tracing::info!("Migrating receipt {}", i);
                     let receipt = self.receipts.get(i, &mut accessory_state).unwrap();
                     self.receipts_rlp.push(&receipt, &mut accessory_state);
                 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -11,7 +11,10 @@ use alloy_rlp::{RlpDecodable, RlpEncodable};
 pub use call::*;
 pub use evm::*;
 pub use genesis::*;
+#[cfg(feature = "native")]
 use primitive_types::DoNotUseSealedBlock;
+#[cfg(feature = "native")]
+use primitive_types::DoNotUseTransactionSignedAndRecovered;
 pub use system_events::SYSTEM_SIGNER;
 
 #[cfg(feature = "native")]
@@ -152,7 +155,7 @@ pub struct Evm<C: sov_modules_api::Context> {
     #[cfg(feature = "native")]
     #[state]
     pub(crate) transactions:
-        sov_modules_api::AccessoryStateVec<TransactionSignedAndRecovered, BcsCodec>,
+        sov_modules_api::AccessoryStateVec<DoNotUseTransactionSignedAndRecovered, BcsCodec>,
 
     #[cfg(feature = "native")]
     #[state]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -11,6 +11,7 @@ use alloy_rlp::{RlpDecodable, RlpEncodable};
 pub use call::*;
 pub use evm::*;
 pub use genesis::*;
+use primitive_types::DoNotUseSealedBlock;
 pub use system_events::SYSTEM_SIGNER;
 
 #[cfg(feature = "native")]
@@ -136,7 +137,11 @@ pub struct Evm<C: sov_modules_api::Context> {
     /// Used only by the RPC: The vec is extended with `pending_head` in `finalize_hook`.
     #[cfg(feature = "native")]
     #[state]
-    pub(crate) blocks: sov_modules_api::AccessoryStateVec<SealedBlock, RlpCodec>,
+    pub(crate) blocks: sov_modules_api::AccessoryStateVec<DoNotUseSealedBlock, BcsCodec>,
+
+    #[cfg(feature = "native")]
+    #[state]
+    pub(crate) blocks_rlp: sov_modules_api::AccessoryStateVec<SealedBlock, RlpCodec>,
 
     /// Used only by the RPC: block_hash => block_number mapping,
     #[cfg(feature = "native")]
@@ -147,6 +152,11 @@ pub struct Evm<C: sov_modules_api::Context> {
     #[cfg(feature = "native")]
     #[state]
     pub(crate) transactions:
+        sov_modules_api::AccessoryStateVec<TransactionSignedAndRecovered, BcsCodec>,
+
+    #[cfg(feature = "native")]
+    #[state]
+    pub(crate) transactions_rlp:
         sov_modules_api::AccessoryStateVec<TransactionSignedAndRecovered, RlpCodec>,
 
     /// Used only by the RPC: transaction_hash => transaction_index mapping.
@@ -157,7 +167,11 @@ pub struct Evm<C: sov_modules_api::Context> {
     /// Used only by the RPC: Receipts.
     #[cfg(feature = "native")]
     #[state]
-    pub(crate) receipts: sov_modules_api::AccessoryStateVec<Receipt, RlpCodec>,
+    pub(crate) receipts: sov_modules_api::AccessoryStateVec<Receipt, BcsCodec>,
+
+    #[cfg(feature = "native")]
+    #[state]
+    pub(crate) receipts_rlp: sov_modules_api::AccessoryStateVec<Receipt, RlpCodec>,
 }
 
 impl<C: sov_modules_api::Context> sov_modules_api::Module for Evm<C> {

--- a/crates/evm/src/provider_functions.rs
+++ b/crates/evm/src/provider_functions.rs
@@ -25,25 +25,14 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
     /// Returns the sealed head block.
     pub fn last_sealed_header(&self, working_set: &mut WorkingSet<C::Storage>) -> SealedHeader {
-        self.blocks
+        self.blocks_rlp
             .last(&mut working_set.accessory_state())
             .or_else(|| {
                 //  upgrading from v0.5.7 to v0.6+ requires a codec change
                 // this only applies to the sequencer
                 // which will only query the genesis block and the head block
                 // right after the upgrade
-                let prefix = <AccessoryStateVec<SealedBlock, RlpCodec> as StateVecAccessor<
-                    SealedBlock,
-                    RlpCodec,
-                    AccessoryWorkingSet<C::Storage>,
-                >>::prefix(&self.blocks);
-                let accessor_with_old_codec =
-                    AccessoryStateVec::<DoNotUseSealedBlock, BcsCodec>::with_codec(
-                        prefix.clone(),
-                        BcsCodec,
-                    );
-
-                accessor_with_old_codec
+                self.blocks
                     .last(&mut working_set.accessory_state())
                     .map(Into::into)
             })

--- a/crates/evm/src/provider_functions.rs
+++ b/crates/evm/src/provider_functions.rs
@@ -1,11 +1,7 @@
 use alloy_primitives::Address;
 use reth_primitives::{Account, SealedHeader};
-use sov_modules_api::{
-    AccessoryStateVec, AccessoryWorkingSet, StateMapAccessor, StateVecAccessor, WorkingSet,
-};
-use sov_state::codec::{BcsCodec, RlpCodec};
+use sov_modules_api::{StateMapAccessor, StateVecAccessor, WorkingSet};
 
-use crate::primitive_types::{DoNotUseSealedBlock, SealedBlock};
 use crate::Evm;
 
 impl<C: sov_modules_api::Context> Evm<C> {

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -278,7 +278,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .clone()
             .map(|id| {
                 let tx = self
-                    .transactions
+                    .transactions_rlp
                     .get(id as usize, &mut working_set.accessory_state())
                     .expect("Transaction must be set");
 
@@ -439,7 +439,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let tx_number = block.transactions.start + index.to::<u64>();
 
         let tx = self
-            .transactions
+            .transactions_rlp
             .get(tx_number as usize, &mut accessory_state)
             .expect("Transaction must be set");
 
@@ -490,7 +490,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let tx_number = block.transactions.start + index.to::<u64>();
 
         let tx = self
-            .transactions
+            .transactions_rlp
             .get(tx_number as usize, &mut working_set.accessory_state())
             .expect("Transaction must be set");
 
@@ -527,7 +527,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         let receipt = tx_number.map(|number| {
             let tx = self
-                .transactions
+                .transactions_rlp
                 .get(number as usize, &mut accessory_state)
                 .expect("Transaction with known hash must be set");
             let block = self
@@ -1240,7 +1240,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         let transaction = tx_number.map(|number| {
             let tx = self
-                .transactions
+                .transactions_rlp
                 .get(number as usize, &mut accessory_state)
                 .unwrap_or_else(|| panic!("Transaction with known hash {} and number {} must be set in all {} transaction",
                 hash,
@@ -1501,7 +1501,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 .get(i as usize, &mut working_set.accessory_state())
                 .expect("Transaction must be set");
             let tx = self
-                .transactions
+                .transactions_rlp
                 .get(i as usize, &mut working_set.accessory_state())
                 .unwrap();
             let logs = receipt.receipt.logs;

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -169,7 +169,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .transactions
             .clone()
             .map(|id| {
-                self.transactions
+                self.transactions_rlp
                     .get(id as usize, &mut working_set.accessory_state())
                     .expect("Transaction must be set")
             })
@@ -261,7 +261,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 };
 
                 // if hash is known, but we don't have the block, fail
-                self.blocks
+                self.blocks_rlp
                     .get(block_number as usize, &mut working_set.accessory_state())
                     .expect("Block must be set")
             }
@@ -283,7 +283,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                     .expect("Transaction must be set");
 
                 let receipt = self
-                    .receipts
+                    .receipts_rlp
                     .get(id as usize, &mut working_set.accessory_state())
                     .expect("Receipt for known transaction must be set");
 
@@ -427,7 +427,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         };
 
         let block = self
-            .blocks
+            .blocks_rlp
             .get(block_number as usize, &mut accessory_state)
             .expect("Block must be set");
 
@@ -444,7 +444,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .expect("Transaction must be set");
 
         let block = self
-            .blocks
+            .blocks_rlp
             .get(tx.block_number as usize, &mut accessory_state)
             .expect("Block number for known transaction must be set");
 
@@ -478,7 +478,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         };
 
         let block = self
-            .blocks
+            .blocks_rlp
             .get(block_number as usize, &mut working_set.accessory_state())
             .expect("Block must be set");
 
@@ -495,7 +495,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .expect("Transaction must be set");
 
         let block = self
-            .blocks
+            .blocks_rlp
             .get(tx.block_number as usize, &mut working_set.accessory_state())
             .expect("Block number for known transaction must be set");
 
@@ -531,12 +531,12 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 .get(number as usize, &mut accessory_state)
                 .expect("Transaction with known hash must be set");
             let block = self
-                .blocks
+                .blocks_rlp
                 .get(tx.block_number as usize, &mut accessory_state)
                 .expect("Block number for known transaction must be set");
 
             let receipt = self
-                .receipts
+                .receipts_rlp
                 .get(number as usize, &mut accessory_state)
                 .expect("Receipt for known transaction must be set");
 
@@ -661,7 +661,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
     #[rpc_method(name = "eth_blockNumber")]
     pub fn block_number(&self, working_set: &mut WorkingSet<C::Storage>) -> RpcResult<U256> {
         let block_number = U256::from(
-            self.blocks
+            self.blocks_rlp
                 .len(&mut working_set.accessory_state())
                 .saturating_sub(1),
         );
@@ -692,7 +692,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             let (l1_fee_rate, block_env) = match block_number {
                 Some(BlockNumberOrTag::Pending) => {
                     let l1_fee_rate = self
-                        .blocks
+                        .blocks_rlp
                         .last(&mut working_set.accessory_state())
                         .expect("Head block must be set")
                         .l1_fee_rate;
@@ -817,7 +817,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             let (l1_fee_rate, block_env) = match block_number {
                 Some(BlockNumberOrTag::Pending) => {
                     let l1_fee_rate = self
-                        .blocks
+                        .blocks_rlp
                         .last(&mut working_set.accessory_state())
                         .expect("Head block must be set")
                         .l1_fee_rate;
@@ -878,7 +878,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         // TODO: this assumes all blocks have the same gas limit
         // if gas limit ever changes this should be updated
         let last_block = self
-            .blocks
+            .blocks_rlp
             .last(&mut working_set.accessory_state())
             .expect("Head block must be set");
 
@@ -1245,10 +1245,10 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 .unwrap_or_else(|| panic!("Transaction with known hash {} and number {} must be set in all {} transaction",
                 hash,
                 number,
-                self.transactions.len(&mut accessory_state)));
+                self.transactions_rlp.len(&mut accessory_state)));
 
             let block = self
-                .blocks
+                .blocks_rlp
                 .get(tx.block_number as usize, &mut accessory_state)
                 .unwrap_or_else(|| panic!("Block with number {} for known transaction {} must be set",
                     tx.block_number,
@@ -1292,7 +1292,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let block_txs: Vec<TransactionSignedEcRecovered> = tx_range
             .clone()
             .map(|id| {
-                self.transactions
+                self.transactions_rlp
                     .get(id as usize, &mut working_set.accessory_state())
                     .expect("Transaction must be set")
                     .into()
@@ -1370,7 +1370,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
                 // if we know the hash, but can't find the block, fail
                 let block = self
-                    .blocks
+                    .blocks_rlp
                     .get(block_number as usize, &mut working_set.accessory_state())
                     .expect("Block must be set");
 
@@ -1387,7 +1387,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             } => {
                 // we start at the most recent block if unset in filter
                 let start_block = self
-                    .blocks
+                    .blocks_rlp
                     .last(&mut working_set.accessory_state())
                     .expect("Head block must be set")
                     .header
@@ -1445,7 +1445,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         {
             for idx in from..=to {
                 let block = match self
-                    .blocks
+                    .blocks_rlp
                     .get((idx) as usize, &mut working_set.accessory_state())
                 {
                     Some(block) => block,
@@ -1497,7 +1497,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         for i in tx_range {
             let receipt = self
-                .receipts
+                .receipts_rlp
                 .get(i as usize, &mut working_set.accessory_state())
                 .expect("Transaction must be set");
             let tx = self
@@ -1540,7 +1540,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Option<B256> {
         let block = self
-            .blocks
+            .blocks_rlp
             .get(block_number as usize, &mut working_set.accessory_state())?;
         Some(block.header.hash())
     }
@@ -1554,7 +1554,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let mut headers = Vec::new();
         for i in range {
             let block = self
-                .blocks
+                .blocks_rlp
                 .get(i as usize, &mut working_set.accessory_state())
                 .ok_or_else(|| EthApiError::InvalidBlockRange)?;
             headers.push(block.header);
@@ -1570,7 +1570,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<u64, EthApiError> {
         let latest_block_number = self
-            .blocks
+            .blocks_rlp
             .last(&mut working_set.accessory_state())
             .map(|block| block.header.number)
             .expect("Head block must be set");
@@ -1579,7 +1579,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             BlockNumberOrTag::Latest => Ok(latest_block_number),
             BlockNumberOrTag::Pending => Err(EthApiError::HeaderNotFound((*block_id).into())),
             BlockNumberOrTag::Number(block_number) => {
-                if *block_number < self.blocks.len(&mut working_set.accessory_state()) as u64 {
+                if *block_number < self.blocks_rlp.len(&mut working_set.accessory_state()) as u64 {
                     Ok(*block_number)
                 } else {
                     Err(EthApiError::HeaderNotFound((*block_id).into()))
@@ -1601,44 +1601,29 @@ impl<C: sov_modules_api::Context> Evm<C> {
         // safe, finalized, and pending are not supported
         match block_number {
             Some(BlockNumberOrTag::Number(block_number)) => Ok(self
-                .blocks
+                .blocks_rlp
                 .get(block_number as usize, &mut working_set.accessory_state())),
             Some(BlockNumberOrTag::Earliest) => Ok(Some(
-                self.blocks
+                self.blocks_rlp
                     .get(0, &mut working_set.accessory_state())
                     .or_else(|| {
                         // upgrading from v0.5.7 to v0.6+ requires a codec change
                         // this only applies to the sequencer
                         // which will only query the genesis block and the head block
                         // right after the upgrade
-                        let prefix = <sov_modules_api::AccessoryStateVec<
-                            SealedBlock,
-                            sov_state::codec::RlpCodec,
-                        > as StateVecAccessor<
-                            SealedBlock,
-                            sov_state::codec::RlpCodec,
-                            sov_state::storage::AccessoryWorkingSet<C::Storage>,
-                        >>::prefix(&self.blocks);
-                        let accessor_with_old_codec = sov_modules_api::AccessoryStateVec::<
-                            crate::primitive_types::DoNotUseSealedBlock,
-                            sov_state::codec::BcsCodec,
-                        >::with_codec(
-                            prefix.clone(), sov_state::codec::BcsCodec
-                        );
-
-                        accessor_with_old_codec
+                        self.blocks
                             .get(0, &mut working_set.accessory_state())
                             .map(Into::into)
                     })
                     .expect("Genesis block must be set"),
             )),
             Some(BlockNumberOrTag::Latest) => Ok(Some(
-                self.blocks
+                self.blocks_rlp
                     .last(&mut working_set.accessory_state())
                     .expect("Head block must be set"),
             )),
             None => Ok(Some(
-                self.blocks
+                self.blocks_rlp
                     .last(&mut working_set.accessory_state())
                     .expect("Head block must be set"),
             )),
@@ -1674,7 +1659,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 match block_num {
                     BlockNumberOrTag::Number(num) => {
                         let curr_block_number = self
-                            .blocks
+                            .blocks_rlp
                             .last(&mut working_set.accessory_state())
                             .expect("Head block must be set")
                             .header
@@ -1927,7 +1912,7 @@ fn get_pending_block_env<C: sov_modules_api::Context>(
     fork_fn: &impl Fn(u64) -> Fork,
 ) -> BlockEnv {
     let latest_block = evm
-        .blocks
+        .blocks_rlp
         .last(&mut working_set.accessory_state())
         .expect("Head block must be set");
 

--- a/crates/evm/src/tests/call_tests.rs
+++ b/crates/evm/src/tests/call_tests.rs
@@ -510,7 +510,10 @@ fn failed_transaction_test() {
                 }
         ]
     );
-    let block = evm.blocks.last(&mut working_set.accessory_state()).unwrap();
+    let block = evm
+        .blocks_rlp
+        .last(&mut working_set.accessory_state())
+        .unwrap();
     assert_eq!(block.transactions.start, 0);
     assert_eq!(block.transactions.end, 3);
 }
@@ -908,7 +911,7 @@ fn test_block_hash_in_evm() {
         if (260..=515).contains(&i) {
             // Should be equal to the hash in accessory state
             let block = evm
-                .blocks
+                .blocks_rlp
                 .get((i) as usize, &mut working_set.accessory_state());
             assert_eq!(
                 resp.unwrap().to_vec(),
@@ -921,7 +924,7 @@ fn test_block_hash_in_evm() {
     }
 
     // last produced block is 516, eth_call with pending should return latest block's hash
-    let latest_block = evm.blocks.get(516, &mut working_set.accessory_state());
+    let latest_block = evm.blocks_rlp.get(516, &mut working_set.accessory_state());
     request.input.input = Some(BlockHashContract::default().get_block_hash(516).into());
 
     let resp = evm.get_call_inner(

--- a/crates/evm/src/tests/call_tests.rs
+++ b/crates/evm/src/tests/call_tests.rs
@@ -868,7 +868,7 @@ fn test_block_hash_in_evm() {
     }
 
     let _last_block_number = evm
-        .blocks
+        .blocks_rlp
         .last(&mut working_set.accessory_state())
         .unwrap()
         .header

--- a/crates/evm/src/tests/call_tests.rs
+++ b/crates/evm/src/tests/call_tests.rs
@@ -128,7 +128,7 @@ fn call_multiple_test() {
     assert_eq!(U256::from(set_arg + 3), storage_value);
 
     assert_eq!(
-        evm.receipts
+        evm.receipts_rlp
             .iter(&mut working_set.accessory_state())
             .collect::<Vec<_>>(),
         [
@@ -273,7 +273,7 @@ fn call_test() {
 
     assert_eq!(U256::from(set_arg), storage_value);
     assert_eq!(
-        evm.receipts
+        evm.receipts_rlp
             .iter(&mut working_set.accessory_state())
             .collect::<Vec<_>>(),
         [
@@ -431,7 +431,7 @@ fn failed_transaction_test() {
     assert_eq!(pending_txs.len(), 0);
 
     assert_eq!(
-        evm.receipts
+        evm.receipts_rlp
             .iter(&mut working_set.accessory_state())
             .collect::<Vec<_>>(),
         [
@@ -644,7 +644,7 @@ fn self_destruct_test() {
         .expect("die to address should exist");
 
     let receipts = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect::<Vec<_>>();
 
@@ -750,7 +750,7 @@ fn self_destruct_test() {
     evm.finalize_hook(&[99u8; 32].into(), &mut working_set.accessory_state());
 
     let receipts = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect::<Vec<_>>();
 
@@ -1248,7 +1248,7 @@ fn test_l1_fee_success() {
         assert_eq!(l1_fee_vault.balance, expected_l1_fee_vault_balance);
 
         assert_eq!(
-            evm.receipts
+            evm.receipts_rlp
                 .iter(&mut working_set.accessory_state())
                 .collect::<Vec<_>>(),
             [
@@ -1416,7 +1416,7 @@ fn test_l1_fee_not_enough_funds() {
             SoftConfirmationModuleCallError::EvmNotEnoughFundsForL1Fee
         );
 
-        assert_eq!(evm.receipts
+        assert_eq!(evm.receipts_rlp
             .iter(&mut working_set.accessory_state())
             .collect::<Vec<_>>(),
             [
@@ -1557,7 +1557,7 @@ fn test_l1_fee_halt() {
     evm.end_soft_confirmation_hook(&soft_confirmation_info, &mut working_set);
     evm.finalize_hook(&[99u8; 32].into(), &mut working_set.accessory_state());
 
-    assert_eq!(evm.receipts
+    assert_eq!(evm.receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect::<Vec<_>>(),
         [
@@ -1839,7 +1839,7 @@ fn test_l1_fee_compression_discount() {
     );
 
     assert_eq!(
-        evm.receipts
+        evm.receipts_rlp
             .iter(&mut working_set.accessory_state())
             .map(|r| r.l1_diff_size)
             .collect::<Vec<_>>(),

--- a/crates/evm/src/tests/fork_tests.rs
+++ b/crates/evm/src/tests/fork_tests.rs
@@ -164,7 +164,7 @@ fn test_cancun_transient_storage_activation() {
     l2_height += 1;
 
     let receipts: Vec<_> = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect();
 
@@ -204,7 +204,7 @@ fn test_cancun_transient_storage_activation() {
     l2_height += 1;
 
     let receipts: Vec<_> = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect();
 
@@ -228,7 +228,7 @@ fn test_cancun_transient_storage_activation() {
     evm.finalize_hook(&[99u8; 32].into(), &mut working_set.accessory_state());
 
     let receipts: Vec<_> = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect();
 
@@ -298,7 +298,7 @@ fn test_cancun_mcopy_activation() {
     l2_height += 1;
 
     let receipts: Vec<_> = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect();
 
@@ -335,7 +335,7 @@ fn test_cancun_mcopy_activation() {
     evm.finalize_hook(&[99u8; 32].into(), &mut working_set.accessory_state());
 
     let receipts: Vec<_> = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect();
 
@@ -505,7 +505,7 @@ fn test_blob_base_fee_should_return_1() {
     l2_height += 1;
 
     let receipts: Vec<_> = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect();
 
@@ -542,7 +542,7 @@ fn test_blob_base_fee_should_return_1() {
     evm.finalize_hook(&[99u8; 32].into(), &mut working_set.accessory_state());
 
     let receipts: Vec<_> = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect();
 
@@ -652,7 +652,7 @@ fn test_kzg_point_eval_should_revert() {
 
     // expect this call to fail because we do not have the kzg feature of revm enabled on fork1
     let receipts: Vec<_> = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect();
 

--- a/crates/evm/src/tests/genesis_tests.rs
+++ b/crates/evm/src/tests/genesis_tests.rs
@@ -119,7 +119,7 @@ fn genesis_block() {
         .unwrap();
 
     let block = evm
-        .blocks
+        .blocks_rlp
         .get(block_number as usize, &mut accessory_state)
         .unwrap();
 
@@ -167,7 +167,7 @@ fn genesis_head() {
     let head = evm.head_rlp.get(&mut working_set).unwrap();
     assert_eq!(head.header.parent_hash, *GENESIS_HASH);
     let genesis_block = evm
-        .blocks
+        .blocks_rlp
         .get(0, &mut working_set.accessory_state())
         .unwrap();
 

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -169,25 +169,25 @@ fn end_soft_confirmation_hook_moves_transactions_and_receipts() {
     let tx2_hash = tx2.transaction.signed_transaction.hash;
 
     assert_eq!(
-        evm.receipts
+        evm.receipts_rlp
             .get(4, &mut working_set.accessory_state())
             .unwrap(),
         tx1.receipt
     );
     assert_eq!(
-        evm.receipts
+        evm.receipts_rlp
             .get(5, &mut working_set.accessory_state())
             .unwrap(),
         tx2.receipt
     );
     assert_eq!(
-        evm.transactions
+        evm.transactions_rlp
             .get(4, &mut working_set.accessory_state())
             .unwrap(),
         tx1.transaction
     );
     assert_eq!(
-        evm.transactions
+        evm.transactions_rlp
             .get(5, &mut working_set.accessory_state())
             .unwrap(),
         tx2.transaction

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -290,7 +290,7 @@ fn finalize_hook_creates_final_block() {
 
     let mut accessory_state = working_set.accessory_state();
     evm.finalize_hook(&root_hash.into(), &mut accessory_state);
-    assert_eq!(evm.blocks.len(&mut accessory_state), 3);
+    assert_eq!(evm.blocks_rlp.len(&mut accessory_state), 3);
 
     l2_height += 1;
 

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -257,7 +257,7 @@ fn finalize_hook_creates_final_block() {
 
     // hack to get the root hash
     let binding = evm
-        .blocks
+        .blocks_rlp
         .get(1, &mut working_set.accessory_state())
         .unwrap();
     let root = binding.header.header().state_root.as_slice();
@@ -312,9 +312,9 @@ fn finalize_hook_creates_final_block() {
 
     let mut accessory_state = working_set.accessory_state();
 
-    let parent_block = evm.blocks.get(1usize, &mut accessory_state).unwrap();
+    let parent_block = evm.blocks_rlp.get(1usize, &mut accessory_state).unwrap();
     let parent_hash = parent_block.header.hash();
-    let block = evm.blocks.get(2usize, &mut accessory_state).unwrap();
+    let block = evm.blocks_rlp.get(2usize, &mut accessory_state).unwrap();
 
     let header = Header {
         parent_hash,
@@ -375,7 +375,7 @@ fn begin_soft_confirmation_hook_appends_last_block_hashes() {
 
     // hack to get the root hash
     let binding = evm
-        .blocks
+        .blocks_rlp
         .get(1, &mut working_set.accessory_state())
         .unwrap();
     let root = binding.header.header().state_root.as_slice();
@@ -404,7 +404,7 @@ fn begin_soft_confirmation_hook_appends_last_block_hashes() {
             evm.latest_block_hashes
                 .get(&U256::from(i), &mut working_set)
                 .unwrap(),
-            evm.blocks
+            evm.blocks_rlp
                 .get(i, &mut working_set.accessory_state())
                 .unwrap()
                 .header
@@ -472,7 +472,7 @@ fn begin_soft_confirmation_hook_appends_last_block_hashes() {
         evm.latest_block_hashes
             .get(&U256::from(256), &mut working_set)
             .unwrap(),
-        evm.blocks
+        evm.blocks_rlp
             .get(256, &mut working_set.accessory_state())
             .unwrap()
             .header

--- a/crates/evm/src/tests/queries/log_tests.rs
+++ b/crates/evm/src/tests/queries/log_tests.rs
@@ -133,7 +133,10 @@ fn log_filter_test_at_block_hash() {
        5) [[A, B], [A, B]] “(A OR B) in first position AND (A OR B) in second position (and anything after)”
     */
 
-    let block = evm.blocks.last(&mut working_set.accessory_state()).unwrap();
+    let block = evm
+        .blocks_rlp
+        .last(&mut working_set.accessory_state())
+        .unwrap();
     let mut address = FilterSet::default();
     // Test without address and topics
     let mut topics: [FilterSet<B256>; 4] = [

--- a/crates/evm/src/tests/sys_tx_tests.rs
+++ b/crates/evm/src/tests/sys_tx_tests.rs
@@ -38,7 +38,7 @@ fn test_sys_bitcoin_light_client() {
     let (mut evm, mut working_set) = get_evm(&config);
 
     assert_eq!(
-        evm.receipts
+        evm.receipts_rlp
             .iter(&mut working_set.accessory_state())
             .collect::<Vec<_>>(),
         [
@@ -199,7 +199,7 @@ fn test_sys_bitcoin_light_client() {
     assert_eq!(system_account.nonce, 4);
 
     let receipts: Vec<_> = evm
-        .receipts
+        .receipts_rlp
         .iter(&mut working_set.accessory_state())
         .collect();
     assert_eq!(receipts.len(), 5); // 3 from first L2 block + 2 from second L2 block


### PR DESCRIPTION
we tried to avoid implementing this but here we are.

only affects native execution so don't worry about the cycles.

~still needs DoNot.... structs to convert stuff just like we did with head and head_rlp~