### PR TITLE
Fix reproducible guest build

### DIFF
--- a/docs/run-testnet.md
+++ b/docs/run-testnet.md
@@ -160,7 +160,7 @@ Compile Citrea by running command:
 cargo build --release
 ```
 
-If you wish to verify ZK-Proofs, add `REPR_GUEST_BUILD=1` before `cargo b...`
+If you wish to verify ZK-Proofs, add `REPR_GUEST_BUILD_LATEST=1` before `cargo b...`
 
 #### Step 2.4: Run Citrea
 

--- a/guests/risc0/batch-proof/build.rs
+++ b/guests/risc0/batch-proof/build.rs
@@ -5,7 +5,7 @@ use risc0_build::{embed_methods_with_options, DockerOptions, GuestOptions};
 fn main() {
     // Build environment variables
     println!("cargo:rerun-if-env-changed=SKIP_GUEST_BUILD");
-    println!("cargo:rerun-if-env-changed=REPR_GUEST_BUILD");
+    println!("cargo:rerun-if-env-changed=REPR_GUEST_BUILD_LATEST");
     println!("cargo:rerun-if-env-changed=OUT_DIR");
     // Compile time constant environment variables
     println!("cargo:rerun-if-env-changed=CITREA_NETWORK");
@@ -59,7 +59,7 @@ fn get_guest_options() -> HashMap<&'static str, risc0_build::GuestOptions> {
         features.push("testing".to_string());
     }
 
-    let use_docker = if std::env::var("REPR_GUEST_BUILD").is_ok() {
+    let use_docker = if std::env::var("REPR_GUEST_BUILD_LATEST").is_ok() {
         let this_package_dir = std::env!("CARGO_MANIFEST_DIR");
         let root_dir = format!("{this_package_dir}/../../../");
         Some(DockerOptions {

--- a/guests/risc0/batch-proof/build.rs
+++ b/guests/risc0/batch-proof/build.rs
@@ -61,7 +61,7 @@ fn get_guest_options() -> HashMap<&'static str, risc0_build::GuestOptions> {
 
     let use_docker = if std::env::var("REPR_GUEST_BUILD").is_ok() {
         let this_package_dir = std::env!("CARGO_MANIFEST_DIR");
-        let root_dir = format!("{this_package_dir}/../../");
+        let root_dir = format!("{this_package_dir}/../../../");
         Some(DockerOptions {
             root_dir: Some(root_dir.into()),
         })

--- a/guests/risc0/light-client-proof/build.rs
+++ b/guests/risc0/light-client-proof/build.rs
@@ -5,7 +5,7 @@ use risc0_build::{embed_methods_with_options, DockerOptions, GuestOptions};
 fn main() {
     // Build environment variables
     println!("cargo:rerun-if-env-changed=SKIP_GUEST_BUILD");
-    println!("cargo:rerun-if-env-changed=REPR_GUEST_BUILD");
+    println!("cargo:rerun-if-env-changed=REPR_GUEST_BUILD_LATEST");
     println!("cargo:rerun-if-env-changed=OUT_DIR");
     // Compile time constant environment variables
     println!("cargo:rerun-if-env-changed=CITREA_NETWORK");
@@ -59,7 +59,7 @@ fn get_guest_options() -> HashMap<&'static str, risc0_build::GuestOptions> {
         features.push("testing".to_string());
     }
 
-    let use_docker = if std::env::var("REPR_GUEST_BUILD").is_ok() {
+    let use_docker = if std::env::var("REPR_GUEST_BUILD_LATEST").is_ok() {
         let this_package_dir = std::env!("CARGO_MANIFEST_DIR");
         let root_dir = format!("{this_package_dir}/../../../");
         Some(DockerOptions {

--- a/guests/risc0/light-client-proof/build.rs
+++ b/guests/risc0/light-client-proof/build.rs
@@ -61,7 +61,7 @@ fn get_guest_options() -> HashMap<&'static str, risc0_build::GuestOptions> {
 
     let use_docker = if std::env::var("REPR_GUEST_BUILD").is_ok() {
         let this_package_dir = std::env!("CARGO_MANIFEST_DIR");
-        let root_dir = format!("{this_package_dir}/../../");
+        let root_dir = format!("{this_package_dir}/../../../");
         Some(DockerOptions {
             root_dir: Some(root_dir.into()),
         })


### PR DESCRIPTION
# Description
`REPR_GUEST_BUILD=1 make build` was failing for me:

```
error: failed to run custom build command for `citrea-risc0-light-client v0.6.0 (/Users/ege/citrea/guests/risc0/light-client-proof)`

Caused by:
  process didn't exit successfully: `/Users/ege/citrea/target/debug/build/citrea-risc0-light-client-c585ed2bb5fac12a/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=SKIP_GUEST_BUILD
  cargo:rerun-if-env-changed=REPR_GUEST_BUILD
  cargo:rerun-if-env-changed=OUT_DIR
  cargo:rerun-if-env-changed=CITREA_NETWORK
  cargo:rerun-if-env-changed=L2_GENESIS_ROOT
  cargo:rerun-if-env-changed=BATCH_PROOF_METHOD_ID
  cargo:rerun-if-env-changed=PROVER_DA_PUB_KEY
  cargo:warning=SKIP_GUEST_BUILD not set. Defaulting to performing guest build.
  cargo:rerun-if-env-changed=RISC0_SKIP_BUILD
  Building guest package citrea-risc0-light-client.light-client-proof-bitcoin
  cargo:rerun-if-env-changed=RISC0_SKIP_BUILD
  Docker version 27.4.0, build bde2b89

  --- stderr
  Docker context: "/Users/ege/citrea/guests"
  Building ELF binaries in light-client-proof-bitcoin for riscv32im-risc0-zkvm-elf target...
  #0 building with "desktop-linux" instance using docker driver

  #1 [internal] load build definition from Dockerfile
  #1 transferring dockerfile: 1.05kB done
  #1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
  #1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 13)
  #1 DONE 0.0s

  #2 [internal] load metadata for docker.io/risczero/risc0-guest-builder:r0.1.81.0
  #2 DONE 1.5s

  #3 [build 1/5] FROM docker.io/risczero/risc0-guest-builder:r0.1.81.0@sha256:0e7defd9eed78139314efbe3e66d7218941e85c85f4fa2ece17087a6eb01f263
  #3 DONE 0.0s

  #4 [internal] load build context
  #4 transferring context: 304.34kB 0.0s done
  #4 DONE 0.0s

  #5 [build 2/5] WORKDIR /src
  #5 CACHED

  #6 [build 3/5] COPY . .
  #6 DONE 0.0s

  #7 [build 4/5] RUN cargo +risc0 fetch --locked --target riscv32im-risc0-zkvm-elf --manifest-path risc0/light-client-proof/bitcoin/Cargo.toml
  #7 0.537 error: failed to load manifest for dependency `bitcoin-da`
  #7 0.537 
  #7 0.537 Caused by:
  #7 0.538   failed to read `/crates/bitcoin-da/Cargo.toml`
  #7 0.538 
  #7 0.538 Caused by:
  #7 0.538   No such file or directory (os error 2)
  #7 ERROR: process "/bin/sh -c cargo +risc0 fetch --locked --target riscv32im-risc0-zkvm-elf --manifest-path $CARGO_MANIFEST_PATH" did not complete successfully: exit code: 101
  ------
   > [build 4/5] RUN cargo +risc0 fetch --locked --target riscv32im-risc0-zkvm-elf --manifest-path risc0/light-client-proof/bitcoin/Cargo.toml:
  0.537 error: failed to load manifest for dependency `bitcoin-da`
  0.537 
  0.537 Caused by:
  0.538   failed to read `/crates/bitcoin-da/Cargo.toml`
  0.538 
  0.538 Caused by:
  0.538   No such file or directory (os error 2)
  ------

   3 warnings found (use docker --debug to expand):
   - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
   - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 13)
   - InvalidBaseImagePlatform: Base image risczero/risc0-guest-builder:r0.1.81.0 was pulled with platform "linux/amd64", expected "linux/arm64" for current build (line 1)
  Dockerfile:9
  --------------------
ENV CC_riscv32im_risc0_zkvm_elf="/root/.local/share/cargo-risczero/cpp/bin/riscv32-unknown-elf-gcc"
ENV CFLAGS_riscv32im_risc0_zkvm_elf="-march=rv32im -nostdlib"
RUN cargo +risc0 fetch --locked --target riscv32im-risc0-zkvm-elf --manifest-path $CARGO_MANIFEST_PATH
RUN cargo +risc0 build --release --locked --target riscv32im-risc0-zkvm-elf --manifest-path $CARGO_MANIFEST_PATH
    11 |     
  --------------------
  ERROR: failed to solve: process "/bin/sh -c cargo +risc0 fetch --locked --target riscv32im-risc0-zkvm-elf --manifest-path $CARGO_MANIFEST_PATH" did not complete successfully: exit code: 101
  325  /usr/local/bin/dockerd --config-file /run/config/docker/daemon.json --containerd /run/containerd/containerd.sock --pidfile /run/desktop/docker.pid --swarm-default-advertise-addr=192.168.65.3 --host-gateway-ip 192.168.65.254
  github.com/moby/buildkit/executor/runcexecutor.exitError
        /root/build-deb/engine/vendor/github.com/moby/buildkit/executor/runcexecutor/executor.go:391
  github.com/moby/buildkit/executor/runcexecutor.(*runcExecutor).Run
        /root/build-deb/engine/vendor/github.com/moby/buildkit/executor/runcexecutor/executor.go:339
  github.com/moby/buildkit/solver/llbsolver/ops.(*ExecOp).Exec
        /root/build-deb/engine/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go:472
  github.com/moby/buildkit/solver.(*sharedOp).Exec.func2
        /root/build-deb/engine/vendor/github.com/moby/buildkit/solver/jobs.go:1100
  github.com/moby/buildkit/util/flightcontrol.(*call[...]).run
        /root/build-deb/engine/vendor/github.com/moby/buildkit/util/flightcontrol/flightcontrol.go:122
  sync.(*Once).doSlow
        /usr/local/go/src/sync/once.go:74
  sync.(*Once).Do
        /usr/local/go/src/sync/once.go:65
  runtime.goexit
        /usr/local/go/src/runtime/asm_arm64.s:1222

  57599 v0.19.2-desktop.1 /Users/ege/.docker/cli-plugins/docker-buildx buildx build --output=/Users/ege/citrea/guests/target/riscv-guest/riscv32im-risc0-zkvm-elf/docker -f /var/folders/70/j4h5vq3s1m989g_7ptp_259c0000gn/T/.tmp4TMF17/Dockerfile /Users/ege/citrea/guests
  google.golang.org/grpc.(*ClientConn).Invoke
        google.golang.org/grpc@v1.66.3/call.go:35
  github.com/moby/buildkit/api/services/control.(*controlClient).Solve
        github.com/moby/buildkit@v0.18.0/api/services/control/control_grpc.pb.go:88
  github.com/moby/buildkit/client.(*Client).solve.func2
        github.com/moby/buildkit@v0.18.0/client/solve.go:269
  golang.org/x/sync/errgroup.(*Group).Go.func1
        golang.org/x/sync@v0.8.0/errgroup/errgroup.go:78
  runtime.goexit
        runtime/asm_arm64.s:1223

  325  /usr/local/bin/dockerd --config-file /run/config/docker/daemon.json --containerd /run/containerd/containerd.sock --pidfile /run/desktop/docker.pid --swarm-default-advertise-addr=192.168.65.3 --host-gateway-ip 192.168.65.254
  github.com/moby/buildkit/solver.(*edge).execOp
        /root/build-deb/engine/vendor/github.com/moby/buildkit/solver/edge.go:966
  github.com/moby/buildkit/solver/internal/pipe.NewWithFunction[...].func2
        /root/build-deb/engine/vendor/github.com/moby/buildkit/solver/internal/pipe/pipe.go:78
  runtime.goexit
        /usr/local/go/src/runtime/asm_arm64.s:1222

  57599 v0.19.2-desktop.1 /Users/ege/.docker/cli-plugins/docker-buildx buildx build --output=/Users/ege/citrea/guests/target/riscv-guest/riscv32im-risc0-zkvm-elf/docker -f /var/folders/70/j4h5vq3s1m989g_7ptp_259c0000gn/T/.tmp4TMF17/Dockerfile /Users/ege/citrea/guests
  github.com/moby/buildkit/client.(*Client).solve.func2
        github.com/moby/buildkit@v0.18.0/client/solve.go:285
  golang.org/x/sync/errgroup.(*Group).Go.func1
        golang.org/x/sync@v0.8.0/errgroup/errgroup.go:78

  325  /usr/local/bin/dockerd --config-file /run/config/docker/daemon.json --containerd /run/containerd/containerd.sock --pidfile /run/desktop/docker.pid --swarm-default-advertise-addr=192.168.65.3 --host-gateway-ip 192.168.65.254
  github.com/moby/buildkit/solver/llbsolver/ops.(*ExecOp).Exec
        /root/build-deb/engine/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go:493
  github.com/moby/buildkit/solver.(*sharedOp).Exec.func2
        /root/build-deb/engine/vendor/github.com/moby/buildkit/solver/jobs.go:1100


  View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/0r1tdxxt1qnzhb11fjnr45t2w
  thread 'main' panicked at /Users/ege/.cargo/registry/src/index.crates.io-6f17d22bba15001f/risc0-build-1.2.0/src/lib.rs:776:14:
  called `Result::unwrap()` on an `Err` value: docker build failed
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
The following warnings were emitted during compilation:

warning: citrea-risc0-batch-proof@0.6.0: SKIP_GUEST_BUILD not set. Defaulting to performing guest build.

error: failed to run custom build command for `citrea-risc0-batch-proof v0.6.0 (/Users/ege/citrea/guests/risc0/batch-proof)`

Caused by:
  process didn't exit successfully: `/Users/ege/citrea/target/debug/build/citrea-risc0-batch-proof-bed1185312ddc263/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=SKIP_GUEST_BUILD
  cargo:rerun-if-env-changed=REPR_GUEST_BUILD
  cargo:rerun-if-env-changed=OUT_DIR
  cargo:rerun-if-env-changed=CITREA_NETWORK
  cargo:rerun-if-env-changed=SEQUENCER_PUBLIC_KEY
  cargo:rerun-if-env-changed=SEQUENCER_DA_PUB_KEY
  cargo:warning=SKIP_GUEST_BUILD not set. Defaulting to performing guest build.
  cargo:rerun-if-env-changed=RISC0_SKIP_BUILD
  Building guest package citrea-risc0-batch-proof.batch-proof-bitcoin
  cargo:rerun-if-env-changed=RISC0_SKIP_BUILD
  Docker version 27.4.0, build bde2b89

  --- stderr
  Docker context: "/Users/ege/citrea/guests"
  Building ELF binaries in batch-proof-bitcoin for riscv32im-risc0-zkvm-elf target...
  #0 building with "desktop-linux" instance using docker driver

  #1 [internal] load build definition from Dockerfile
  #1 transferring dockerfile: 1.03kB done
  #1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
  #1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 13)
  #1 DONE 0.0s

  #2 [internal] load metadata for docker.io/risczero/risc0-guest-builder:r0.1.81.0
  #2 ...

  #3 [auth] risczero/risc0-guest-builder:pull token for registry-1.docker.io
  #3 DONE 0.0s

  #2 [internal] load metadata for docker.io/risczero/risc0-guest-builder:r0.1.81.0
  #2 DONE 1.5s

  #4 [build 1/5] FROM docker.io/risczero/risc0-guest-builder:r0.1.81.0@sha256:0e7defd9eed78139314efbe3e66d7218941e85c85f4fa2ece17087a6eb01f263
  #4 DONE 0.0s

  #5 [build 2/5] WORKDIR /src
  #5 CACHED

  #6 [internal] load build context
  #6 transferring context: 413.25kB 0.0s done
  #6 DONE 0.0s

  #7 [build 3/5] COPY . .
  #7 DONE 0.0s

  #8 [build 3/5] COPY . .
  #8 CACHED

  #9 [build 4/5] RUN cargo +risc0 fetch --locked --target riscv32im-risc0-zkvm-elf --manifest-path risc0/batch-proof/bitcoin/Cargo.toml
  #9 0.536 error: failed to load manifest for dependency `bitcoin-da`
  #9 0.536 
  #9 0.536 Caused by:
  #9 0.538   failed to read `/crates/bitcoin-da/Cargo.toml`
  #9 0.538 
  #9 0.538 Caused by:
  #9 0.538   No such file or directory (os error 2)
  #9 ERROR: process "/bin/sh -c cargo +risc0 fetch --locked --target riscv32im-risc0-zkvm-elf --manifest-path $CARGO_MANIFEST_PATH" did not complete successfully: exit code: 101
  ------
   > [build 4/5] RUN cargo +risc0 fetch --locked --target riscv32im-risc0-zkvm-elf --manifest-path risc0/batch-proof/bitcoin/Cargo.toml:
  0.536 error: failed to load manifest for dependency `bitcoin-da`
  0.536 
  0.536 Caused by:
  0.538   failed to read `/crates/bitcoin-da/Cargo.toml`
  0.538 
  0.538 Caused by:
  0.538   No such file or directory (os error 2)
  ------
```
