### PR TITLE
Use stored tx hashes

### DIFF
--- a/bin/citrea/tests/e2e/sequencer_behaviour.rs
+++ b/bin/citrea/tests/e2e/sequencer_behaviour.rs
@@ -308,7 +308,7 @@ async fn transaction_failing_on_l1_is_removed_from_mempool() -> Result<(), anyho
 
     assert_eq!(block.transactions.len(), 0);
     assert!(tx_from_mempool.is_none());
-    assert_eq!(soft_confirmation.txs.unwrap().len(), 0);
+    assert_eq!(soft_confirmation.txs.len(), 0);
 
     wait_for_l2_block(&full_node_test_client, block.header.number, None).await;
 
@@ -572,9 +572,7 @@ async fn test_system_tx_effect_on_block_gas_limit() -> Result<(), anyhow::Error>
 
     // last in tx byte array should be a subarray of txs[0]
     assert!(find_subarray(
-        initial_soft_confirmation.clone().txs.unwrap()[0]
-            .tx
-            .as_slice(),
+        initial_soft_confirmation.clone().txs[0].1.tx.as_slice(),
         &last_tx_raw[2..]
     )
     .is_some());
@@ -598,7 +596,7 @@ async fn test_system_tx_effect_on_block_gas_limit() -> Result<(), anyhow::Error>
 
     // not in tx byte array should not be a subarray of txs[0]
     assert!(find_subarray(
-        initial_soft_confirmation.txs.unwrap()[0].tx.as_slice(),
+        initial_soft_confirmation.txs[0].1.tx.as_slice(),
         &not_in_raw[2..]
     )
     .is_none());
@@ -612,7 +610,7 @@ async fn test_system_tx_effect_on_block_gas_limit() -> Result<(), anyhow::Error>
 
     // should be in tx byte array of the soft confirmation after
     assert!(find_subarray(
-        second_soft_confirmation.txs.unwrap()[0].tx.as_slice(),
+        second_soft_confirmation.txs[0].1.tx.as_slice(),
         &not_in_raw[2..]
     )
     .is_some());

--- a/crates/batch-prover/src/runner.rs
+++ b/crates/batch-prover/src/runner.rs
@@ -209,6 +209,11 @@ where
             .storage_manager
             .create_storage_on_l2_height(l2_height)?;
 
+        let tx_hashes = soft_confirmation
+            .txs
+            .iter()
+            .map(|(hash, _)| *hash)
+            .collect();
         let mut signed_soft_confirmation: SignedSoftConfirmation<StfTransaction<C, Da::Spec, RT>> =
             soft_confirmation
                 .clone()
@@ -255,8 +260,11 @@ where
 
         self.storage_manager.finalize_l2(l2_height)?;
 
-        let receipt =
-            soft_confirmation_to_receipt::<C, _, Da::Spec>(signed_soft_confirmation, current_spec);
+        let receipt = soft_confirmation_to_receipt::<C, _, Da::Spec>(
+            signed_soft_confirmation,
+            current_spec,
+            Some(tx_hashes),
+        );
 
         self.ledger_db.commit_soft_confirmation(
             next_state_root.as_ref(),

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -87,20 +87,23 @@ pub fn check_l2_range_exists<DB: SharedLedgerOps>(
 pub fn soft_confirmation_to_receipt<C: Context, Tx: TransactionDigest + Clone, DS: DaSpec>(
     soft_confirmation: SignedSoftConfirmation<'_, Tx>,
     current_spec: SpecId,
+    tx_hashes: Option<Vec<[u8; 32]>>,
 ) -> SoftConfirmationReceipt<DS> {
-    let tx_hashes = if current_spec >= SpecId::Kumquat {
-        soft_confirmation
-            .txs()
-            .iter()
-            .map(|tx| tx.compute_digest::<<C as Spec>::Hasher>().into())
-            .collect()
-    } else {
-        soft_confirmation
-            .blobs()
-            .iter()
-            .map(|raw_tx| <C as Spec>::Hasher::digest(raw_tx).into())
-            .collect()
-    };
+    let tx_hashes = tx_hashes.unwrap_or_else(|| {
+        if current_spec >= SpecId::Kumquat {
+            soft_confirmation
+                .txs()
+                .iter()
+                .map(|tx| tx.compute_digest::<<C as Spec>::Hasher>().into())
+                .collect()
+        } else {
+            soft_confirmation
+                .blobs()
+                .iter()
+                .map(|raw_tx| <C as Spec>::Hasher::digest(raw_tx).into())
+                .collect()
+        }
+    });
 
     SoftConfirmationReceipt {
         l2_height: soft_confirmation.l2_height(),

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -139,6 +139,11 @@ where
             .storage_manager
             .create_storage_on_l2_height(l2_height)?;
 
+        let tx_hashes = soft_confirmation
+            .txs
+            .iter()
+            .map(|(hash, _)| *hash)
+            .collect();
         let mut signed_soft_confirmation: SignedSoftConfirmation<StfTransaction<C, Da::Spec, RT>> =
             soft_confirmation
                 .clone()
@@ -178,8 +183,11 @@ where
             None
         };
 
-        let receipt =
-            soft_confirmation_to_receipt::<C, _, Da::Spec>(signed_soft_confirmation, current_spec);
+        let receipt = soft_confirmation_to_receipt::<C, _, Da::Spec>(
+            signed_soft_confirmation,
+            current_spec,
+            Some(tx_hashes),
+        );
 
         self.ledger_db
             .commit_soft_confirmation(next_state_root.as_ref(), receipt, tx_bodies)?;

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -482,9 +482,11 @@ where
 
                 let tx_bodies = signed_soft_confirmation.blobs().to_owned();
                 let soft_confirmation_hash = signed_soft_confirmation.hash();
+
                 let receipt = soft_confirmation_to_receipt::<C, _, Da::Spec>(
                     signed_soft_confirmation,
                     active_fork_spec,
+                    None,
                 );
                 self.ledger_db.commit_soft_confirmation(
                     next_state_root.as_ref(),

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types.rs
@@ -372,13 +372,12 @@ impl TryFrom<StoredSoftConfirmation> for SoftConfirmationResponse {
             da_slot_txs_commitment: value.da_slot_txs_commitment,
             hash: value.hash,
             prev_hash: value.prev_hash,
-            txs: Some(
-                value
-                    .txs
-                    .into_iter()
-                    .filter_map(|tx| tx.body.map(Into::into))
-                    .collect(),
-            ), // Rollup full nodes don't store tx bodies
+            txs: value
+                .txs
+                .into_iter()
+                .filter_map(|tx| tx.body.map(|body| (tx.hash, body.into())))
+                .collect(),
+            // Rollup full nodes don't store tx bodies
             state_root: value.state_root,
             soft_confirmation_signature: value.soft_confirmation_signature,
             pub_key: value.pub_key,

--- a/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
@@ -68,8 +68,7 @@ pub struct SoftConfirmationResponse {
     #[serde(with = "hex::serde")]
     pub prev_hash: [u8; 32],
     /// The transactions in this batch.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub txs: Option<Vec<HexTx>>,
+    pub txs: Vec<([u8; 32], HexTx)>,
     /// State root of the soft confirmation.
     #[serde(with = "hex::serde")]
     pub state_root: Vec<u8>,
@@ -96,8 +95,7 @@ where
         let parsed_txs = val
             .txs
             .iter()
-            .flatten()
-            .map(|tx| {
+            .map(|(_hash, tx)| {
                 let body = &tx.tx;
                 borsh::from_slice::<Tx>(body)
             })
@@ -110,11 +108,7 @@ where
             val.da_slot_hash,
             val.da_slot_txs_commitment,
             val.l1_fee_rate,
-            val.txs
-                .unwrap_or_default()
-                .into_iter()
-                .map(|tx| tx.tx)
-                .collect(),
+            val.txs.into_iter().map(|(_hash, tx)| tx.tx).collect(),
             parsed_txs.into(),
             val.deposit_data.into_iter().map(|tx| tx.tx).collect(),
             val.soft_confirmation_signature,


### PR DESCRIPTION
# Description

- Extract tx hashes out of `SoftConfirmationResponse` before converting to `SignedSoftConfirmation`
- Don't re-compute stored tx hashes
