### PR TITLE
fix & improve exponential backoff

### DIFF
--- a/crates/batch-prover/src/runner.rs
+++ b/crates/batch-prover/src/runner.rs
@@ -308,7 +308,7 @@ async fn sync_l2(
         let exponential_backoff = ExponentialBackoffBuilder::<backoff::SystemClock>::new()
             .with_initial_interval(Duration::from_secs(1))
             .with_max_elapsed_time(Some(Duration::from_secs(15 * 60)))
-            .with_multiplier(1.0)
+            .with_multiplier(1.5)
             .build();
 
         let inner_client = &sequencer_client;

--- a/crates/common/src/da.rs
+++ b/crates/common/src/da.rs
@@ -93,6 +93,7 @@ pub async fn get_da_block_at_height<Da: DaService>(
     let exponential_backoff = ExponentialBackoffBuilder::new()
         .with_initial_interval(Duration::from_secs(1))
         .with_max_elapsed_time(Some(Duration::from_secs(15 * 60)))
+        .with_multiplier(1.5)
         .build();
 
     let l1_block = retry_backoff(exponential_backoff.clone(), || async {

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -297,10 +297,11 @@ async fn sync_l2(
         let exponential_backoff = ExponentialBackoffBuilder::new()
             .with_initial_interval(Duration::from_secs(1))
             .with_max_elapsed_time(Some(Duration::from_secs(15 * 60)))
+            .with_multiplier(1.5)
             .build();
 
         let inner_client = &sequencer_client;
-        let soft_confirmations = match retry_backoff(exponential_backoff.clone(), || async move {
+        let soft_confirmations = match retry_backoff(exponential_backoff, || async move {
             match inner_client
                 .get_soft_confirmation_range(
                     U64::from(l2_height),

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -889,8 +889,9 @@ where
     ) -> anyhow::Result<()> {
         debug!("We have {} missed DA blocks", missed_da_blocks_count);
         let exponential_backoff = ExponentialBackoffBuilder::new()
-            .with_initial_interval(Duration::from_millis(50))
-            .with_max_elapsed_time(Some(Duration::from_secs(1)))
+            .with_initial_interval(Duration::from_millis(200))
+            .with_max_elapsed_time(Some(Duration::from_secs(30)))
+            .with_multiplier(1.5)
             .build();
         for i in 1..=missed_da_blocks_count {
             let needed_da_block_height = last_used_l1_height + i;


### PR DESCRIPTION
# Description

In batch prover runner, backoff multiplier was 1 which means no actual backoff.
Also made the default multiplier 1.5 explicit.
Also increased max elapsed time for querying da in sequencer runner 30 secs from 1 sec. 1 sec meant that if we cant query the da block in 2 seconds we stop the sequencer, which is very short amount for retrying.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
