### PR TITLE
Lift L1 fields out of L2Header

### DIFF
--- a/bin/citrea/src/test_rpc.rs
+++ b/bin/citrea/src/test_rpc.rs
@@ -111,8 +111,6 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
 
     let header1 = L2Header::new(
         1,
-        0,
-        [0u8; 32],
         [1u8; 32],
         ::sha2::Sha256::digest(b"prev_batch_receipt").into(),
         [1; 32],
@@ -123,15 +121,13 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
 
     let header2 = L2Header::new(
         2,
-        1,
-        [2; 32],
         [3; 32],
         ::sha2::Sha256::digest(b"prev_batch_receipt2").into(),
         [1; 32],
         0,
         compute_tx_merkle_root(&batch_2_receipts.iter().map(|r| r.hash).collect::<Vec<_>>())
             .unwrap(),
-        0,
+        1,
     );
 
     let signed_header1 = SignedL2Header::new(
@@ -157,6 +153,8 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
                 "aaaaab".as_bytes().to_vec(),
                 "eeeeeeeeee".as_bytes().to_vec(),
             ],
+            0,
+            [0u8; 32],
         ),
         L2Block::<[u8; 32]>::new(
             signed_header2,
@@ -171,6 +169,8 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
                 .collect::<Vec<_>>()
                 .into(),
             vec!["c44444".as_bytes().to_vec()],
+            1,
+            [0u8; 32],
         ),
     ];
 

--- a/bin/citrea/src/test_rpc.rs
+++ b/bin/citrea/src/test_rpc.rs
@@ -127,7 +127,7 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
         0,
         compute_tx_merkle_root(&batch_2_receipts.iter().map(|r| r.hash).collect::<Vec<_>>())
             .unwrap(),
-        1,
+        0,
     );
 
     let signed_header1 = SignedL2Header::new(
@@ -170,7 +170,7 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
                 .into(),
             vec!["c44444".as_bytes().to_vec()],
             1,
-            [0u8; 32],
+            [2u8; 32],
         ),
     ];
 

--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -406,6 +406,8 @@ pub(crate) async fn get_batch_proof_circuit_input_from_commitments<
                     parsed_txs.into(),
                     blobs.into(),
                     l2_block.deposit_data,
+                    l2_block.da_slot_height,
+                    l2_block.da_slot_hash,
                 )
             };
 

--- a/crates/batch-prover/src/runner.rs
+++ b/crates/batch-prover/src/runner.rs
@@ -272,6 +272,8 @@ where
                 parsed_txs.into(),
                 blobs.into(),
                 l2_block.deposit_data,
+                l2_block.da_slot_height,
+                l2_block.da_slot_hash,
             )
         };
 

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -165,6 +165,9 @@ where
         self.fork_manager.register_block(l2_height)?;
         let current_spec = self.fork_manager.active_fork().spec_id;
 
+        let da_slot_height = soft_confirmation.da_slot_height;
+        let da_slot_hash = soft_confirmation.da_slot_hash;
+
         let mut l2_block: L2Block<StfTransaction<Da::Spec>> = if current_spec >= SpecId::Kumquat {
             soft_confirmation
                 .clone()
@@ -191,6 +194,8 @@ where
                 parsed_txs.into(),
                 blobs.into(),
                 l2_block.deposit_data,
+                da_slot_height,
+                da_slot_hash,
             )
         };
 

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -208,10 +208,11 @@ impl SharedLedgerOps for LedgerDB {
         };
 
         let l2_height = l2_block.l2_height();
+        let da_slot_height = l2_block.da_slot_height;
 
         // Insert soft confirmation
         let soft_confirmation_to_store = StoredSoftConfirmation {
-            da_slot_height: l2_block.da_slot_height(),
+            da_slot_height,
             l2_height,
             da_slot_hash: l2_block.da_slot_hash(),
             da_slot_txs_commitment: l2_block.da_slot_txs_commitment(),

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/soft_confirmation.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/soft_confirmation.rs
@@ -63,8 +63,6 @@ where
 
         let header = L2Header::new(
             val.l2_height,
-            val.da_slot_height,
-            val.da_slot_hash,
             val.da_slot_txs_commitment,
             val.prev_hash,
             val.state_root,
@@ -84,6 +82,8 @@ where
             parsed_txs.into(),
             blobs.into(),
             val.deposit_data,
+            val.da_slot_height,
+            val.da_slot_hash,
         );
         Ok(res)
     }

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/hooks.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/hooks.rs
@@ -95,8 +95,8 @@ impl HookSoftConfirmationInfo {
     ) -> Self {
         HookSoftConfirmationInfo {
             l2_height: l2_block.l2_height(),
-            da_slot_height: l2_block.da_slot_height(),
             da_slot_hash: l2_block.da_slot_hash(),
+            da_slot_height: l2_block.da_slot_height(),
             da_slot_txs_commitment: l2_block.da_slot_txs_commitment(),
             pre_state_root,
             current_spec,

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -473,6 +473,8 @@ where
                         parsed_txs.into(),
                         blobs.into(),
                         l2_block.deposit_data,
+                        l2_block.da_slot_height,
+                        l2_block.da_slot_hash,
                     );
                     (sc, state_witness, offchain_witness)
                 };

--- a/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
@@ -111,8 +111,6 @@ where
 
         let header = L2Header::new(
             val.l2_height,
-            val.da_slot_height,
-            val.da_slot_hash,
             val.da_slot_txs_commitment,
             val.prev_hash,
             val.state_root,
@@ -132,6 +130,8 @@ where
             parsed_txs.into(),
             blobs.into(),
             val.deposit_data.into_iter().map(|tx| tx.tx).collect(),
+            val.da_slot_height,
+            val.da_slot_hash,
         );
         Ok(res)
     }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/soft_confirmation.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/soft_confirmation.rs
@@ -11,8 +11,6 @@ use serde::{Deserialize, Serialize};
 #[derive(PartialEq, Eq, BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone, Debug)]
 pub struct L2Header {
     l2_height: u64,
-    da_slot_height: u64,
-    da_slot_hash: [u8; 32],
     da_slot_txs_commitment: [u8; 32],
     prev_hash: [u8; 32],
     state_root: [u8; 32],
@@ -26,8 +24,6 @@ impl L2Header {
     /// New L2Header
     pub fn new(
         l2_height: u64,
-        da_slot_height: u64,
-        da_slot_hash: [u8; 32],
         da_slot_txs_commitment: [u8; 32],
         prev_hash: [u8; 32],
         state_root: [u8; 32],
@@ -37,8 +33,6 @@ impl L2Header {
     ) -> Self {
         Self {
             l2_height,
-            da_slot_height,
-            da_slot_hash,
             da_slot_txs_commitment,
             prev_hash,
             state_root,
@@ -52,8 +46,6 @@ impl L2Header {
     pub fn compute_digest<D: Digest>(&self) -> Output<D> {
         let mut hasher = D::new();
         hasher.update(self.l2_height.to_be_bytes());
-        hasher.update(self.da_slot_height.to_be_bytes());
-        hasher.update(self.da_slot_hash);
         hasher.update(self.da_slot_txs_commitment);
         hasher.update(self.prev_hash);
         hasher.update(self.state_root);
@@ -100,6 +92,10 @@ pub struct L2Block<'txs, Tx: Clone + BorshSerialize> {
     pub blobs: Cow<'txs, [Vec<u8>]>,
     /// Deposit data
     pub deposit_data: Vec<Vec<u8>>,
+    /// L1 height
+    pub da_slot_height: u64,
+    /// L1 hash
+    pub da_slot_hash: [u8; 32],
 }
 
 impl<'txs, Tx: Clone + BorshSerialize> L2Block<'txs, Tx> {
@@ -109,12 +105,16 @@ impl<'txs, Tx: Clone + BorshSerialize> L2Block<'txs, Tx> {
         txs: Cow<'txs, [Tx]>,
         blobs: Cow<'txs, [Vec<u8>]>,
         deposit_data: Vec<Vec<u8>>,
+        da_slot_height: u64,
+        da_slot_hash: [u8; 32],
     ) -> Self {
         Self {
             header,
             txs,
             blobs,
             deposit_data,
+            da_slot_hash,
+            da_slot_height,
         }
     }
 
@@ -135,12 +135,12 @@ impl<'txs, Tx: Clone + BorshSerialize> L2Block<'txs, Tx> {
 
     /// DA block this soft confirmation was given for
     pub fn da_slot_height(&self) -> u64 {
-        self.header.inner.da_slot_height
+        self.da_slot_height
     }
 
     /// DA block to build on
     pub fn da_slot_hash(&self) -> [u8; 32] {
-        self.header.inner.da_slot_hash
+        self.da_slot_hash
     }
 
     /// DA block transactions commitment
@@ -173,16 +173,6 @@ impl<'txs, Tx: Clone + BorshSerialize> L2Block<'txs, Tx> {
         self.header.pub_key.as_slice()
     }
 
-    /// Sets l1 fee rate
-    pub fn set_l1_fee_rate(&mut self, l1_fee_rate: u128) {
-        self.header.inner.l1_fee_rate = l1_fee_rate;
-    }
-
-    /// Sets da slot hash
-    pub fn set_da_slot_hash(&mut self, da_slot_hash: [u8; 32]) {
-        self.header.inner.da_slot_hash = da_slot_hash;
-    }
-
     /// Sequencer block timestamp
     pub fn timestamp(&self) -> u64 {
         self.header.inner.timestamp
@@ -212,67 +202,29 @@ pub struct UnsignedSoftConfirmation<'txs, Tx> {
     timestamp: u64,
 }
 
-impl<'txs, Tx: BorshSerialize> From<(&L2Header, Vec<Vec<u8>>, &'txs [Tx], Vec<Vec<u8>>)>
-    for UnsignedSoftConfirmation<'txs, Tx>
-{
-    fn from(
-        (header, blobs, txs, deposit_data): (&L2Header, Vec<Vec<u8>>, &'txs [Tx], Vec<Vec<u8>>),
-    ) -> Self {
-        UnsignedSoftConfirmation::new(
-            header.l2_height,
-            header.da_slot_height,
-            header.da_slot_hash,
-            header.da_slot_txs_commitment,
-            blobs,
-            txs,
-            deposit_data,
-            header.l1_fee_rate,
-            header.timestamp,
-        )
-    }
-}
-
-/// Old version of UnsignedSoftConfirmation
-/// Used for backwards compatibility
-/// Always use ```UnsignedSoftConfirmation``` instead
-#[derive(BorshSerialize)]
-pub struct UnsignedSoftConfirmationV1 {
-    l2_height: u64,
-    da_slot_height: u64,
-    da_slot_hash: [u8; 32],
-    da_slot_txs_commitment: [u8; 32],
-    blobs: Vec<Vec<u8>>,
-    deposit_data: Vec<Vec<u8>>,
-    l1_fee_rate: u128,
-    timestamp: u64,
-}
-
 impl<'txs, Tx: BorshSerialize> UnsignedSoftConfirmation<'txs, Tx> {
-    #[allow(clippy::too_many_arguments)]
-    /// Creates a new unsigned soft confirmation batch
+    /// Create UnsignedSoftConfirmation from header and required for backwards compatibility fields
     pub fn new(
-        l2_height: u64,
-        da_slot_height: u64,
-        da_slot_hash: [u8; 32],
-        da_slot_txs_commitment: [u8; 32],
+        header: &L2Header,
         blobs: Vec<Vec<u8>>,
         txs: &'txs [Tx],
         deposit_data: Vec<Vec<u8>>,
-        l1_fee_rate: u128,
-        timestamp: u64,
+        da_slot_height: u64,
+        da_slot_hash: [u8; 32],
     ) -> Self {
-        Self {
-            l2_height,
+        UnsignedSoftConfirmation {
+            l2_height: header.l2_height,
             da_slot_height,
             da_slot_hash,
-            da_slot_txs_commitment,
+            da_slot_txs_commitment: header.da_slot_txs_commitment,
             blobs,
             txs,
             deposit_data,
-            l1_fee_rate,
-            timestamp,
+            l1_fee_rate: header.l1_fee_rate,
+            timestamp: header.timestamp,
         }
     }
+
     /// Compute digest for the whole UnsignedSoftConfirmation struct
     pub fn compute_digest<D: Digest>(&self) -> Output<D> {
         let mut hasher = D::new();
@@ -292,6 +244,21 @@ impl<'txs, Tx: BorshSerialize> UnsignedSoftConfirmation<'txs, Tx> {
     }
 }
 
+/// Old version of UnsignedSoftConfirmation
+/// Used for backwards compatibility
+/// Always use ```UnsignedSoftConfirmation``` instead
+#[derive(BorshSerialize)]
+pub struct UnsignedSoftConfirmationV1 {
+    l2_height: u64,
+    da_slot_height: u64,
+    da_slot_hash: [u8; 32],
+    da_slot_txs_commitment: [u8; 32],
+    blobs: Vec<Vec<u8>>,
+    deposit_data: Vec<Vec<u8>>,
+    l1_fee_rate: u128,
+    timestamp: u64,
+}
+
 impl<'txs, Tx: Clone + BorshSerialize> From<&'txs L2Block<'_, Tx>>
     for UnsignedSoftConfirmation<'txs, Tx>
 {
@@ -299,8 +266,8 @@ impl<'txs, Tx: Clone + BorshSerialize> From<&'txs L2Block<'_, Tx>>
         let header = &block.header.inner;
         Self {
             l2_height: header.l2_height,
-            da_slot_height: header.da_slot_height,
-            da_slot_hash: header.da_slot_hash,
+            da_slot_height: block.da_slot_height(),
+            da_slot_hash: block.da_slot_hash(),
             da_slot_txs_commitment: header.da_slot_txs_commitment,
             blobs: block.blobs.to_vec(),
             txs: &block.txs,
@@ -316,8 +283,8 @@ impl<'txs, Tx: Clone + BorshSerialize> From<&'txs L2Block<'_, Tx>> for UnsignedS
         let header = &block.header.inner;
         Self {
             l2_height: header.l2_height,
-            da_slot_height: header.da_slot_height,
-            da_slot_hash: header.da_slot_hash,
+            da_slot_height: block.da_slot_height(),
+            da_slot_hash: block.da_slot_hash(),
             da_slot_txs_commitment: header.da_slot_txs_commitment,
             blobs: block.blobs.to_vec(),
             deposit_data: block.deposit_data.clone(),
@@ -327,24 +294,27 @@ impl<'txs, Tx: Clone + BorshSerialize> From<&'txs L2Block<'_, Tx>> for UnsignedS
     }
 }
 
-impl<'txs, Tx: BorshSerialize> From<UnsignedSoftConfirmation<'txs, Tx>>
-    for UnsignedSoftConfirmationV1
-{
-    fn from(value: UnsignedSoftConfirmation<Tx>) -> Self {
+impl UnsignedSoftConfirmationV1 {
+    /// Create UnsignedSoftConfirmation from header and required for backwards compatibility fields
+    pub fn new(
+        header: &L2Header,
+        blobs: Vec<Vec<u8>>,
+        deposit_data: Vec<Vec<u8>>,
+        da_slot_height: u64,
+        da_slot_hash: [u8; 32],
+    ) -> Self {
         UnsignedSoftConfirmationV1 {
-            l2_height: value.l2_height,
-            da_slot_height: value.da_slot_height,
-            da_slot_hash: value.da_slot_hash,
-            da_slot_txs_commitment: value.da_slot_txs_commitment,
-            blobs: value.blobs,
-            deposit_data: value.deposit_data,
-            l1_fee_rate: value.l1_fee_rate,
-            timestamp: value.timestamp,
+            l2_height: header.l2_height,
+            da_slot_height,
+            da_slot_hash,
+            da_slot_txs_commitment: header.da_slot_txs_commitment,
+            blobs,
+            deposit_data,
+            l1_fee_rate: header.l1_fee_rate,
+            timestamp: header.timestamp,
         }
     }
-}
 
-impl UnsignedSoftConfirmationV1 {
     /// Pre fork1 version of compute_digest
     // TODO: Remove derive(BorshSerialize) for UnsignedSoftConfirmation
     //   when removing this fn

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/soft_confirmation.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/soft_confirmation.rs
@@ -82,6 +82,8 @@ impl SignedL2Header {
 }
 
 /// Signed L2 block
+/// `blobs`, `deposit_data`, `da_slot_height` and `da_slot_hash` are kept for compatibility reason
+/// and hash checking against PreFork2 *SoftConfirmations structs.
 #[derive(PartialEq, Eq, BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone, Debug)]
 pub struct L2Block<'txs, Tx: Clone + BorshSerialize> {
     /// Header
@@ -89,12 +91,16 @@ pub struct L2Block<'txs, Tx: Clone + BorshSerialize> {
     /// Txs of signed batch
     pub txs: Cow<'txs, [Tx]>,
     /// Blobs of signed batch
+    /// TODO remove before mainnet
     pub blobs: Cow<'txs, [Vec<u8>]>,
     /// Deposit data
+    /// TODO remove before mainnet
     pub deposit_data: Vec<Vec<u8>>,
     /// L1 height
+    /// TODO remove before mainnet
     pub da_slot_height: u64,
     /// L1 hash
+    /// TODO remove before mainnet
     pub da_slot_hash: [u8; 32],
 }
 


### PR DESCRIPTION
# Description

- Lift L1 related fields out of header and keep at L2Block level for backward compatibility reasons.
Further versioning work should take care of removing this fields from this L2Block variant as well.

## Linked Issues
- Fixes #1791
