### PR TITLE
Use sha2 for block hash calculation

### DIFF
--- a/crates/bitcoin-da/src/spec/header.rs
+++ b/crates/bitcoin-da/src/spec/header.rs
@@ -8,9 +8,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::BlockHeaderTrait;
 
-use crate::helpers::calculate_double_sha256;
-
 use super::block_hash::BlockHashWrapper;
+use crate::helpers::calculate_double_sha256;
 
 // HeaderWrapper is a wrapper around BlockHash to implement BlockHeaderTrait
 #[derive(
@@ -37,7 +36,9 @@ impl BlockHeaderTrait for HeaderWrapper {
 
     fn verify_hash(&self) -> bool {
         let mut enc = vec![];
-        self.header.consensus_encode(&mut enc).expect("engines don't error");
+        self.header
+            .consensus_encode(&mut enc)
+            .expect("engines don't error");
         let calculated = calculate_double_sha256(&enc);
 
         self.hash() == BlockHashWrapper::from(calculated)
@@ -144,30 +145,37 @@ impl From<BitcoinHeader> for BitcoinHeaderWrapper {
 }
 
 #[cfg(test)]
-mod tests{
-    use crate::{helpers::calculate_double_sha256, spec::block_hash::BlockHashWrapper};
-    use super::BitcoinHeaderWrapper;
-    
-    use borsh::BorshDeserialize;
-    use bitcoin::consensus::Encodable;
-    use std::{fs::File, io::{BufRead, BufReader}};
+mod tests {
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
 
-    #[test]  
-    fn calculate_block_hash(){
+    use bitcoin::consensus::Encodable;
+    use borsh::BorshDeserialize;
+
+    use super::BitcoinHeaderWrapper;
+    use crate::helpers::calculate_double_sha256;
+    use crate::spec::block_hash::BlockHashWrapper;
+
+    #[test]
+    fn calculate_block_hash() {
         let file = File::open("test_data/testnet4/headers-40310-42346.txt").unwrap();
         let reader = BufReader::new(file);
         for (line, _) in reader.lines().zip(40310..=42346) {
             let header_hex = line.unwrap();
             let header_bytes = hex::decode(&header_hex).unwrap();
 
-            let header =
-                BitcoinHeaderWrapper::deserialize(&mut header_bytes.as_ref()).unwrap();
+            let header = BitcoinHeaderWrapper::deserialize(&mut header_bytes.as_ref()).unwrap();
 
             let mut enc = vec![];
-            header.consensus_encode(&mut enc).expect("engines don't error");
+            header
+                .consensus_encode(&mut enc)
+                .expect("engines don't error");
             let calculated = calculate_double_sha256(&enc);
 
-            assert_eq!(BlockHashWrapper(header.block_hash()), BlockHashWrapper::from(calculated));
+            assert_eq!(
+                BlockHashWrapper(header.block_hash()),
+                BlockHashWrapper::from(calculated)
+            );
         }
     }
 }

--- a/crates/bitcoin-da/src/spec/header.rs
+++ b/crates/bitcoin-da/src/spec/header.rs
@@ -78,7 +78,13 @@ impl HeaderWrapper {
     }
 
     pub fn block_hash(&self) -> BlockHash {
-        self.header.block_hash()
+        let mut enc = vec![];
+        self.header
+            .consensus_encode(&mut enc)
+            .expect("engines don't error");
+        BlockHash::from_raw_hash(
+            Hash::from_byte_array(calculate_double_sha256(&enc))
+        )
     }
 
     pub fn merkle_root(&self) -> [u8; 32] {
@@ -148,6 +154,7 @@ impl From<BitcoinHeader> for BitcoinHeaderWrapper {
 mod tests {
     use std::fs::File;
     use std::io::{BufRead, BufReader};
+    use std::ops::Deref;
 
     use bitcoin::consensus::Encodable;
     use borsh::BorshDeserialize;
@@ -155,27 +162,31 @@ mod tests {
     use super::BitcoinHeaderWrapper;
     use crate::helpers::calculate_double_sha256;
     use crate::spec::block_hash::BlockHashWrapper;
+    use crate::spec::header::HeaderWrapper;
 
     #[test]
     fn calculate_block_hash() {
         let file = File::open("test_data/testnet4/headers-40310-42346.txt").unwrap();
         let reader = BufReader::new(file);
-        for (line, _) in reader.lines().zip(40310..=42346) {
+        for (line, height) in reader.lines().zip(40310..=42346) {
             let header_hex = line.unwrap();
             let header_bytes = hex::decode(&header_hex).unwrap();
 
-            let header = BitcoinHeaderWrapper::deserialize(&mut header_bytes.as_ref()).unwrap();
-
+            let inner_header = BitcoinHeaderWrapper::deserialize(&mut header_bytes.as_ref()).unwrap();
+            let header = HeaderWrapper::new(*inner_header.deref(), 0, height, [0; 32]);
+            
             let mut enc = vec![];
             header
+                .header
                 .consensus_encode(&mut enc)
                 .expect("engines don't error");
             let calculated = calculate_double_sha256(&enc);
 
             assert_eq!(
-                BlockHashWrapper(header.block_hash()),
+                BlockHashWrapper(inner_header.block_hash()), // bitcoin impl
                 BlockHashWrapper::from(calculated)
             );
+            assert_eq!(inner_header.block_hash(), header.block_hash())
         }
     }
 }

--- a/crates/bitcoin-da/src/spec/header.rs
+++ b/crates/bitcoin-da/src/spec/header.rs
@@ -144,10 +144,11 @@ impl From<BitcoinHeader> for BitcoinHeaderWrapper {
 
 #[cfg(test)]
 mod tests {
-    use borsh::BorshDeserialize;
     use std::fs::File;
     use std::io::{BufRead, BufReader};
     use std::ops::Deref;
+
+    use borsh::BorshDeserialize;
 
     use super::BitcoinHeaderWrapper;
     use crate::spec::header::HeaderWrapper;

--- a/crates/bitcoin-da/src/spec/header.rs
+++ b/crates/bitcoin-da/src/spec/header.rs
@@ -82,9 +82,7 @@ impl HeaderWrapper {
         self.header
             .consensus_encode(&mut enc)
             .expect("engines don't error");
-        BlockHash::from_raw_hash(
-            Hash::from_byte_array(calculate_double_sha256(&enc))
-        )
+        BlockHash::from_raw_hash(Hash::from_byte_array(calculate_double_sha256(&enc)))
     }
 
     pub fn merkle_root(&self) -> [u8; 32] {
@@ -172,9 +170,10 @@ mod tests {
             let header_hex = line.unwrap();
             let header_bytes = hex::decode(&header_hex).unwrap();
 
-            let inner_header = BitcoinHeaderWrapper::deserialize(&mut header_bytes.as_ref()).unwrap();
+            let inner_header =
+                BitcoinHeaderWrapper::deserialize(&mut header_bytes.as_ref()).unwrap();
             let header = HeaderWrapper::new(*inner_header.deref(), 0, height, [0; 32]);
-            
+
             let mut enc = vec![];
             header
                 .header

--- a/crates/bitcoin-da/src/spec/header.rs
+++ b/crates/bitcoin-da/src/spec/header.rs
@@ -1,11 +1,14 @@
 use core::ops::Deref;
 
 use bitcoin::block::{Header as BitcoinHeader, Version};
+use bitcoin::consensus::Encodable;
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, CompactTarget, TxMerkleNode};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::BlockHeaderTrait;
+
+use crate::helpers::calculate_double_sha256;
 
 use super::block_hash::BlockHashWrapper;
 
@@ -33,7 +36,11 @@ impl BlockHeaderTrait for HeaderWrapper {
     }
 
     fn verify_hash(&self) -> bool {
-        self.hash() == BlockHashWrapper::from(self.header.block_hash().to_byte_array())
+        let mut enc = vec![];
+        self.header.consensus_encode(&mut enc).expect("engines don't error");
+        let calculated = calculate_double_sha256(&enc);
+
+        self.hash() == BlockHashWrapper::from(calculated)
     }
 
     fn txs_commitment(&self) -> Self::Hash {

--- a/crates/bitcoin-da/src/spec/header.rs
+++ b/crates/bitcoin-da/src/spec/header.rs
@@ -35,13 +35,7 @@ impl BlockHeaderTrait for HeaderWrapper {
     }
 
     fn verify_hash(&self) -> bool {
-        let mut enc = vec![];
-        self.header
-            .consensus_encode(&mut enc)
-            .expect("engines don't error");
-        let calculated = calculate_double_sha256(&enc);
-
-        self.hash() == BlockHashWrapper::from(calculated)
+        self.hash() == BlockHashWrapper(self.block_hash())
     }
 
     fn txs_commitment(&self) -> Self::Hash {
@@ -150,16 +144,12 @@ impl From<BitcoinHeader> for BitcoinHeaderWrapper {
 
 #[cfg(test)]
 mod tests {
+    use borsh::BorshDeserialize;
     use std::fs::File;
     use std::io::{BufRead, BufReader};
     use std::ops::Deref;
 
-    use bitcoin::consensus::Encodable;
-    use borsh::BorshDeserialize;
-
     use super::BitcoinHeaderWrapper;
-    use crate::helpers::calculate_double_sha256;
-    use crate::spec::block_hash::BlockHashWrapper;
     use crate::spec::header::HeaderWrapper;
 
     #[test]
@@ -174,17 +164,6 @@ mod tests {
                 BitcoinHeaderWrapper::deserialize(&mut header_bytes.as_ref()).unwrap();
             let header = HeaderWrapper::new(*inner_header.deref(), 0, height, [0; 32]);
 
-            let mut enc = vec![];
-            header
-                .header
-                .consensus_encode(&mut enc)
-                .expect("engines don't error");
-            let calculated = calculate_double_sha256(&enc);
-
-            assert_eq!(
-                BlockHashWrapper(inner_header.block_hash()), // bitcoin impl
-                BlockHashWrapper::from(calculated)
-            );
             assert_eq!(inner_header.block_hash(), header.block_hash())
         }
     }

--- a/crates/bitcoin-da/src/spec/header.rs
+++ b/crates/bitcoin-da/src/spec/header.rs
@@ -142,3 +142,32 @@ impl From<BitcoinHeader> for BitcoinHeaderWrapper {
         Self(header)
     }
 }
+
+#[cfg(test)]
+mod tests{
+    use crate::{helpers::calculate_double_sha256, spec::block_hash::BlockHashWrapper};
+    use super::BitcoinHeaderWrapper;
+    
+    use borsh::BorshDeserialize;
+    use bitcoin::consensus::Encodable;
+    use std::{fs::File, io::{BufRead, BufReader}};
+
+    #[test]  
+    fn calculate_block_hash(){
+        let file = File::open("test_data/testnet4/headers-40310-42346.txt").unwrap();
+        let reader = BufReader::new(file);
+        for (line, _) in reader.lines().zip(40310..=42346) {
+            let header_hex = line.unwrap();
+            let header_bytes = hex::decode(&header_hex).unwrap();
+
+            let header =
+                BitcoinHeaderWrapper::deserialize(&mut header_bytes.as_ref()).unwrap();
+
+            let mut enc = vec![];
+            header.consensus_encode(&mut enc).expect("engines don't error");
+            let calculated = calculate_double_sha256(&enc);
+
+            assert_eq!(BlockHashWrapper(header.block_hash()), BlockHashWrapper::from(calculated));
+        }
+    }
+}


### PR DESCRIPTION
# Description
Modifies `HeaderWrapper::verify_hash` to use accelerated sha2 crate.

## Linked Issues
- Fixes #1819 

## Testing
Added unit test `calculate_block_hash`

