### PR TITLE
make StateDiff RefCount to avoid cache key/value clone in zk

### DIFF
--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -26,6 +26,7 @@ use sov_ledger_rpc::LedgerRpcClient;
 use sov_rollup_interface::da::{BatchProofMethodId, DaTxRequest};
 use sov_rollup_interface::rpc::BatchProofMethodIdRpcResponse;
 use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
+use sov_rollup_interface::zk::batch_proof::output::CumulativeStateDiff;
 
 use super::batch_prover_test::wait_for_zkproofs;
 use super::get_citrea_path;
@@ -1307,7 +1308,7 @@ async fn test_verify_chunked_txs_in_light_client() -> Result<()> {
         .await
 }
 
-pub fn create_random_state_diff(size_in_kb: u64) -> BTreeMap<Vec<u8>, Option<Vec<u8>>> {
+pub(crate) fn create_random_state_diff(size_in_kb: u64) -> BTreeMap<Arc<[u8]>, Option<Arc<[u8]>>> {
     let mut rng = thread_rng();
     let mut map = BTreeMap::new();
     let mut total_size: u64 = 0;
@@ -1335,7 +1336,10 @@ pub fn create_random_state_diff(size_in_kb: u64) -> BTreeMap<Vec<u8>, Option<Vec
         };
 
         // Add to the map
-        map.insert(key, value);
+        map.insert(
+            Arc::from(key.into_boxed_slice()),
+            value.map(|v| Arc::from(v.into_boxed_slice())),
+        );
 
         // Update the total size
         total_size += key_size + value_size;
@@ -1349,7 +1353,7 @@ fn create_serialized_fake_receipt_batch_proof(
     final_state_root: [u8; 32],
     last_l2_height: u64,
     method_id: [u32; 8],
-    state_diff: Option<BTreeMap<Vec<u8>, Option<Vec<u8>>>>,
+    state_diff: Option<CumulativeStateDiff>,
     malformed_journal: bool,
 ) -> Vec<u8> {
     let batch_proof_output = BatchProofCircuitOutputV3 {

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use sov_db::ledger_db::SharedLedgerOps;
 use sov_db::schema::types::SoftConfirmationNumber;
@@ -11,7 +12,7 @@ use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::stf::{SoftConfirmationReceipt, StateDiff, TransactionDigest};
 
 pub fn merge_state_diffs(old_diff: StateDiff, new_diff: StateDiff) -> StateDiff {
-    let mut new_diff_map = HashMap::<Vec<u8>, Option<Vec<u8>>>::from_iter(old_diff);
+    let mut new_diff_map: HashMap<Arc<[u8]>, Option<Arc<[u8]>>> = HashMap::from_iter(old_diff);
 
     new_diff_map.extend(new_diff);
     new_diff_map.into_iter().collect()

--- a/crates/sovereign-sdk/full-node/db/sov-db/benches/state_db_bench.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/benches/state_db_bench.rs
@@ -62,7 +62,7 @@ fn prepare_data(size: usize) -> TestData {
         let key = &chunk[0];
         let value = chunk[1].clone();
         let key_hash = KeyHash::with::<sha2::Sha256>(&key);
-        key_preimages.push((key_hash, key));
+        key_preimages.push((key_hash, key.as_slice()));
         batch.push((key_hash, Some(value)));
     }
 

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/native_db.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/native_db.rs
@@ -5,7 +5,6 @@ use sov_schema_db::{SchemaBatch, DB};
 
 use crate::rocks_db_config::RocksdbConfig;
 use crate::schema::tables::{ModuleAccessoryState, NATIVE_TABLES};
-use crate::schema::types::AccessoryKey;
 
 /// Specifies a particular version of the Accessory state.
 pub type Version = u64;
@@ -54,7 +53,7 @@ impl NativeDB {
     /// Queries for a value in the [`NativeDB`], given a key.
     pub fn get_value_option(
         &self,
-        key: &AccessoryKey,
+        key: &[u8],
         version: Version,
     ) -> anyhow::Result<Option<Vec<u8>>> {
         let found = self
@@ -62,7 +61,7 @@ impl NativeDB {
             .get_prev::<ModuleAccessoryState>(&(key.to_vec(), version))?;
         match found {
             Some(((found_key, found_version), value)) => {
-                if &found_key == key {
+                if found_key == key {
                     anyhow::ensure!(found_version <= version, "Bug! iterator isn't returning expected values. expected a version <= {version:} but found {found_version:}");
                     Ok(value)
                 } else {

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/native_db.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/native_db.rs
@@ -5,6 +5,7 @@ use sov_schema_db::{SchemaBatch, DB};
 
 use crate::rocks_db_config::RocksdbConfig;
 use crate::schema::tables::{ModuleAccessoryState, NATIVE_TABLES};
+use crate::schema::types::StateKeyRef;
 
 /// Specifies a particular version of the Accessory state.
 pub type Version = u64;
@@ -53,7 +54,7 @@ impl NativeDB {
     /// Queries for a value in the [`NativeDB`], given a key.
     pub fn get_value_option(
         &self,
-        key: &[u8],
+        key: StateKeyRef,
         version: Version,
     ) -> anyhow::Result<Option<Vec<u8>>> {
         let found = self

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/mod.rs
@@ -19,6 +19,7 @@ pub type DbHash = [u8; 32];
 /// The "value" half of a key/value pair from the JMT
 pub type JmtValue = Option<Vec<u8>>;
 pub(crate) type StateKey = Vec<u8>;
+pub(crate) type StateKeyRef<'a> = &'a [u8];
 
 /// The range of L2 heights (soft confirmations) for a given L1 block
 /// (start, end) inclusive

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/state_db.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/state_db.rs
@@ -8,6 +8,7 @@ use sov_schema_db::{SchemaBatch, DB};
 
 use crate::rocks_db_config::RocksdbConfig;
 use crate::schema::tables::{JmtNodes, JmtValues, KeyHashToKey, StaleNodes, STATE_TABLES};
+use crate::schema::types::StateKeyRef;
 
 /// A typed wrapper around the db for storing rollup state. Internally,
 /// this is roughly just an [`Arc<sov_schema_db::DB>`] with pointer to list of non-finalized writes.
@@ -72,7 +73,7 @@ impl StateDB {
     /// since the DB is unaware of the hash function used by the JMT.
     pub fn put_preimages<'a>(
         &self,
-        items: impl IntoIterator<Item = (KeyHash, &'a [u8])>,
+        items: impl IntoIterator<Item = (KeyHash, StateKeyRef<'a>)>,
     ) -> Result<(), anyhow::Error> {
         let mut batch = SchemaBatch::new();
         for (key_hash, key) in items.into_iter() {
@@ -86,7 +87,7 @@ impl StateDB {
     pub fn get_value_option_by_key(
         &self,
         version: Version,
-        key: &[u8],
+        key: StateKeyRef,
     ) -> anyhow::Result<Option<jmt::OwnedValue>> {
         let found = self.db.get_prev::<JmtValues>(&(&key, version))?;
         match found {

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/state_db.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/state_db.rs
@@ -8,7 +8,6 @@ use sov_schema_db::{SchemaBatch, DB};
 
 use crate::rocks_db_config::RocksdbConfig;
 use crate::schema::tables::{JmtNodes, JmtValues, KeyHashToKey, StaleNodes, STATE_TABLES};
-use crate::schema::types::StateKey;
 
 /// A typed wrapper around the db for storing rollup state. Internally,
 /// this is roughly just an [`Arc<sov_schema_db::DB>`] with pointer to list of non-finalized writes.
@@ -73,11 +72,11 @@ impl StateDB {
     /// since the DB is unaware of the hash function used by the JMT.
     pub fn put_preimages<'a>(
         &self,
-        items: impl IntoIterator<Item = (KeyHash, &'a Vec<u8>)>,
+        items: impl IntoIterator<Item = (KeyHash, &'a [u8])>,
     ) -> Result<(), anyhow::Error> {
         let mut batch = SchemaBatch::new();
         for (key_hash, key) in items.into_iter() {
-            batch.put::<KeyHashToKey>(&key_hash.0, key)?;
+            batch.put::<KeyHashToKey>(&key_hash.0, &key.to_vec())?;
         }
         self.db.write_many(batch)?;
         Ok(())
@@ -87,12 +86,12 @@ impl StateDB {
     pub fn get_value_option_by_key(
         &self,
         version: Version,
-        key: &StateKey,
+        key: &[u8],
     ) -> anyhow::Result<Option<jmt::OwnedValue>> {
         let found = self.db.get_prev::<JmtValues>(&(&key, version))?;
         match found {
             Some(((found_key, found_version), value)) => {
-                if &found_key == key {
+                if found_key == key {
                     anyhow::ensure!(found_version <= version, "Bug! iterator isn't returning expected values. expected a version <= {version:} but found {found_version:}");
                     Ok(value)
                 } else {
@@ -188,7 +187,7 @@ mod state_db_tests {
         let key = vec![2u8; 100];
         let value = [8u8; 150];
 
-        db.put_preimages(vec![(key_hash, &key)]).unwrap();
+        db.put_preimages(vec![(key_hash, key.as_slice())]).unwrap();
         let mut batch = NodeBatch::default();
         batch.extend(vec![], vec![((0, key_hash), Some(value.to_vec()))]);
         db.write_node_batch(&batch).unwrap();

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/cache.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/cache.rs
@@ -12,7 +12,7 @@ use crate::common::{MergeError, ReadError};
 #[derive(Debug, Eq, PartialEq, Clone, Hash, PartialOrd, Ord)]
 pub struct CacheKey {
     /// The key of the cache entry.
-    pub key: RefCount<Vec<u8>>,
+    pub key: RefCount<[u8]>,
 }
 
 impl fmt::Display for CacheKey {
@@ -26,7 +26,7 @@ impl fmt::Display for CacheKey {
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct CacheValue {
     /// The value of the cache entry.
-    pub value: RefCount<Vec<u8>>,
+    pub value: RefCount<[u8]>,
 }
 
 impl fmt::Display for CacheValue {
@@ -375,13 +375,13 @@ mod tests {
 
     pub fn create_key(key: u8) -> CacheKey {
         CacheKey {
-            key: RefCount::new(alloc::vec![key]),
+            key: RefCount::from(alloc::vec![key]),
         }
     }
 
     pub fn create_value(v: u8) -> Option<CacheValue> {
         Some(CacheValue {
-            value: RefCount::new(alloc::vec![v]),
+            value: RefCount::from(alloc::vec![v]),
         })
     }
 

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/mod.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/mod.rs
@@ -29,7 +29,7 @@ pub use scratchpad::*;
     derive(Serialize, serde::Deserialize, BorshDeserialize, BorshSerialize)
 )]
 pub struct StorageKey {
-    key: RefCount<Vec<u8>>,
+    key: RefCount<[u8]>,
 }
 
 impl From<CacheKey> for StorageKey {
@@ -40,7 +40,7 @@ impl From<CacheKey> for StorageKey {
 
 impl StorageKey {
     /// Returns a new [`RefCount`] reference to the bytes of this key.
-    pub fn key(&self) -> RefCount<Vec<u8>> {
+    pub fn key(&self) -> RefCount<[u8]> {
         self.key.clone()
     }
 
@@ -59,9 +59,9 @@ impl StorageKey {
             },
             Some(v) => {
                 let mut bytes = v.to_be_bytes().to_vec();
-                bytes.extend((*self.key).clone());
+                bytes.extend_from_slice(&self.key);
                 CacheKey {
-                    key: RefCount::new(bytes),
+                    key: RefCount::from(bytes),
                 }
             }
         }
@@ -73,8 +73,8 @@ impl StorageKey {
     }
 }
 
-impl AsRef<Vec<u8>> for StorageKey {
-    fn as_ref(&self) -> &Vec<u8> {
+impl AsRef<[u8]> for StorageKey {
+    fn as_ref(&self) -> &[u8] {
         &self.key
     }
 }
@@ -101,14 +101,14 @@ impl StorageKey {
         full_key.extend(&encoded_key);
 
         Self {
-            key: RefCount::new(full_key.into_inner()),
+            key: RefCount::from(full_key.into_inner()),
         }
     }
 
     /// Creates a new [`StorageKey`] that combines a prefix and a key.
     pub fn singleton(prefix: &Prefix) -> Self {
         Self {
-            key: RefCount::new(prefix.as_aligned_vec().clone().into_inner()),
+            key: RefCount::from(prefix.as_aligned_vec().clone().into_inner()),
         }
     }
 }
@@ -121,7 +121,7 @@ impl StorageKey {
     derive(Serialize, serde::Deserialize, BorshDeserialize, BorshSerialize)
 )]
 pub struct StorageValue {
-    value: RefCount<Vec<u8>>,
+    value: RefCount<[u8]>,
 }
 
 impl From<CacheValue> for StorageValue {
@@ -135,7 +135,7 @@ impl From<CacheValue> for StorageValue {
 impl From<Vec<u8>> for StorageValue {
     fn from(value: Vec<u8>) -> Self {
         Self {
-            value: RefCount::new(value),
+            value: RefCount::from(value),
         }
     }
 }
@@ -148,7 +148,7 @@ impl StorageValue {
     {
         let encoded_value = codec.encode_value(value);
         Self {
-            value: RefCount::new(encoded_value),
+            value: RefCount::from(encoded_value),
         }
     }
 
@@ -289,7 +289,7 @@ pub trait Storage: Clone {
 impl From<&str> for StorageKey {
     fn from(key: &str) -> Self {
         Self {
-            key: RefCount::new(key.as_bytes().to_vec()),
+            key: RefCount::from(key.as_bytes()),
         }
     }
 }
@@ -298,7 +298,7 @@ impl From<&str> for StorageKey {
 impl From<&str> for StorageValue {
     fn from(value: &str) -> Self {
         Self {
-            value: RefCount::new(value.as_bytes().to_vec()),
+            value: RefCount::from(value.as_bytes()),
         }
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-state/src/zk_storage.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/zk_storage.rs
@@ -6,7 +6,6 @@ use sov_modules_core::{
 };
 use sov_rollup_interface::stf::{StateDiff, StateRootTransition};
 use sov_rollup_interface::zk::StorageRootHash;
-use sov_rollup_interface::RefCount;
 
 use crate::DefaultHasher;
 
@@ -89,9 +88,8 @@ where
             .map(|(key, value)| {
                 let key_hash = KeyHash::with::<DefaultHasher>(key.key.as_ref());
 
-                let key_bytes = RefCount::try_unwrap(key.key).unwrap_or_else(|arc| (*arc).clone());
-                let value_bytes = value
-                    .map(|v| RefCount::try_unwrap(v.value).unwrap_or_else(|arc| (*arc).clone()));
+                let key_bytes = key.key.clone();
+                let value_bytes = value.map(|v| v.value.clone());
 
                 diff.push((key_bytes, value_bytes.clone()));
 

--- a/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
@@ -13,6 +13,7 @@ use crate::mmr::MMRGuest;
 use crate::soft_confirmation::SignedSoftConfirmation;
 use crate::zk::batch_proof::output::CumulativeStateDiff;
 use crate::zk::light_client_proof::output::BatchProofInfo;
+use crate::RefCount;
 
 /// A struct containing enough information to uniquely specify single batch.
 
@@ -405,7 +406,7 @@ where
                     }
                     None => None,
                 };
-                btree_map.insert(key, value);
+                btree_map.insert(RefCount::from(key), value.map(RefCount::from));
             }
             Ok(btree_map)
         }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
@@ -16,6 +16,7 @@ use crate::fork::Fork;
 use crate::soft_confirmation::SignedSoftConfirmation;
 use crate::spec::SpecId;
 use crate::zk::batch_proof::output::CumulativeStateDiff;
+use crate::RefCount;
 
 /// The configuration of a full node of the rollup which creates zk proofs.
 pub struct ProverConfig;
@@ -84,7 +85,7 @@ pub struct SoftConfirmationReceipt<DS: DaSpec> {
 }
 
 /// A diff of the state, represented as a list of key-value pairs.
-pub type StateDiff = Vec<(Vec<u8>, Option<Vec<u8>>)>;
+pub type StateDiff = Vec<(RefCount<[u8]>, Option<RefCount<[u8]>>)>;
 
 /// Helper struct which contains initial and final state roots.
 pub struct StateRootTransition {

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/mod.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use crate::RefCount;
+
 /// Genesis output module
 pub mod v1;
 /// Kumquat output module
@@ -8,4 +10,4 @@ pub mod v2;
 pub mod v3;
 
 /// State diff produced by the Zk proof
-pub type CumulativeStateDiff = BTreeMap<Vec<u8>, Option<Vec<u8>>>;
+pub type CumulativeStateDiff = BTreeMap<RefCount<[u8]>, Option<RefCount<[u8]>>>;


### PR DESCRIPTION
# Description

We collect StateDiff in zk to return it as output, so we only need to serialize it. Hence, we actually can we avoid cloning the keys and values just to collect them into a StateDiff. Hence my first idea was to wrap the StateDiff key and values with `RefCount` (Arc in native Rc in zk), so it became Arc<Vec<u8>>. Another improvement I saw was that, we don't need to Arc<Vec<u8>> if the key or values aren't going to change and we can just simplify it to Arc<[u8]>, this also brought changes to CacheKey and CacheValue obviously.

Will post cycle bench.

nightly (15.2 billion total cycles):
```
2025-02-17T15:25:39.861345Z  INFO risc0_zkvm::host::server::exec::executor: execution time: 728.919246167s
2025-02-17T15:25:39.861368Z  INFO risc0_zkvm::host::server::session: number of segments: 14533
2025-02-17T15:25:39.861370Z  INFO risc0_zkvm::host::server::session: 15238955008 total cycles
2025-02-17T15:25:39.861371Z  INFO risc0_zkvm::host::server::session: 5943691314 user cycles (39.00%)
2025-02-17T15:25:39.861374Z  INFO risc0_zkvm::host::server::session: 9237267430 paging cycles (60.62%)
2025-02-17T15:25:39.861375Z  INFO risc0_zkvm::host::server::session: 57996264 reserved cycles (0.38%)
2025-02-17T15:25:39.861376Z  INFO risc0_zkvm::host::server::session: ecalls
2025-02-17T15:25:39.861378Z  INFO risc0_zkvm::host::server::session:    4783875 BigInt2 calls, 633060444 cycles, (4.15%)
2025-02-17T15:25:39.861405Z  INFO risc0_zkvm::host::server::session:    1614223 Sha2 calls, 121798366 cycles, (0.80%)
2025-02-17T15:25:39.861407Z  INFO risc0_zkvm::host::server::session:    7793922 BigInt calls, 77939220 cycles, (0.51%)
2025-02-17T15:25:39.861408Z  INFO risc0_zkvm::host::server::session:    158189 Software calls, 2626538 cycles, (0.02%)
2025-02-17T15:25:39.861410Z  INFO risc0_zkvm::host::server::session:    0 Input calls, 0 cycles, (0.00%)
2025-02-17T15:25:39.861411Z  INFO risc0_zkvm::host::server::session: syscalls
2025-02-17T15:25:39.861413Z  INFO risc0_zkvm::host::server::session:    130470 Keccak calls
2025-02-17T15:25:39.861415Z  INFO risc0_zkvm::host::server::session:    27275 Read calls
2025-02-17T15:25:39.861416Z  INFO risc0_zkvm::host::server::session:    200 VerifyIntegrity calls
2025-02-17T15:25:39.861550Z  INFO risc0_zkvm::host::server::session:    200 ProveKeccak calls
2025-02-17T15:25:39.861552Z  INFO risc0_zkvm::host::server::session:    41 Write calls
```

yaziciahmet/rm-cache-value-clone (14.3 billion total cycles):
```
2025-02-17T15:19:10.616017Z  INFO risc0_zkvm::host::server::exec::executor: execution time: 723.004571333s
2025-02-17T15:19:10.616174Z  INFO risc0_zkvm::host::server::session: number of segments: 13684
2025-02-17T15:19:10.616177Z  INFO risc0_zkvm::host::server::session: 14348713984 total cycles
2025-02-17T15:19:10.616179Z  INFO risc0_zkvm::host::server::session: 5938556427 user cycles (41.39%)
2025-02-17T15:19:10.616181Z  INFO risc0_zkvm::host::server::session: 8356524914 paging cycles (58.24%)
2025-02-17T15:19:10.616183Z  INFO risc0_zkvm::host::server::session: 53632643 reserved cycles (0.37%)
2025-02-17T15:19:10.616184Z  INFO risc0_zkvm::host::server::session: ecalls
2025-02-17T15:19:10.616186Z  INFO risc0_zkvm::host::server::session:    4783875 BigInt2 calls, 633060444 cycles, (4.41%)
2025-02-17T15:19:10.616200Z  INFO risc0_zkvm::host::server::session:    1614223 Sha2 calls, 121798366 cycles, (0.85%)
2025-02-17T15:19:10.616202Z  INFO risc0_zkvm::host::server::session:    7793922 BigInt calls, 77939220 cycles, (0.54%)
2025-02-17T15:19:10.616203Z  INFO risc0_zkvm::host::server::session:    158189 Software calls, 2626538 cycles, (0.02%)
2025-02-17T15:19:10.616205Z  INFO risc0_zkvm::host::server::session:    0 Input calls, 0 cycles, (0.00%)
2025-02-17T15:19:10.616206Z  INFO risc0_zkvm::host::server::session: syscalls
2025-02-17T15:19:10.616208Z  INFO risc0_zkvm::host::server::session:    130470 Keccak calls
2025-02-17T15:19:10.616209Z  INFO risc0_zkvm::host::server::session:    27275 Read calls
2025-02-17T15:19:10.616210Z  INFO risc0_zkvm::host::server::session:    200 VerifyIntegrity calls
2025-02-17T15:19:10.616242Z  INFO risc0_zkvm::host::server::session:    200 ProveKeccak calls
2025-02-17T15:19:10.616244Z  INFO risc0_zkvm::host::server::session:    41 Write calls
```

It is about 6% total cycle drop, although it is mainly coming from paging.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
