### PR TITLE
Remove rev method on SchemaIterator

### DIFF
--- a/crates/sovereign-sdk/full-node/db/sov-schema-db/src/iterator.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-schema-db/src/iterator.rs
@@ -30,8 +30,11 @@ pub trait SeekKeyEncoder<S: Schema>: Sized {
     fn encode_seek_key(&self) -> crate::schema::Result<Vec<u8>>;
 }
 
-pub(crate) enum ScanDirection {
+/// The direction which is used with the iterator
+pub enum ScanDirection {
+    /// Going forward
     Forward,
+    /// Going backward
     Backward,
 }
 

--- a/crates/sovereign-sdk/full-node/db/sov-schema-db/src/iterator.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-schema-db/src/iterator.rs
@@ -83,19 +83,6 @@ where
         Ok(())
     }
 
-    /// Reverses iterator direction.
-    pub fn rev(self) -> Self {
-        let new_direction = match self.direction {
-            ScanDirection::Forward => ScanDirection::Backward,
-            ScanDirection::Backward => ScanDirection::Forward,
-        };
-        SchemaIterator {
-            db_iter: self.db_iter,
-            direction: new_direction,
-            phantom: Default::default(),
-        }
-    }
-
     fn next_impl(&mut self) -> Result<Option<IteratorOutput<S::Key, S::Value>>> {
         let start = Instant::now();
 

--- a/crates/sovereign-sdk/full-node/db/sov-schema-db/src/lib.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-schema-db/src/lib.rs
@@ -248,6 +248,13 @@ impl DB {
         self.iter_with_direction::<S>(read_options, ScanDirection::Forward)
     }
 
+    /// Returns a backward [`SchemaIterator`] on a certain schema with the default read options.
+    pub fn rev_iter<S: Schema>(&self) -> anyhow::Result<SchemaIterator<S>> {
+        let mut read_options = ReadOptions::default();
+        read_options.set_async_io(true);
+        self.iter_with_direction::<S>(read_options, ScanDirection::Backward)
+    }
+
     /// Drops a column family from the database.
     pub fn drop_cf(&mut self, cf_name: &str) -> anyhow::Result<()> {
         Ok(self.inner.drop_cf(cf_name)?)

--- a/crates/sovereign-sdk/full-node/db/sov-schema-db/src/lib.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-schema-db/src/lib.rs
@@ -27,8 +27,7 @@ use std::time::Instant;
 
 use ::metrics::{gauge, histogram};
 use anyhow::format_err;
-pub use iterator::ScanDirection;
-pub use iterator::{RawDbReverseIterator, SchemaIterator, SeekKeyEncoder};
+pub use iterator::{RawDbReverseIterator, ScanDirection, SchemaIterator, SeekKeyEncoder};
 pub use rocksdb;
 pub use rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
 use rocksdb::{DBIterator, ReadOptions};

--- a/crates/sovereign-sdk/full-node/db/sov-schema-db/src/lib.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-schema-db/src/lib.rs
@@ -27,7 +27,7 @@ use std::time::Instant;
 
 use ::metrics::{gauge, histogram};
 use anyhow::format_err;
-use iterator::ScanDirection;
+pub use iterator::ScanDirection;
 pub use iterator::{RawDbReverseIterator, SchemaIterator, SeekKeyEncoder};
 pub use rocksdb;
 pub use rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
@@ -229,7 +229,8 @@ impl DB {
         Ok(())
     }
 
-    fn iter_with_direction<S: Schema>(
+    /// Returns a [`SchemaIterator`] on a certain schema with the provided read options and direction.
+    pub fn iter_with_direction<S: Schema>(
         &self,
         opts: ReadOptions,
         direction: ScanDirection,
@@ -246,13 +247,6 @@ impl DB {
         let mut read_options = ReadOptions::default();
         read_options.set_async_io(true);
         self.iter_with_direction::<S>(read_options, ScanDirection::Forward)
-    }
-
-    /// Returns a backward [`SchemaIterator`] on a certain schema with the default read options.
-    pub fn rev_iter<S: Schema>(&self) -> anyhow::Result<SchemaIterator<S>> {
-        let mut read_options = ReadOptions::default();
-        read_options.set_async_io(true);
-        self.iter_with_direction::<S>(read_options, ScanDirection::Backward)
     }
 
     /// Drops a column family from the database.

--- a/crates/sovereign-sdk/full-node/db/sov-schema-db/tests/iterator_test.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-schema-db/tests/iterator_test.rs
@@ -87,7 +87,7 @@ impl TestDB {
     }
 
     fn rev_iter(&self) -> SchemaIterator<S> {
-        self.db.iter().expect("Failed to create iterator.").rev()
+        self.db.rev_iter().expect("Failed to create iterator.")
     }
 }
 

--- a/crates/sovereign-sdk/full-node/db/sov-schema-db/tests/iterator_test.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-schema-db/tests/iterator_test.rs
@@ -3,13 +3,13 @@
 
 use std::sync::{Arc, RwLock};
 
-use rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
+use rocksdb::{ReadOptions, DEFAULT_COLUMN_FAMILY_NAME};
 use sov_schema_db::schema::{KeyDecoder, KeyEncoder, ValueCodec};
 use sov_schema_db::snapshot::{DbSnapshot, ReadOnlyLock, SingleSnapshotQueryManager};
 use sov_schema_db::test::{KeyPrefix1, KeyPrefix2, TestCompositeField, TestField};
 use sov_schema_db::{
-    define_schema, Operation, RawRocksdbOptions, Schema, SchemaBatch, SchemaIterator,
-    SeekKeyEncoder, DB,
+    define_schema, Operation, RawRocksdbOptions, ScanDirection, Schema, SchemaBatch,
+    SchemaIterator, SeekKeyEncoder, DB,
 };
 use tempfile::TempDir;
 
@@ -87,7 +87,11 @@ impl TestDB {
     }
 
     fn rev_iter(&self) -> SchemaIterator<S> {
-        self.db.rev_iter().expect("Failed to create iterator.")
+        let mut read_options = ReadOptions::default();
+        read_options.set_async_io(true);
+        self.db
+            .iter_with_direction::<S>(read_options, ScanDirection::Backward)
+            .expect("Failed to create iterator.")
     }
 }
 


### PR DESCRIPTION
# Description

- Remove `rev` method on SchemaIterator. 
Cannot think of a use case for us to iterate in one direction then back. Make public and use iter_with_direction which returns a SchemaIterator with selected direction
