### PR TITLE
Add combine() fn for compressors

### DIFF
--- a/crates/sovereign-sdk/module-system/sov-state/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/lib.rs
@@ -7,7 +7,8 @@ pub mod codec;
 #[cfg(feature = "native")]
 mod prover_storage;
 
-mod stateful_statediff;
+/// Stateful Statediff primitives
+pub mod stateful_statediff;
 
 mod witness;
 mod zk_storage;

--- a/crates/sovereign-sdk/module-system/sov-state/src/stateful_statediff/mod.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/stateful_statediff/mod.rs
@@ -1,3 +1,4 @@
+/// Compression primitives
 pub mod compression;
 
 use std::collections::BTreeMap;
@@ -111,19 +112,22 @@ pub(crate) fn build_post_state(ordered_writes: &[(CacheKey, Option<CacheValue>)]
     }
 }
 
+/// Reflects account change
 #[derive(BorshSerialize, Debug)]
 pub struct AccountChange {
-    pub balance: SlotChange,
-    pub nonce: SlotChange,
-    pub code_hash: CodeHashChange,
+    balance: SlotChange,
+    nonce: SlotChange,
+    code_hash: CodeHashChange,
 }
 
+/// Reflects storage change
 #[derive(BorshSerialize, Debug)]
 pub struct StorageChange {
     #[borsh(serialize_with = "borsh_ser_btree_u256")]
-    pub storage: BTreeMap<U256, Option<SlotChange>>,
+    storage: BTreeMap<U256, Option<SlotChange>>,
 }
 
+/// Reflects all state change
 #[derive(BorshSerialize, Debug)]
 pub struct StatefulStateDiff {
     #[borsh(serialize_with = "borsh_ser_btree_address")]


### PR DESCRIPTION
# Description

We need this feature to merge two diffs into one. Before we implemented it like this:

```
pub fn merge_state_diffs(old_diff: StateDiff, new_diff: StateDiff) -> StateDiff {
    let mut new_diff_map = HashMap::<Vec<u8>, Option<Vec<u8>>>::from_iter(old_diff);

    new_diff_map.extend(new_diff);
    new_diff_map.into_iter().collect()
}
```

So this combine() function gives `Add(a).combine(Add(b)) = Add(a + b)`

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/1508
- Related to https://github.com/chainwayxyz/citrea/issues/1237
