### PR TITLE
Pass down testing feature to citrea-risc0-adapter

### DIFF
--- a/bin/citrea/Cargo.toml
+++ b/bin/citrea/Cargo.toml
@@ -69,6 +69,7 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 citrea-evm = { path = "../../crates/evm", features = ["native"] }
 citrea-primitives = { path = "../../crates/primitives", features = ["testing"] }
+citrea-risc0-adapter = { path = "../../crates/risc0", features = ["native", "testing"] }
 sov-mock-da = { path = "../../crates/sovereign-sdk/adapters/mock-da", default-features = false }
 sov-prover-storage-manager = { path = "../../crates/sovereign-sdk/full-node/sov-prover-storage-manager", features = ["test-utils"] }
 sov-rollup-interface = { path = "../../crates/sovereign-sdk/rollup-interface", features = ["testing"] }


### PR DESCRIPTION
# Description

- [Run citrea-risc0-adapter with testing when dev-dep](https://github.com/chainwayxyz/citrea/commit/b45b8b2511d00b707f6256a698557e8e9951e01f)
- "testing" feature was not trickling down correctly to risc0 package which led to `ALL_FORKS` env not being passed down to guest.