### PR TITLE
Enhance Prefix extended method

### DIFF
--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/common/bytes.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/common/bytes.rs
@@ -136,9 +136,11 @@ impl Prefix {
     /// Returns a new prefix allocated on the fly, by extending the current
     /// prefix with the given bytes.
     pub fn extended(&self, bytes: &[u8]) -> Self {
-        let mut prefix = self.clone();
-        prefix.extend(bytes.iter().copied());
-        prefix
+        let mut new_prefix = Vec::with_capacity(self.len() + bytes.len());
+        new_prefix.extend_from_slice(self.as_aligned_vec().as_ref());
+        new_prefix.extend_from_slice(bytes);
+
+        Self::new(new_prefix)
     }
 }
 


### PR DESCRIPTION
# Description

- Reduces realloc 

Nightly as of `3bc6027bf5d4c5f7fe20b97702de46aeb6d6ce17` :

```
2025-02-17T21:53:05.884519Z  INFO risc0_zkvm::host::server::session: number of segments: 14457
2025-02-17T21:53:05.884524Z  INFO risc0_zkvm::host::server::session: 15159263232 total cycles
2025-02-17T21:53:05.884535Z  INFO risc0_zkvm::host::server::session: 5895111682 user cycles (38.89%)
2025-02-17T21:53:05.884537Z  INFO risc0_zkvm::host::server::session: 9207003276 paging cycles (60.74%)
2025-02-17T21:53:05.884538Z  INFO risc0_zkvm::host::server::session: 57148274 reserved cycles (0.38%)
2025-02-17T21:53:05.884539Z  INFO risc0_zkvm::host::server::session: ecalls
2025-02-17T21:53:05.884541Z  INFO risc0_zkvm::host::server::session:    4777331 BigInt2 calls, 632198515 cycles, (4.17%)
2025-02-17T21:53:05.884718Z  INFO risc0_zkvm::host::server::session:    1575718 Sha2 calls, 118949064 cycles, (0.78%)
2025-02-17T21:53:05.884719Z  INFO risc0_zkvm::host::server::session:    7781511 BigInt calls, 77815110 cycles, (0.51%)
2025-02-17T21:53:05.884720Z  INFO risc0_zkvm::host::server::session:    155658 Software calls, 2573989 cycles, (0.02%)
2025-02-17T21:53:05.884721Z  INFO risc0_zkvm::host::server::session:    0 Input calls, 0 cycles, (0.00%)
2025-02-17T21:53:05.884723Z  INFO risc0_zkvm::host::server::session: syscalls
2025-02-17T21:53:05.884724Z  INFO risc0_zkvm::host::server::session:    129337 Keccak calls
2025-02-17T21:53:05.884726Z  INFO risc0_zkvm::host::server::session:    25881 Read calls
2025-02-17T21:53:05.884727Z  INFO risc0_zkvm::host::server::session:    198 VerifyIntegrity calls
2025-02-17T21:53:05.884728Z  INFO risc0_zkvm::host::server::session:    198 ProveKeccak calls
2025-02-17T21:53:05.884729Z  INFO risc0_zkvm::host::server::session:    41 Write calls
```

This PR :

```
2025-02-17T21:11:24.899870Z  INFO risc0_zkvm::host::server::session: number of segments: 14251
2025-02-17T21:11:24.899877Z  INFO risc0_zkvm::host::server::session: 14943256576 total cycles
2025-02-17T21:11:24.899890Z  INFO risc0_zkvm::host::server::session: 5858315993 user cycles (39.20%)
2025-02-17T21:11:24.899892Z  INFO risc0_zkvm::host::server::session: 9028562078 paging cycles (60.42%)
2025-02-17T21:11:24.899893Z  INFO risc0_zkvm::host::server::session: 56378505 reserved cycles (0.38%)
2025-02-17T21:11:24.899894Z  INFO risc0_zkvm::host::server::session: ecalls
2025-02-17T21:11:24.899898Z  INFO risc0_zkvm::host::server::session:    4777315 BigInt2 calls, 632195544 cycles, (4.23%)
2025-02-17T21:11:24.900100Z  INFO risc0_zkvm::host::server::session:    1575654 Sha2 calls, 118944328 cycles, (0.80%)
2025-02-17T21:11:24.900101Z  INFO risc0_zkvm::host::server::session:    7781511 BigInt calls, 77815110 cycles, (0.52%)
2025-02-17T21:11:24.900103Z  INFO risc0_zkvm::host::server::session:    155658 Software calls, 2573946 cycles, (0.02%)
2025-02-17T21:11:24.900104Z  INFO risc0_zkvm::host::server::session:    0 Input calls, 0 cycles, (0.00%)
2025-02-17T21:11:24.900105Z  INFO risc0_zkvm::host::server::session: syscalls
2025-02-17T21:11:24.900106Z  INFO risc0_zkvm::host::server::session:    129337 Keccak calls
2025-02-17T21:11:24.900108Z  INFO risc0_zkvm::host::server::session:    25881 Read calls
2025-02-17T21:11:24.900109Z  INFO risc0_zkvm::host::server::session:    198 VerifyIntegrity calls
2025-02-17T21:11:24.900110Z  INFO risc0_zkvm::host::server::session:    198 ProveKeccak calls
2025-02-17T21:11:24.900111Z  INFO risc0_zkvm::host::server::session:    41 Write calls
```