### PR TITLE
Light client prover parallel proof limit defaults to 1

### DIFF
--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -265,6 +265,7 @@ impl RollupBlueprint for BitcoinRollup {
         da_service: &Arc<Self::DaService>,
         ledger_db: LedgerDB,
         proof_sampling_number: usize,
+        is_light_client_prover: bool,
     ) -> Self::ProverService {
         let vm = Risc0BonsaiHost::new(ledger_db.clone(), self.network);
         // let vm = SP1Host::new(
@@ -281,7 +282,13 @@ impl RollupBlueprint for BitcoinRollup {
             }
         };
 
-        ParallelProverService::new_from_env(da_service.clone(), vm, proof_mode, ledger_db)
-            .expect("Should be able to instantiate prover service")
+        if is_light_client_prover {
+            // Parallel proof limit should be 1 for light client prover
+            ParallelProverService::new(da_service.clone(), vm, proof_mode, 1, ledger_db)
+                .expect("Should be able to instantiate prover service")
+        } else {
+            ParallelProverService::new_from_env(da_service.clone(), vm, proof_mode, ledger_db)
+                .expect("Should be able to instantiate prover service")
+        }
     }
 }

--- a/bin/citrea/src/rollup/mock.rs
+++ b/bin/citrea/src/rollup/mock.rs
@@ -133,6 +133,7 @@ impl RollupBlueprint for MockDemoRollup {
         da_service: &Arc<Self::DaService>,
         ledger_db: LedgerDB,
         proof_sampling_number: usize,
+        is_light_client_prover: bool,
     ) -> Self::ProverService {
         let vm = Risc0BonsaiHost::new(ledger_db.clone(), self.network);
 
@@ -145,8 +146,14 @@ impl RollupBlueprint for MockDemoRollup {
             }
         };
 
-        ParallelProverService::new(da_service.clone(), vm, proof_mode, 1, ledger_db)
-            .expect("Should be able to instantiate prover service")
+        if is_light_client_prover {
+            // Parallel proof limit should be 1 for light client prover
+            ParallelProverService::new(da_service.clone(), vm, proof_mode, 1, ledger_db)
+                .expect("Should be able to instantiate prover service")
+        } else {
+            ParallelProverService::new_from_env(da_service.clone(), vm, proof_mode, ledger_db)
+                .expect("Should be able to instantiate prover service")
+        }
     }
 
     fn create_storage_manager(

--- a/bin/citrea/src/rollup/mod.rs
+++ b/bin/citrea/src/rollup/mod.rs
@@ -297,6 +297,7 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
                 &da_service,
                 ledger_db.clone(),
                 prover_config.proof_sampling_number,
+                false,
             )
             .await,
         );
@@ -357,6 +358,7 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
                 &da_service,
                 ledger_db.clone(),
                 prover_config.proof_sampling_number,
+                true,
             )
             .await,
         );

--- a/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
@@ -127,6 +127,7 @@ pub trait RollupBlueprint: Sized + Send + Sync {
         da_service: &Arc<Self::DaService>,
         ledger_db: LedgerDB,
         proof_sampling_number: usize,
+        is_light_client_prover: bool,
     ) -> Self::ProverService;
 
     /// Creates instance of [`Self::StorageManager`].


### PR DESCRIPTION
# Description
Light client prover parallel proof limit defaults to 1

## Linked Issues
- Fixes #1722 
