### PR TITLE
enable risc0 unstable feature and new precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,7 +2191,6 @@ dependencies = [
  "clap",
  "hex",
  "jsonrpsee",
- "secp256k1",
  "serde",
  "serde_json",
  "soft-confirmation-rule-enforcer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "bitcoin",
+ "bitcoin-da",
  "bitcoincore-rpc",
  "borsh",
  "citrea-common",
@@ -1313,6 +1314,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "jsonrpsee",
+ "k256",
  "metrics",
  "pin-project",
  "rand",
@@ -4179,6 +4181,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2",
+ "signature",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ alloy-rlp = { version = "0.3.8", default-features = false }
 alloy-rpc-types = { version = "0.4.2", features = ["eth"], default-features = false }
 alloy-rpc-types-eth = { version = "0.4.2", default-features = false }
 alloy-rpc-types-trace = { version = "0.4.2", default-features = false }
-alloy-primitives = { version = "0.8.7", default-features = false }
+alloy-primitives = { version = "0.8.7", default-features = false, features = ["rand", "serde", "tiny-keccak", "k256"] }
 alloy-serde = { version = "0.4.2", default-features = false }
 alloy-sol-types = { version = "0.8.0", default-features = false, features = ["json"] }
 alloy = { version = "0.4.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ hyper = "1.5.2"
 itertools = { version = "0.13.0", default-features = false }
 jmt = { git = "https://github.com/penumbra-zone/jmt.git", rev = "550a2f2" }
 jsonrpsee = { version = "0.24.2", features = ["jsonrpsee-types"] }
+k256 = { version = "0.13.4" }
 lru = "0.12.3"
 hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 lazy_static = "1.5.0"

--- a/crates/bitcoin-da/Cargo.toml
+++ b/crates/bitcoin-da/Cargo.toml
@@ -26,11 +26,12 @@ crypto-bigint = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 jsonrpsee = { workspace = true, optional = true }
+k256 = { workspace = true }
 metrics = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true, features = [] }
 rand = { workspace = true }
 reqwest = { workspace = true, optional = true }
-secp256k1 = { workspace = true }
+secp256k1 = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
@@ -43,6 +44,7 @@ sha2 = { workspace = true }
 bitcoincore-rpc = { workspace = true, optional = true }
 
 [dev-dependencies]
+bitcoin-da = { path = ".", features = ["native"] }
 citrea-e2e = { workspace = true }
 
 [features]
@@ -59,4 +61,5 @@ native = [
   "dep:bitcoincore-rpc",
   "dep:reqwest",
   "dep:jsonrpsee",
+  "dep:secp256k1",
 ]

--- a/crates/bitcoin-da/src/helpers/builders/mod.rs
+++ b/crates/bitcoin-da/src/helpers/builders/mod.rs
@@ -23,9 +23,10 @@ use bitcoin::{
 };
 use secp256k1::SECP256K1;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use tracing::{instrument, trace, warn};
 
-use super::{calculate_sha256, TransactionKindBatchProof, TransactionKindLightClient};
+use super::{TransactionKindBatchProof, TransactionKindLightClient};
 use crate::spec::utxo::UTXO;
 use crate::REVEAL_OUTPUT_AMOUNT;
 
@@ -472,4 +473,10 @@ pub fn sign_blob_with_private_key(blob: &[u8], private_key: &SecretKey) -> (Vec<
         sig.serialize_compact().to_vec(),
         public_key.serialize().to_vec(),
     )
+}
+
+pub fn calculate_sha256(input: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::default();
+    hasher.update(input);
+    hasher.finalize().into()
 }

--- a/crates/bitcoin-da/src/helpers/mod.rs
+++ b/crates/bitcoin-da/src/helpers/mod.rs
@@ -95,12 +95,6 @@ pub fn calculate_double_sha256(input: &[u8]) -> [u8; 32] {
     hasher.finalize().into()
 }
 
-pub fn calculate_sha256(input: &[u8]) -> [u8; 32] {
-    let mut hasher = Sha256::default();
-    hasher.update(input);
-    hasher.finalize().into()
-}
-
 /// Computes the [`Txid`].
 ///
 /// Hashes the transaction **excluding** the segwit data (i.e. the marker, flag bytes, and the

--- a/crates/citrea-stf/Cargo.toml
+++ b/crates/citrea-stf/Cargo.toml
@@ -18,7 +18,6 @@ clap = { workspace = true, optional = true }
 # tokio = { workspace = true, features = ["sync"], optional = true }
 hex = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"], optional = true }
-secp256k1 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -33,7 +33,7 @@ tracing = { workspace = true, optional = true }
 alloy-consensus = { workspace = true }
 alloy-eips = { workspace = true }
 alloy-network = { workspace = true, optional = true }
-alloy-primitives = { workspace = true, features = ["rand", "serde"] }
+alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 alloy-rpc-types = { workspace = true, optional = true }
 alloy-rpc-types-eth = { version = "0.4.2", optional = true }
@@ -50,7 +50,7 @@ reth-rpc-eth-types = { workspace = true, optional = true }
 reth-rpc-server-types = { workspace = true, optional = true }
 reth-rpc-types-compat = { workspace = true, optional = true }
 reth-transaction-pool = { workspace = true, optional = true }
-revm = { workspace = true, default-features = false, features = ["secp256k1"] }
+revm = { workspace = true, default-features = false }
 revm-inspectors = { workspace = true, optional = true }
 secp256k1 = { workspace = true, optional = true }
 

--- a/guests/risc0/Dockerfile
+++ b/guests/risc0/Dockerfile
@@ -11,6 +11,7 @@ ENV RUSTFLAGS="-C passes=loweratomic -C link-arg=-Ttext=0x00200800 -C link-arg=-
 ENV CARGO_TARGET_DIR="target"
 ENV CC_riscv32im_risc0_zkvm_elf="/root/.local/share/cargo-risczero/cpp/bin/riscv32-unknown-elf-gcc"
 ENV CFLAGS_riscv32im_risc0_zkvm_elf="-march=rv32im -nostdlib"
+ENV RISC0_FEATURE_bigint2=""
 ENV CITREA_NETWORK=${CITREA_NETWORK}
 
 RUN cargo +risc0 fetch --locked --target riscv32im-risc0-zkvm-elf --manifest-path ${CARGO_MANIFEST_PATH}

--- a/guests/risc0/batch-proof/Cargo.toml
+++ b/guests/risc0/batch-proof/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 resolver = "2"
 
 [build-dependencies]
-risc0-build = { workspace = true }
+risc0-build = { workspace = true, features = ["unstable"] }
 
 [package.metadata.risc0]
 methods = [

--- a/guests/risc0/batch-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.lock
@@ -1045,7 +1045,6 @@ dependencies = [
  "citrea-evm",
  "citrea-primitives",
  "hex",
- "secp256k1",
  "serde",
  "soft-confirmation-rule-enforcer",
  "sov-accounts",
@@ -1840,6 +1839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,13 +1933,15 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
-source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.3-risczero.0#d4f457a04410397cbb652a67c168b6cd6e9757c4"
+version = "0.13.4"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.4-risczero.1#7d4a8d6477e258ce4169ee4669cf92aee0582c39"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "risc0-bigint2",
  "sha2",
 ]
 
@@ -2681,7 +2688,6 @@ dependencies = [
  "once_cell",
  "revm-primitives",
  "ripemd",
- "secp256k1",
  "sha2",
  "substrate-bn",
 ]
@@ -2723,6 +2729,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "risc0-bigint2"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7549b31ad8d81afea787c807803a592bc73151926bbb951a6823e23d998c34f0"
+dependencies = [
+ "include_bytes_aligned",
+ "stability",
 ]
 
 [[package]]
@@ -3082,8 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.0"
-source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
  "rand",
@@ -3093,8 +3110,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.0"
-source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -3639,8 +3657,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+source = "git+https://github.com/risc0/tiny-keccak?tag=tiny-keccak/v2.0.2-risczero.0#8fcc866dc94dcec3e79c3b2bc8fbc51b22f2d5e1"
 dependencies = [
  "crunchy",
 ]

--- a/guests/risc0/batch-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.lock
@@ -730,8 +730,8 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.13.0",
+ "k256",
  "rand",
- "secp256k1",
  "serde",
  "serde_json",
  "sha2",
@@ -1943,6 +1943,7 @@ dependencies = [
  "once_cell",
  "risc0-bigint2",
  "sha2",
+ "signature",
 ]
 
 [[package]]

--- a/guests/risc0/batch-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.lock
@@ -3098,9 +3098,8 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+version = "0.29.0"
+source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
 dependencies = [
  "bitcoin_hashes",
  "rand",
@@ -3110,9 +3109,8 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+version = "0.10.0"
+source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
 dependencies = [
  "cc",
 ]

--- a/guests/risc0/batch-proof/bitcoin/Cargo.toml
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.toml
@@ -28,8 +28,9 @@ testing = ["citrea-primitives/testing"]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
-secp256k1 = { git = "https://github.com/Sovereign-Labs/rust-secp256k1.git", branch = "risc0-compatible-0-29-0" }
-k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
+# secp256k1 = { git = "https://github.com/Sovereign-Labs/rust-secp256k1.git", branch = "risc0-compatible-0-29-0" }
+tiny-keccak = { git = "https://github.com/risc0/tiny-keccak", tag = "tiny-keccak/v2.0.2-risczero.0" }
+k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 
 [profile.release]
 debug = 0

--- a/guests/risc0/batch-proof/bitcoin/Cargo.toml
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.2.1", default-features = false }
+risc0-zkvm = { version = "1.2.1", default-features = false, features = ["unstable"] }
 risc0-zkvm-platform = { version = "1.2.1", features = ["heap-embedded-alloc"] }
 
 anyhow = "1.0.95"

--- a/guests/risc0/batch-proof/bitcoin/Cargo.toml
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.toml
@@ -28,7 +28,7 @@ testing = ["citrea-primitives/testing"]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
-# secp256k1 = { git = "https://github.com/Sovereign-Labs/rust-secp256k1.git", branch = "risc0-compatible-0-29-0" }
+secp256k1 = { git = "https://github.com/Sovereign-Labs/rust-secp256k1.git", branch = "risc0-compatible-0-29-0" }
 tiny-keccak = { git = "https://github.com/risc0/tiny-keccak", tag = "tiny-keccak/v2.0.2-risczero.0" }
 k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 

--- a/guests/risc0/batch-proof/mock/Cargo.lock
+++ b/guests/risc0/batch-proof/mock/Cargo.lock
@@ -953,7 +953,6 @@ dependencies = [
  "citrea-evm",
  "citrea-primitives",
  "hex",
- "secp256k1",
  "serde",
  "soft-confirmation-rule-enforcer",
  "sov-accounts",
@@ -1644,6 +1643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,13 +1737,15 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
-source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.3-risczero.0#d4f457a04410397cbb652a67c168b6cd6e9757c4"
+version = "0.13.4"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.4-risczero.1#7d4a8d6477e258ce4169ee4669cf92aee0582c39"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "risc0-bigint2",
  "sha2",
 ]
 
@@ -2479,7 +2486,6 @@ dependencies = [
  "once_cell",
  "revm-primitives",
  "ripemd",
- "secp256k1",
  "sha2",
  "substrate-bn",
 ]
@@ -2521,6 +2527,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "risc0-bigint2"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7549b31ad8d81afea787c807803a592bc73151926bbb951a6823e23d998c34f0"
+dependencies = [
+ "include_bytes_aligned",
+ "stability",
 ]
 
 [[package]]
@@ -2876,23 +2892,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.29.0"
-source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
-dependencies = [
- "rand",
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.10.0"
-source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -3441,8 +3440,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+source = "git+https://github.com/risc0/tiny-keccak?tag=tiny-keccak/v2.0.2-risczero.0#8fcc866dc94dcec3e79c3b2bc8fbc51b22f2d5e1"
 dependencies = [
  "crunchy",
 ]

--- a/guests/risc0/batch-proof/mock/Cargo.toml
+++ b/guests/risc0/batch-proof/mock/Cargo.toml
@@ -28,8 +28,9 @@ testing = ["citrea-primitives/testing"]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
-secp256k1 = { git = "https://github.com/Sovereign-Labs/rust-secp256k1.git", branch = "risc0-compatible-0-29-0" }
-k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
+# secp256k1 = { git = "https://github.com/Sovereign-Labs/rust-secp256k1.git", branch = "risc0-compatible-0-29-0" }
+tiny-keccak = { git = "https://github.com/risc0/tiny-keccak", tag = "tiny-keccak/v2.0.2-risczero.0" }
+k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 
 [profile.release]
 debug = 0

--- a/guests/risc0/batch-proof/mock/Cargo.toml
+++ b/guests/risc0/batch-proof/mock/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.2.1", default-features = false }
+risc0-zkvm = { version = "1.2.1", default-features = false, features = ["unstable"] }
 risc0-zkvm-platform = { version = "1.2.1", features = ["heap-embedded-alloc"] }
 
 anyhow = "1.0.95"

--- a/guests/risc0/light-client-proof/Cargo.toml
+++ b/guests/risc0/light-client-proof/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 resolver = "2"
 
 [build-dependencies]
-risc0-build = { workspace = true }
+risc0-build = { workspace = true, features = ["unstable"] }
 
 [package.metadata.risc0]
 methods = [

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.lock
@@ -1829,9 +1829,8 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+version = "0.29.0"
+source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
 dependencies = [
  "bitcoin_hashes",
  "rand",
@@ -1841,9 +1840,8 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+version = "0.10.0"
+source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
 dependencies = [
  "cc",
 ]
@@ -2437,8 +2435,3 @@ dependencies = [
 name = "k256"
 version = "0.13.4"
 source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.4-risczero.1#7d4a8d6477e258ce4169ee4669cf92aee0582c39"
-
-[[patch.unused]]
-name = "secp256k1"
-version = "0.29.0"
-source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.lock
@@ -1829,8 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.0"
-source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
  "rand",
@@ -1840,8 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.0"
-source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -2121,8 +2123,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+source = "git+https://github.com/risc0/tiny-keccak?tag=tiny-keccak/v2.0.2-risczero.0#8fcc866dc94dcec3e79c3b2bc8fbc51b22f2d5e1"
 dependencies = [
  "crunchy",
 ]
@@ -2434,5 +2435,10 @@ dependencies = [
 
 [[patch.unused]]
 name = "k256"
-version = "0.13.3"
-source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.3-risczero.0#d4f457a04410397cbb652a67c168b6cd6e9757c4"
+version = "0.13.4"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.4-risczero.1#7d4a8d6477e258ce4169ee4669cf92aee0582c39"
+
+[[patch.unused]]
+name = "secp256k1"
+version = "0.29.0"
+source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.lock
@@ -310,6 +310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base58ck"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +330,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bcs"
@@ -387,8 +399,8 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.13.0",
+ "k256",
  "rand",
- "secp256k1",
  "serde",
  "serde_json",
  "sha2",
@@ -752,6 +764,7 @@ name = "crypto-bigint"
 version = "0.5.5"
 source = "git+https://github.com/risc0/RustCrypto-crypto-bigint?tag=v0.5.5-risczero.0#3ab63a6f1048833f7047d5a50532e4a4cc789384"
 dependencies = [
+ "generic-array",
  "getrandom",
  "rand_core",
  "subtle",
@@ -793,6 +806,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -879,6 +902,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +950,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +989,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1064,6 +1130,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1075,6 +1142,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -1123,6 +1201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "ics23"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1227,12 @@ dependencies = [
  "sha2",
  "sha3",
 ]
+
+[[package]]
+name = "include_bytes_aligned"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
 
 [[package]]
 name = "indexmap"
@@ -1204,6 +1297,21 @@ dependencies = [
  "sha2",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.4-risczero.1#7d4a8d6477e258ce4169ee4669cf92aee0582c39"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "risc0-bigint2",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -1391,6 +1499,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "platforms"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,12 +1669,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "risc0-bigint2"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7549b31ad8d81afea787c807803a592bc73151926bbb951a6823e23d998c34f0"
+dependencies = [
+ "include_bytes_aligned",
+ "stability",
 ]
 
 [[package]]
@@ -1828,6 +1966,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secp256k1"
 version = "0.29.0"
 source = "git+https://github.com/Sovereign-Labs/rust-secp256k1.git?branch=risc0-compatible-0-29-0#3769ab9b2227d430ca2c58546daf3680017cfefb"
@@ -1939,6 +2091,10 @@ name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
 
 [[package]]
 name = "slab"
@@ -2033,6 +2189,16 @@ dependencies = [
  "sha2",
  "sov-modules-core",
  "sov-rollup-interface",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2430,8 +2596,3 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[patch.unused]]
-name = "k256"
-version = "0.13.4"
-source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.4-risczero.1#7d4a8d6477e258ce4169ee4669cf92aee0582c39"

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.toml
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.toml
@@ -31,7 +31,8 @@ sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 secp256k1 = { git = "https://github.com/Sovereign-Labs/rust-secp256k1.git", branch = "risc0-compatible-0-29-0" }
-k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
+tiny-keccak = { git = "https://github.com/risc0/tiny-keccak", tag = "tiny-keccak/v2.0.2-risczero.0" }
+k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 
 [profile.release]
 debug = 0

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.toml
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.2.1", default-features = false }
+risc0-zkvm = { version = "1.2.1", default-features = false, features = ["unstable"] }
 risc0-zkvm-platform = { version = "1.2.1", features = ["sys-getenv"] }
 
 anyhow = "1.0.95"

--- a/guests/risc0/light-client-proof/mock/Cargo.lock
+++ b/guests/risc0/light-client-proof/mock/Cargo.lock
@@ -1908,8 +1908,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+source = "git+https://github.com/risc0/tiny-keccak?tag=tiny-keccak/v2.0.2-risczero.0#8fcc866dc94dcec3e79c3b2bc8fbc51b22f2d5e1"
 dependencies = [
  "crunchy",
 ]
@@ -2221,5 +2220,5 @@ dependencies = [
 
 [[patch.unused]]
 name = "k256"
-version = "0.13.3"
-source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.3-risczero.0#d4f457a04410397cbb652a67c168b6cd6e9757c4"
+version = "0.13.4"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.4-risczero.1#7d4a8d6477e258ce4169ee4669cf92aee0582c39"

--- a/guests/risc0/light-client-proof/mock/Cargo.toml
+++ b/guests/risc0/light-client-proof/mock/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.2.1", default-features = false }
+risc0-zkvm = { version = "1.2.1", default-features = false, features = ["unstable"] }
 risc0-zkvm-platform = { version = "1.2.1", features = ["sys-getenv"] }
 
 anyhow = "1.0.95"

--- a/guests/risc0/light-client-proof/mock/Cargo.toml
+++ b/guests/risc0/light-client-proof/mock/Cargo.toml
@@ -31,7 +31,8 @@ testing = ["citrea-primitives/testing", "citrea-risc0-batch-proof/testing"]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
-k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
+tiny-keccak = { git = "https://github.com/risc0/tiny-keccak", tag = "tiny-keccak/v2.0.2-risczero.0" }
+k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 
 [profile.release]
 debug = 0


### PR DESCRIPTION
# Description
enables new precompiles.
in bitcoin-da replaces secp256k1 on the guest side with k256 crate, which has a new precompile.