### PR TITLE
New Witness type

### DIFF
--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -72,7 +72,7 @@ pub(crate) async fn data_to_prove<'txs, Da, DB>(
 ) -> Result<
     (
         Vec<SequencerCommitment>,
-        Vec<BatchProofCircuitInput<'txs, Witness, Da::Spec, Transaction>>,
+        Vec<BatchProofCircuitInput<'txs, Da::Spec, Transaction>>,
     ),
     L1ProcessingError,
 >
@@ -243,7 +243,7 @@ pub(crate) async fn prove_l1<Da, Vm, DB>(
     elfs_by_spec: HashMap<SpecId, Vec<u8>>,
     l1_block: &Da::FilteredBlock,
     sequencer_commitments: Vec<SequencerCommitment>,
-    inputs: Vec<BatchProofCircuitInput<'_, Witness, Da::Spec, Transaction>>,
+    inputs: Vec<BatchProofCircuitInput<'_, Da::Spec, Transaction>>,
 ) -> anyhow::Result<()>
 where
     Da: DaService,
@@ -566,7 +566,7 @@ async fn generate_cumulative_witness<'txs, Da: DaService, DB: BatchProverLedgerO
 /// TODO: This check needs a rewrite for sure.
 /// We could check on the sequencer commitments range only and not generate inputs
 pub(crate) fn state_transition_already_proven<Da: DaService>(
-    input: &BatchProofCircuitInput<Witness, Da::Spec, Transaction>,
+    input: &BatchProofCircuitInput<Da::Spec, Transaction>,
     proofs: &Vec<StoredBatchProof>,
 ) -> bool {
     for proof in proofs {

--- a/crates/batch-prover/tests/prover_tests.rs
+++ b/crates/batch-prover/tests/prover_tests.rs
@@ -341,7 +341,7 @@ fn make_new_prover(thread_pool_size: usize, da_service: Arc<MockDaService>) -> T
 
 fn make_transition_data(
     header_hash: MockHash,
-) -> BatchProofCircuitInput<'static, Vec<u8>, MockDaSpec, ()> {
+) -> BatchProofCircuitInput<'static, MockDaSpec, ()> {
     BatchProofCircuitInput {
         initial_state_root: [0; 32],
         inclusion_proof: [0; 32],
@@ -386,7 +386,7 @@ async fn spawn_prove(
 }
 
 fn extract_output_header(proof: &Vec<u8>) -> MockBlockHeader {
-    MockZkvm::extract_output::<BatchProofCircuitInput<'static, Vec<u8>, MockDaSpec, ()>>(proof)
+    MockZkvm::extract_output::<BatchProofCircuitInput<'static, MockDaSpec, ()>>(proof)
         .unwrap()
         .da_block_header_of_commitments
 }

--- a/crates/batch-prover/tests/prover_tests.rs
+++ b/crates/batch-prover/tests/prover_tests.rs
@@ -339,9 +339,7 @@ fn make_new_prover(thread_pool_size: usize, da_service: Arc<MockDaService>) -> T
     }
 }
 
-fn make_transition_data(
-    header_hash: MockHash,
-) -> BatchProofCircuitInput<'static, MockDaSpec, ()> {
+fn make_transition_data(header_hash: MockHash) -> BatchProofCircuitInput<'static, MockDaSpec, ()> {
     BatchProofCircuitInput {
         initial_state_root: [0; 32],
         inclusion_proof: [0; 32],

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/mod.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/mod.rs
@@ -8,6 +8,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[cfg(feature = "sync")]
 use serde::Serialize;
 use sov_rollup_interface::stf::{StateDiff, StateRootTransition};
+use sov_rollup_interface::witness::Witness;
 use sov_rollup_interface::zk::{SparseMerkleProofSha2, StorageRootHash};
 use sov_rollup_interface::RefCount;
 
@@ -16,12 +17,10 @@ use crate::common::{Prefix, Version};
 mod cache;
 mod codec;
 mod scratchpad;
-mod witness;
 
 pub use cache::*;
 pub use codec::*;
 pub use scratchpad::*;
-pub use witness::*;
 
 /// The key type suitable for use in [`Storage::get`] and other getter methods of
 /// [`Storage`]. Cheaply-clonable.

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -3,6 +3,7 @@
 use alloc::collections::BTreeMap;
 use core::mem;
 
+use sov_rollup_interface::witness::Witness;
 use sov_rollup_interface::zk::StorageRootHash;
 
 use self::archival_state::ArchivalOffchainWorkingSet;
@@ -13,7 +14,7 @@ use crate::storage::{
     CacheKey, CacheValue, EncodeKeyLike, NativeStorage, StateCodec, StateValueCodec, Storage,
     StorageKey, StorageProof, StorageValue,
 };
-use crate::{ValueExists, Version, Witness};
+use crate::{ValueExists, Version};
 
 /// A storage reader and writer
 pub trait StateReaderAndWriter {

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/witness.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/witness.rs
@@ -2,6 +2,13 @@ use std::collections::VecDeque;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
+/// OldWitness should only be used for forks < Fork2
+#[derive(BorshDeserialize, BorshSerialize)]
+pub struct OldWitness {
+    next_idx: usize,
+    hints: Vec<Vec<u8>>,
+}
+
 /// A [`Vec`]-based implementation of [`Witness`] with no special logic.
 ///
 /// # Example
@@ -33,5 +40,14 @@ impl Witness {
         let hint = self.hints.pop_front().expect("No more hints left");
         T::deserialize_reader(&mut hint.as_slice())
             .expect("Hint deserialization should never fail")
+    }
+}
+
+impl From<Witness> for OldWitness {
+    fn from(value: Witness) -> Self {
+        Self {
+            next_idx: 0,
+            hints: value.hints.into(),
+        }
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/witness.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/storage/witness.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 
 /// A [`Vec`]-based implementation of [`Witness`] with no special logic.
@@ -17,21 +19,19 @@ use borsh::{BorshDeserialize, BorshSerialize};
 /// ```
 #[derive(Default, BorshDeserialize, BorshSerialize, Debug)]
 pub struct Witness {
-    next_idx: usize,
-    hints: Vec<Vec<u8>>,
+    hints: VecDeque<Vec<u8>>,
 }
 
 impl Witness {
     /// Add a serializable hint
     pub fn add_hint<T: BorshSerialize>(&mut self, hint: &T) {
-        self.hints.push(borsh::to_vec(hint).unwrap())
+        self.hints.push_back(borsh::to_vec(hint).unwrap())
     }
 
     /// Get the next deserializable hint
     pub fn get_hint<T: BorshDeserialize>(&mut self) -> T {
-        let idx = self.next_idx;
-        self.next_idx += 1;
-        T::deserialize_reader(&mut std::io::Cursor::new(&self.hints[idx]))
+        let hint = self.hints.pop_front().expect("No more hints left");
+        T::deserialize_reader(&mut hint.as_slice())
             .expect("Hint deserialization should never fail")
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-state/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/lib.rs
@@ -16,8 +16,9 @@ pub use zk_storage::ZkStorage;
 pub mod config;
 pub use config::Config;
 pub use sov_modules_core::{
-    storage, CacheLog, OrderedReads, OrderedWrites, Prefix, ReadWriteLog, Storage, Witness,
+    storage, CacheLog, OrderedReads, OrderedWrites, Prefix, ReadWriteLog, Storage,
 };
+pub use sov_rollup_interface::witness::Witness;
 
 /// The default Witness type used in merkle proofs for storage access, typically found as a type parameter for [`ProverStorage`].
 /// The default Hasher type used in merkle proofs for storage access, typically found as a type parameter for [`ProverStorage`].

--- a/crates/sovereign-sdk/module-system/sov-state/src/prover_storage.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/prover_storage.rs
@@ -8,9 +8,10 @@ use sov_db::native_db::NativeDB;
 use sov_db::state_db::StateDB;
 use sov_modules_core::{
     CacheKey, NativeStorage, OrderedWrites, ReadWriteLog, Storage, StorageKey, StorageProof,
-    StorageValue, Witness,
+    StorageValue,
 };
 use sov_rollup_interface::stf::{StateDiff, StateRootTransition};
+use sov_rollup_interface::witness::Witness;
 use sov_rollup_interface::zk::StorageRootHash;
 use sov_schema_db::SchemaBatch;
 

--- a/crates/sovereign-sdk/module-system/sov-state/src/zk_storage.rs
+++ b/crates/sovereign-sdk/module-system/sov-state/src/zk_storage.rs
@@ -1,8 +1,9 @@
 use jmt::KeyHash;
 use sov_modules_core::{
-    OrderedWrites, ReadWriteLog, Storage, StorageKey, StorageProof, StorageValue, Witness,
+    OrderedWrites, ReadWriteLog, Storage, StorageKey, StorageProof, StorageValue,
 };
 use sov_rollup_interface::stf::{StateDiff, StateRootTransition};
+use sov_rollup_interface::witness::Witness;
 use sov_rollup_interface::zk::StorageRootHash;
 
 use crate::DefaultHasher;

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/mod.rs
@@ -3,6 +3,7 @@
 pub mod da;
 pub mod soft_confirmation;
 pub mod stf;
+pub mod witness;
 pub mod zk;
 
 pub use bytes::{Buf, BufMut, Bytes, BytesMut};

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/witness.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/witness.rs
@@ -1,3 +1,5 @@
+//! Defines versioned witness types to be used.
+
 use std::collections::VecDeque;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -38,8 +40,7 @@ impl Witness {
     /// Get the next deserializable hint
     pub fn get_hint<T: BorshDeserialize>(&mut self) -> T {
         let hint = self.hints.pop_front().expect("No more hints left");
-        T::deserialize_reader(&mut hint.as_slice())
-            .expect("Hint deserialization should never fail")
+        T::deserialize_reader(&mut hint.as_slice()).expect("Hint deserialization should never fail")
     }
 }
 

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/witness.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/witness.rs
@@ -11,7 +11,7 @@ pub struct PreFork2Witness {
     hints: Vec<Vec<u8>>,
 }
 
-/// A [`Vec`]-based implementation of [`Witness`] with no special logic.
+/// A [`VecDeque`]-based implementation of [`Witness`] with no special logic.
 ///
 /// # Example
 ///

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/witness.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/witness.rs
@@ -4,9 +4,9 @@ use std::collections::VecDeque;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-/// OldWitness should only be used for forks < Fork2
+/// PreFork2Witness should only be used for forks < Fork2
 #[derive(BorshDeserialize, BorshSerialize)]
-pub struct OldWitness {
+pub struct PreFork2Witness {
     next_idx: usize,
     hints: Vec<Vec<u8>>,
 }
@@ -44,7 +44,7 @@ impl Witness {
     }
 }
 
-impl From<Witness> for OldWitness {
+impl From<Witness> for PreFork2Witness {
     fn from(value: Witness) -> Self {
         Self {
             next_idx: 0,

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/mod.rs
@@ -90,7 +90,11 @@ where
                 .into_iter()
                 .zip(witnesses)
                 .map(|(confirmation, (state_witness, offchain_witness))| {
-                    (confirmation.into(), state_witness.into(), offchain_witness.into())
+                    (
+                        confirmation.into(),
+                        state_witness.into(),
+                        offchain_witness.into(),
+                    )
                 })
                 .collect();
 

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/mod.rs
@@ -6,6 +6,7 @@ use v3::{BatchProofCircuitInputV3Part1, BatchProofCircuitInputV3Part2};
 
 use crate::da::{DaSpec, SequencerCommitment};
 use crate::soft_confirmation::L2Block;
+use crate::witness::Witness;
 use crate::zk::StorageRootHash;
 
 /// Genesis input module
@@ -21,7 +22,7 @@ pub mod v3;
 // StateTransitionFunction, DA, and Zkvm traits.
 /// Data required to verify a state transition.
 /// This is more like a glue type to create V1/V2 batch proof circuit inputs later in the program
-pub struct BatchProofCircuitInput<'txs, Witness, Da: DaSpec, Tx: Clone + BorshSerialize> {
+pub struct BatchProofCircuitInput<'txs, Da: DaSpec, Tx: Clone + BorshSerialize> {
     /// The state root before the state transition
     pub initial_state_root: StorageRootHash,
     /// The state root after the state transition
@@ -63,7 +64,7 @@ pub struct BatchProofCircuitInput<'txs, Witness, Da: DaSpec, Tx: Clone + BorshSe
     pub cache_prune_l2_heights: Vec<u64>,
 }
 
-impl<'txs, Witness, Da, Tx> BatchProofCircuitInput<'txs, Witness, Da, Tx>
+impl<'txs, Da, Tx> BatchProofCircuitInput<'txs, Da, Tx>
 where
     Da: DaSpec,
     Tx: Clone + BorshSerialize,
@@ -73,7 +74,7 @@ where
         self,
     ) -> (
         BatchProofCircuitInputV2Part1<Da>,
-        BatchProofCircuitInputV2Part2<'txs, Witness, Tx>,
+        BatchProofCircuitInputV2Part2<'txs, Tx>,
     ) {
         assert_eq!(self.l2_blocks.len(), self.state_transition_witnesses.len());
         let mut x = VecDeque::with_capacity(self.l2_blocks.len());
@@ -89,7 +90,7 @@ where
                 .into_iter()
                 .zip(witnesses)
                 .map(|(confirmation, (state_witness, offchain_witness))| {
-                    (confirmation.into(), state_witness, offchain_witness)
+                    (confirmation.into(), state_witness.into(), offchain_witness.into())
                 })
                 .collect();
 
@@ -118,7 +119,7 @@ where
         self,
     ) -> (
         BatchProofCircuitInputV3Part1<Da>,
-        BatchProofCircuitInputV3Part2<'txs, Witness, Tx>,
+        BatchProofCircuitInputV3Part2<'txs, Tx>,
     ) {
         assert_eq!(self.l2_blocks.len(), self.state_transition_witnesses.len());
         let mut x = VecDeque::with_capacity(self.l2_blocks.len());

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v1.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v1.rs
@@ -5,7 +5,7 @@ use borsh::BorshSerialize;
 use super::BatchProofCircuitInput;
 use crate::da::{BlobReaderTrait, DaSpec};
 use crate::soft_confirmation::SignedSoftConfirmationV1;
-use crate::witness::OldWitness;
+use crate::witness::PreFork2Witness;
 use crate::zk::StorageRootHash;
 
 /// Data required to verify a state transition.
@@ -29,7 +29,7 @@ pub struct BatchProofCircuitInputV1<Da: DaSpec> {
     /// The soft confirmations that are inside the sequencer commitments.
     pub soft_confirmations: VecDeque<Vec<SignedSoftConfirmationV1>>,
     /// Corresponding witness for the soft confirmations.
-    pub state_transition_witnesses: VecDeque<Vec<OldWitness>>,
+    pub state_transition_witnesses: VecDeque<Vec<PreFork2Witness>>,
     /// DA block headers the L2 blocks were constructed on.
     pub da_block_headers_of_l2_blocks: VecDeque<Vec<Da::BlockHeader>>,
     /// Sequencer soft confirmation public key.
@@ -113,7 +113,12 @@ where
             state_transition_witnesses: input
                 .state_transition_witnesses
                 .into_iter()
-                .map(|witnesses| witnesses.into_iter().map(|(witness, _)| witness.into()).collect())
+                .map(|witnesses| {
+                    witnesses
+                        .into_iter()
+                        .map(|(witness, _)| witness.into())
+                        .collect()
+                })
                 .collect(),
             da_block_headers_of_l2_blocks: input.da_block_headers_of_l2_blocks,
             sequencer_public_key: input.sequencer_public_key,

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v1.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v1.rs
@@ -5,10 +5,11 @@ use borsh::BorshSerialize;
 use super::BatchProofCircuitInput;
 use crate::da::{BlobReaderTrait, DaSpec};
 use crate::soft_confirmation::SignedSoftConfirmationV1;
+use crate::witness::OldWitness;
 use crate::zk::StorageRootHash;
 
 /// Data required to verify a state transition.
-pub struct BatchProofCircuitInputV1<Witness, Da: DaSpec> {
+pub struct BatchProofCircuitInputV1<Da: DaSpec> {
     /// The state root before the state transition
     pub initial_state_root: StorageRootHash,
     /// The state root after the state transition
@@ -28,7 +29,7 @@ pub struct BatchProofCircuitInputV1<Witness, Da: DaSpec> {
     /// The soft confirmations that are inside the sequencer commitments.
     pub soft_confirmations: VecDeque<Vec<SignedSoftConfirmationV1>>,
     /// Corresponding witness for the soft confirmations.
-    pub state_transition_witnesses: VecDeque<Vec<Witness>>,
+    pub state_transition_witnesses: VecDeque<Vec<OldWitness>>,
     /// DA block headers the L2 blocks were constructed on.
     pub da_block_headers_of_l2_blocks: VecDeque<Vec<Da::BlockHeader>>,
     /// Sequencer soft confirmation public key.
@@ -39,9 +40,7 @@ pub struct BatchProofCircuitInputV1<Witness, Da: DaSpec> {
     /// The range is inclusive.
     pub sequencer_commitments_range: (u32, u32),
 }
-impl<Witness: borsh::BorshSerialize, Da: DaSpec> BorshSerialize
-    for BatchProofCircuitInputV1<Witness, Da>
-{
+impl<Da: DaSpec> BorshSerialize for BatchProofCircuitInputV1<Da> {
     /// Pre fork 1 serialization
     /// An additional [u8; 32] is added to the end of the bitcoin da header
     /// So the genesis fork guest fails to deserialize the header
@@ -86,13 +85,12 @@ impl<Witness: borsh::BorshSerialize, Da: DaSpec> BorshSerialize
     }
 }
 
-impl<'txs, Witness, Da, Tx> From<BatchProofCircuitInput<'txs, Witness, Da, Tx>>
-    for BatchProofCircuitInputV1<Witness, Da>
+impl<'txs, Da, Tx> From<BatchProofCircuitInput<'txs, Da, Tx>> for BatchProofCircuitInputV1<Da>
 where
     Da: DaSpec,
     Tx: Clone + BorshSerialize,
 {
-    fn from(input: BatchProofCircuitInput<'txs, Witness, Da, Tx>) -> Self {
+    fn from(input: BatchProofCircuitInput<'txs, Da, Tx>) -> Self {
         BatchProofCircuitInputV1 {
             initial_state_root: input.initial_state_root,
             final_state_root: input.final_state_root,
@@ -115,7 +113,7 @@ where
             state_transition_witnesses: input
                 .state_transition_witnesses
                 .into_iter()
-                .map(|witnesses| witnesses.into_iter().map(|(witness, _)| witness).collect())
+                .map(|witnesses| witnesses.into_iter().map(|(witness, _)| witness.into()).collect())
                 .collect(),
             da_block_headers_of_l2_blocks: input.da_block_headers_of_l2_blocks,
             sequencer_public_key: input.sequencer_public_key,

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v2.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v2.rs
@@ -4,14 +4,15 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::da::DaSpec;
 use crate::soft_confirmation::SignedSoftConfirmation;
+use crate::witness::OldWitness;
 use crate::zk::StorageRootHash;
 
 #[derive(BorshDeserialize, BorshSerialize)]
 /// Second part of the Kumquat elf input
 /// This is going to be read per-need basis to not go out of memory
 /// in the zkvm
-pub struct BatchProofCircuitInputV2Part2<'txs, Witness, Tx: Clone + BorshSerialize>(
-    pub VecDeque<Vec<(SignedSoftConfirmation<'txs, Tx>, Witness, Witness)>>,
+pub struct BatchProofCircuitInputV2Part2<'txs, Tx: Clone + BorshSerialize>(
+    pub VecDeque<Vec<(SignedSoftConfirmation<'txs, Tx>, OldWitness, OldWitness)>>,
 );
 
 #[derive(BorshDeserialize, BorshSerialize)]

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v2.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v2.rs
@@ -4,7 +4,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::da::DaSpec;
 use crate::soft_confirmation::SignedSoftConfirmation;
-use crate::witness::OldWitness;
+use crate::witness::PreFork2Witness;
 use crate::zk::StorageRootHash;
 
 #[derive(BorshDeserialize, BorshSerialize)]
@@ -12,7 +12,13 @@ use crate::zk::StorageRootHash;
 /// This is going to be read per-need basis to not go out of memory
 /// in the zkvm
 pub struct BatchProofCircuitInputV2Part2<'txs, Tx: Clone + BorshSerialize>(
-    pub VecDeque<Vec<(SignedSoftConfirmation<'txs, Tx>, OldWitness, OldWitness)>>,
+    pub  VecDeque<
+        Vec<(
+            SignedSoftConfirmation<'txs, Tx>,
+            PreFork2Witness,
+            PreFork2Witness,
+        )>,
+    >,
 );
 
 #[derive(BorshDeserialize, BorshSerialize)]

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v3.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v3.rs
@@ -4,6 +4,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::da::{DaSpec, SequencerCommitment};
 use crate::soft_confirmation::L2Block;
+use crate::witness::Witness;
 use crate::zk::StorageRootHash;
 
 type InputV3Part2<'txs, Tx, Witness> = VecDeque<Vec<(u64, L2Block<'txs, Tx>, Witness, Witness)>>;
@@ -12,7 +13,7 @@ type InputV3Part2<'txs, Tx, Witness> = VecDeque<Vec<(u64, L2Block<'txs, Tx>, Wit
 /// Second part of the Fork2 elf input
 /// This is going to be read per-need basis to not go out of memory
 /// in the zkvm
-pub struct BatchProofCircuitInputV3Part2<'txs, Witness, Tx: Clone + BorshSerialize>(
+pub struct BatchProofCircuitInputV3Part2<'txs, Tx: Clone + BorshSerialize>(
     pub InputV3Part2<'txs, Tx, Witness>,
 );
 


### PR DESCRIPTION
# Description

There is no reason for us to track index in Witness. We can just use VecDequeue. It seems to slightly lower cycle counts ~1% most likely due to less Read Calls when deserializing. The main aim of this PR is not even lowering cycle counts, but versioning the Witness so that I can play around with new Witness types easily without thinking about anything else.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
