### PR TITLE
Simplify WorkingSet Delta

### DIFF
--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -253,55 +253,6 @@ pub trait StateReaderAndWriter {
     }
 }
 
-/// A working set accumulates reads and writes on top of the underlying DB,
-/// automating witness creation.
-pub struct Delta<S: Storage> {
-    inner: S,
-    witness: S::Witness,
-    cache: StorageInternalCache,
-}
-
-impl<S: Storage> Delta<S> {
-    fn new(inner: S, version: Option<u64>) -> Self {
-        Self::with_witness(inner, Default::default(), version)
-    }
-
-    fn with_witness(inner: S, witness: S::Witness, version: Option<u64>) -> Self {
-        Self {
-            inner,
-            witness,
-            cache: StorageInternalCache::new(version, CacheMode::State),
-        }
-    }
-
-    fn freeze(&mut self) -> (OrderedReadsAndWrites, S::Witness) {
-        let cache = mem::take(&mut self.cache);
-        let witness = mem::take(&mut self.witness);
-
-        (cache.into(), witness)
-    }
-}
-
-impl<S: Storage> fmt::Debug for Delta<S> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Delta").finish()
-    }
-}
-
-impl<S: Storage> StateReaderAndWriter for Delta<S> {
-    fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
-        self.cache.get_or_fetch(key, &self.inner, &mut self.witness)
-    }
-
-    fn set(&mut self, key: &StorageKey, value: StorageValue) {
-        self.cache.set(key, value)
-    }
-
-    fn delete(&mut self, key: &StorageKey) {
-        self.cache.delete(key)
-    }
-}
-
 #[derive(Default)]
 struct RevertableWrites {
     pub cache: BTreeMap<CacheKey, Option<CacheValue>>,

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -134,7 +134,7 @@ impl<S: Storage> AccessoryDelta<S> {
     fn freeze(&mut self) -> OrderedReadsAndWrites {
         let ordered_writes = mem::take(&mut self.committed_writes)
             .into_iter()
-            .collect::<Vec<_>>();
+            .collect();
 
         OrderedReadsAndWrites {
             ordered_reads: Vec::default(),

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -15,21 +15,6 @@ use crate::storage::{
 };
 use crate::{ValueExists, Version};
 
-/*
-JmtWorkingSet:
-    jmt_delta: JmtDelta
-
-OffchainWorkingSet:
-    offchain_delta: OffchainDelta
-
-Delta<S: Storage>:
-    storage: S
-    logs: CacheLog
-    uncommitted_writes: BTreeMap<CacheKey, Option<CacheValue>>
-    witness: S::Witness
-    version: Option<u64>
-*/
-
 struct StateDelta<S: Storage> {
     storage: S,
     cache_log: CacheLog,

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -15,6 +15,138 @@ use crate::storage::{
 };
 use crate::{ValueExists, Version};
 
+/// A storage reader and writer
+pub trait StateReaderAndWriter {
+    /// Get a value from the storage.
+    fn get(&mut self, key: &StorageKey) -> Option<StorageValue>;
+
+    /// Replaces a storage value.
+    fn set(&mut self, key: &StorageKey, value: StorageValue);
+
+    /// Deletes a storage value.
+    fn delete(&mut self, key: &StorageKey);
+
+    /// Replaces a storage value with the provided prefix, using the provided codec.
+    fn set_value<Q, K, V, Codec>(
+        &mut self,
+        prefix: &Prefix,
+        storage_key: &Q,
+        value: &V,
+        codec: &Codec,
+    ) where
+        Q: ?Sized,
+        Codec: StateCodec,
+        Codec::KeyCodec: EncodeKeyLike<Q, K>,
+        Codec::ValueCodec: StateValueCodec<V>,
+    {
+        let storage_key = StorageKey::new(prefix, storage_key, codec.key_codec());
+        let storage_value = StorageValue::new(value, codec.value_codec());
+        self.set(&storage_key, storage_value);
+    }
+
+    /// Replaces a storage value with a singleton prefix. For more information, check
+    /// [StorageKey::singleton].
+    fn set_singleton<V, Codec>(&mut self, prefix: &Prefix, value: &V, codec: &Codec)
+    where
+        Codec: StateCodec,
+        Codec::ValueCodec: StateValueCodec<V>,
+    {
+        let storage_key = StorageKey::singleton(prefix);
+        let storage_value = StorageValue::new(value, codec.value_codec());
+        self.set(&storage_key, storage_value);
+    }
+
+    /// Get a decoded value from the storage.
+    fn get_decoded<V, Codec>(&mut self, storage_key: &StorageKey, codec: &Codec) -> Option<V>
+    where
+        Codec: StateCodec,
+        Codec::ValueCodec: StateValueCodec<V>,
+    {
+        let storage_value = self.get(storage_key)?;
+
+        Some(
+            codec
+                .value_codec()
+                .decode_value_unwrap(storage_value.value()),
+        )
+    }
+
+    /// Get a value from the storage.
+    fn get_value<Q, K, V, Codec>(
+        &mut self,
+        prefix: &Prefix,
+        storage_key: &Q,
+        codec: &Codec,
+    ) -> Option<V>
+    where
+        Q: ?Sized,
+        Codec: StateCodec,
+        Codec::KeyCodec: EncodeKeyLike<Q, K>,
+        Codec::ValueCodec: StateValueCodec<V>,
+    {
+        let storage_key = StorageKey::new(prefix, storage_key, codec.key_codec());
+        self.get_decoded(&storage_key, codec)
+    }
+
+    /// Get a singleton value from the storage. For more information, check [StorageKey::singleton].
+    fn get_singleton<V, Codec>(&mut self, prefix: &Prefix, codec: &Codec) -> Option<V>
+    where
+        Codec: StateCodec,
+        Codec::ValueCodec: StateValueCodec<V>,
+    {
+        let storage_key = StorageKey::singleton(prefix);
+        self.get_decoded(&storage_key, codec)
+    }
+
+    /// Removes a value from the storage.
+    fn remove_value<Q, K, V, Codec>(
+        &mut self,
+        prefix: &Prefix,
+        storage_key: &Q,
+        codec: &Codec,
+    ) -> Option<V>
+    where
+        Q: ?Sized,
+        Codec: StateCodec,
+        Codec::KeyCodec: EncodeKeyLike<Q, K>,
+        Codec::ValueCodec: StateValueCodec<V>,
+    {
+        let storage_key = StorageKey::new(prefix, storage_key, codec.key_codec());
+        let storage_value = self.get_decoded(&storage_key, codec)?;
+        self.delete(&storage_key);
+        Some(storage_value)
+    }
+
+    /// Removes a singleton from the storage. For more information, check [StorageKey::singleton].
+    fn remove_singleton<V, Codec>(&mut self, prefix: &Prefix, codec: &Codec) -> Option<V>
+    where
+        Codec: StateCodec,
+        Codec::ValueCodec: StateValueCodec<V>,
+    {
+        let storage_key = StorageKey::singleton(prefix);
+        let storage_value = self.get_decoded(&storage_key, codec)?;
+        self.delete(&storage_key);
+        Some(storage_value)
+    }
+
+    /// Deletes a value from the storage.
+    fn delete_value<Q, K, Codec>(&mut self, prefix: &Prefix, storage_key: &Q, codec: &Codec)
+    where
+        Q: ?Sized,
+        Codec: StateCodec,
+        Codec::KeyCodec: EncodeKeyLike<Q, K>,
+    {
+        let storage_key = StorageKey::new(prefix, storage_key, codec.key_codec());
+        self.delete(&storage_key);
+    }
+
+    /// Deletes a singleton from the storage. For more information, check [StorageKey::singleton].
+    fn delete_singleton(&mut self, prefix: &Prefix) {
+        let storage_key = StorageKey::singleton(prefix);
+        self.delete(&storage_key);
+    }
+}
+
 struct StateDelta<S: Storage> {
     storage: S,
     cache_log: CacheLog,
@@ -253,138 +385,6 @@ impl<S: Storage> StateReaderAndWriter for OffchainDelta<S> {
     fn delete(&mut self, key: &StorageKey) {
         self.uncommitted_writes
             .insert(key.to_cache_key_version(self.version), None);
-    }
-}
-
-/// A storage reader and writer
-pub trait StateReaderAndWriter {
-    /// Get a value from the storage.
-    fn get(&mut self, key: &StorageKey) -> Option<StorageValue>;
-
-    /// Replaces a storage value.
-    fn set(&mut self, key: &StorageKey, value: StorageValue);
-
-    /// Deletes a storage value.
-    fn delete(&mut self, key: &StorageKey);
-
-    /// Replaces a storage value with the provided prefix, using the provided codec.
-    fn set_value<Q, K, V, Codec>(
-        &mut self,
-        prefix: &Prefix,
-        storage_key: &Q,
-        value: &V,
-        codec: &Codec,
-    ) where
-        Q: ?Sized,
-        Codec: StateCodec,
-        Codec::KeyCodec: EncodeKeyLike<Q, K>,
-        Codec::ValueCodec: StateValueCodec<V>,
-    {
-        let storage_key = StorageKey::new(prefix, storage_key, codec.key_codec());
-        let storage_value = StorageValue::new(value, codec.value_codec());
-        self.set(&storage_key, storage_value);
-    }
-
-    /// Replaces a storage value with a singleton prefix. For more information, check
-    /// [StorageKey::singleton].
-    fn set_singleton<V, Codec>(&mut self, prefix: &Prefix, value: &V, codec: &Codec)
-    where
-        Codec: StateCodec,
-        Codec::ValueCodec: StateValueCodec<V>,
-    {
-        let storage_key = StorageKey::singleton(prefix);
-        let storage_value = StorageValue::new(value, codec.value_codec());
-        self.set(&storage_key, storage_value);
-    }
-
-    /// Get a decoded value from the storage.
-    fn get_decoded<V, Codec>(&mut self, storage_key: &StorageKey, codec: &Codec) -> Option<V>
-    where
-        Codec: StateCodec,
-        Codec::ValueCodec: StateValueCodec<V>,
-    {
-        let storage_value = self.get(storage_key)?;
-
-        Some(
-            codec
-                .value_codec()
-                .decode_value_unwrap(storage_value.value()),
-        )
-    }
-
-    /// Get a value from the storage.
-    fn get_value<Q, K, V, Codec>(
-        &mut self,
-        prefix: &Prefix,
-        storage_key: &Q,
-        codec: &Codec,
-    ) -> Option<V>
-    where
-        Q: ?Sized,
-        Codec: StateCodec,
-        Codec::KeyCodec: EncodeKeyLike<Q, K>,
-        Codec::ValueCodec: StateValueCodec<V>,
-    {
-        let storage_key = StorageKey::new(prefix, storage_key, codec.key_codec());
-        self.get_decoded(&storage_key, codec)
-    }
-
-    /// Get a singleton value from the storage. For more information, check [StorageKey::singleton].
-    fn get_singleton<V, Codec>(&mut self, prefix: &Prefix, codec: &Codec) -> Option<V>
-    where
-        Codec: StateCodec,
-        Codec::ValueCodec: StateValueCodec<V>,
-    {
-        let storage_key = StorageKey::singleton(prefix);
-        self.get_decoded(&storage_key, codec)
-    }
-
-    /// Removes a value from the storage.
-    fn remove_value<Q, K, V, Codec>(
-        &mut self,
-        prefix: &Prefix,
-        storage_key: &Q,
-        codec: &Codec,
-    ) -> Option<V>
-    where
-        Q: ?Sized,
-        Codec: StateCodec,
-        Codec::KeyCodec: EncodeKeyLike<Q, K>,
-        Codec::ValueCodec: StateValueCodec<V>,
-    {
-        let storage_key = StorageKey::new(prefix, storage_key, codec.key_codec());
-        let storage_value = self.get_decoded(&storage_key, codec)?;
-        self.delete(&storage_key);
-        Some(storage_value)
-    }
-
-    /// Removes a singleton from the storage. For more information, check [StorageKey::singleton].
-    fn remove_singleton<V, Codec>(&mut self, prefix: &Prefix, codec: &Codec) -> Option<V>
-    where
-        Codec: StateCodec,
-        Codec::ValueCodec: StateValueCodec<V>,
-    {
-        let storage_key = StorageKey::singleton(prefix);
-        let storage_value = self.get_decoded(&storage_key, codec)?;
-        self.delete(&storage_key);
-        Some(storage_value)
-    }
-
-    /// Deletes a value from the storage.
-    fn delete_value<Q, K, Codec>(&mut self, prefix: &Prefix, storage_key: &Q, codec: &Codec)
-    where
-        Q: ?Sized,
-        Codec: StateCodec,
-        Codec::KeyCodec: EncodeKeyLike<Q, K>,
-    {
-        let storage_key = StorageKey::new(prefix, storage_key, codec.key_codec());
-        self.delete(&storage_key);
-    }
-
-    /// Deletes a singleton from the storage. For more information, check [StorageKey::singleton].
-    fn delete_singleton(&mut self, prefix: &Prefix) {
-        let storage_key = StorageKey::singleton(prefix);
-        self.delete(&storage_key);
     }
 }
 

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -321,69 +321,6 @@ pub trait StateReaderAndWriter {
     }
 }
 
-#[derive(Default)]
-struct RevertableWrites {
-    pub cache: BTreeMap<CacheKey, Option<CacheValue>>,
-    pub version: Option<u64>,
-}
-
-struct AccessoryDelta<S: Storage> {
-    // This inner storage is never accessed inside the zkVM because reads are
-    // not allowed, so it can result as dead code.
-    storage: S,
-    writes: RevertableWrites,
-}
-
-impl<S: Storage> AccessoryDelta<S> {
-    fn new(storage: S, version: Option<u64>) -> Self {
-        let writes = match version {
-            None => Default::default(),
-            Some(v) => RevertableWrites {
-                cache: Default::default(),
-                version: Some(v),
-            },
-        };
-        Self { storage, writes }
-    }
-
-    fn freeze(&mut self) -> OrderedReadsAndWrites {
-        let writes = mem::take(&mut self.writes);
-        let ordered_writes = writes
-            .cache
-            .into_iter()
-            .map(|write| (write.0, write.1))
-            .collect();
-
-        OrderedReadsAndWrites {
-            ordered_writes,
-            ..Default::default()
-        }
-    }
-}
-
-impl<S: Storage> StateReaderAndWriter for AccessoryDelta<S> {
-    fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
-        let cache_key = key.to_cache_key_version(self.writes.version);
-        if let Some(value) = self.writes.cache.get(&cache_key) {
-            return value.clone().map(Into::into);
-        }
-        self.storage.get_accessory(key, self.writes.version)
-    }
-
-    fn set(&mut self, key: &StorageKey, value: StorageValue) {
-        self.writes.cache.insert(
-            key.to_cache_key_version(self.writes.version),
-            Some(value.into_cache_value()),
-        );
-    }
-
-    fn delete(&mut self, key: &StorageKey) {
-        self.writes
-            .cache
-            .insert(key.to_cache_key_version(self.writes.version), None);
-    }
-}
-
 struct OffchainDelta<S: Storage> {
     storage: S,
     witness: S::Witness,

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -398,8 +398,7 @@ impl<S: Storage> StateCheckpoint<S> {
     }
 
     /// Transforms this [`StateCheckpoint`] back into a [`WorkingSet`].
-    pub fn to_revertable(mut self) -> WorkingSet<S> {
-        self.delta.version = None;
+    pub fn to_revertable(self) -> WorkingSet<S> {
         WorkingSet {
             delta: self.delta,
             offchain_delta: RevertableWriter::new(self.offchain_delta, None),

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -401,7 +401,7 @@ impl<S: Storage> StateCheckpoint<S> {
     pub fn to_revertable(mut self) -> WorkingSet<S> {
         self.delta.version = None;
         WorkingSet {
-            delta: self.delta.revert(),
+            delta: self.delta,
             offchain_delta: RevertableWriter::new(self.offchain_delta, None),
             accessory_delta: RevertableWriter::new(self.accessory_delta, None),
             archival_working_set: None,

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -30,7 +30,7 @@ Delta<S: Storage>:
     version: Option<u64>
 */
 
-struct NewDelta<S: Storage> {
+struct StateDelta<S: Storage> {
     storage: S,
     cache_log: CacheLog,
     uncommitted_writes: BTreeMap<CacheKey, Option<CacheValue>>,
@@ -39,7 +39,7 @@ struct NewDelta<S: Storage> {
     version: Option<Version>,
 }
 
-impl<S: Storage> NewDelta<S> {
+impl<S: Storage> StateDelta<S> {
     fn new(storage: S, version: Option<Version>) -> Self {
         Self::with_witness(storage, Default::default(), version)
     }
@@ -84,7 +84,7 @@ impl<S: Storage> NewDelta<S> {
     }
 }
 
-impl<S: Storage> StateReaderAndWriter for NewDelta<S> {
+impl<S: Storage> StateReaderAndWriter for StateDelta<S> {
     fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
         let cache_key = key.to_cache_key_version(self.version);
 
@@ -371,7 +371,7 @@ impl<S: Storage> StateReaderAndWriter for OffchainDelta<S> {
 ///  1. With [`WorkingSet::checkpoint`].
 ///  2. With [`WorkingSet::revert`].
 pub struct StateCheckpoint<S: Storage> {
-    delta: NewDelta<S>,
+    delta: StateDelta<S>,
     accessory_delta: AccessoryDelta<S>,
     offchain_delta: OffchainDelta<S>,
 }
@@ -391,7 +391,7 @@ impl<S: Storage> StateCheckpoint<S> {
         offchain_witness: <S as Storage>::Witness,
     ) -> Self {
         Self {
-            delta: NewDelta::with_witness(inner.clone(), state_witness, None),
+            delta: StateDelta::with_witness(inner.clone(), state_witness, None),
             accessory_delta: AccessoryDelta::new(inner.clone(), None),
             offchain_delta: OffchainDelta::with_witness(inner, offchain_witness, None),
         }
@@ -444,7 +444,7 @@ impl<S: Storage> StateCheckpoint<S> {
 /// 1. By using the checkpoint() method, where all the changes are added to the underlying StateCheckpoint.
 /// 2. By using the revert method, where the most recent changes are reverted and the previous `StateCheckpoint` is returned.
 pub struct WorkingSet<S: Storage> {
-    delta: NewDelta<S>,
+    delta: StateDelta<S>,
     accessory_delta: RevertableWriter<AccessoryDelta<S>>,
     offchain_delta: RevertableWriter<OffchainDelta<S>>,
     archival_working_set: Option<ArchivalJmtWorkingSet<S>>,
@@ -643,7 +643,7 @@ pub mod archival_state {
 
     /// Archival JMT
     pub struct ArchivalJmtWorkingSet<S: Storage> {
-        delta: RevertableWriter<NewDelta<S>>,
+        delta: RevertableWriter<StateDelta<S>>,
     }
 
     impl<S: Storage> ArchivalJmtWorkingSet<S> {
@@ -651,7 +651,7 @@ pub mod archival_state {
         pub fn new(inner: &S, version: Version) -> Self {
             Self {
                 delta: RevertableWriter::new(
-                    NewDelta::new(inner.clone(), Some(version)),
+                    StateDelta::new(inner.clone(), Some(version)),
                     Some(version),
                 ),
             }

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -132,9 +132,7 @@ impl<S: Storage> AccessoryDelta<S> {
     }
 
     fn freeze(&mut self) -> OrderedReadsAndWrites {
-        let ordered_writes = mem::take(&mut self.committed_writes)
-            .into_iter()
-            .collect();
+        let ordered_writes = mem::take(&mut self.committed_writes).into_iter().collect();
 
         OrderedReadsAndWrites {
             ordered_reads: Vec::default(),

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -6,13 +6,118 @@ use core::{fmt, mem};
 use sov_rollup_interface::zk::StorageRootHash;
 
 use self::archival_state::ArchivalOffchainWorkingSet;
+use super::CacheLog;
 use crate::archival_state::{ArchivalAccessoryWorkingSet, ArchivalJmtWorkingSet};
 use crate::common::Prefix;
 use crate::storage::{
     CacheKey, CacheValue, EncodeKeyLike, NativeStorage, OrderedReadsAndWrites, StateCodec,
     StateValueCodec, Storage, StorageInternalCache, StorageKey, StorageProof, StorageValue,
 };
-use crate::{CacheMode, Version};
+use crate::{CacheMode, ValueExists, Version};
+
+/*
+JmtWorkingSet:
+    jmt_delta: JmtDelta
+
+OffchainWorkingSet:
+    offchain_delta: OffchainDelta
+
+Delta<S: Storage>:
+    storage: S
+    logs: CacheLog
+    uncommitted_writes: BTreeMap<CacheKey, Option<CacheValue>>
+    witness: S::Witness
+    version: Option<u64>
+*/
+
+struct NewDelta<S: Storage> {
+    storage: S,
+    cache_log: CacheLog,
+    uncommitted_writes: BTreeMap<CacheKey, Option<CacheValue>>,
+    ordered_storage_reads: Vec<(CacheKey, Option<CacheValue>)>,
+    witness: S::Witness,
+    version: Option<Version>,
+}
+
+impl<S: Storage> NewDelta<S> {
+    fn new(storage: S, version: Option<Version>) -> Self {
+        Self::with_witness(storage, Default::default(), version)
+    }
+
+    fn with_witness(storage: S, witness: S::Witness, version: Option<Version>) -> Self {
+        Self {
+            storage,
+            cache_log: CacheLog::default(),
+            uncommitted_writes: BTreeMap::default(),
+            ordered_storage_reads: Vec::default(),
+            witness,
+            version,
+        }
+    }
+
+    fn commit(mut self) -> Self {
+        let writes = mem::take(&mut self.uncommitted_writes);
+        for (key, value) in writes {
+            self.cache_log.add_write(key, value);
+        }
+        self
+    }
+
+    fn revert(mut self) -> Self {
+        self.uncommitted_writes.clear();
+        self
+    }
+
+    fn freeze(&mut self) -> (OrderedReadsAndWrites, S::Witness) {
+        let ordered_reads = mem::take(&mut self.ordered_storage_reads);
+        let ordered_writes = mem::take(&mut self.cache_log).take_writes();
+
+        let ordered_reads_writes = OrderedReadsAndWrites {
+            ordered_reads,
+            ordered_writes,
+        };
+        let witness = mem::take(&mut self.witness);
+
+        (ordered_reads_writes, witness)
+    }
+}
+
+impl<S: Storage> StateReaderAndWriter for NewDelta<S> {
+    fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
+        let cache_key = key.to_cache_key_version(self.version);
+
+        if let Some(value) = self.uncommitted_writes.get(&cache_key) {
+            return value.as_ref().cloned().map(Into::into);
+        }
+
+        match self.cache_log.get_value(&cache_key) {
+            ValueExists::Yes(value) => value.map(Into::into),
+            ValueExists::No => {
+                let storage_value = self.storage.get(key, self.version, &mut self.witness);
+                let cache_value = storage_value.as_ref().map(|v| v.clone().into_cache_value());
+
+                self.cache_log
+                    .add_read(cache_key.clone(), cache_value.clone())
+                    .expect("Read from CacheLog failed");
+                self.ordered_storage_reads.push((cache_key, cache_value));
+
+                storage_value
+            }
+        }
+    }
+
+    fn set(&mut self, key: &StorageKey, value: StorageValue) {
+        self.uncommitted_writes.insert(
+            key.to_cache_key_version(self.version),
+            Some(value.into_cache_value()),
+        );
+    }
+
+    fn delete(&mut self, key: &StorageKey) {
+        self.uncommitted_writes
+            .insert(key.to_cache_key_version(self.version), None);
+    }
+}
 
 /// A storage reader and writer
 pub trait StateReaderAndWriter {
@@ -313,7 +418,7 @@ impl<S: Storage> StateReaderAndWriter for OffchainDelta<S> {
 ///  1. With [`WorkingSet::checkpoint`].
 ///  2. With [`WorkingSet::revert`].
 pub struct StateCheckpoint<S: Storage> {
-    delta: Delta<S>,
+    delta: NewDelta<S>,
     accessory_delta: AccessoryDelta<S>,
     offchain_delta: OffchainDelta<S>,
 }
@@ -333,16 +438,17 @@ impl<S: Storage> StateCheckpoint<S> {
         offchain_witness: <S as Storage>::Witness,
     ) -> Self {
         Self {
-            delta: Delta::with_witness(inner.clone(), state_witness, None),
+            delta: NewDelta::with_witness(inner.clone(), state_witness, None),
             accessory_delta: AccessoryDelta::new(inner.clone(), None),
             offchain_delta: OffchainDelta::with_witness(inner, offchain_witness, None),
         }
     }
 
     /// Transforms this [`StateCheckpoint`] back into a [`WorkingSet`].
-    pub fn to_revertable(self) -> WorkingSet<S> {
+    pub fn to_revertable(mut self) -> WorkingSet<S> {
+        self.delta.version = None;
         WorkingSet {
-            delta: RevertableWriter::new(self.delta, None),
+            delta: self.delta.revert(),
             offchain_delta: RevertableWriter::new(self.offchain_delta, None),
             accessory_delta: RevertableWriter::new(self.accessory_delta, None),
             archival_working_set: None,
@@ -386,7 +492,7 @@ impl<S: Storage> StateCheckpoint<S> {
 /// 1. By using the checkpoint() method, where all the changes are added to the underlying StateCheckpoint.
 /// 2. By using the revert method, where the most recent changes are reverted and the previous `StateCheckpoint` is returned.
 pub struct WorkingSet<S: Storage> {
-    delta: RevertableWriter<Delta<S>>,
+    delta: NewDelta<S>,
     accessory_delta: RevertableWriter<AccessoryDelta<S>>,
     offchain_delta: RevertableWriter<OffchainDelta<S>>,
     archival_working_set: Option<ArchivalJmtWorkingSet<S>>,
@@ -427,7 +533,7 @@ impl<S: Storage> WorkingSet<S> {
 
     /// Returns a handler for the archival state (JMT state).
     fn archival_state(&mut self, version: Version) -> ArchivalJmtWorkingSet<S> {
-        ArchivalJmtWorkingSet::new(&self.delta.inner.inner, version)
+        ArchivalJmtWorkingSet::new(&self.delta.storage, version)
     }
 
     /// Returns a handler for the archival offchain state.
@@ -481,7 +587,7 @@ impl<S: Storage> WorkingSet<S> {
         S: NativeStorage,
     {
         // First inner is `RevertableWriter` and second inner is actually a `Storage` instance
-        self.delta.inner.inner.get_with_proof(key, version)
+        self.delta.storage.get_with_proof(key, version)
     }
 
     /// Get the root hash of the tree.
@@ -490,7 +596,7 @@ impl<S: Storage> WorkingSet<S> {
         S: NativeStorage,
     {
         // First inner is `RevertableWriter` and second inner is actually a `Storage` instance
-        self.delta.inner.inner.get_root_hash(version)
+        self.delta.storage.get_root_hash(version)
     }
 }
 
@@ -585,7 +691,7 @@ pub mod archival_state {
 
     /// Archival JMT
     pub struct ArchivalJmtWorkingSet<S: Storage> {
-        delta: RevertableWriter<Delta<S>>,
+        delta: RevertableWriter<NewDelta<S>>,
     }
 
     impl<S: Storage> ArchivalJmtWorkingSet<S> {
@@ -593,7 +699,7 @@ pub mod archival_state {
         pub fn new(inner: &S, version: Version) -> Self {
             Self {
                 delta: RevertableWriter::new(
-                    Delta::new(inner.clone(), Some(version)),
+                    NewDelta::new(inner.clone(), Some(version)),
                     Some(version),
                 ),
             }

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -71,6 +71,8 @@ impl<S: Storage> NewDelta<S> {
     fn freeze(&mut self) -> (OrderedReadsAndWrites, S::Witness) {
         let ordered_reads = mem::take(&mut self.ordered_storage_reads);
         let ordered_writes = mem::take(&mut self.cache_log).take_writes();
+        println!("ordered reads: {}", ordered_reads.len());
+        println!("ordered writes: {}", ordered_writes.len());
 
         let ordered_reads_writes = OrderedReadsAndWrites {
             ordered_reads,

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -121,14 +121,14 @@ impl<S: Storage> StateReaderAndWriter for StateDelta<S> {
     }
 }
 
-struct NewAccessoryDelta<S: Storage> {
+struct AccessoryDelta<S: Storage> {
     storage: S,
     committed_writes: BTreeMap<CacheKey, Option<CacheValue>>,
     uncommitted_writes: BTreeMap<CacheKey, Option<CacheValue>>,
     version: Option<Version>,
 }
 
-impl<S: Storage> NewAccessoryDelta<S> {
+impl<S: Storage> AccessoryDelta<S> {
     fn new(storage: S, version: Option<Version>) -> Self {
         Self {
             storage,
@@ -161,7 +161,7 @@ impl<S: Storage> NewAccessoryDelta<S> {
     }
 }
 
-impl<S: Storage> StateReaderAndWriter for NewAccessoryDelta<S> {
+impl<S: Storage> StateReaderAndWriter for AccessoryDelta<S> {
     fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
         let cache_key = key.to_cache_key_version(self.version);
 
@@ -377,7 +377,7 @@ impl<S: Storage> StateReaderAndWriter for OffchainDelta<S> {
 ///  2. With [`WorkingSet::revert`].
 pub struct StateCheckpoint<S: Storage> {
     delta: StateDelta<S>,
-    accessory_delta: NewAccessoryDelta<S>,
+    accessory_delta: AccessoryDelta<S>,
     offchain_delta: OffchainDelta<S>,
 }
 
@@ -397,7 +397,7 @@ impl<S: Storage> StateCheckpoint<S> {
     ) -> Self {
         Self {
             delta: StateDelta::with_witness(inner.clone(), state_witness, None),
-            accessory_delta: NewAccessoryDelta::new(inner.clone(), None),
+            accessory_delta: AccessoryDelta::new(inner.clone(), None),
             offchain_delta: OffchainDelta::with_witness(inner, offchain_witness, None),
         }
     }
@@ -450,7 +450,7 @@ impl<S: Storage> StateCheckpoint<S> {
 /// 2. By using the revert method, where the most recent changes are reverted and the previous `StateCheckpoint` is returned.
 pub struct WorkingSet<S: Storage> {
     delta: StateDelta<S>,
-    accessory_delta: NewAccessoryDelta<S>,
+    accessory_delta: AccessoryDelta<S>,
     offchain_delta: RevertableWriter<OffchainDelta<S>>,
     archival_working_set: Option<ArchivalJmtWorkingSet<S>>,
     archival_offchain_working_set: Option<ArchivalOffchainWorkingSet<S>>,
@@ -665,14 +665,14 @@ pub mod archival_state {
 
     /// Archival Accessory
     pub struct ArchivalAccessoryWorkingSet<S: Storage> {
-        delta: NewAccessoryDelta<S>,
+        delta: AccessoryDelta<S>,
     }
 
     impl<S: Storage> ArchivalAccessoryWorkingSet<S> {
         /// create a new instance of ArchivalAccessoryWorkingSet
         pub fn new(inner: &S, version: Version) -> Self {
             Self {
-                delta: NewAccessoryDelta::new(inner.clone(), Some(version)),
+                delta: AccessoryDelta::new(inner.clone(), Some(version)),
             }
         }
     }

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -1,7 +1,7 @@
 //! Runtime state machine definitions.
 
 use alloc::collections::BTreeMap;
-use core::{fmt, mem};
+use core::mem;
 
 use sov_rollup_interface::zk::StorageRootHash;
 
@@ -11,9 +11,9 @@ use crate::archival_state::{ArchivalAccessoryWorkingSet, ArchivalJmtWorkingSet};
 use crate::common::Prefix;
 use crate::storage::{
     CacheKey, CacheValue, EncodeKeyLike, NativeStorage, OrderedReadsAndWrites, StateCodec,
-    StateValueCodec, Storage, StorageInternalCache, StorageKey, StorageProof, StorageValue,
+    StateValueCodec, Storage, StorageKey, StorageProof, StorageValue,
 };
-use crate::{CacheMode, ValueExists, Version};
+use crate::{ValueExists, Version};
 
 /*
 JmtWorkingSet:
@@ -189,6 +189,95 @@ impl<S: Storage> StateReaderAndWriter for AccessoryDelta<S> {
     }
 }
 
+struct OffchainDelta<S: Storage> {
+    storage: S,
+    cache_log: CacheLog,
+    uncommitted_writes: BTreeMap<CacheKey, Option<CacheValue>>,
+    witness: S::Witness,
+    version: Option<Version>,
+}
+
+impl<S: Storage> OffchainDelta<S> {
+    fn new(storage: S, version: Option<Version>) -> Self {
+        Self::with_witness(storage, Default::default(), version)
+    }
+
+    fn with_witness(storage: S, witness: S::Witness, version: Option<Version>) -> Self {
+        Self {
+            storage,
+            cache_log: CacheLog::default(),
+            uncommitted_writes: BTreeMap::default(),
+            witness,
+            version,
+        }
+    }
+
+    fn commit(mut self) -> Self {
+        let writes = mem::take(&mut self.uncommitted_writes);
+        for (key, value) in writes {
+            self.cache_log.add_write(key, value);
+        }
+        self
+    }
+
+    fn revert(mut self) -> Self {
+        self.uncommitted_writes.clear();
+        self
+    }
+
+    fn freeze(&mut self) -> (OrderedReadsAndWrites, S::Witness) {
+        let ordered_writes = mem::take(&mut self.cache_log).take_writes();
+        println!("offchain ordered reads: 0");
+        println!("offchain ordered writes: {}", ordered_writes.len());
+
+        let ordered_reads_writes = OrderedReadsAndWrites {
+            ordered_reads: Vec::default(),
+            ordered_writes,
+        };
+        let witness = mem::take(&mut self.witness);
+
+        (ordered_reads_writes, witness)
+    }
+}
+
+impl<S: Storage> StateReaderAndWriter for OffchainDelta<S> {
+    fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
+        let cache_key = key.to_cache_key_version(self.version);
+
+        if let Some(value) = self.uncommitted_writes.get(&cache_key) {
+            return value.as_ref().cloned().map(Into::into);
+        }
+
+        match self.cache_log.get_value(&cache_key) {
+            ValueExists::Yes(value) => value.map(Into::into),
+            ValueExists::No => {
+                let storage_value = self
+                    .storage
+                    .get_offchain(key, self.version, &mut self.witness);
+                let cache_value = storage_value.as_ref().map(|v| v.clone().into_cache_value());
+
+                self.cache_log
+                    .add_read(cache_key.clone(), cache_value.clone())
+                    .expect("Read from CacheLog failed");
+
+                storage_value
+            }
+        }
+    }
+
+    fn set(&mut self, key: &StorageKey, value: StorageValue) {
+        self.uncommitted_writes.insert(
+            key.to_cache_key_version(self.version),
+            Some(value.into_cache_value()),
+        );
+    }
+
+    fn delete(&mut self, key: &StorageKey) {
+        self.uncommitted_writes
+            .insert(key.to_cache_key_version(self.version), None);
+    }
+}
+
 /// A storage reader and writer
 pub trait StateReaderAndWriter {
     /// Get a value from the storage.
@@ -321,55 +410,6 @@ pub trait StateReaderAndWriter {
     }
 }
 
-struct OffchainDelta<S: Storage> {
-    storage: S,
-    witness: S::Witness,
-    cache: StorageInternalCache,
-}
-
-impl<S: Storage> OffchainDelta<S> {
-    fn new(storage: S, version: Option<u64>) -> Self {
-        Self::with_witness(storage, Default::default(), version)
-    }
-
-    fn with_witness(storage: S, witness: S::Witness, version: Option<u64>) -> Self {
-        Self {
-            storage,
-            witness,
-            cache: StorageInternalCache::new(version, CacheMode::Offchain),
-        }
-    }
-
-    fn freeze(&mut self) -> (OrderedReadsAndWrites, S::Witness) {
-        let cache = mem::take(&mut self.cache);
-
-        let witness = mem::take(&mut self.witness);
-
-        // Since mem::take leaves Default::default() in place, we need to reset
-        // the cache mode to Offchain.
-        // TODO: change freeze signature to consume self
-
-        self.cache.mode = CacheMode::Offchain;
-
-        (cache.into(), witness)
-    }
-}
-
-impl<S: Storage> StateReaderAndWriter for OffchainDelta<S> {
-    fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
-        self.cache
-            .get_or_fetch(key, &self.storage, &mut self.witness)
-    }
-
-    fn set(&mut self, key: &StorageKey, value: StorageValue) {
-        self.cache.set(key, value)
-    }
-
-    fn delete(&mut self, key: &StorageKey) {
-        self.cache.delete(key)
-    }
-}
-
 /// This structure is responsible for storing the `read-write` set.
 ///
 /// A [`StateCheckpoint`] can be obtained from a [`WorkingSet`] in two ways:
@@ -406,7 +446,7 @@ impl<S: Storage> StateCheckpoint<S> {
     pub fn to_revertable(self) -> WorkingSet<S> {
         WorkingSet {
             delta: self.delta,
-            offchain_delta: RevertableWriter::new(self.offchain_delta, None),
+            offchain_delta: self.offchain_delta,
             accessory_delta: self.accessory_delta,
             archival_working_set: None,
             archival_accessory_working_set: None,
@@ -451,7 +491,7 @@ impl<S: Storage> StateCheckpoint<S> {
 pub struct WorkingSet<S: Storage> {
     delta: StateDelta<S>,
     accessory_delta: AccessoryDelta<S>,
-    offchain_delta: RevertableWriter<OffchainDelta<S>>,
+    offchain_delta: OffchainDelta<S>,
     archival_working_set: Option<ArchivalJmtWorkingSet<S>>,
     archival_offchain_working_set: Option<ArchivalOffchainWorkingSet<S>>,
     archival_accessory_working_set: Option<ArchivalAccessoryWorkingSet<S>>,
@@ -495,7 +535,7 @@ impl<S: Storage> WorkingSet<S> {
 
     /// Returns a handler for the archival offchain state.
     fn archival_offchain_state(&mut self, version: Version) -> ArchivalOffchainWorkingSet<S> {
-        ArchivalOffchainWorkingSet::new(&self.offchain_delta.inner.storage, version)
+        ArchivalOffchainWorkingSet::new(&self.offchain_delta.storage, version)
     }
 
     /// Returns a handler for the archival accessory state (non-JMT state).
@@ -648,17 +688,14 @@ pub mod archival_state {
 
     /// Archival JMT
     pub struct ArchivalJmtWorkingSet<S: Storage> {
-        delta: RevertableWriter<StateDelta<S>>,
+        delta: StateDelta<S>,
     }
 
     impl<S: Storage> ArchivalJmtWorkingSet<S> {
         /// create a new instance of ArchivalJmtWorkingSet
         pub fn new(inner: &S, version: Version) -> Self {
             Self {
-                delta: RevertableWriter::new(
-                    StateDelta::new(inner.clone(), Some(version)),
-                    Some(version),
-                ),
+                delta: StateDelta::new(inner.clone(), Some(version)),
             }
         }
     }
@@ -711,17 +748,14 @@ pub mod archival_state {
 
     /// Archival Offchain
     pub struct ArchivalOffchainWorkingSet<S: Storage> {
-        delta: RevertableWriter<OffchainDelta<S>>,
+        delta: OffchainDelta<S>,
     }
 
     impl<S: Storage> ArchivalOffchainWorkingSet<S> {
         /// create a new instance of ArchivalOffchainWorkingSet
         pub fn new(inner: &S, version: Version) -> Self {
             Self {
-                delta: RevertableWriter::new(
-                    OffchainDelta::new(inner.clone(), Some(version)),
-                    Some(version),
-                ),
+                delta: OffchainDelta::new(inner.clone(), Some(version)),
             }
         }
     }
@@ -742,70 +776,5 @@ pub mod archival_state {
         fn delete(&mut self, key: &StorageKey) {
             self.delta.delete(key)
         }
-    }
-}
-
-struct RevertableWriter<T> {
-    inner: T,
-    writes: BTreeMap<CacheKey, Option<CacheValue>>,
-    version: Option<u64>,
-}
-
-impl<T: fmt::Debug> fmt::Debug for RevertableWriter<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RevertableWriter")
-            .field("inner", &self.inner)
-            .finish()
-    }
-}
-
-impl<T> RevertableWriter<T>
-where
-    T: StateReaderAndWriter,
-{
-    fn new(inner: T, version: Option<u64>) -> Self {
-        Self {
-            inner,
-            writes: Default::default(),
-            version,
-        }
-    }
-
-    fn commit(mut self) -> T {
-        for (k, v) in self.writes.into_iter() {
-            if let Some(v) = v {
-                self.inner.set(&k.into(), v.into());
-            } else {
-                self.inner.delete(&k.into());
-            }
-        }
-
-        self.inner
-    }
-
-    fn revert(self) -> T {
-        self.inner
-    }
-}
-
-impl<T: StateReaderAndWriter> StateReaderAndWriter for RevertableWriter<T> {
-    fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
-        if let Some(value) = self.writes.get(&key.to_cache_key_version(self.version)) {
-            value.as_ref().cloned().map(Into::into)
-        } else {
-            self.inner.get(key)
-        }
-    }
-
-    fn set(&mut self, key: &StorageKey, value: StorageValue) {
-        self.writes.insert(
-            key.to_cache_key_version(self.version),
-            Some(value.into_cache_value()),
-        );
-    }
-
-    fn delete(&mut self, key: &StorageKey) {
-        self.writes
-            .insert(key.to_cache_key_version(self.version), None);
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -56,8 +56,6 @@ impl<S: Storage> StateDelta<S> {
     fn freeze(&mut self) -> (OrderedReadsAndWrites, S::Witness) {
         let ordered_reads = mem::take(&mut self.ordered_storage_reads);
         let ordered_writes = mem::take(&mut self.cache_log).take_writes();
-        println!("ordered reads: {}", ordered_reads.len());
-        println!("ordered writes: {}", ordered_writes.len());
 
         let ordered_reads_writes = OrderedReadsAndWrites {
             ordered_reads,
@@ -137,7 +135,6 @@ impl<S: Storage> AccessoryDelta<S> {
         let ordered_writes = mem::take(&mut self.committed_writes)
             .into_iter()
             .collect::<Vec<_>>();
-        println!("accessory ordered writes: {}", ordered_writes.len());
 
         OrderedReadsAndWrites {
             ordered_reads: Vec::default(),
@@ -212,8 +209,6 @@ impl<S: Storage> OffchainDelta<S> {
 
     fn freeze(&mut self) -> (OrderedReadsAndWrites, S::Witness) {
         let ordered_writes = mem::take(&mut self.cache_log).take_writes();
-        println!("offchain ordered reads: 0");
-        println!("offchain ordered writes: {}", ordered_writes.len());
 
         let ordered_reads_writes = OrderedReadsAndWrites {
             ordered_reads: Vec::default(),
@@ -242,7 +237,7 @@ impl<S: Storage> StateReaderAndWriter for OffchainDelta<S> {
                 let cache_value = storage_value.as_ref().map(|v| v.clone().into_cache_value());
 
                 self.cache_log
-                    .add_read(cache_key.clone(), cache_value.clone())
+                    .add_read(cache_key, cache_value)
                     .expect("Read from CacheLog failed");
 
                 storage_value
@@ -568,7 +563,7 @@ impl<S: Storage> WorkingSet<S> {
     where
         S: NativeStorage,
     {
-        // First inner is `RevertableWriter` and second inner is actually a `Storage` instance
+        // First inner is `R.clone()evertableWriter` and second inner is actually a `Storage` instance
         self.delta.storage.get_with_proof(key, version)
     }
 

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -121,6 +121,74 @@ impl<S: Storage> StateReaderAndWriter for StateDelta<S> {
     }
 }
 
+struct NewAccessoryDelta<S: Storage> {
+    storage: S,
+    committed_writes: BTreeMap<CacheKey, Option<CacheValue>>,
+    uncommitted_writes: BTreeMap<CacheKey, Option<CacheValue>>,
+    version: Option<Version>,
+}
+
+impl<S: Storage> NewAccessoryDelta<S> {
+    fn new(storage: S, version: Option<Version>) -> Self {
+        Self {
+            storage,
+            committed_writes: BTreeMap::default(),
+            uncommitted_writes: BTreeMap::default(),
+            version,
+        }
+    }
+
+    fn commit(mut self) -> Self {
+        self.committed_writes.append(&mut self.uncommitted_writes);
+        self
+    }
+
+    fn revert(mut self) -> Self {
+        self.uncommitted_writes.clear();
+        self
+    }
+
+    fn freeze(&mut self) -> OrderedReadsAndWrites {
+        let ordered_writes = mem::take(&mut self.committed_writes)
+            .into_iter()
+            .collect::<Vec<_>>();
+        println!("accessory ordered writes: {}", ordered_writes.len());
+
+        OrderedReadsAndWrites {
+            ordered_reads: Vec::default(),
+            ordered_writes,
+        }
+    }
+}
+
+impl<S: Storage> StateReaderAndWriter for NewAccessoryDelta<S> {
+    fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
+        let cache_key = key.to_cache_key_version(self.version);
+
+        if let Some(value) = self.uncommitted_writes.get(&cache_key) {
+            return value.as_ref().cloned().map(Into::into);
+        }
+
+        if let Some(value) = self.committed_writes.get(&cache_key) {
+            return value.as_ref().cloned().map(Into::into);
+        }
+
+        self.storage.get_accessory(key, self.version)
+    }
+
+    fn set(&mut self, key: &StorageKey, value: StorageValue) {
+        self.uncommitted_writes.insert(
+            key.to_cache_key_version(self.version),
+            Some(value.into_cache_value()),
+        );
+    }
+
+    fn delete(&mut self, key: &StorageKey) {
+        self.uncommitted_writes
+            .insert(key.to_cache_key_version(self.version), None);
+    }
+}
+
 /// A storage reader and writer
 pub trait StateReaderAndWriter {
     /// Get a value from the storage.
@@ -372,7 +440,7 @@ impl<S: Storage> StateReaderAndWriter for OffchainDelta<S> {
 ///  2. With [`WorkingSet::revert`].
 pub struct StateCheckpoint<S: Storage> {
     delta: StateDelta<S>,
-    accessory_delta: AccessoryDelta<S>,
+    accessory_delta: NewAccessoryDelta<S>,
     offchain_delta: OffchainDelta<S>,
 }
 
@@ -392,7 +460,7 @@ impl<S: Storage> StateCheckpoint<S> {
     ) -> Self {
         Self {
             delta: StateDelta::with_witness(inner.clone(), state_witness, None),
-            accessory_delta: AccessoryDelta::new(inner.clone(), None),
+            accessory_delta: NewAccessoryDelta::new(inner.clone(), None),
             offchain_delta: OffchainDelta::with_witness(inner, offchain_witness, None),
         }
     }
@@ -402,7 +470,7 @@ impl<S: Storage> StateCheckpoint<S> {
         WorkingSet {
             delta: self.delta,
             offchain_delta: RevertableWriter::new(self.offchain_delta, None),
-            accessory_delta: RevertableWriter::new(self.accessory_delta, None),
+            accessory_delta: self.accessory_delta,
             archival_working_set: None,
             archival_accessory_working_set: None,
             archival_offchain_working_set: None,
@@ -445,7 +513,7 @@ impl<S: Storage> StateCheckpoint<S> {
 /// 2. By using the revert method, where the most recent changes are reverted and the previous `StateCheckpoint` is returned.
 pub struct WorkingSet<S: Storage> {
     delta: StateDelta<S>,
-    accessory_delta: RevertableWriter<AccessoryDelta<S>>,
+    accessory_delta: NewAccessoryDelta<S>,
     offchain_delta: RevertableWriter<OffchainDelta<S>>,
     archival_working_set: Option<ArchivalJmtWorkingSet<S>>,
     archival_offchain_working_set: Option<ArchivalOffchainWorkingSet<S>>,
@@ -495,7 +563,7 @@ impl<S: Storage> WorkingSet<S> {
 
     /// Returns a handler for the archival accessory state (non-JMT state).
     fn archival_accessory_state(&mut self, version: Version) -> ArchivalAccessoryWorkingSet<S> {
-        ArchivalAccessoryWorkingSet::new(&self.accessory_delta.inner.storage, version)
+        ArchivalAccessoryWorkingSet::new(&self.accessory_delta.storage, version)
     }
 
     /// Sets archival version for a working set
@@ -660,17 +728,14 @@ pub mod archival_state {
 
     /// Archival Accessory
     pub struct ArchivalAccessoryWorkingSet<S: Storage> {
-        delta: RevertableWriter<AccessoryDelta<S>>,
+        delta: NewAccessoryDelta<S>,
     }
 
     impl<S: Storage> ArchivalAccessoryWorkingSet<S> {
         /// create a new instance of ArchivalAccessoryWorkingSet
         pub fn new(inner: &S, version: Version) -> Self {
             Self {
-                delta: RevertableWriter::new(
-                    AccessoryDelta::new(inner.clone(), Some(version)),
-                    Some(version),
-                ),
+                delta: NewAccessoryDelta::new(inner.clone(), Some(version)),
             }
         }
     }

--- a/crates/sovereign-sdk/module-system/sov-state/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/lib.rs
@@ -17,8 +17,7 @@ pub use zk_storage::ZkStorage;
 pub mod config;
 
 pub use sov_modules_core::{
-    storage, AlignedVec, CacheLog, OrderedReadsAndWrites, Prefix, Storage, StorageInternalCache,
-    Witness,
+    storage, AlignedVec, CacheLog, OrderedReadsAndWrites, Prefix, Storage, Witness,
 };
 
 pub use crate::witness::ArrayWitness;


### PR DESCRIPTION
# Description

Before it was:
WorkingSet -> RevertableWriter -> Delta -> StorageInternalCache -> CacheLog
now:
WorkingSet -> Delta -> CacheLog

Before:
StateCheckpoint -> Delta -> StorageInternalCache -> CacheLog
now:
StateCheckpoint -> Delta -> CacheLog

This PR removes couple of unnecessary layers which makes it harder to follow the path data is taking.

Also it makes both WorkingSet and StateCheckpoint to have Delta instead of WorkingSet having RevertableWriter and StateCheckpoint having Delta, which caused the version to be lost in case of calling `working_set.checkpoint().to_revertable()`. And the loss of version causes problems when trying to replay previous txs on historical blocks.

To make sure there are no changes, and it behaves exactly the same as before, I ran basic_proving_test and test_light_client_proving tests and observed that the ordered reads and writes of each corresponding deltas are equal.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
