### PR TITLE
Preallocate exact size for borsh serialization

### DIFF
--- a/crates/evm/src/evm/mod.rs
+++ b/crates/evm/src/evm/mod.rs
@@ -89,7 +89,9 @@ impl StateValueCodec<AccountInfo> for BorshCodec {
     type Error = std::io::Error;
 
     fn encode_value(&self, value: &AccountInfo) -> Vec<u8> {
-        borsh::to_vec(&value).unwrap()
+        let mut buf = Vec::with_capacity(32 + 8 + 32 + 1);
+        BorshSerialize::serialize(value, &mut buf).unwrap();
+        buf
     }
 
     fn try_decode_value(&self, bytes: &[u8]) -> Result<AccountInfo, Self::Error> {

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-accounts/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-accounts/src/lib.rs
@@ -1,5 +1,6 @@
 mod genesis;
 mod hooks;
+use borsh::BorshSerialize;
 pub use genesis::*;
 #[cfg(feature = "native")]
 mod query;
@@ -35,7 +36,9 @@ impl StateValueCodec<Account> for BorshCodec {
     type Error = std::io::Error;
 
     fn encode_value(&self, value: &Account) -> Vec<u8> {
-        borsh::to_vec(&value).unwrap()
+        let mut buf = Vec::with_capacity(32 + 8);
+        BorshSerialize::serialize(value, &mut buf).unwrap();
+        buf
     }
 
     fn try_decode_value(&self, bytes: &[u8]) -> Result<Account, Self::Error> {

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/default_signature.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/default_signature.rs
@@ -336,7 +336,9 @@ impl BorshSerialize for DefaultPublicKey {
 
 impl StateKeyCodec<DefaultPublicKey> for BorshCodec {
     fn encode_key(&self, value: &DefaultPublicKey) -> Vec<u8> {
-        borsh::to_vec(value).expect("Failed to serialize key")
+        let mut buf = Vec::with_capacity(32);
+        BorshSerialize::serialize(value, &mut buf).unwrap();
+        buf
     }
 }
 
@@ -344,7 +346,9 @@ impl StateValueCodec<DefaultPublicKey> for BorshCodec {
     type Error = std::io::Error;
 
     fn encode_value(&self, value: &DefaultPublicKey) -> Vec<u8> {
-        borsh::to_vec(&value).unwrap()
+        let mut buf = Vec::with_capacity(32);
+        BorshSerialize::serialize(value, &mut buf).unwrap();
+        buf
     }
 
     fn try_decode_value(&self, bytes: &[u8]) -> Result<DefaultPublicKey, Self::Error> {

--- a/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
@@ -76,7 +76,9 @@ macro_rules! impl_borsh_codec {
     ($t:tt) => {
         impl StateKeyCodec<$t> for BorshCodec {
             fn encode_key(&self, value: &$t) -> Vec<u8> {
-                borsh::to_vec(value).expect("Failed to serialize key")
+                let mut buf = Vec::with_capacity(8);
+                BorshSerialize::serialize(value, &mut buf).unwrap();
+                buf
             }
         }
 
@@ -84,7 +86,9 @@ macro_rules! impl_borsh_codec {
             type Error = std::io::Error;
 
             fn encode_value(&self, value: &$t) -> Vec<u8> {
-                borsh::to_vec(value).expect("Failed to serialize value")
+                let mut buf = Vec::with_capacity(8);
+                BorshSerialize::serialize(value, &mut buf).unwrap();
+                buf
             }
 
             fn try_decode_value(&self, bytes: &[u8]) -> Result<$t, Self::Error> {
@@ -121,6 +125,8 @@ where
     T: BorshSerialize,
 {
     fn encode_key_like(&self, borrowed: &[T]) -> Vec<u8> {
-        borsh::to_vec(borrowed).unwrap()
+        let mut buf = Vec::with_capacity(64);
+        BorshSerialize::serialize(borrowed, &mut buf).unwrap();
+        buf
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
@@ -57,6 +57,15 @@ impl StateKeyCodec<Vec<u8>> for BorshCodec {
         buf
     }
 }
+// FIXME: Remove before mainnet
+impl EncodeKeyLike<[u8], Vec<u8>> for BorshCodec
+{
+    fn encode_key_like(&self, borrowed: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(4 + borrowed.len());
+        BorshSerialize::serialize(borrowed, &mut buf).unwrap();
+        buf
+    }
+}
 
 impl StateValueCodec<Vec<u8>> for BorshCodec {
     type Error = std::io::Error;
@@ -115,18 +124,5 @@ impl StateCodec for BorshCodec {
 
     fn value_codec(&self) -> &Self::ValueCodec {
         self
-    }
-}
-
-// In borsh, a slice is encoded the same way as a vector except in edge case where
-// T is zero-sized, in which case Vec<T> is not borsh encodable.
-impl<T> EncodeKeyLike<[T], Vec<T>> for BorshCodec
-where
-    T: BorshSerialize,
-{
-    fn encode_key_like(&self, borrowed: &[T]) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(64);
-        BorshSerialize::serialize(borrowed, &mut buf).unwrap();
-        buf
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
@@ -52,9 +52,7 @@ impl StateValueCodec<AlloyU256> for BorshCodec {
 // FIXME: Remove before mainnet
 impl StateKeyCodec<Vec<u8>> for BorshCodec {
     fn encode_key(&self, value: &Vec<u8>) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(4 + value.len());
-        BorshSerialize::serialize(value, &mut buf).unwrap();
-        buf
+        value.clone()
     }
 }
 
@@ -62,13 +60,11 @@ impl StateValueCodec<Vec<u8>> for BorshCodec {
     type Error = std::io::Error;
 
     fn encode_value(&self, value: &Vec<u8>) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(4 + value.len());
-        BorshSerialize::serialize(value, &mut buf).unwrap();
-        buf
+        value.clone()
     }
 
     fn try_decode_value(&self, bytes: &[u8]) -> Result<Vec<u8>, Self::Error> {
-        borsh::from_slice(bytes)
+        Ok(bytes.to_vec())
     }
 }
 

--- a/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
@@ -11,19 +11,25 @@ pub struct BorshCodec;
 
 impl StateKeyCodec<AlloyU256> for BorshCodec {
     fn encode_key(&self, value: &AlloyU256) -> Vec<u8> {
-        borsh::to_vec(value.as_limbs()).expect("Failed to serialize key")
+        let mut buf = Vec::with_capacity(32);
+        BorshSerialize::serialize(value.as_limbs(), &mut buf).unwrap();
+        buf
     }
 }
 
 impl StateKeyCodec<AlloyAddress> for BorshCodec {
     fn encode_key(&self, value: &AlloyAddress) -> Vec<u8> {
-        borsh::to_vec(&value.0 .0).expect("Failed to serialize key")
+        let mut buf = Vec::with_capacity(20);
+        BorshSerialize::serialize(&value.0 .0, &mut buf).unwrap();
+        buf
     }
 }
 
 impl StateKeyCodec<ModuleAddress> for BorshCodec {
     fn encode_key(&self, value: &ModuleAddress) -> Vec<u8> {
-        borsh::to_vec(&value).expect("Failed to serialize key")
+        let mut buf = Vec::with_capacity(32);
+        BorshSerialize::serialize(&value, &mut buf).unwrap();
+        buf
     }
 }
 
@@ -31,8 +37,9 @@ impl StateValueCodec<AlloyU256> for BorshCodec {
     type Error = std::io::Error;
 
     fn encode_value(&self, value: &AlloyU256) -> Vec<u8> {
-        let t = value.as_limbs();
-        borsh::to_vec(t).unwrap()
+        let mut buf = Vec::with_capacity(32);
+        BorshSerialize::serialize(value.as_limbs(), &mut buf).unwrap();
+        buf
     }
 
     fn try_decode_value(&self, bytes: &[u8]) -> Result<AlloyU256, Self::Error> {
@@ -41,12 +48,13 @@ impl StateValueCodec<AlloyU256> for BorshCodec {
     }
 }
 
-impl<T> StateKeyCodec<Vec<T>> for BorshCodec
-where
-    T: BorshSerialize,
-{
-    fn encode_key(&self, value: &Vec<T>) -> Vec<u8> {
-        borsh::to_vec(value).expect("Failed to serialize key")
+// This one is needed for PublicKey only.
+// FIXME: Remove before mainnet
+impl StateKeyCodec<Vec<u8>> for BorshCodec {
+    fn encode_key(&self, value: &Vec<u8>) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(4 + value.len());
+        BorshSerialize::serialize(value, &mut buf).unwrap();
+        buf
     }
 }
 

--- a/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
@@ -52,7 +52,9 @@ impl StateValueCodec<AlloyU256> for BorshCodec {
 // FIXME: Remove before mainnet
 impl StateKeyCodec<Vec<u8>> for BorshCodec {
     fn encode_key(&self, value: &Vec<u8>) -> Vec<u8> {
-        value.clone()
+        let mut buf = Vec::with_capacity(4 + value.len());
+        BorshSerialize::serialize(value, &mut buf).unwrap();
+        buf
     }
 }
 
@@ -60,11 +62,13 @@ impl StateValueCodec<Vec<u8>> for BorshCodec {
     type Error = std::io::Error;
 
     fn encode_value(&self, value: &Vec<u8>) -> Vec<u8> {
-        value.clone()
+        let mut buf = Vec::with_capacity(4 + value.len());
+        BorshSerialize::serialize(value, &mut buf).unwrap();
+        buf
     }
 
     fn try_decode_value(&self, bytes: &[u8]) -> Result<Vec<u8>, Self::Error> {
-        Ok(bytes.to_vec())
+        borsh::from_slice(bytes)
     }
 }
 

--- a/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/codec/borsh_codec.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address as AlloyAddress, U256 as AlloyU256};
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshSerialize;
 use sov_modules_core::{Address as ModuleAddress, EncodeKeyLike};
 
 use super::{StateCodec, StateKeyCodec};
@@ -58,17 +58,16 @@ impl StateKeyCodec<Vec<u8>> for BorshCodec {
     }
 }
 
-impl<T> StateValueCodec<Vec<T>> for BorshCodec
-where
-    T: BorshSerialize + BorshDeserialize,
-{
+impl StateValueCodec<Vec<u8>> for BorshCodec {
     type Error = std::io::Error;
 
-    fn encode_value(&self, value: &Vec<T>) -> Vec<u8> {
-        borsh::to_vec(value).expect("Failed to serialize value")
+    fn encode_value(&self, value: &Vec<u8>) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(4 + value.len());
+        BorshSerialize::serialize(value, &mut buf).unwrap();
+        buf
     }
 
-    fn try_decode_value(&self, bytes: &[u8]) -> Result<Vec<T>, Self::Error> {
+    fn try_decode_value(&self, bytes: &[u8]) -> Result<Vec<u8>, Self::Error> {
         borsh::from_slice(bytes)
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-state/src/codec/mod.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/codec/mod.rs
@@ -38,6 +38,12 @@ mod tests {
     proptest::proptest! {
         #[test]
         fn test_borsh_slice_encode_alike(vec in arb_vec_i32()) {
+            impl EncodeKeyLike<[i32], Vec<i32>> for BorshCodec
+            {
+                fn encode_key_like(&self, borrowed: &[i32]) -> Vec<u8> {
+                    borsh::to_vec(&borrowed).unwrap()
+                }
+            }
             let codec = BorshCodec;
             assert_eq!(
                 <BorshCodec as EncodeKeyLike<[i32], Vec<i32>>>::encode_key_like(&codec, &vec[..]),

--- a/crates/sovereign-sdk/module-system/sov-state/src/codec/mod.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/codec/mod.rs
@@ -19,6 +19,18 @@ mod tests {
 
     use super::*;
 
+    impl StateValueCodec<Vec<i32>> for BorshCodec {
+        type Error = std::io::Error;
+
+        fn encode_value(&self, value: &Vec<i32>) -> Vec<u8> {
+            borsh::to_vec(value).unwrap()
+        }
+
+        fn try_decode_value(&self, bytes: &[u8]) -> Result<Vec<i32>, Self::Error> {
+            borsh::from_slice(bytes)
+        }
+    }
+
     fn arb_vec_i32() -> impl Strategy<Value = Vec<i32>> {
         vec(any::<i32>(), 0..2048)
     }


### PR DESCRIPTION
# Description

- [x] Optimize AlloyU256, AlloyAddress, ModuleAddress, AccountInfo
- [x] Replace `impl<T> StateValueCodec<Vec<T>> for BorshCodec` with a concrete impls for missing T

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/1931
