### PR TITLE
eth_getCode Pending tag support

### DIFF
--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -389,8 +389,13 @@ impl<C: sov_modules_api::Context> Evm<C> {
             None => BlockNumberOrTag::Latest,
         };
 
-        let block_number = self.block_number_for_id(&block_number, working_set)?;
-
+        let block_number = match block_number {
+            BlockNumberOrTag::Pending => 
+                self.block_number_for_id(&BlockNumberOrTag::Latest, working_set)? + 1,
+            _ => 
+                self.block_number_for_id(&block_number, working_set)?
+        };
+        
         let current_spec = citrea_spec_id_to_evm_spec_id(fork_fn(block_number).spec_id);
 
         self.set_state_to_end_of_evm_block_by_block_id(block_id, working_set)?;

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -390,12 +390,12 @@ impl<C: sov_modules_api::Context> Evm<C> {
         };
 
         let block_number = match block_number {
-            BlockNumberOrTag::Pending => 
-                self.block_number_for_id(&BlockNumberOrTag::Latest, working_set)? + 1,
-            _ => 
-                self.block_number_for_id(&block_number, working_set)?
+            BlockNumberOrTag::Pending => {
+                self.block_number_for_id(&BlockNumberOrTag::Latest, working_set)? + 1
+            }
+            _ => self.block_number_for_id(&block_number, working_set)?,
         };
-        
+
         let current_spec = citrea_spec_id_to_evm_spec_id(fork_fn(block_number).spec_id);
 
         self.set_state_to_end_of_evm_block_by_block_id(block_id, working_set)?;


### PR DESCRIPTION
# Description
`block_number_for_id` returns `Err` for `Pending`, so use `block_number_for_id(Latest) + 1` for spec look-up

## Linked Issues
- Fixes #1749 
