### PR TITLE
Fix make lint-fix fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,9 @@ lint:  ## cargo check and clippy. Skip clippy on guest code since it's not suppo
 
 lint-fix:  ## dprint fmt, cargo fmt, fix and clippy. Skip clippy on guest code since it's not supported by risc0
 	dprint fmt
-	cargo +nightly fmt --all
 	cargo fix --allow-dirty
 	SKIP_GUEST_BUILD=1 cargo clippy --fix --allow-dirty
+	cargo +nightly fmt --all
 
 check-features: ## Checks that project compiles with all combinations of features.
 	cargo hack check --workspace --feature-powerset --exclude-features default --all-targets


### PR DESCRIPTION
# Description

- Fix an edge case where a `clippy fix` will lead to an out of format code. Runs `cargo fmt` last to be sure the clippy changes end up formatted
