### PR TITLE
fix off-by-one error in light client prover

### DIFF
--- a/crates/light-client-prover/src/runner.rs
+++ b/crates/light-client-prover/src/runner.rs
@@ -8,7 +8,6 @@ use jsonrpsee::server::{BatchRequestConfig, ServerBuilder};
 use jsonrpsee::RpcModule;
 use sov_db::ledger_db::{LightClientProverLedgerOps, SharedLedgerOps};
 use sov_db::mmr_db::MmrDB;
-use sov_db::schema::types::SlotNumber;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::zk::ZkvmHost;
@@ -145,10 +144,11 @@ where
     /// Runs the rollup.
     #[instrument(level = "trace", skip_all, err)]
     pub async fn run(&mut self) -> Result<(), anyhow::Error> {
-        let last_l1_height_scanned = match self.ledger_db.get_last_scanned_l1_height()? {
-            Some(l1_height) => l1_height,
-            // If not found, start from the first L2 block's L1 height
-            None => SlotNumber(self.prover_config.initial_da_height),
+        let starting_block = match self.ledger_db.get_last_scanned_l1_height()? {
+            Some(l1_height) => StartVariant::LastScanned(l1_height.0),
+            // first time starting the prover
+            // start from the block given in the config
+            None => StartVariant::FromBlock(self.prover_config.initial_da_height),
         };
 
         let prover_config = self.prover_config.clone();
@@ -174,7 +174,7 @@ where
                 mmr_db,
             );
             l1_block_handler
-                .run(last_l1_height_scanned.0, cancellation_token)
+                .run(starting_block, cancellation_token)
                 .await
         });
 
@@ -201,4 +201,9 @@ where
         rpc_methods.merge(rpc)?;
         Ok(rpc_methods)
     }
+}
+
+pub(crate) enum StartVariant {
+    LastScanned(u64),
+    FromBlock(u64),
 }

--- a/crates/light-client-prover/src/runner.rs
+++ b/crates/light-client-prover/src/runner.rs
@@ -19,6 +19,11 @@ use tracing::{error, info, instrument};
 use crate::da_block_handler::L1BlockHandler;
 use crate::rpc::{create_rpc_module, RpcContext};
 
+pub(crate) enum StartVariant {
+    LastScanned(u64),
+    FromBlock(u64),
+}
+
 pub struct CitreaLightClientProver<Da, Vm, Ps, DB>
 where
     Da: DaService + Send + Sync,
@@ -201,9 +206,4 @@ where
         rpc_methods.merge(rpc)?;
         Ok(rpc_methods)
     }
-}
-
-pub(crate) enum StartVariant {
-    LastScanned(u64),
-    FromBlock(u64),
 }


### PR DESCRIPTION
# Description
once we deploy the code on a bitcoin network that has built-in constants for starting height, we got an off by one error and everything fails.

we didn't notice this because on e2e, regtest, we don't force the proof to start from a specific DA block and appearently if we set to 200, it would start from 201.

we noticed this while deploying on devnet.
