### PR TITLE
Don't remove Evm.latest_block_hashes

### DIFF
--- a/crates/evm/src/evm/db.rs
+++ b/crates/evm/src/evm/db.rs
@@ -139,6 +139,9 @@ impl<'a, C: sov_modules_api::Context> Database for EvmDb<'a, C> {
     }
 
     fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        // no need to check block number ranges
+        // revm already checks it
+
         let block_hash = self
             .evm
             .latest_block_hashes

--- a/crates/evm/src/hooks.rs
+++ b/crates/evm/src/hooks.rs
@@ -136,15 +136,20 @@ impl<C: sov_modules_api::Context> Evm<C> {
             );
         }
 
-        // if height > 256, start removing the oldest block
-        // keeping only 256 most recent blocks
-        // this first happens on txs in block 257
-        // remove block 0, keep blocks 1-256
-        // then on block 258
-        // remove block 1, keep blocks 2-257
-        if self.block_env.number > U256::from(256) {
-            self.latest_block_hashes
-                .remove(&(self.block_env.number - U256::from(257)), working_set);
+        if current_spec < CitreaSpecId::Fork2 {
+            // There is no reason to remove them from the state at all.
+            // We remove them only before Fork2 for backwards compatibility.
+
+            // if height > 256, start removing the oldest block
+            // keeping only 256 most recent blocks
+            // this first happens on txs in block 257
+            // remove block 0, keep blocks 1-256
+            // then on block 258
+            // remove block 1, keep blocks 2-257
+            if self.block_env.number > U256::from(256) {
+                self.latest_block_hashes
+                    .remove(&(self.block_env.number - U256::from(257)), working_set);
+            }
         }
 
         self.last_l1_hash

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -118,11 +118,15 @@ pub struct Evm<C: sov_modules_api::Context> {
     pub cfg: sov_modules_api::StateValue<EvmChainConfig, BcsCodec>,
 
     /// Block environment used by the evm. This field is set in `begin_slot_hook`.
+    /// WARNING: only use in the L2 block hook & tx execution path.
+    /// And not in any place such as functions that might be called from RPC etc.
     #[memory]
     pub(crate) block_env: BlockEnv,
 
     /// Transactions that will be added to the current block.
     /// Valid transactions are added to the vec on every call message.
+    /// WARNING: only use in the L2 block hook & tx execution path.
+    /// And not in any place such as functions that might be called from RPC etc.
     #[memory]
     pub(crate) pending_transactions: Vec<PendingTransaction>,
 

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1999,16 +1999,15 @@ fn get_pending_block_env<C: sov_modules_api::Context>(
         latest_block.header.base_fee_per_gas.unwrap_or_default(),
         cfg.base_fee_params,
     ));
+    let citrea_spec_id = fork_fn(block_env.number.saturating_to()).spec_id;
     block_env.blob_excess_gas_and_price =
-        if citrea_spec_id_to_evm_spec_id(fork_fn(block_env.number.saturating_to()).spec_id)
-            >= SpecId::CANCUN
-        {
+        if citrea_spec_id_to_evm_spec_id(citrea_spec_id) >= SpecId::CANCUN {
             Some(BlobExcessGasAndPrice::new(0))
         } else {
             None
         };
 
-    if block_env.number > U256::from(256) {
+    if citrea_spec_id < CitreaSpecId::Fork2 && block_env.number > U256::from(256) {
         evm.latest_block_hashes
             .remove(&(block_env.number - U256::from(257)), working_set);
     }

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -370,6 +370,9 @@ fn finalize_hook_creates_final_block() {
 }
 
 #[test]
+// this test is run with kumquat spec
+// because pre fork2 we were deleting block hashes and
+// we'd still like to test that
 fn begin_soft_confirmation_hook_appends_last_block_hashes() {
     let (mut evm, mut working_set, _spec_id) = get_evm(&get_evm_test_config());
 
@@ -390,7 +393,7 @@ fn begin_soft_confirmation_hook_appends_last_block_hashes() {
         da_slot_height: 1,
         da_slot_txs_commitment: txs_commitment.into(),
         pre_state_root: root,
-        current_spec: SpecId::Fork2,
+        current_spec: SpecId::Kumquat,
         pub_key: vec![],
         deposit_data: vec![],
         l1_fee_rate,
@@ -433,7 +436,7 @@ fn begin_soft_confirmation_hook_appends_last_block_hashes() {
             da_slot_height: 1,
             da_slot_txs_commitment: random_32_bytes,
             pre_state_root: random_32_bytes,
-            current_spec: SpecId::Fork2,
+            current_spec: SpecId::Kumquat,
             pub_key: vec![],
             deposit_data: vec![],
             l1_fee_rate,
@@ -457,7 +460,7 @@ fn begin_soft_confirmation_hook_appends_last_block_hashes() {
         da_slot_height: 1,
         da_slot_txs_commitment: random_32_bytes,
         pre_state_root: random_32_bytes,
-        current_spec: SpecId::Fork2,
+        current_spec: SpecId::Kumquat,
         pub_key: vec![],
         deposit_data: vec![],
         l1_fee_rate,


### PR DESCRIPTION
# Description

There is no reason to remove them from the state at all.
We remove them only before Fork2 for backwards compatibility.

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/1957
