### PR TITLE
use btreemap in db commit method

### DIFF
--- a/crates/evm/src/evm/db_commit.rs
+++ b/crates/evm/src/evm/db_commit.rs
@@ -10,6 +10,8 @@ use super::{AccountInfo as DbAccountInfo, DbAccount};
 
 impl<'a, C: sov_modules_api::Context> DatabaseCommit for EvmDb<'a, C> {
     fn commit(&mut self, changes: HashMap<Address, Account>) {
+        // DO NOT REMOVE THIS LINE UNTIL REVM HAS BTREEMAP VERSION. WE MUST ENFORCE THE SAME ORDER.
+        let changes = changes.into_iter().collect::<BTreeMap<_, _>>();
         for (address, account) in changes {
             if !account.is_touched() {
                 continue;


### PR DESCRIPTION
# Description
Due to HashMap, the order of iteration changes for native and zkvm, I have no idea how it didn't fail so far. @eyusufatik opened a pr to revm to have a version which uses btreemap, until then, we manually convert.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
