### PR TITLE
no vec alloc in block hash calculation, following #1823

### DIFF
--- a/crates/bitcoin-da/src/spec/header.rs
+++ b/crates/bitcoin-da/src/spec/header.rs
@@ -75,7 +75,7 @@ impl HeaderWrapper {
         let mut enc = [0; BitcoinHeader::SIZE];
         self.header
             .consensus_encode(&mut enc.as_mut_slice())
-            .expect("engines don't error");
+            .expect("consensus encode cannot fail");
         BlockHash::from_raw_hash(Hash::from_byte_array(calculate_double_sha256(&enc)))
     }
 

--- a/crates/bitcoin-da/src/spec/header.rs
+++ b/crates/bitcoin-da/src/spec/header.rs
@@ -72,9 +72,9 @@ impl HeaderWrapper {
     }
 
     pub fn block_hash(&self) -> BlockHash {
-        let mut enc = vec![];
+        let mut enc = [0; BitcoinHeader::SIZE];
         self.header
-            .consensus_encode(&mut enc)
+            .consensus_encode(&mut enc.as_mut_slice())
             .expect("engines don't error");
         BlockHash::from_raw_hash(Hash::from_byte_array(calculate_double_sha256(&enc)))
     }


### PR DESCRIPTION
# Description

no need to vec alloc when header size is known

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
