### PR TITLE
Fix inconsistent db naming

### DIFF
--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/migrations/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/migrations/mod.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error, info};
 
 use super::migrations::utils::{drop_column_families, list_column_families};
 use super::LedgerDB;
-use crate::ledger_db::{SharedLedgerOps, LEDGER_DB_PATH_SUFFIX};
+use crate::ledger_db::SharedLedgerOps;
 use crate::rocks_db_config::RocksdbConfig;
 
 /// Utilities for ledger db migrations
@@ -68,7 +68,7 @@ impl<'a> LedgerDBMigrator<'a> {
 
         let dbs_path = &self.ledger_path;
 
-        if !dbs_path.join(LEDGER_DB_PATH_SUFFIX).exists() {
+        if !dbs_path.join(LedgerDB::DB_PATH_SUFFIX).exists() {
             // If this is the first time the ledger db is being created, then we don't need to run migrations
             // all migrations up to this point are considered successful
             let ledger_db = LedgerDB::with_config(&RocksdbConfig::new(
@@ -176,8 +176,8 @@ impl<'a> LedgerDBMigrator<'a> {
 
         info!("Migrations executed, restoring to original path");
         // Construct a backup path adjacent to original path
-        let ledger_path = dbs_path.join(LEDGER_DB_PATH_SUFFIX);
-        let temp_ledger_path = temp_db_path.path().join(LEDGER_DB_PATH_SUFFIX);
+        let ledger_path = dbs_path.join(LedgerDB::DB_PATH_SUFFIX);
+        let temp_ledger_path = temp_db_path.path().join(LedgerDB::DB_PATH_SUFFIX);
         let last_part = ledger_path
             .components()
             .last()

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/migrations/utils.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/migrations/utils.rs
@@ -2,16 +2,16 @@ use std::path::Path;
 
 use sov_schema_db::DB;
 
-use crate::ledger_db::{LEDGER_DB_NAME, LEDGER_DB_PATH_SUFFIX, LEDGER_TABLES};
+use crate::ledger_db::{LedgerDB, LEDGER_TABLES};
 use crate::rocks_db_config::RocksdbConfig;
 
 /// Drop a column family from the database
 pub fn drop_column_families(cfg: &RocksdbConfig, cf_names: Vec<String>) -> anyhow::Result<()> {
-    let path = cfg.path.join(LEDGER_DB_PATH_SUFFIX);
+    let path = cfg.path.join(LedgerDB::DB_PATH_SUFFIX);
     let raw_options = cfg.as_raw_options(false);
     let mut inner = DB::open(
         path,
-        LEDGER_DB_NAME,
+        LedgerDB::DB_NAME,
         cfg.column_families
             .clone()
             .unwrap_or_else(|| LEDGER_TABLES.iter().map(|s| s.to_string()).collect()),
@@ -29,7 +29,7 @@ pub fn drop_column_families(cfg: &RocksdbConfig, cf_names: Vec<String>) -> anyho
 pub fn list_column_families(path: &Path) -> Vec<String> {
     rocksdb::DB::list_cf(
         &rocksdb::Options::default(),
-        path.join(LEDGER_DB_PATH_SUFFIX),
+        path.join(LedgerDB::DB_PATH_SUFFIX),
     )
     .unwrap()
 }

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/migrations/utils.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/migrations/utils.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use sov_schema_db::DB;
 
-use crate::ledger_db::{LEDGER_DB_PATH_SUFFIX, LEDGER_TABLES};
+use crate::ledger_db::{LEDGER_DB_NAME, LEDGER_DB_PATH_SUFFIX, LEDGER_TABLES};
 use crate::rocks_db_config::RocksdbConfig;
 
 /// Drop a column family from the database
@@ -11,7 +11,7 @@ pub fn drop_column_families(cfg: &RocksdbConfig, cf_names: Vec<String>) -> anyho
     let raw_options = cfg.as_raw_options(false);
     let mut inner = DB::open(
         path,
-        "ledger-db",
+        LEDGER_DB_NAME,
         cfg.column_families
             .clone()
             .unwrap_or_else(|| LEDGER_TABLES.iter().map(|s| s.to_string()).collect()),

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -36,9 +36,6 @@ mod traits;
 
 pub use traits::*;
 
-const LEDGER_DB_PATH_SUFFIX: &str = "ledger";
-const LEDGER_DB_NAME: &str = "ledger-db";
-
 #[derive(Clone, Debug)]
 /// A database which stores the ledger history (slots, transactions, events, etc).
 /// Ledger data is first ingested into an in-memory map before being fed to the state-transition function.
@@ -50,18 +47,21 @@ pub struct LedgerDB {
 }
 
 impl LedgerDB {
+    const DB_PATH_SUFFIX: &'static str = "ledger";
+    const DB_NAME: &'static str = "ledger-db";
+
     /// Open a [`LedgerDB`] (backed by RocksDB) at the specified path.
     /// Will take optional column families, used for migration purposes.
     /// The returned instance will be at the path `{path}/ledger`.
     #[instrument(level = "trace", skip_all, err)]
     pub fn with_config(cfg: &RocksdbConfig) -> Result<Self, anyhow::Error> {
-        let path = cfg.path.join(LEDGER_DB_PATH_SUFFIX);
+        let path = cfg.path.join(LedgerDB::DB_PATH_SUFFIX);
         let raw_options = cfg.as_raw_options(false);
         let tables = cfg
             .column_families
             .clone()
             .unwrap_or_else(|| LEDGER_TABLES.iter().map(|e| e.to_string()).collect());
-        let inner = DB::open(path, LEDGER_DB_NAME, tables, &raw_options)?;
+        let inner = DB::open(path, LedgerDB::DB_NAME, tables, &raw_options)?;
 
         Ok(Self {
             db: Arc::new(inner),

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -37,6 +37,7 @@ mod traits;
 pub use traits::*;
 
 const LEDGER_DB_PATH_SUFFIX: &str = "ledger";
+const LEDGER_DB_NAME: &str = "ledger-db";
 
 #[derive(Clone, Debug)]
 /// A database which stores the ledger history (slots, transactions, events, etc).
@@ -60,7 +61,7 @@ impl LedgerDB {
             .column_families
             .clone()
             .unwrap_or_else(|| LEDGER_TABLES.iter().map(|e| e.to_string()).collect());
-        let inner = DB::open(path, "ledger-db", tables, &raw_options)?;
+        let inner = DB::open(path, LEDGER_DB_NAME, tables, &raw_options)?;
 
         Ok(Self {
             db: Arc::new(inner),

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/native_db.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/native_db.rs
@@ -27,8 +27,8 @@ impl<Q> Clone for NativeDB<Q> {
 }
 
 impl<Q> NativeDB<Q> {
-    const DB_PATH_SUFFIX: &'static str = "native-db";
-    const DB_NAME: &'static str = "native";
+    const DB_PATH_SUFFIX: &'static str = "native";
+    const DB_NAME: &'static str = "native-db";
 
     /// Initialize [`sov_schema_db::DB`] that matches tables and columns for NativeDB
     pub fn setup_schema_db(cfg: &RocksdbConfig) -> anyhow::Result<sov_schema_db::DB> {


### PR DESCRIPTION
# Description

- Fix DB_NAME in place of DB_PATH_SUFFIX in NativeDB
- Declare and use LEDGER_DB_NAME in line with the other dbs

## Caveat
Will require a reindex 