### PR TITLE
use finality depth 5 with testing feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=3383e0e#3383e0eb1df568b397799fd08ec8cd48e0cef3bf"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=56abf56#56abf56bf4e5f2dea137a505e23943d7766a11f5"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ alloy-eips = { version = "0.4.2", default-features = false }
 alloy-consensus = { version = "0.4.2", default-features = false, features = ["serde", "serde-bincode-compat"] }
 alloy-network = { version = "0.4.2", default-features = false }
 
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "3383e0e" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "56abf56" }
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "ca3cfa2" }

--- a/bin/citrea/Cargo.toml
+++ b/bin/citrea/Cargo.toml
@@ -109,6 +109,7 @@ sp1-helper = { version = "3.0.0", default-features = false }
 [features]
 default = [] # Deviate from convention by making the "native" feature active by default. This aligns with how this package is meant to be used (as a binary first, library second).
 testing = [
+  "bitcoin-da/testing",
   "citrea-primitives/testing",
   "citrea-risc0-batch-proof/testing",
   "citrea-risc0-light-client/testing",

--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -89,7 +89,7 @@ impl TestCase for BasicProverTest {
         da.wait_mempool_len(2, None).await?;
 
         da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)
@@ -230,7 +230,7 @@ impl TestCase for SkipPreprovenCommitmentsTest {
 
         da.generate(FINALITY_DEPTH).await?;
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
         batch_prover
             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
             .await?;
@@ -295,7 +295,7 @@ impl TestCase for SkipPreprovenCommitmentsTest {
         da.wait_mempool_len(4, None).await?;
 
         da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         batch_prover
             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
@@ -305,7 +305,7 @@ impl TestCase for SkipPreprovenCommitmentsTest {
         da.wait_mempool_len(2, None).await?;
 
         da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         // Wait for the full node to see all process verify and store all batch proofs
         full_node.wait_for_l1_height(finalized_height, None).await?;
@@ -396,7 +396,7 @@ impl TestCase for LocalProvingTest {
         // Make commitment tx into a finalized block
         da.generate(FINALITY_DEPTH).await?;
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
         // Wait for batch prover to process the proof
         batch_prover
             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(7200)))
@@ -408,7 +408,7 @@ impl TestCase for LocalProvingTest {
         // Make batch proof tx into a finalized block
         da.generate(FINALITY_DEPTH).await?;
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
         // Wait for full node to see zkproofs
         let proofs =
             wait_for_zkproofs(full_node, finalized_height, Some(Duration::from_secs(7200)))
@@ -495,7 +495,7 @@ impl TestCase for ParallelProvingTest {
 
         // Write commitments to a finalized DA block
         da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         // Wait until batch prover processes the commitments
         batch_prover
@@ -507,7 +507,7 @@ impl TestCase for ParallelProvingTest {
 
         // Write 2 batch proofs to a finalized DA block
         da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         // Retrieve proofs from fullnode
         let proofs = wait_for_zkproofs(full_node, finalized_height, None)
@@ -619,7 +619,7 @@ impl TestCase for ForkElfSwitchingTest {
 
         da.generate(FINALITY_DEPTH).await?;
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)

--- a/bin/citrea/tests/bitcoin/bitcoin_test.rs
+++ b/bin/citrea/tests/bitcoin/bitcoin_test.rs
@@ -117,7 +117,7 @@ impl TestCase for BitcoinReorgTest {
         assert_eq!(block.txdata.len(), 3); // Coinbase + seq commit/reveal txs
 
         da1.generate(FINALITY_DEPTH - 1).await?;
-        let finalized_height = da1.get_finalized_height().await?;
+        let finalized_height = da1.get_finalized_height(None).await?;
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)
@@ -326,7 +326,7 @@ impl TestCase for CpfpFeeBumpingTest {
         );
 
         da.generate(FINALITY_DEPTH - 1).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)

--- a/bin/citrea/tests/bitcoin/guest_cycles.rs
+++ b/bin/citrea/tests/bitcoin/guest_cycles.rs
@@ -89,7 +89,8 @@ impl TestCase for GenerateProofInput {
         da.wait_mempool_len(4, None).await?;
         da.generate(FINALITY_DEPTH).await?;
 
-        let finalized_height = da.get_finalized_height().await.unwrap();
+        // passing in finality depth as this test should be run without testing feature
+        let finalized_height = da.get_finalized_height(Some(FINALITY_DEPTH)).await.unwrap();
 
         println!("Waiting batch prover l1 height: {finalized_height}");
         batch_prover

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -95,7 +95,7 @@ impl TestCase for LightClientProvingTest {
         // Finalize the DA block which contains the commitment tx
         da.generate(FINALITY_DEPTH).await?;
 
-        let commitment_l1_height = da.get_finalized_height().await?;
+        let commitment_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for batch prover to generate proof for commitment
         batch_prover
@@ -119,7 +119,7 @@ impl TestCase for LightClientProvingTest {
         // Finalize the DA block which contains the batch proof tx
         da.generate(FINALITY_DEPTH).await?;
 
-        let batch_proof_l1_height = da.get_finalized_height().await?;
+        let batch_proof_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for light client prover to process batch proofs.
         light_client_prover
@@ -135,7 +135,7 @@ impl TestCase for LightClientProvingTest {
             .await?;
         assert!(lcp.is_some());
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
         // Wait for full node to see zkproofs
         let batch_proof =
             wait_for_zkproofs(full_node, finalized_height, Some(Duration::from_secs(7200)))
@@ -234,7 +234,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         // Finalize the DA block which contains the commitment txs
         da.generate(FINALITY_DEPTH).await?;
 
-        let commitment_l1_height = da.get_finalized_height().await?;
+        let commitment_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for batch prover to generate proofs for commitments
         batch_prover
@@ -265,7 +265,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
 
         // Finalize the DA block which contains the batch proof tx
         da.generate(FINALITY_DEPTH).await?;
-        let batch_proof_l1_height = da.get_finalized_height().await?;
+        let batch_proof_l1_height = da.get_finalized_height(None).await?;
         // Wait for the full node to see all process verify and store all batch proofs
         full_node
             .wait_for_l1_height(batch_proof_l1_height, Some(TEN_MINS))
@@ -306,7 +306,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         // Generate another da block so we generate another lcp
         da.generate(1).await?;
 
-        let last_finalized_height = da.get_finalized_height().await?;
+        let last_finalized_height = da.get_finalized_height(None).await?;
 
         // Wait for light client prover to process batch proofs.
         light_client_prover
@@ -360,7 +360,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         // Finalize the DA block which contains the commitment txs
         da.generate(FINALITY_DEPTH).await?;
 
-        let commitment_l1_height = da.get_finalized_height().await?;
+        let commitment_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for batch prover to generate proofs for commitments
         batch_prover
@@ -390,7 +390,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
 
         // Finalize the DA block which contains the batch proof tx
         da.generate(FINALITY_DEPTH).await?;
-        let batch_proof_l1_height = da.get_finalized_height().await?;
+        let batch_proof_l1_height = da.get_finalized_height(None).await?;
         // Wait for the full node to see all process verify and store all batch proofs
         full_node
             .wait_for_l1_height(batch_proof_l1_height, Some(TEN_MINS))
@@ -556,7 +556,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
         // Finalize the DA block which contains the commitment tx
         da.generate(FINALITY_DEPTH).await?;
 
-        let commitment_l1_height = da.get_finalized_height().await?;
+        let commitment_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for batch prover to generate proof for commitment
         batch_prover
@@ -580,7 +580,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
         // Finalize the DA block which contains the batch proof tx
         da.generate(FINALITY_DEPTH).await?;
 
-        let batch_proof_l1_height = da.get_finalized_height().await?;
+        let batch_proof_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for light client prover to process batch proofs.
         light_client_prover
@@ -633,7 +633,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
         // Finalize the DA block which contains the method id tx
         da.generate(FINALITY_DEPTH).await?;
 
-        let method_id_l1_height = da.get_finalized_height().await?;
+        let method_id_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for light client prover to process method id update
         light_client_prover
@@ -819,7 +819,7 @@ impl TestCase for LightClientUnverifiableBatchProofTest {
             .spawn(|tk| bitcoin_da_service.clone().run_da_queue(rx, tk));
 
         da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         // Wait for light client prover to create light client proof.
         light_client_prover
@@ -915,7 +915,7 @@ impl TestCase for LightClientUnverifiableBatchProofTest {
         // Finalize the DA block which contains the batch proof txs
         da.generate(FINALITY_DEPTH).await?;
 
-        let batch_proof_l1_height = da.get_finalized_height().await?;
+        let batch_proof_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for light client prover to process unverifiable batch proof
         light_client_prover
@@ -1028,7 +1028,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
             .spawn(|tk| bitcoin_da_service.clone().run_da_queue(rx, tk));
 
         da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         // Wait for light client prover to create light client proof.
         light_client_prover
@@ -1078,7 +1078,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
         // Make sure all of them are in the block
         da.wait_mempool_len(0, Some(TEN_MINS)).await?;
 
-        let batch_proof_l1_height = da.get_finalized_height().await?;
+        let batch_proof_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for light client prover to process verifiable batch proof
         light_client_prover
@@ -1163,7 +1163,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
         // Finalize the DA block which contains the aggregate txs
         da.generate(FINALITY_DEPTH - 1).await?;
 
-        let batch_proof_l1_height = da.get_finalized_height().await?;
+        let batch_proof_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for light client prover to process verifiable batch proof
         light_client_prover
@@ -1241,7 +1241,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
         // Make sure all of them are in the block
         da.wait_mempool_len(0, Some(TEN_MINS)).await?;
 
-        let batch_proof_l1_height = da.get_finalized_height().await?;
+        let batch_proof_l1_height = da.get_finalized_height(None).await?;
 
         // Wait for light client prover to process verifiable batch proof
         light_client_prover

--- a/bin/citrea/tests/bitcoin/sequencer_commitments.rs
+++ b/bin/citrea/tests/bitcoin/sequencer_commitments.rs
@@ -85,7 +85,7 @@ impl TestCase for LedgerGetCommitmentsProverTest {
         // Include commitment in block and finalize it
         da.generate(FINALITY_DEPTH).await?;
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         // wait here until we see from prover's rpc that it finished proving
         prover.wait_for_l1_height(finalized_height, None).await?;
@@ -167,7 +167,7 @@ impl TestCase for LedgerGetCommitmentsTest {
             .wait_for_l2_height(min_soft_confirmations_per_commitment, None)
             .await?;
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         let commitments = wait_for_sequencer_commitments(full_node, finalized_height, None).await?;
 
@@ -233,7 +233,7 @@ impl TestCase for SequencerSendCommitmentsToDaTest {
         da.generate(FINALITY_DEPTH).await?;
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         for height in initial_height..finalized_height {
             let hash = da.get_block_hash(height).await?;
@@ -294,7 +294,7 @@ impl SequencerSendCommitmentsToDaTest {
         start_l2_block: u64,
         end_l2_block: u64,
     ) -> Result<()> {
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         // Extract and verify the commitment from the block
         let hash = da.get_block_hash(finalized_height).await?;

--- a/bin/citrea/tests/bitcoin/sequencer_test.rs
+++ b/bin/citrea/tests/bitcoin/sequencer_test.rs
@@ -81,7 +81,7 @@ impl TestCase for SequencerMissedDaBlocksTest {
         let sequencer = f.sequencer.as_mut().unwrap();
         let da = f.bitcoin_nodes.get(0).unwrap();
 
-        let initial_l1_height = da.get_finalized_height().await?;
+        let initial_l1_height = da.get_finalized_height(None).await?;
 
         // Create initial DA blocks
         da.generate(3).await?;
@@ -131,7 +131,7 @@ impl TestCase for SequencerMissedDaBlocksTest {
             last_used_l1_height = soft_confirmation.da_slot_height;
         }
 
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
         assert_eq!(last_used_l1_height, finalized_height);
 
         Ok(())

--- a/bin/citrea/tests/bitcoin/tx_chain.rs
+++ b/bin/citrea/tests/bitcoin/tx_chain.rs
@@ -1,9 +1,10 @@
 use async_trait::async_trait;
 use bitcoin::{Amount, Transaction};
 use bitcoin_da::rpc::DaRpcClient;
+use bitcoin_da::service::FINALITY_DEPTH;
 use bitcoin_da::REVEAL_OUTPUT_AMOUNT;
 use bitcoincore_rpc::RpcApi;
-use citrea_e2e::bitcoin::{BitcoinNode, FINALITY_DEPTH};
+use citrea_e2e::bitcoin::BitcoinNode;
 use citrea_e2e::config::{BitcoinConfig, SequencerConfig, TestCaseConfig};
 use citrea_e2e::framework::TestFramework;
 use citrea_e2e::node::Sequencer;
@@ -484,7 +485,7 @@ impl TestCase for TestProverTransactionChaining {
         da.wait_mempool_len(2, None).await?;
 
         da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)
@@ -527,7 +528,7 @@ impl TestCase for TestProverTransactionChaining {
         da.wait_mempool_len(2, None).await?;
 
         da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)
@@ -572,7 +573,7 @@ impl TestCase for TestProverTransactionChaining {
         da.wait_mempool_len(2, None).await?;
 
         da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)

--- a/crates/bitcoin-da/Cargo.toml
+++ b/crates/bitcoin-da/Cargo.toml
@@ -66,3 +66,4 @@ native = [
   "dep:jsonrpsee",
   "dep:secp256k1",
 ]
+testing = []

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -62,6 +62,9 @@ use crate::spec::{BitcoinSpec, RollupParams};
 use crate::verifier::BitcoinVerifier;
 use crate::REVEAL_OUTPUT_AMOUNT;
 
+#[cfg(feature = "testing")]
+pub const FINALITY_DEPTH: u64 = 5; // blocks
+#[cfg(not(feature = "testing"))]
 pub const FINALITY_DEPTH: u64 = 30; // blocks
 const POLLING_INTERVAL: u64 = 10; // seconds
 


### PR DESCRIPTION
# Description

Our longest tests are light client proving tests, which are limited by the finality depth. Lowering it to 5 when testing feature is enabled. citrea-e2e repo is also updated accordingly.

**UPDATE:** Based on the ci run of this pr, ci times should be 3-4 minutes lower.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
