### PR TITLE
Rename postfork2 Evm::storage prefix

### DIFF
--- a/bin/citrea/tests/mock/evm/mod.rs
+++ b/bin/citrea/tests/mock/evm/mod.rs
@@ -403,7 +403,7 @@ fn check_proof(acc_proof: &EIP1186AccountProofResponse, account_address: Address
                 U256::from_le_slice(&arr)
             };
             let storage_key = [
-                b"Evm/s/".as_slice(),
+                b"Evm/S/".as_slice(),
                 &[32],
                 kaddr.to_be_bytes::<32>().as_slice(),
             ]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -101,7 +101,7 @@ pub struct Evm<C: sov_modules_api::Context> {
     pub(crate) code: sov_modules_api::StateMap<B256, revm::primitives::Bytecode, BcsCodec>,
 
     /// Mapping from storage hash ( sha256(address | key) ) to storage value.
-    #[state(rename = "s")]
+    #[state(rename = "S")]
     pub storage: sov_modules_api::StateMap<U256, U256, BcsCodec>,
 
     /// Mapping from code hash to code. Used for lazy-loading code into a contract account.


### PR DESCRIPTION
# Description

Because we need to distinguish Evm::storage prefork2 from postfork2. Because in prefork2 key is "acc_address/key" and in postfork2 key is "sha2(address | key)".