### PR TITLE
Get rid of RlpTransaction in Evm call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,6 +1974,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
+ "serde_with",
  "sha2",
  "sov-modules-api",
  "sov-prover-storage-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ reqwest = { version = "0.12.12", features = ["rustls-tls", "json", "http2"], def
 rocksdb = { version = "0.22.0", features = ["lz4"], default-features = false }
 serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
+serde_with = "3"
 sha2 = { version = "0.10.8", default-features = false, features = ["asm"] }
 schemars = { version = "0.8.16", features = ["derive"] }
 secp256k1 = { version = "0.29.0", default-features = false, features = ["global-context", "recovery"] }

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -19,7 +19,8 @@ sov-state = { path = "../sovereign-sdk/module-system/sov-state" }
 
 citrea-primitives = { path = "../primitives" }
 
-borsh = { workspace = true, features = ["rc"] }
+borsh = { workspace = true, features = ["bytes", "rc"] }
+bytes = { workspace = true }
 clap = { workspace = true, optional = true }
 derive_more = { workspace = true, optional = true }
 hex = { workspace = true }

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -27,6 +27,7 @@ jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], 
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
+serde_with = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
 
@@ -101,6 +102,7 @@ native = [
   "clap",
   "itertools",
   "serde_json",
+  "serde_with",
   "secp256k1",
   "dep:tracing",
   "derive_more",

--- a/crates/evm/src/borsh_compat.rs
+++ b/crates/evm/src/borsh_compat.rs
@@ -1,0 +1,531 @@
+use alloy_consensus::{TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy};
+use alloy_eips::eip7702::{Authorization, SignedAuthorization};
+use alloy_primitives::{Parity, Signature, TxKind, U256};
+use alloy_rpc_types::{AccessList, AccessListItem};
+use borsh::{BorshDeserialize, BorshSerialize};
+use bytes::Bytes;
+use reth_primitives::{Transaction, TransactionSigned};
+
+#[derive(BorshDeserialize, BorshSerialize)]
+enum CompatParity {
+    Eip155(u64),
+    NonEip155(bool),
+    Parity(bool),
+}
+
+impl From<Parity> for CompatParity {
+    fn from(value: Parity) -> Self {
+        match value {
+            Parity::Eip155(x) => Self::Eip155(x),
+            Parity::NonEip155(x) => Self::NonEip155(x),
+            Parity::Parity(x) => Self::Parity(x),
+        }
+    }
+}
+
+impl From<CompatParity> for Parity {
+    fn from(value: CompatParity) -> Self {
+        match value {
+            CompatParity::Eip155(x) => Self::Eip155(x),
+            CompatParity::NonEip155(x) => Self::NonEip155(x),
+            CompatParity::Parity(x) => Self::Parity(x),
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+#[repr(transparent)]
+struct CompatU256 {
+    limbs: [u64; 4],
+}
+
+impl From<U256> for CompatU256 {
+    fn from(value: U256) -> Self {
+        Self {
+            limbs: value.into_limbs(),
+        }
+    }
+}
+
+impl From<CompatU256> for U256 {
+    fn from(value: CompatU256) -> Self {
+        Self::from_limbs(value.limbs)
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatSignature {
+    v: CompatParity,
+    r: CompatU256,
+    s: CompatU256,
+}
+
+impl From<Signature> for CompatSignature {
+    fn from(value: Signature) -> Self {
+        Self {
+            v: value.v().into(),
+            r: value.r().into(),
+            s: value.s().into(),
+        }
+    }
+}
+
+impl From<CompatSignature> for Signature {
+    fn from(value: CompatSignature) -> Self {
+        Self::new(value.r.into(), value.s.into(), value.v.into())
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+enum CompatTxKind {
+    Create,
+    Call([u8; 20]),
+}
+
+impl From<TxKind> for CompatTxKind {
+    fn from(value: TxKind) -> Self {
+        match value {
+            TxKind::Create => Self::Create,
+            TxKind::Call(x) => Self::Call(x.into()),
+        }
+    }
+}
+
+impl From<CompatTxKind> for TxKind {
+    fn from(value: CompatTxKind) -> Self {
+        match value {
+            CompatTxKind::Create => Self::Create,
+            CompatTxKind::Call(x) => Self::Call(x.into()),
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatAccessListItem {
+    address: [u8; 20],
+    storage_keys: Vec<[u8; 32]>,
+}
+
+impl From<AccessListItem> for CompatAccessListItem {
+    fn from(value: AccessListItem) -> Self {
+        Self {
+            address: value.address.into(),
+            storage_keys: value.storage_keys.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<CompatAccessListItem> for AccessListItem {
+    fn from(value: CompatAccessListItem) -> Self {
+        Self {
+            address: value.address.into(),
+            storage_keys: value.storage_keys.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatAccessList(Vec<CompatAccessListItem>);
+
+impl From<AccessList> for CompatAccessList {
+    fn from(value: AccessList) -> Self {
+        Self(value.0.into_iter().map(Into::into).collect())
+    }
+}
+
+impl From<CompatAccessList> for AccessList {
+    fn from(value: CompatAccessList) -> Self {
+        Self(value.0.into_iter().map(Into::into).collect())
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatAuthorization {
+    chain_id: CompatU256,
+    address: [u8; 20],
+    nonce: u64,
+}
+
+impl From<Authorization> for CompatAuthorization {
+    fn from(value: Authorization) -> Self {
+        Self {
+            chain_id: value.chain_id.into(),
+            address: value.address.into(),
+            nonce: value.nonce,
+        }
+    }
+}
+
+impl From<CompatAuthorization> for Authorization {
+    fn from(value: CompatAuthorization) -> Self {
+        Self {
+            chain_id: value.chain_id.into(),
+            address: value.address.into(),
+            nonce: value.nonce,
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatSignedAuthorization {
+    inner: CompatAuthorization,
+    signature: CompatSignature,
+}
+
+impl From<SignedAuthorization> for CompatSignedAuthorization {
+    fn from(value: SignedAuthorization) -> Self {
+        let (auth, sig) = value.into_parts();
+        Self {
+            inner: auth.into(),
+            signature: sig.into(),
+        }
+    }
+}
+
+impl From<CompatSignedAuthorization> for SignedAuthorization {
+    fn from(value: CompatSignedAuthorization) -> Self {
+        let auth: Authorization = value.inner.into();
+        auth.into_signed(value.signature.into())
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatTxLegacy {
+    chain_id: Option<u64>,
+    nonce: u64,
+    gas_price: u128,
+    gas_limit: u64,
+    to: CompatTxKind,
+    value: CompatU256,
+    input: Bytes,
+}
+
+impl From<TxLegacy> for CompatTxLegacy {
+    fn from(value: TxLegacy) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_price: value.gas_price,
+            gas_limit: value.gas_limit,
+            to: value.to.into(),
+            value: value.value.into(),
+            input: value.input.into(),
+        }
+    }
+}
+
+impl From<CompatTxLegacy> for TxLegacy {
+    fn from(value: CompatTxLegacy) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_price: value.gas_price,
+            gas_limit: value.gas_limit,
+            to: value.to.into(),
+            value: value.value.into(),
+            input: value.input.into(),
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatTxEip2930 {
+    chain_id: u64,
+    nonce: u64,
+    gas_price: u128,
+    gas_limit: u64,
+    to: CompatTxKind,
+    value: CompatU256,
+    access_list: CompatAccessList,
+    input: Bytes,
+}
+
+impl From<TxEip2930> for CompatTxEip2930 {
+    fn from(value: TxEip2930) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_price: value.gas_price,
+            gas_limit: value.gas_limit,
+            to: value.to.into(),
+            value: value.value.into(),
+            access_list: value.access_list.into(),
+            input: value.input.into(),
+        }
+    }
+}
+
+impl From<CompatTxEip2930> for TxEip2930 {
+    fn from(value: CompatTxEip2930) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_price: value.gas_price,
+            gas_limit: value.gas_limit,
+            to: value.to.into(),
+            value: value.value.into(),
+            access_list: value.access_list.into(),
+            input: value.input.into(),
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatTxEip1559 {
+    chain_id: u64,
+    nonce: u64,
+    gas_limit: u64,
+    max_fee_per_gas: u128,
+    max_priority_fee_per_gas: u128,
+    to: CompatTxKind,
+    value: CompatU256,
+    access_list: CompatAccessList,
+    input: Bytes,
+}
+
+impl From<TxEip1559> for CompatTxEip1559 {
+    fn from(value: TxEip1559) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_limit: value.gas_limit,
+            max_fee_per_gas: value.max_fee_per_gas,
+            max_priority_fee_per_gas: value.max_priority_fee_per_gas,
+            to: value.to.into(),
+            value: value.value.into(),
+            access_list: value.access_list.into(),
+            input: value.input.into(),
+        }
+    }
+}
+
+impl From<CompatTxEip1559> for TxEip1559 {
+    fn from(value: CompatTxEip1559) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_limit: value.gas_limit,
+            max_fee_per_gas: value.max_fee_per_gas,
+            max_priority_fee_per_gas: value.max_priority_fee_per_gas,
+            to: value.to.into(),
+            value: value.value.into(),
+            access_list: value.access_list.into(),
+            input: value.input.into(),
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatTxEip4844 {
+    chain_id: u64,
+    nonce: u64,
+    gas_limit: u64,
+    max_fee_per_gas: u128,
+    max_priority_fee_per_gas: u128,
+    to: [u8; 20],
+    value: CompatU256,
+    access_list: CompatAccessList,
+    blob_versioned_hashes: Vec<[u8; 32]>,
+    max_fee_per_blob_gas: u128,
+    input: Bytes,
+}
+
+impl From<TxEip4844> for CompatTxEip4844 {
+    fn from(value: TxEip4844) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_limit: value.gas_limit,
+            max_fee_per_gas: value.max_fee_per_gas,
+            max_priority_fee_per_gas: value.max_priority_fee_per_gas,
+            to: value.to.into(),
+            value: value.value.into(),
+            access_list: value.access_list.into(),
+            blob_versioned_hashes: value
+                .blob_versioned_hashes
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            max_fee_per_blob_gas: value.max_fee_per_blob_gas,
+            input: value.input.into(),
+        }
+    }
+}
+
+impl From<CompatTxEip4844> for TxEip4844 {
+    fn from(value: CompatTxEip4844) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_limit: value.gas_limit,
+            max_fee_per_gas: value.max_fee_per_gas,
+            max_priority_fee_per_gas: value.max_priority_fee_per_gas,
+            to: value.to.into(),
+            value: value.value.into(),
+            access_list: value.access_list.into(),
+            blob_versioned_hashes: value
+                .blob_versioned_hashes
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            max_fee_per_blob_gas: value.max_fee_per_blob_gas,
+            input: value.input.into(),
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatTxEip7702 {
+    chain_id: u64,
+    nonce: u64,
+    gas_limit: u64,
+    max_fee_per_gas: u128,
+    max_priority_fee_per_gas: u128,
+    to: [u8; 20],
+    value: CompatU256,
+    access_list: CompatAccessList,
+    authorization_list: Vec<CompatSignedAuthorization>,
+    input: Bytes,
+}
+
+impl From<TxEip7702> for CompatTxEip7702 {
+    fn from(value: TxEip7702) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_limit: value.gas_limit,
+            max_fee_per_gas: value.max_fee_per_gas,
+            max_priority_fee_per_gas: value.max_priority_fee_per_gas,
+            to: value.to.into(),
+            value: value.value.into(),
+            access_list: value.access_list.into(),
+            authorization_list: value
+                .authorization_list
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            input: value.input.into(),
+        }
+    }
+}
+
+impl From<CompatTxEip7702> for TxEip7702 {
+    fn from(value: CompatTxEip7702) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            nonce: value.nonce,
+            gas_limit: value.gas_limit,
+            max_fee_per_gas: value.max_fee_per_gas,
+            max_priority_fee_per_gas: value.max_priority_fee_per_gas,
+            to: value.to.into(),
+            value: value.value.into(),
+            access_list: value.access_list.into(),
+            authorization_list: value
+                .authorization_list
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            input: value.input.into(),
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+enum CompatTransaction {
+    Legacy(CompatTxLegacy),
+    Eip2930(CompatTxEip2930),
+    Eip1559(CompatTxEip1559),
+    Eip4844(CompatTxEip4844),
+    Eip7702(CompatTxEip7702),
+}
+
+impl From<Transaction> for CompatTransaction {
+    fn from(value: Transaction) -> Self {
+        match value {
+            Transaction::Legacy(x) => Self::Legacy(x.into()),
+            Transaction::Eip2930(x) => Self::Eip2930(x.into()),
+            Transaction::Eip1559(x) => Self::Eip1559(x.into()),
+            Transaction::Eip4844(x) => Self::Eip4844(x.into()),
+            Transaction::Eip7702(x) => Self::Eip7702(x.into()),
+        }
+    }
+}
+
+impl From<CompatTransaction> for Transaction {
+    fn from(value: CompatTransaction) -> Self {
+        match value {
+            CompatTransaction::Legacy(x) => Self::Legacy(x.into()),
+            CompatTransaction::Eip2930(x) => Self::Eip2930(x.into()),
+            CompatTransaction::Eip1559(x) => Self::Eip1559(x.into()),
+            CompatTransaction::Eip4844(x) => Self::Eip4844(x.into()),
+            CompatTransaction::Eip7702(x) => Self::Eip7702(x.into()),
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CompatTransactionSigned {
+    pub hash: [u8; 32],
+    pub signature: CompatSignature,
+    pub transaction: CompatTransaction,
+}
+
+impl From<TransactionSigned> for CompatTransactionSigned {
+    fn from(value: TransactionSigned) -> Self {
+        Self {
+            hash: value.hash.into(),
+            signature: value.signature.into(),
+            transaction: value.transaction.into(),
+        }
+    }
+}
+
+impl From<CompatTransactionSigned> for TransactionSigned {
+    fn from(value: CompatTransactionSigned) -> Self {
+        Self {
+            hash: value.hash.into(),
+            signature: value.signature.into(),
+            transaction: value.transaction.into(),
+        }
+    }
+}
+
+fn compat_to_orig(txs: Vec<CompatTransactionSigned>) -> Vec<TransactionSigned> {
+    fn assert_type<A, B>() {
+        debug_assert_eq!(size_of::<A>(), size_of::<B>());
+        debug_assert_eq!(align_of::<A>(), align_of::<B>());
+    }
+    assert_type::<TransactionSigned, CompatTransactionSigned>();
+    assert_type::<TxLegacy, CompatTxLegacy>();
+    assert_type::<TxEip2930, CompatTxEip2930>();
+    assert_type::<TxEip1559, CompatTxEip1559>();
+    assert_type::<TxEip4844, CompatTxEip4844>();
+    assert_type::<TxEip7702, CompatTxEip7702>();
+    assert_type::<Signature, CompatSignature>();
+    assert_type::<SignedAuthorization, CompatSignedAuthorization>();
+    assert_type::<Parity, CompatParity>();
+    assert_type::<AccessList, CompatAccessList>();
+    assert_type::<AccessListItem, CompatAccessListItem>();
+    assert_type::<TxKind, CompatTxKind>();
+
+    // Unfortunately `xs.into_iter().map(Into::into).collect()` is not
+    //  optimized due to rustc limitations.
+
+    unsafe { core::mem::transmute(txs) }
+}
+
+pub(crate) fn borsh_ser_txsigned<W: borsh::io::Write>(
+    txs: &[TransactionSigned],
+    writer: &mut W,
+) -> Result<(), borsh::io::Error> {
+    let txs: Vec<CompatTransactionSigned> = txs.iter().cloned().map(Into::into).collect();
+    borsh::BorshSerialize::serialize(&txs, writer)
+}
+
+pub(crate) fn borsh_de_txsigned<R: borsh::io::Read>(
+    reader: &mut R,
+) -> Result<Vec<TransactionSigned>, borsh::io::Error> {
+    let txs: Vec<CompatTransactionSigned> = borsh::BorshDeserialize::deserialize_reader(reader)?;
+    let txs = compat_to_orig(txs);
+    Ok(txs)
+}

--- a/crates/evm/src/call.rs
+++ b/crates/evm/src/call.rs
@@ -1,7 +1,10 @@
 use core::panic;
 
-use reth_primitives::TransactionSignedEcRecovered;
+use alloy_rlp::{Decodable, Encodable};
+use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
 use revm::primitives::{BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, SpecId};
+#[cfg(feature = "serde")]
+use serde_with::serde_as;
 use sov_modules_api::prelude::*;
 use sov_modules_api::{native_error, CallResponse, SoftConfirmationModuleCallError, WorkingSet};
 
@@ -15,17 +18,118 @@ use crate::system_contracts::{BitcoinLightClient, BridgeWrapper};
 use crate::system_events::{create_system_transactions, SYSTEM_SIGNER};
 use crate::{citrea_spec_id_to_evm_spec_id, Evm, PendingTransaction, SystemEvent};
 
+/// EVM call message.
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize),
     derive(serde::Deserialize)
 )]
-
-/// EVM call message.
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
 pub struct CallMessage {
     /// RLP encoded transaction.
     pub txs: Vec<RlpEvmTransaction>,
+}
+
+/// EVM post kumquat (Fork2) call message.
+#[derive(borsh::BorshSerialize, borsh::BorshDeserialize, Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", serde_as)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
+)]
+pub struct CallMessage2 {
+    /// Borsh encoded transaction.
+    #[cfg_attr(
+        feature = "serde",
+        serde_as(as = "Vec<reth_primitives::serde_bincode_compat::TransactionSigned>")
+    )]
+    #[borsh(
+        serialize_with = "borsh_ser_txsigned",
+        deserialize_with = "borsh_de_txsigned"
+    )]
+    pub txs: Vec<TransactionSigned>,
+}
+
+/// EVM either pre or post kumquat call message.
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    derive(serde::Deserialize),
+    serde(untagged)
+)]
+pub enum VersionedCallMessage {
+    /// Post kumquat
+    Fork2(CallMessage2),
+    /// Pre or equal to kumquat
+    Kumquat(CallMessage),
+}
+
+impl From<CallMessage> for VersionedCallMessage {
+    fn from(msg: CallMessage) -> Self {
+        Self::Kumquat(msg)
+    }
+}
+
+impl From<CallMessage2> for VersionedCallMessage {
+    fn from(msg: CallMessage2) -> Self {
+        Self::Fork2(msg)
+    }
+}
+
+impl borsh::BorshSerialize for VersionedCallMessage {
+    fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        match self {
+            VersionedCallMessage::Kumquat(msg) => msg.serialize(writer),
+            VersionedCallMessage::Fork2(msg) => msg.serialize(writer),
+        }
+    }
+}
+
+impl borsh::BorshDeserialize for VersionedCallMessage {
+    fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+        if let Ok(msg) = CallMessage2::deserialize_reader(reader) {
+            return Ok(VersionedCallMessage::Fork2(msg));
+        };
+        let msg = CallMessage::deserialize_reader(reader)?;
+        Ok(VersionedCallMessage::Kumquat(msg))
+    }
+}
+
+fn borsh_ser_txsigned<W: borsh::io::Write>(
+    txs: &Vec<TransactionSigned>,
+    writer: &mut W,
+) -> Result<(), borsh::io::Error> {
+    borsh::BorshSerialize::serialize(&txs.len(), writer)?;
+
+    let mut res = Vec::with_capacity(txs.len());
+    for tx in txs {
+        let mut buf = vec![];
+        tx.encode(&mut buf);
+        res.push(buf);
+    }
+
+    borsh::BorshSerialize::serialize(&res, writer)
+}
+
+fn borsh_de_txsigned<R: borsh::io::Read>(
+    reader: &mut R,
+) -> Result<Vec<TransactionSigned>, borsh::io::Error> {
+    let bufs: Vec<Vec<u8>> = borsh::BorshDeserialize::deserialize_reader(reader)?;
+    let mut res = Vec::with_capacity(bufs.len());
+    for (i, buf) in bufs.into_iter().enumerate() {
+        match TransactionSigned::decode(&mut &*buf) {
+            Ok(tx) => res.push(tx),
+            Err(e) => {
+                return Err(borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
+                    format!("Failed to deserialize {i} tx: {e}"),
+                ));
+            }
+        }
+    }
+    Ok(res)
 }
 
 impl<C: sov_modules_api::Context> Evm<C> {
@@ -135,6 +239,96 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let users_txs: Vec<TransactionSignedEcRecovered> = txs
             .into_iter()
             .map(|tx| tx.try_into())
+            .collect::<Result<Vec<_>, ConversionError>>()
+            .map_err(|_| SoftConfirmationModuleCallError::EvmTxNotSerializable)?;
+
+        let cfg = self.cfg.get(working_set).expect("Evm config must be set");
+        let active_evm_spec = citrea_spec_id_to_evm_spec_id(context.active_spec());
+        let cfg_env: CfgEnvWithHandlerCfg = get_cfg_env(cfg, active_evm_spec);
+
+        let l1_fee_rate = context.l1_fee_rate();
+        let mut citrea_handler_ext = CitreaExternal::new(l1_fee_rate);
+
+        let block_number = self.block_env.number;
+        let mut cumulative_gas_used = 0;
+        let mut log_index_start = 0;
+
+        if let Some(tx) = self.pending_transactions.last() {
+            cumulative_gas_used = tx.receipt.receipt.cumulative_gas_used;
+            log_index_start = tx.receipt.log_index_start + tx.receipt.receipt.logs.len() as u64;
+        }
+
+        let evm_db: EvmDb<'_, C> = self.get_db(working_set, cfg_env.handler_cfg.spec_id);
+
+        let results = executor::execute_multiple_tx(
+            evm_db,
+            self.block_env.clone(),
+            &users_txs,
+            cfg_env,
+            &mut citrea_handler_ext,
+            cumulative_gas_used,
+        )?;
+
+        // Iterate each evm_txs_recovered and results pair
+        // Create a PendingTransaction for each pair
+        // Push each PendingTransaction to pending_transactions
+        for (evm_tx_recovered, result) in users_txs.into_iter().zip(results.into_iter()) {
+            let gas_used = result.gas_used();
+            cumulative_gas_used += gas_used;
+            let tx_hash = evm_tx_recovered.hash();
+            let tx_info = citrea_handler_ext
+                .get_tx_info(tx_hash)
+                .unwrap_or_else(|| panic!("evm: Could not get associated info for tx: {tx_hash}"));
+
+            let success = result.is_success();
+
+            let logs = result.into_logs();
+            let logs_len = logs.len() as u64;
+
+            let receipt = Receipt {
+                receipt: reth_primitives::Receipt {
+                    tx_type: evm_tx_recovered.tx_type(),
+                    success,
+                    cumulative_gas_used,
+                    logs,
+                },
+                gas_used: gas_used as u128,
+                log_index_start,
+                l1_diff_size: tx_info.l1_diff_size,
+            };
+
+            log_index_start += logs_len;
+
+            let pending_transaction = PendingTransaction {
+                transaction: TransactionSignedAndRecovered {
+                    signer: evm_tx_recovered.signer(),
+                    signed_transaction: evm_tx_recovered.into(),
+                    block_number: block_number.saturating_to(),
+                },
+                receipt,
+            };
+
+            self.pending_transactions.push(pending_transaction);
+        }
+        Ok(CallResponse::default())
+    }
+
+    // so we don't convert errors twice
+    /// Executes a call message since Fork2.
+    pub(crate) fn execute_call2(
+        &mut self,
+        txs: Vec<TransactionSigned>,
+        context: &C,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<CallResponse, SoftConfirmationModuleCallError> {
+        // use of `self.block_env` is allowed here
+
+        let users_txs: Vec<TransactionSignedEcRecovered> = txs
+            .into_iter()
+            .map(|tx| {
+                tx.into_ecrecovered()
+                    .ok_or(ConversionError::FailedToDecodeSignedTransaction)
+            })
             .collect::<Result<Vec<_>, ConversionError>>()
             .map_err(|_| SoftConfirmationModuleCallError::EvmTxNotSerializable)?;
 

--- a/crates/evm/src/call.rs
+++ b/crates/evm/src/call.rs
@@ -1,6 +1,5 @@
 use core::panic;
 
-use alloy_rlp::{Decodable, Encodable};
 use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
 use revm::primitives::{BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, SpecId};
 #[cfg(feature = "serde")]
@@ -8,6 +7,7 @@ use serde_with::serde_as;
 use sov_modules_api::prelude::*;
 use sov_modules_api::{native_error, CallResponse, SoftConfirmationModuleCallError, WorkingSet};
 
+use crate::borsh_compat::{borsh_de_txsigned, borsh_ser_txsigned};
 use crate::conversions::ConversionError;
 use crate::evm::db::EvmDb;
 use crate::evm::executor::{self};
@@ -95,41 +95,6 @@ impl borsh::BorshDeserialize for VersionedCallMessage {
         let msg = CallMessage::deserialize_reader(reader)?;
         Ok(VersionedCallMessage::Kumquat(msg))
     }
-}
-
-fn borsh_ser_txsigned<W: borsh::io::Write>(
-    txs: &Vec<TransactionSigned>,
-    writer: &mut W,
-) -> Result<(), borsh::io::Error> {
-    borsh::BorshSerialize::serialize(&txs.len(), writer)?;
-
-    let mut res = Vec::with_capacity(txs.len());
-    for tx in txs {
-        let mut buf = vec![];
-        tx.encode(&mut buf);
-        res.push(buf);
-    }
-
-    borsh::BorshSerialize::serialize(&res, writer)
-}
-
-fn borsh_de_txsigned<R: borsh::io::Read>(
-    reader: &mut R,
-) -> Result<Vec<TransactionSigned>, borsh::io::Error> {
-    let bufs: Vec<Vec<u8>> = borsh::BorshDeserialize::deserialize_reader(reader)?;
-    let mut res = Vec::with_capacity(bufs.len());
-    for (i, buf) in bufs.into_iter().enumerate() {
-        match TransactionSigned::decode(&mut &*buf) {
-            Ok(tx) => res.push(tx),
-            Err(e) => {
-                return Err(borsh::io::Error::new(
-                    borsh::io::ErrorKind::InvalidData,
-                    format!("Failed to deserialize {i} tx: {e}"),
-                ));
-            }
-        }
-    }
-    Ok(res)
 }
 
 impl<C: sov_modules_api::Context> Evm<C> {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -182,7 +182,7 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Evm<C> {
 
     type Config = EvmConfig;
 
-    type CallMessage = call::CallMessage;
+    type CallMessage = call::VersionedCallMessage;
 
     fn genesis(&self, config: &Self::Config, working_set: &mut WorkingSet<C::Storage>) {
         self.init_module(config, working_set)
@@ -194,7 +194,10 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Evm<C> {
         context: &Self::Context,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<sov_modules_api::CallResponse, SoftConfirmationModuleCallError> {
-        self.execute_call(msg.txs, context, working_set)
+        match msg {
+            VersionedCallMessage::Kumquat(msg) => self.execute_call(msg.txs, context, working_set),
+            VersionedCallMessage::Fork2(msg) => self.execute_call2(msg.txs, context, working_set),
+        }
     }
 }
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
+mod borsh_compat;
 mod call;
 mod evm;
 mod genesis;

--- a/crates/evm/src/tests/call_tests.rs
+++ b/crates/evm/src/tests/call_tests.rs
@@ -93,7 +93,7 @@ fn call_multiple_test() {
         ];
 
         evm.call(
-            CallMessage { txs: transactions },
+            CallMessage { txs: transactions }.into(),
             &context,
             &mut working_set,
         )
@@ -258,7 +258,8 @@ fn call_test() {
 
         let call_message = CallMessage {
             txs: rlp_transactions,
-        };
+        }
+        .into();
 
         evm.call(call_message, &context, &mut working_set).unwrap();
     }
@@ -413,7 +414,8 @@ fn failed_transaction_test() {
 
         let call_message = CallMessage {
             txs: rlp_transactions,
-        };
+        }
+        .into();
 
         assert_eq!(
             evm.call(call_message, &context, working_set).unwrap_err(),
@@ -564,7 +566,8 @@ fn self_destruct_test() {
         evm.call(
             CallMessage {
                 txs: rlp_transactions,
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -624,7 +627,8 @@ fn self_destruct_test() {
                     3,
                     die_to_address,
                 )],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -688,7 +692,8 @@ fn self_destruct_test() {
         evm.call(
             CallMessage {
                 txs: rlp_transactions,
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -740,7 +745,8 @@ fn self_destruct_test() {
                     7,
                     die_to_address,
                 )],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -834,7 +840,8 @@ fn test_block_hash_in_evm() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -1007,7 +1014,8 @@ fn test_block_gas_limit() {
             evm.call(
                 CallMessage {
                     txs: rlp_transactions.clone(),
-                },
+                }
+                .into(),
                 &context,
                 &mut working_set,
             )
@@ -1071,7 +1079,8 @@ fn test_block_gas_limit() {
         let result = evm.call(
             CallMessage {
                 txs: rlp_transactions.clone(),
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         );
@@ -1219,7 +1228,8 @@ fn test_l1_fee_success() {
             evm.call(
                 CallMessage {
                     txs: vec![deploy_message],
-                },
+                }
+                .into(),
                 &context,
                 &mut working_set,
             )
@@ -1404,7 +1414,8 @@ fn test_l1_fee_not_enough_funds() {
         let call_result = evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         );
@@ -1548,7 +1559,8 @@ fn test_l1_fee_halt() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message, call_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -1724,7 +1736,7 @@ fn test_l1_fee_compression_discount() {
             .unwrap();
 
         evm.call(
-            CallMessage { txs: vec![call_tx] },
+            CallMessage { txs: vec![call_tx] }.into(),
             &context,
             &mut working_set,
         )
@@ -1797,7 +1809,8 @@ fn test_l1_fee_compression_discount() {
         evm.call(
             CallMessage {
                 txs: vec![simple_tx],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -1880,7 +1893,8 @@ fn test_call_with_block_overrides() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -2013,7 +2027,8 @@ fn test_blob_tx() {
             evm.call(
                 CallMessage {
                     txs: vec![blob_message],
-                },
+                }
+                .into(),
                 &context,
                 &mut working_set,
             )

--- a/crates/evm/src/tests/fork_tests.rs
+++ b/crates/evm/src/tests/fork_tests.rs
@@ -114,7 +114,8 @@ fn test_cancun_transient_storage_activation() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -133,7 +134,7 @@ fn test_cancun_transient_storage_activation() {
             send_money_to_contract_message(contract_addr, &dev_signer, 1, 10000000000000000000);
 
         evm.call(
-            CallMessage { txs: vec![call_tx] },
+            CallMessage { txs: vec![call_tx] }.into(),
             &context,
             &mut working_set,
         )
@@ -152,7 +153,7 @@ fn test_cancun_transient_storage_activation() {
             claim_gift_from_transient_storage_contract_transaction(contract_addr, &dev_signer, 2);
 
         evm.call(
-            CallMessage { txs: vec![call_tx] },
+            CallMessage { txs: vec![call_tx] }.into(),
             &context,
             &mut working_set,
         )
@@ -192,7 +193,7 @@ fn test_cancun_transient_storage_activation() {
             claim_gift_from_transient_storage_contract_transaction(contract_addr, &dev_signer, 3);
 
         evm.call(
-            CallMessage { txs: vec![call_tx] },
+            CallMessage { txs: vec![call_tx] }.into(),
             &context,
             &mut working_set,
         )
@@ -218,7 +219,7 @@ fn test_cancun_transient_storage_activation() {
             claim_gift_from_transient_storage_contract_transaction(contract_addr, &dev_signer, 4);
 
         evm.call(
-            CallMessage { txs: vec![call_tx] },
+            CallMessage { txs: vec![call_tx] }.into(),
             &context,
             &mut working_set,
         )
@@ -268,7 +269,8 @@ fn test_cancun_mcopy_activation() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -286,7 +288,7 @@ fn test_cancun_mcopy_activation() {
         let call_tx = call_mcopy(contract_addr, &dev_signer, 1);
 
         evm.call(
-            CallMessage { txs: vec![call_tx] },
+            CallMessage { txs: vec![call_tx] }.into(),
             &context,
             &mut working_set,
         )
@@ -325,7 +327,7 @@ fn test_cancun_mcopy_activation() {
         let call_tx = call_mcopy(contract_addr, &dev_signer, 2);
 
         evm.call(
-            CallMessage { txs: vec![call_tx] },
+            CallMessage { txs: vec![call_tx] }.into(),
             &context,
             &mut working_set,
         )
@@ -397,7 +399,8 @@ fn test_self_destructing_constructor() {
         evm.call(
             CallMessage {
                 txs: rlp_transactions,
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -470,7 +473,8 @@ fn test_blob_base_fee_should_return_1() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -494,7 +498,7 @@ fn test_blob_base_fee_should_return_1() {
         let call_tx = store_blob_base_fee_transaction(contract_addr, &dev_signer, 1);
 
         evm.call(
-            CallMessage { txs: vec![call_tx] },
+            CallMessage { txs: vec![call_tx] }.into(),
             &context,
             &mut working_set,
         )
@@ -532,7 +536,7 @@ fn test_blob_base_fee_should_return_1() {
         let call_tx = store_blob_base_fee_transaction(contract_addr, &dev_signer, 2);
 
         evm.call(
-            CallMessage { txs: vec![call_tx] },
+            CallMessage { txs: vec![call_tx] }.into(),
             &context,
             &mut working_set,
         )
@@ -591,7 +595,8 @@ fn test_kzg_point_eval_should_revert() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -641,7 +646,8 @@ fn test_kzg_point_eval_should_revert() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -714,7 +720,8 @@ fn test_offchain_contract_storage_evm() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -798,7 +805,8 @@ fn test_offchain_contract_storage_evm() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -845,7 +853,8 @@ fn test_offchain_contract_storage_evm() {
         evm.call(
             CallMessage {
                 txs: vec![call_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )

--- a/crates/evm/src/tests/queries/log_tests.rs
+++ b/crates/evm/src/tests/queries/log_tests.rs
@@ -105,7 +105,8 @@ fn log_filter_test_at_block_hash() {
         evm.call(
             CallMessage {
                 txs: rlp_transcations,
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -317,7 +318,8 @@ fn log_filter_test_with_range() {
         evm.call(
             CallMessage {
                 txs: rlp_transactions,
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -373,7 +375,8 @@ fn log_filter_test_with_range() {
                     3,
                     "message".to_string(),
                 )],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -466,7 +469,8 @@ fn test_log_limits() {
         evm.call(
             CallMessage {
                 txs: rlp_transactions,
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )

--- a/crates/evm/src/tests/queries/mod.rs
+++ b/crates/evm/src/tests/queries/mod.rs
@@ -99,7 +99,7 @@ fn init_evm() -> (
         ];
 
         evm.call(
-            CallMessage { txs: transactions },
+            CallMessage { txs: transactions }.into(),
             &context,
             &mut working_set,
         )
@@ -141,7 +141,7 @@ fn init_evm() -> (
         ];
 
         evm.call(
-            CallMessage { txs: transactions },
+            CallMessage { txs: transactions }.into(),
             &context,
             &mut working_set,
         )
@@ -181,7 +181,7 @@ fn init_evm() -> (
         ];
 
         evm.call(
-            CallMessage { txs: transactions },
+            CallMessage { txs: transactions }.into(),
             &context,
             &mut working_set,
         )
@@ -258,7 +258,8 @@ pub fn init_evm_single_block() -> (Evm<C>, WorkingSet<<C as Spec>::Storage>, Tes
     evm.call(
         CallMessage {
             txs: vec![simple_payable_contract_tx],
-        },
+        }
+        .into(),
         &context,
         &mut working_set,
     )
@@ -333,7 +334,7 @@ pub fn init_evm_with_caller_contract() -> (Evm<C>, WorkingSet<<C as Spec>::Stora
         ];
 
         evm.call(
-            CallMessage { txs: transactions },
+            CallMessage { txs: transactions }.into(),
             &context,
             &mut working_set,
         )
@@ -374,7 +375,7 @@ pub fn init_evm_with_caller_contract() -> (Evm<C>, WorkingSet<<C as Spec>::Stora
         )];
 
         evm.call(
-            CallMessage { txs: transactions },
+            CallMessage { txs: transactions }.into(),
             &context,
             &mut working_set,
         )

--- a/crates/evm/src/tests/sys_tx_tests.rs
+++ b/crates/evm/src/tests/sys_tx_tests.rs
@@ -184,7 +184,8 @@ fn test_sys_bitcoin_light_client() {
         evm.call(
             CallMessage {
                 txs: vec![deploy_message],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -321,7 +322,8 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
                     0,
                     LogsContract::default(),
                 )],
-            },
+            }
+            .into(),
             &context,
             &mut working_set,
         )
@@ -393,7 +395,8 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
             evm.call(
                 CallMessage {
                     txs: rlp_transactions,
-                },
+                }
+                .into(),
                 &context,
                 &mut working_set,
             )
@@ -469,7 +472,8 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
             .call(
                 CallMessage {
                     txs: rlp_transactions,
-                },
+                }
+                .into(),
                 &context,
                 &mut working_set,
             )
@@ -657,7 +661,8 @@ fn test_upgrade_light_client() {
     evm.call(
         CallMessage {
             txs: vec![upgrade_tx],
-        },
+        }
+        .into(),
         &context,
         &mut working_set,
     )
@@ -781,7 +786,8 @@ fn test_change_upgrade_owner() {
     evm.call(
         CallMessage {
             txs: vec![change_owner_tx],
-        },
+        }
+        .into(),
         &context,
         &mut working_set,
     )
@@ -825,7 +831,8 @@ fn test_change_upgrade_owner() {
     evm.call(
         CallMessage {
             txs: vec![upgrade_tx],
-        },
+        }
+        .into(),
         &context,
         &mut working_set,
     )

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::vec;
 
-use alloy_eips::eip2718::Encodable2718;
+use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_primitives::{Address, Bytes, TxHash};
 use anyhow::{anyhow, bail};
 use backoff::future::retry as retry_backoff;
@@ -12,7 +12,7 @@ use backoff::ExponentialBackoffBuilder;
 use citrea_common::tasks::manager::TaskManager;
 use citrea_common::utils::soft_confirmation_to_receipt;
 use citrea_common::{RollupPublicKeys, RpcConfig, SequencerConfig};
-use citrea_evm::{CallMessage, RlpEvmTransaction, MIN_TRANSACTION_GAS};
+use citrea_evm::{CallMessage, CallMessage2, RlpEvmTransaction, MIN_TRANSACTION_GAS};
 use citrea_primitives::basefee::calculate_next_block_base_fee;
 use citrea_primitives::types::SoftConfirmationHash;
 use citrea_stf::runtime::Runtime;
@@ -22,6 +22,7 @@ use jsonrpsee::server::{BatchRequestConfig, RpcServiceBuilder, ServerBuilder};
 use jsonrpsee::RpcModule;
 use parking_lot::Mutex;
 use reth_execution_types::ChangedAccount;
+use reth_primitives::TransactionSigned;
 use reth_provider::{AccountReader, BlockReaderIdExt};
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, EthPooledTransaction, PoolTransaction,
@@ -309,9 +310,19 @@ where
                                     .encode_2718(&mut buf);
                                 let rlp_tx = RlpEvmTransaction { rlp: buf };
 
-                                let call_txs = CallMessage {
-                                    txs: vec![rlp_tx.clone()],
+                                let call_txs = if soft_confirmation_info.current_spec
+                                    >= sov_modules_api::SpecId::Fork2
+                                {
+                                    let tx = evm_tx.to_recovered_transaction().into_signed();
+
+                                    CallMessage2 { txs: vec![tx] }.into()
+                                } else {
+                                    CallMessage {
+                                        txs: vec![rlp_tx.clone()],
+                                    }
+                                    .into()
                                 };
+
                                 let raw_message = <Runtime<C, Da::Spec> as EncodeCall<
                                     citrea_evm::Evm<C>,
                                 >>::encode_call(
@@ -509,7 +520,15 @@ where
 
                 let evm_txs_count = txs_to_run.len();
                 if evm_txs_count > 0 {
-                    let call_txs = CallMessage { txs: txs_to_run };
+                    let call_txs = if active_fork_spec >= sov_modules_api::SpecId::Fork2 {
+                        let txs: Vec<_> = txs_to_run
+                            .into_iter()
+                            .map(|tx| TransactionSigned::decode_2718(&mut &*tx.rlp).unwrap())
+                            .collect();
+                        CallMessage2 { txs }.into()
+                    } else {
+                        CallMessage { txs: txs_to_run }.into()
+                    };
                     let raw_message =
                         <Runtime<C, Da::Spec> as EncodeCall<citrea_evm::Evm<C>>>::encode_call(
                             call_txs,


### PR DESCRIPTION
# Description

Get rid of Rlp encoding (not really actually =() in Evm::call.

I don't know if this PR is actually worth merging due to `unsafe { core:: mem::transmute }`.

TODO: measure cycle count diff on batch proof with a lot of evm txs.

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/1522
