### PR TITLE
Handle shutdown signals

### DIFF
--- a/bin/citrea/tests/test_helpers/mod.rs
+++ b/bin/citrea/tests/test_helpers/mod.rs
@@ -184,7 +184,13 @@ pub async fn start_rollup(
             Some(rpc_reporting_channel),
         );
 
-        sequencer.run(task_manager).instrument(span).await.unwrap();
+        task_manager.spawn(|cancellation_token| async move {
+            sequencer
+                .run(cancellation_token)
+                .instrument(span)
+                .await
+                .unwrap();
+        });
     } else if let Some(rollup_prover_config) = rollup_prover_config {
         let span = info_span!("Prover");
 
@@ -222,7 +228,14 @@ pub async fn start_rollup(
                 .instrument(handler_span.clone())
                 .await
         });
-        prover.run(task_manager).instrument(span).await.unwrap();
+
+        task_manager.spawn(|cancellation_token| async move {
+            prover
+                .run(cancellation_token)
+                .instrument(span)
+                .await
+                .unwrap();
+        });
     } else if let Some(light_client_prover_config) = light_client_prover_config {
         let span = info_span!("LightClientProver");
 
@@ -265,7 +278,13 @@ pub async fn start_rollup(
                 .await
         });
 
-        rollup.run(task_manager).instrument(span).await.unwrap();
+        task_manager.spawn(|cancellation_token| async move {
+            rollup
+                .run(cancellation_token)
+                .instrument(span)
+                .await
+                .unwrap();
+        });
     } else {
         let span = info_span!("FullNode");
 
@@ -301,8 +320,16 @@ pub async fn start_rollup(
                 .await
         });
 
-        rollup.run(task_manager).instrument(span).await.unwrap();
+        task_manager.spawn(|cancellation_token| async move {
+            rollup
+                .run(cancellation_token)
+                .instrument(span)
+                .await
+                .unwrap();
+        });
     }
+
+    task_manager.wait_shutdown().await;
 }
 
 pub fn create_default_rollup_config(

--- a/bin/citrea/tests/test_helpers/mod.rs
+++ b/bin/citrea/tests/test_helpers/mod.rs
@@ -7,6 +7,7 @@ use borsh::BorshDeserialize;
 use citrea::{CitreaRollupBlueprint, Dependencies, MockDemoRollup, Storage};
 use citrea_common::da::get_start_l1_height;
 use citrea_common::rpc::server::start_rpc_server;
+use citrea_common::tasks::manager::TaskManager;
 use citrea_common::{
     BatchProverConfig, FullNodeConfig, LightClientProverConfig, RollupPublicKeys, RpcConfig,
     RunnerConfig, SequencerConfig, StorageConfig,
@@ -52,7 +53,7 @@ pub async fn start_rollup(
     light_client_prover_config: Option<LightClientProverConfig>,
     rollup_config: FullNodeConfig<MockDaConfig>,
     sequencer_config: Option<SequencerConfig>,
-) {
+) -> TaskManager<()> {
     // create rollup config default creator function and use them here for the configs
 
     // We enable risc0 dev mode in tests because the provers in dev mode generate fake receipts that can be verified if the verifier is also in dev mode
@@ -329,7 +330,7 @@ pub async fn start_rollup(
         });
     }
 
-    task_manager.wait_shutdown().await;
+    task_manager
 }
 
 pub fn create_default_rollup_config(

--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -147,6 +147,7 @@ where
             select! {
                 biased;
                 _ = cancellation_token.cancelled() => {
+                    l1_rx.close();
                     return;
                 }
                 _ = &mut l1_sync_worker => {},

--- a/crates/batch-prover/src/runner.rs
+++ b/crates/batch-prover/src/runner.rs
@@ -173,6 +173,7 @@ where
                 },
                 _ = cancellation_token.cancelled() => {
                     info!("Shutting down batch prover");
+                    l2_rx.close();
                     return Ok(());
                 },
             }

--- a/crates/batch-prover/src/runner.rs
+++ b/crates/batch-prover/src/runner.rs
@@ -9,8 +9,7 @@ use backoff::exponential::ExponentialBackoffBuilder;
 use backoff::future::retry as retry_backoff;
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::get_da_block_at_height;
-use citrea_common::tasks::manager::TaskManager;
-use citrea_common::utils::{create_shutdown_signal, soft_confirmation_to_receipt};
+use citrea_common::utils::soft_confirmation_to_receipt;
 use citrea_common::{RollupPublicKeys, RunnerConfig};
 use citrea_primitives::types::SoftConfirmationHash;
 use jsonrpsee::core::client::Error as JsonrpseeError;
@@ -30,6 +29,7 @@ use sov_stf_runner::InitParams;
 use tokio::select;
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument};
 
 use crate::metrics::BATCH_PROVER_METRICS;
@@ -112,7 +112,10 @@ where
 
     /// Runs the rollup.
     #[instrument(level = "trace", skip_all, err)]
-    pub async fn run(&mut self, task_manager: TaskManager<()>) -> Result<(), anyhow::Error> {
+    pub async fn run(
+        &mut self,
+        cancellation_token: CancellationToken,
+    ) -> Result<(), anyhow::Error> {
         // Create l2 sync worker task
         let (l2_tx, mut l2_rx) = mpsc::channel(1);
 
@@ -128,8 +131,6 @@ where
         let mut pending_l2_blocks = VecDeque::new();
         let mut interval = tokio::time::interval(Duration::from_secs(1));
         interval.tick().await;
-
-        let mut shutdown_signal = create_shutdown_signal().await;
 
         loop {
             select! {
@@ -170,9 +171,9 @@ where
                         }
                     }
                 },
-                Some(_) = shutdown_signal.recv() => {
-                    info!("Shutting down");
-                    task_manager.abort().await;
+                _ = cancellation_token.cancelled() => {
+                    info!("Shutting down batch prover");
+                    return Ok(());
                 },
             }
         }

--- a/crates/common/src/tasks/manager.rs
+++ b/crates/common/src/tasks/manager.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 use std::time::Duration;
 
+use tokio::signal;
+use tokio::signal::unix::{signal, SignalKind};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
@@ -54,5 +56,31 @@ impl<T: Send + 'static> TaskManager<T> {
     /// so that all child tasks can be cancelled at once.
     pub fn child_token(&self) -> CancellationToken {
         self.cancellation_token.child_token()
+    }
+
+    /// Wait for a termination signal and cancel all running tasks
+    pub async fn wait_shutdown(&self) {
+        let mut term_signal =
+            signal(SignalKind::terminate()).expect("Failed to create termination signal");
+        let mut interrupt_signal =
+            signal(SignalKind::interrupt()).expect("Failed to create interrupt signal");
+
+        loop {
+            tokio::select! {
+                _ = signal::ctrl_c() => {
+                    self.shutdown();
+                }
+                _ = term_signal.recv() => {
+                    self.shutdown();
+                },
+                _ = interrupt_signal.recv() => {
+                    self.shutdown();
+                }
+            }
+        }
+    }
+
+    fn shutdown(&self) {
+        self.cancellation_token.cancel()
     }
 }

--- a/crates/common/src/tasks/manager.rs
+++ b/crates/common/src/tasks/manager.rs
@@ -65,22 +65,16 @@ impl<T: Send + 'static> TaskManager<T> {
         let mut interrupt_signal =
             signal(SignalKind::interrupt()).expect("Failed to create interrupt signal");
 
-        loop {
-            tokio::select! {
-                _ = signal::ctrl_c() => {
-                    self.shutdown();
-                }
-                _ = term_signal.recv() => {
-                    self.shutdown();
-                },
-                _ = interrupt_signal.recv() => {
-                    self.shutdown();
-                }
+        tokio::select! {
+            _ = signal::ctrl_c() => {
+                self.abort().await;
+            }
+            _ = term_signal.recv() => {
+                self.abort().await;
+            },
+            _ = interrupt_signal.recv() => {
+                self.abort().await;
             }
         }
-    }
-
-    fn shutdown(&self) {
-        self.cancellation_token.cancel()
     }
 }

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -116,6 +116,7 @@ where
             select! {
                 biased;
                 _ = cancellation_token.cancelled() => {
+                    l1_rx.close();
                     return;
                 }
                 _ = &mut l1_sync_worker => {},

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -8,8 +8,7 @@ use backoff::future::retry as retry_backoff;
 use backoff::ExponentialBackoffBuilder;
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::get_da_block_at_height;
-use citrea_common::tasks::manager::TaskManager;
-use citrea_common::utils::{create_shutdown_signal, soft_confirmation_to_receipt};
+use citrea_common::utils::soft_confirmation_to_receipt;
 use citrea_common::{RollupPublicKeys, RunnerConfig};
 use citrea_primitives::types::SoftConfirmationHash;
 use citrea_pruning::{Pruner, PruningConfig};
@@ -30,6 +29,7 @@ use sov_stf_runner::InitParams;
 use tokio::select;
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tokio::time::{sleep, Duration};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument};
 
 use crate::metrics::FULLNODE_METRICS;
@@ -215,7 +215,10 @@ where
 
     /// Runs the rollup.
     #[instrument(level = "trace", skip_all, err)]
-    pub async fn run(&mut self, mut task_manager: TaskManager<()>) -> Result<(), anyhow::Error> {
+    pub async fn run(
+        &mut self,
+        cancellation_token: CancellationToken,
+    ) -> Result<(), anyhow::Error> {
         // Last L1/L2 height before shutdown.
         if let Some(config) = &self.pruning_config {
             let pruner = Pruner::<DB>::new(
@@ -225,7 +228,7 @@ where
                 self.ledger_db.clone(),
             );
 
-            task_manager.spawn(|cancellation_token| pruner.run(cancellation_token));
+            tokio::spawn(pruner.run(cancellation_token.child_token()));
         }
 
         let (l2_tx, mut l2_rx) = mpsc::channel(1);
@@ -242,8 +245,6 @@ where
         let mut pending_l2_blocks = VecDeque::new();
         let mut interval = tokio::time::interval(Duration::from_secs(1));
         interval.tick().await;
-
-        let mut shutdown_signal = create_shutdown_signal().await;
 
         loop {
             select! {
@@ -284,9 +285,9 @@ where
                         }
                     }
                 },
-                Some(_) = shutdown_signal.recv() => {
-                    info!("Shutting down");
-                    task_manager.abort().await;
+                _ = cancellation_token.cancelled() => {
+                    info!("Shutting down fullnode");
+                    return Ok(());
                 },
             }
         }

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -287,6 +287,7 @@ where
                 },
                 _ = cancellation_token.cancelled() => {
                     info!("Shutting down fullnode");
+                    l2_rx.close();
                     return Ok(());
                 },
             }

--- a/crates/light-client-prover/src/runner.rs
+++ b/crates/light-client-prover/src/runner.rs
@@ -1,6 +1,5 @@
-use citrea_common::tasks::manager::TaskManager;
 use citrea_common::RunnerConfig;
-use tokio::signal;
+use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 pub struct CitreaLightClientProver {
@@ -17,9 +16,11 @@ impl CitreaLightClientProver {
 
     /// Runs the rollup.
     #[instrument(level = "trace", skip_all, err)]
-    pub async fn run(&mut self, task_manager: TaskManager<()>) -> Result<(), anyhow::Error> {
-        signal::ctrl_c().await.expect("Failed to listen ctrl+c");
-        task_manager.abort().await;
+    pub async fn run(
+        &mut self,
+        cancellation_token: CancellationToken,
+    ) -> Result<(), anyhow::Error> {
+        cancellation_token.cancelled().await;
 
         Ok(())
     }

--- a/crates/sequencer/src/commitment/mod.rs
+++ b/crates/sequencer/src/commitment/mod.rs
@@ -70,6 +70,7 @@ where
             select! {
                 biased;
                 _ = cancellation_token.cancelled() => {
+                    self.soft_confirmation_rx.close();
                     return;
                 },
                 info = self.soft_confirmation_rx.recv() => {

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -702,6 +702,8 @@ where
                 },
                 _ = cancellation_token.cancelled() => {
                     info!("Shutting down sequencer");
+                    da_height_update_rx.close();
+                    self.l2_force_block_rx.close();
                     return Ok(());
                 }
             }

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -8,7 +8,6 @@ use alloy_primitives::{Address, Bytes, TxHash};
 use anyhow::{anyhow, bail};
 use backoff::future::retry as retry_backoff;
 use backoff::ExponentialBackoffBuilder;
-use citrea_common::tasks::manager::TaskManager;
 use citrea_common::utils::soft_confirmation_to_receipt;
 use citrea_common::{RollupPublicKeys, SequencerConfig};
 use citrea_evm::{CallMessage, RlpEvmTransaction, MIN_TRANSACTION_GAS};
@@ -40,7 +39,6 @@ use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::stf::StateTransitionFunction;
 use sov_state::ProverStorage;
 use sov_stf_runner::InitParams;
-use tokio::signal;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio::sync::{broadcast, mpsc};
 use tokio::time::sleep;
@@ -553,8 +551,11 @@ where
         }
     }
 
-    #[instrument(level = "trace", skip(self, task_manager), err, ret)]
-    pub async fn run(&mut self, mut task_manager: TaskManager<()>) -> Result<(), anyhow::Error> {
+    #[instrument(level = "trace", skip(self, cancellation_token), err, ret)]
+    pub async fn run(
+        &mut self,
+        cancellation_token: CancellationToken,
+    ) -> Result<(), anyhow::Error> {
         // TODO: hotfix for mock da
         self.da_service
             .get_block_at(1)
@@ -604,16 +605,14 @@ where
             commitment_service.resubmit_pending_commitments().await?;
         }
 
-        task_manager.spawn(|cancellation_token| commitment_service.run(cancellation_token));
+        tokio::spawn(commitment_service.run(cancellation_token.child_token()));
 
-        task_manager.spawn(|cancellation_token| {
-            da_block_monitor(
-                self.da_service.clone(),
-                da_height_update_tx,
-                self.config.da_update_interval_ms,
-                cancellation_token,
-            )
-        });
+        tokio::spawn(da_block_monitor(
+            self.da_service.clone(),
+            da_height_update_tx,
+            self.config.da_update_interval_ms,
+            cancellation_token.child_token(),
+        ));
 
         let target_block_time = Duration::from_millis(self.config.block_production_interval_ms);
 
@@ -701,9 +700,8 @@ where
                         }
                     };
                 },
-                _ = signal::ctrl_c() => {
+                _ = cancellation_token.cancelled() => {
                     info!("Shutting down sequencer");
-                    task_manager.abort().await;
                     return Ok(());
                 }
             }


### PR DESCRIPTION
# Description
Instead of passing `task_manager` into node runners, `spawn` those node runners using the task manager and use the latter to handle shutdown signals for every node type.

## Linked Issues
- Fixes #1750 