### PR TITLE
Better l2 range check

### DIFF
--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -311,14 +311,19 @@ pub(crate) async fn get_batch_proof_circuit_input_from_commitments<
     ledger_db: &DB,
     l1_block_cache: &Arc<Mutex<L1BlockCache<Da>>>,
 ) -> Result<CommitmentStateTransitionData<'txs, Witness, Da, Tx>, anyhow::Error> {
-    let mut state_transition_witnesses: VecDeque<Vec<(Witness, Witness)>> = VecDeque::new();
-    let mut soft_confirmations: VecDeque<Vec<SignedSoftConfirmation<Tx>>> = VecDeque::new();
+    let mut state_transition_witnesses: VecDeque<Vec<(Witness, Witness)>> =
+        VecDeque::with_capacity(sequencer_commitments.len());
+    let mut soft_confirmations: VecDeque<Vec<SignedSoftConfirmation<Tx>>> =
+        VecDeque::with_capacity(sequencer_commitments.len());
     let mut da_block_headers_of_soft_confirmations: VecDeque<
         Vec<<<Da as DaService>::Spec as DaSpec>::BlockHeader>,
-    > = VecDeque::new();
-    for sequencer_commitment in sequencer_commitments.to_owned().iter() {
+    > = VecDeque::with_capacity(sequencer_commitments.len());
+    for sequencer_commitment in sequencer_commitments.iter() {
         // get the l2 height ranges of each seq_commitments
-        let mut witnesses = vec![];
+        let mut witnesses = Vec::with_capacity(
+            (sequencer_commitment.l2_end_block_number - sequencer_commitment.l2_start_block_number
+                + 1) as usize,
+        );
         let start_l2 = sequencer_commitment.l2_start_block_number;
         let end_l2 = sequencer_commitment.l2_end_block_number;
         let soft_confirmations_in_commitment = match ledger_db.get_soft_confirmation_range(
@@ -332,7 +337,8 @@ pub(crate) async fn get_batch_proof_circuit_input_from_commitments<
                 ));
             }
         };
-        let mut commitment_soft_confirmations = vec![];
+        let mut commitment_soft_confirmations =
+            Vec::with_capacity(soft_confirmations_in_commitment.len());
         let mut da_block_headers_to_push: Vec<<<Da as DaService>::Spec as DaSpec>::BlockHeader> =
             vec![];
         for soft_confirmation in soft_confirmations_in_commitment {

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -68,20 +68,15 @@ fn filter_out_commitments_by_status<DB: SharedLedgerOps>(
     Ok((filtered, skipped_commitments))
 }
 
-pub fn check_l2_range_exists<DB: SharedLedgerOps>(
-    ledger_db: &DB,
-    first_l2_height_of_l1: u64,
-    last_l2_height_of_l1: u64,
-) -> bool {
-    if let Ok(range) = ledger_db.get_soft_confirmation_range(
-        &(SoftConfirmationNumber(first_l2_height_of_l1)
-            ..=SoftConfirmationNumber(last_l2_height_of_l1)),
-    ) {
-        if (range.len() as u64) >= (last_l2_height_of_l1 - first_l2_height_of_l1 + 1) {
-            return true;
-        }
-    }
-    false
+pub fn check_l2_block_exists<DB: SharedLedgerOps>(ledger_db: &DB, l2_height: u64) -> bool {
+    let Some(head_l2_height) = ledger_db
+        .get_head_soft_confirmation_height()
+        .expect("Ledger db read must not fail")
+    else {
+        return false;
+    };
+
+    head_l2_height >= l2_height
 }
 
 pub fn soft_confirmation_to_receipt<C: Context, Tx: TransactionDigest + Clone, DS: DaSpec>(

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -6,7 +6,7 @@ use anyhow::anyhow;
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::{extract_sequencer_commitments, extract_zk_proofs, sync_l1};
 use citrea_common::error::SyncError;
-use citrea_common::utils::check_l2_range_exists;
+use citrea_common::utils::check_l2_block_exists;
 use citrea_primitives::forks::fork_from_block_number;
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
@@ -145,9 +145,8 @@ where
         if !sequencer_commitments.is_empty() {
             // If the L2 range does not exist, we break off the current process call
             // We retry the L1 block at a later tick.
-            if !check_l2_range_exists(
+            if !check_l2_block_exists(
                 &self.ledger_db,
-                sequencer_commitments[0].l2_start_block_number,
                 sequencer_commitments[sequencer_commitments.len() - 1].l2_end_block_number,
             ) {
                 warn!("L1 commitment received, but L2 range is not synced yet...");


### PR DESCRIPTION
# Description

No need to load 100s of blocks when checking the range exists. Since the syncing is sequential, we can just check that the head is greater than the last commitment l2 height.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
