### PR TITLE
L2Block refinements

### DIFF
--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/lib.rs
@@ -190,9 +190,7 @@ pub use sov_modules_core::{
 };
 pub use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 pub use sov_rollup_interface::services::da::SlotData;
-pub use sov_rollup_interface::soft_confirmation::{
-    L2Block, UnsignedSoftConfirmation, UnsignedSoftConfirmationV1,
-};
+pub use sov_rollup_interface::soft_confirmation::L2Block;
 pub use sov_rollup_interface::stf::StateDiff;
 pub use sov_rollup_interface::zk::batch_proof::output::v2::BatchProofCircuitOutputV2;
 pub use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/transaction.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/transaction.rs
@@ -31,6 +31,7 @@ pub struct TransactionV2 {
 }
 
 impl TransactionV2 {
+    #[cfg(feature = "native")]
     fn new(priv_key: &[u8], runtime_msg: Vec<u8>, chain_id: u64, nonce: u64) -> Self {
         let mut message = Vec::with_capacity(runtime_msg.len() + EXTEND_MESSAGE_LEN);
         message.extend_from_slice(&runtime_msg);
@@ -79,6 +80,7 @@ pub struct TransactionV1 {
 }
 
 impl TransactionV1 {
+    #[cfg(feature = "native")]
     fn new(priv_key: &[u8], runtime_msg: Vec<u8>, chain_id: u64, nonce: u64) -> Self {
         let mut message = Vec::with_capacity(runtime_msg.len() + EXTEND_MESSAGE_LEN);
         message.extend_from_slice(&runtime_msg);

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/transaction.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/transaction.rs
@@ -30,6 +30,40 @@ pub struct TransactionV2 {
     nonce: u64,
 }
 
+impl TransactionV2 {
+    fn new(priv_key: &[u8], runtime_msg: Vec<u8>, chain_id: u64, nonce: u64) -> Self {
+        let mut message = Vec::with_capacity(runtime_msg.len() + EXTEND_MESSAGE_LEN);
+        message.extend_from_slice(&runtime_msg);
+        message.extend_from_slice(&chain_id.to_le_bytes());
+        message.extend_from_slice(&nonce.to_le_bytes());
+
+        let priv_key = K256PrivateKey::try_from(priv_key).unwrap();
+        let pub_key = priv_key.pub_key();
+        let signature = priv_key.sign(&message);
+
+        Self {
+            signature: borsh::to_vec(&signature).unwrap(),
+            pub_key: borsh::to_vec(&pub_key).unwrap(),
+            runtime_msg,
+            chain_id,
+            nonce,
+        }
+    }
+
+    fn verify(&self) -> anyhow::Result<()> {
+        let signature = K256Signature::try_from_slice(&self.signature)?;
+        let pub_key = K256PublicKey::try_from(self.pub_key.as_slice())?;
+        let mut serialized_tx = Vec::with_capacity(self.runtime_msg.len() + EXTEND_MESSAGE_LEN);
+
+        serialized_tx.extend_from_slice(&self.runtime_msg);
+        serialized_tx.extend_from_slice(&self.chain_id.to_le_bytes());
+        serialized_tx.extend_from_slice(&self.nonce.to_le_bytes());
+
+        signature.verify(&pub_key, &serialized_tx)?;
+        Ok(())
+    }
+}
+
 /// A Transaction object that is compatible with the module-system/sov-default-stf.
 #[derive(Debug, PartialEq, Eq, Clone, borsh::BorshSerialize)]
 pub struct TransactionV1 {
@@ -42,6 +76,39 @@ pub struct TransactionV1 {
     runtime_msg: Vec<u8>,
     chain_id: u64,
     nonce: u64,
+}
+
+impl TransactionV1 {
+    fn new(priv_key: &[u8], runtime_msg: Vec<u8>, chain_id: u64, nonce: u64) -> Self {
+        let mut message = Vec::with_capacity(runtime_msg.len() + EXTEND_MESSAGE_LEN);
+        message.extend_from_slice(&runtime_msg);
+        message.extend_from_slice(&chain_id.to_le_bytes());
+        message.extend_from_slice(&nonce.to_le_bytes());
+
+        let priv_key = DefaultPrivateKey::try_from(priv_key).unwrap();
+        let pub_key = priv_key.pub_key();
+        let signature = priv_key.sign(&message);
+
+        Self {
+            serialized_signature: borsh::to_vec(&signature).unwrap(),
+            signature,
+            serialized_pub_key: borsh::to_vec(&pub_key).unwrap(),
+            pub_key,
+            runtime_msg,
+            chain_id,
+            nonce,
+        }
+    }
+    fn verify(&self) -> anyhow::Result<()> {
+        let mut serialized_tx = Vec::with_capacity(self.runtime_msg.len() + EXTEND_MESSAGE_LEN);
+
+        serialized_tx.extend_from_slice(&self.runtime_msg);
+        serialized_tx.extend_from_slice(&self.chain_id.to_le_bytes());
+        serialized_tx.extend_from_slice(&self.nonce.to_le_bytes());
+
+        self.signature.verify(&self.pub_key, &serialized_tx)?;
+        Ok(())
+    }
 }
 
 impl BorshDeserialize for TransactionV1 {
@@ -161,66 +228,23 @@ impl Transaction {
         nonce: u64,
         fork2: bool,
     ) -> Self {
-        let mut message = Vec::with_capacity(runtime_msg.len() + EXTEND_MESSAGE_LEN);
-        message.extend_from_slice(&runtime_msg);
-        message.extend_from_slice(&chain_id.to_le_bytes());
-        message.extend_from_slice(&nonce.to_le_bytes());
-
         if fork2 {
-            let priv_key = K256PrivateKey::try_from(priv_key).unwrap();
-            let pub_key = priv_key.pub_key();
-            let signature = priv_key.sign(&message);
-
-            Self::V2(TransactionV2 {
-                signature: borsh::to_vec(&signature).unwrap(),
-                pub_key: borsh::to_vec(&pub_key).unwrap(),
-                runtime_msg,
-                chain_id,
-                nonce,
-            })
+            Self::V2(TransactionV2::new(priv_key, runtime_msg, chain_id, nonce))
         } else {
-            let priv_key = DefaultPrivateKey::try_from(priv_key).unwrap();
-            let pub_key = priv_key.pub_key();
-            let signature = priv_key.sign(&message);
-
-            Self::V1(Box::new(TransactionV1 {
-                serialized_signature: borsh::to_vec(&signature).unwrap(),
-                signature,
-                serialized_pub_key: borsh::to_vec(&pub_key).unwrap(),
-                pub_key,
+            Self::V1(Box::new(TransactionV1::new(
+                priv_key,
                 runtime_msg,
                 chain_id,
                 nonce,
-            }))
+            )))
         }
     }
 
     pub fn verify(&self) -> anyhow::Result<()> {
         match self {
-            Self::V1(tx) => {
-                let mut serialized_tx =
-                    Vec::with_capacity(tx.runtime_msg.len() + EXTEND_MESSAGE_LEN);
-
-                serialized_tx.extend_from_slice(&tx.runtime_msg);
-                serialized_tx.extend_from_slice(&tx.chain_id.to_le_bytes());
-                serialized_tx.extend_from_slice(&tx.nonce.to_le_bytes());
-
-                tx.signature.verify(&tx.pub_key, &serialized_tx)?;
-            }
-            Self::V2(tx) => {
-                let signature = K256Signature::try_from_slice(&tx.signature)?;
-                let pub_key = K256PublicKey::try_from(tx.pub_key.as_slice())?;
-                let mut serialized_tx =
-                    Vec::with_capacity(tx.runtime_msg.len() + EXTEND_MESSAGE_LEN);
-
-                serialized_tx.extend_from_slice(&tx.runtime_msg);
-                serialized_tx.extend_from_slice(&tx.chain_id.to_le_bytes());
-                serialized_tx.extend_from_slice(&tx.nonce.to_le_bytes());
-
-                signature.verify(&pub_key, &serialized_tx)?;
-            }
+            Self::V1(tx) => tx.verify(),
+            Self::V2(tx) => tx.verify(),
         }
-        Ok(())
     }
 
     pub fn compute_digest<D: digest::Digest>(&self) -> digest::Output<D> {

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/soft_confirmation.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/soft_confirmation.rs
@@ -197,7 +197,7 @@ impl<'txs, Tx: Clone + BorshSerialize> L2Block<'txs, Tx> {
             .collect()
     }
 
-    /// Serialized L2Block in a Genesis ELF compatible way
+    /// Serialized L2Block in a Genesis compatible way
     pub fn serialize_v1<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
         BorshSerialize::serialize(&self.l2_height(), writer)?;
         BorshSerialize::serialize(&self.hash(), writer)?;
@@ -213,24 +213,22 @@ impl<'txs, Tx: Clone + BorshSerialize> L2Block<'txs, Tx> {
         BorshSerialize::serialize(&self.timestamp(), writer)
     }
 
-    // impl<Tx: Clone + BorshSerialize> From<L2Block<'_, Tx>> for SignedSoftConfirmationV1 {
-    //     fn from(input: L2Block<'_, Tx>) -> Self {
-    //         SignedSoftConfirmationV1 {
-    //             l2_height: input.l2_height(),
-    //             hash: input.hash(),
-    //             prev_hash: input.prev_hash(),
-    //             da_slot_height: input.da_slot_height(),
-    //             da_slot_hash: input.da_slot_hash(),
-    //             da_slot_txs_commitment: input.da_slot_txs_commitment(),
-    //             l1_fee_rate: input.l1_fee_rate(),
-    //             txs: input.compute_blobs(),
-    //             signature: input.signature().to_vec(),
-    //             deposit_data: input.deposit_data().to_vec(),
-    //             pub_key: input.pub_key().to_vec(),
-    //             timestamp: input.timestamp(),
-    //         }
-    //     }
-    // }
+    /// Serialized L2Block in a Kumquat compatible way
+    pub fn serialize_v2<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        BorshSerialize::serialize(&self.l2_height(), writer)?;
+        BorshSerialize::serialize(&self.hash(), writer)?;
+        BorshSerialize::serialize(&self.prev_hash(), writer)?;
+        BorshSerialize::serialize(&self.da_slot_height(), writer)?;
+        BorshSerialize::serialize(&self.da_slot_hash(), writer)?;
+        BorshSerialize::serialize(&self.da_slot_txs_commitment(), writer)?;
+        BorshSerialize::serialize(&self.l1_fee_rate(), writer)?;
+        BorshSerialize::serialize(&self.compute_blobs(), writer)?;
+        BorshSerialize::serialize(&self.txs, writer)?;
+        BorshSerialize::serialize(&self.signature().to_vec(), writer)?;
+        BorshSerialize::serialize(&self.deposit_data().to_vec(), writer)?;
+        BorshSerialize::serialize(&self.pub_key().to_vec(), writer)?;
+        BorshSerialize::serialize(&self.timestamp(), writer)
+    }
 }
 
 /// Contains raw transactions and information about the soft confirmation block
@@ -367,80 +365,5 @@ impl UnsignedSoftConfirmationV1 {
     pub fn hash<D: Digest>(&self) -> Output<D> {
         let raw = borsh::to_vec(&self).unwrap();
         D::digest(raw.as_slice())
-    }
-}
-
-/// Signed version of the `UnsignedSoftConfirmation`
-/// Contains the signature and public key of the sequencer
-#[derive(PartialEq, Eq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
-pub struct SignedSoftConfirmation<'txs, Tx: Clone + BorshSerialize> {
-    l2_height: u64,
-    hash: [u8; 32],
-    prev_hash: [u8; 32],
-    da_slot_height: u64,
-    da_slot_hash: [u8; 32],
-    da_slot_txs_commitment: [u8; 32],
-    l1_fee_rate: u128,
-    blobs: Cow<'txs, [Vec<u8>]>,
-    txs: Cow<'txs, [Tx]>,
-    signature: Vec<u8>,
-    deposit_data: Vec<Vec<u8>>,
-    pub_key: Vec<u8>,
-    timestamp: u64,
-}
-
-impl<'txs, Tx: Clone + BorshSerialize> SignedSoftConfirmation<'txs, Tx> {
-    /// Creates a signed soft confirmation batch
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        l2_height: u64,
-        hash: [u8; 32],
-        prev_hash: [u8; 32],
-        da_slot_height: u64,
-        da_slot_hash: [u8; 32],
-        da_slot_txs_commitment: [u8; 32],
-        l1_fee_rate: u128,
-        blobs: Cow<'txs, [Vec<u8>]>,
-        txs: Cow<'txs, [Tx]>,
-        deposit_data: Vec<Vec<u8>>,
-        signature: Vec<u8>,
-        pub_key: Vec<u8>,
-        timestamp: u64,
-    ) -> Self {
-        Self {
-            l2_height,
-            hash,
-            prev_hash,
-            da_slot_height,
-            da_slot_hash,
-            da_slot_txs_commitment,
-            l1_fee_rate,
-            blobs,
-            txs,
-            deposit_data,
-            signature,
-            pub_key,
-            timestamp,
-        }
-    }
-}
-
-impl<'txs, Tx: Clone + BorshSerialize> From<L2Block<'_, Tx>> for SignedSoftConfirmation<'txs, Tx> {
-    fn from(input: L2Block<'_, Tx>) -> Self {
-        SignedSoftConfirmation {
-            l2_height: input.l2_height(),
-            hash: input.hash(),
-            prev_hash: input.prev_hash(),
-            da_slot_height: input.da_slot_height(),
-            da_slot_hash: input.da_slot_hash(),
-            da_slot_txs_commitment: input.da_slot_txs_commitment(),
-            l1_fee_rate: input.l1_fee_rate(),
-            blobs: Cow::Owned(input.compute_blobs()),
-            txs: Cow::Owned(input.txs.to_vec()),
-            signature: input.signature().to_vec(),
-            deposit_data: input.deposit_data().to_vec(),
-            pub_key: input.pub_key().to_vec(),
-            timestamp: input.timestamp(),
-        }
     }
 }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/soft_confirmation.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/soft_confirmation.rs
@@ -54,6 +54,52 @@ impl L2Header {
         hasher.update(self.timestamp.to_be_bytes());
         hasher.finalize()
     }
+
+    /// Hash L2Block in a Genesis compatible way
+    pub fn hash_v1<D: Digest>(
+        &self,
+        da_slot_height: u64,
+        da_slot_hash: [u8; 32],
+        blobs: Vec<Vec<u8>>,
+        deposit_data: Vec<Vec<u8>>,
+    ) -> borsh::io::Result<(Output<D>, Vec<u8>)> {
+        let mut vec = Vec::new();
+
+        BorshSerialize::serialize(&self.l2_height, &mut vec)?;
+        BorshSerialize::serialize(&da_slot_height, &mut vec)?;
+        BorshSerialize::serialize(&da_slot_hash, &mut vec)?;
+        BorshSerialize::serialize(&self.da_slot_txs_commitment, &mut vec)?;
+        BorshSerialize::serialize(&blobs, &mut vec)?;
+        BorshSerialize::serialize(&deposit_data.to_vec(), &mut vec)?;
+        BorshSerialize::serialize(&self.l1_fee_rate, &mut vec)?;
+        BorshSerialize::serialize(&self.timestamp, &mut vec)?;
+
+        Ok((D::digest(vec.as_slice()), vec))
+    }
+
+    /// Hash L2Block in a Kumquat compatible way
+    pub fn hash_v2<D: Digest>(
+        &self,
+        da_slot_height: u64,
+        da_slot_hash: [u8; 32],
+        blobs: Vec<Vec<u8>>,
+        deposit_data: Vec<Vec<u8>>,
+    ) -> Output<D> {
+        let mut hasher = D::new();
+        hasher.update(self.l2_height.to_be_bytes());
+        hasher.update(da_slot_height.to_be_bytes());
+        hasher.update(da_slot_hash);
+        hasher.update(self.da_slot_txs_commitment);
+        for tx in blobs {
+            hasher.update(tx);
+        }
+        for deposit in deposit_data {
+            hasher.update(deposit);
+        }
+        hasher.update(self.l1_fee_rate.to_be_bytes());
+        hasher.update(self.timestamp.to_be_bytes());
+        hasher.finalize()
+    }
 }
 
 /// Signed L2 header
@@ -190,7 +236,7 @@ impl<'txs, Tx: Clone + BorshSerialize> L2Block<'txs, Tx> {
 
     /// Borsh serialize all txs as blobs
     /// Required for backward compatiblity
-    fn compute_blobs(&self) -> Vec<Vec<u8>> {
+    pub fn compute_blobs(&self) -> Vec<Vec<u8>> {
         self.txs
             .iter()
             .map(|tx| borsh::to_vec(tx).unwrap())
@@ -228,142 +274,5 @@ impl<'txs, Tx: Clone + BorshSerialize> L2Block<'txs, Tx> {
         BorshSerialize::serialize(&self.deposit_data().to_vec(), writer)?;
         BorshSerialize::serialize(&self.pub_key().to_vec(), writer)?;
         BorshSerialize::serialize(&self.timestamp(), writer)
-    }
-}
-
-/// Contains raw transactions and information about the soft confirmation block
-#[derive(Debug, PartialEq, BorshSerialize, Clone)]
-pub struct UnsignedSoftConfirmation<'txs, Tx> {
-    l2_height: u64,
-    da_slot_height: u64,
-    da_slot_hash: [u8; 32],
-    da_slot_txs_commitment: [u8; 32],
-    blobs: Vec<Vec<u8>>,
-    txs: &'txs [Tx],
-    deposit_data: Vec<Vec<u8>>,
-    l1_fee_rate: u128,
-    timestamp: u64,
-}
-
-impl<'txs, Tx: BorshSerialize> UnsignedSoftConfirmation<'txs, Tx> {
-    /// Create UnsignedSoftConfirmation from header and required for backwards compatibility fields
-    pub fn new(
-        header: &L2Header,
-        blobs: Vec<Vec<u8>>,
-        txs: &'txs [Tx],
-        deposit_data: Vec<Vec<u8>>,
-        da_slot_height: u64,
-        da_slot_hash: [u8; 32],
-    ) -> Self {
-        UnsignedSoftConfirmation {
-            l2_height: header.l2_height,
-            da_slot_height,
-            da_slot_hash,
-            da_slot_txs_commitment: header.da_slot_txs_commitment,
-            blobs,
-            txs,
-            deposit_data,
-            l1_fee_rate: header.l1_fee_rate,
-            timestamp: header.timestamp,
-        }
-    }
-
-    /// Compute digest for the whole UnsignedSoftConfirmation struct
-    pub fn compute_digest<D: Digest>(&self) -> Output<D> {
-        let mut hasher = D::new();
-        hasher.update(self.l2_height.to_be_bytes());
-        hasher.update(self.da_slot_height.to_be_bytes());
-        hasher.update(self.da_slot_hash);
-        hasher.update(self.da_slot_txs_commitment);
-        for tx in &self.blobs {
-            hasher.update(tx);
-        }
-        for deposit in &self.deposit_data {
-            hasher.update(deposit);
-        }
-        hasher.update(self.l1_fee_rate.to_be_bytes());
-        hasher.update(self.timestamp.to_be_bytes());
-        hasher.finalize()
-    }
-}
-
-/// Old version of UnsignedSoftConfirmation
-/// Used for backwards compatibility
-/// Always use ```UnsignedSoftConfirmation``` instead
-#[derive(BorshSerialize)]
-pub struct UnsignedSoftConfirmationV1 {
-    l2_height: u64,
-    da_slot_height: u64,
-    da_slot_hash: [u8; 32],
-    da_slot_txs_commitment: [u8; 32],
-    blobs: Vec<Vec<u8>>,
-    deposit_data: Vec<Vec<u8>>,
-    l1_fee_rate: u128,
-    timestamp: u64,
-}
-
-impl<'txs, Tx: Clone + BorshSerialize> From<&'txs L2Block<'_, Tx>>
-    for UnsignedSoftConfirmation<'txs, Tx>
-{
-    fn from(block: &'txs L2Block<'_, Tx>) -> Self {
-        let header = &block.header.inner;
-        Self {
-            l2_height: header.l2_height,
-            da_slot_height: block.da_slot_height(),
-            da_slot_hash: block.da_slot_hash(),
-            da_slot_txs_commitment: header.da_slot_txs_commitment,
-            blobs: block.compute_blobs(),
-            txs: &block.txs,
-            deposit_data: block.deposit_data.clone(),
-            l1_fee_rate: header.l1_fee_rate,
-            timestamp: header.timestamp,
-        }
-    }
-}
-
-impl<'txs, Tx: Clone + BorshSerialize> From<&'txs L2Block<'_, Tx>> for UnsignedSoftConfirmationV1 {
-    fn from(block: &'txs L2Block<'_, Tx>) -> Self {
-        let header = &block.header.inner;
-        Self {
-            l2_height: header.l2_height,
-            da_slot_height: block.da_slot_height(),
-            da_slot_hash: block.da_slot_hash(),
-            da_slot_txs_commitment: header.da_slot_txs_commitment,
-            blobs: block.compute_blobs(),
-            deposit_data: block.deposit_data.clone(),
-            l1_fee_rate: header.l1_fee_rate,
-            timestamp: header.timestamp,
-        }
-    }
-}
-
-impl UnsignedSoftConfirmationV1 {
-    /// Create UnsignedSoftConfirmation from header and required for backwards compatibility fields
-    pub fn new(
-        header: &L2Header,
-        blobs: Vec<Vec<u8>>,
-        deposit_data: Vec<Vec<u8>>,
-        da_slot_height: u64,
-        da_slot_hash: [u8; 32],
-    ) -> Self {
-        UnsignedSoftConfirmationV1 {
-            l2_height: header.l2_height,
-            da_slot_height,
-            da_slot_hash,
-            da_slot_txs_commitment: header.da_slot_txs_commitment,
-            blobs,
-            deposit_data,
-            l1_fee_rate: header.l1_fee_rate,
-            timestamp: header.timestamp,
-        }
-    }
-
-    /// Pre fork1 version of compute_digest
-    // TODO: Remove derive(BorshSerialize) for UnsignedSoftConfirmation
-    //   when removing this fn
-    // FIXME: ^
-    pub fn hash<D: Digest>(&self) -> Output<D> {
-        let raw = borsh::to_vec(&self).unwrap();
-        D::digest(raw.as_slice())
     }
 }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/soft_confirmation.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/soft_confirmation.rs
@@ -196,6 +196,41 @@ impl<'txs, Tx: Clone + BorshSerialize> L2Block<'txs, Tx> {
             .map(|tx| borsh::to_vec(tx).unwrap())
             .collect()
     }
+
+    /// Serialized L2Block in a Genesis ELF compatible way
+    pub fn serialize_v1<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        BorshSerialize::serialize(&self.l2_height(), writer)?;
+        BorshSerialize::serialize(&self.hash(), writer)?;
+        BorshSerialize::serialize(&self.prev_hash(), writer)?;
+        BorshSerialize::serialize(&self.da_slot_height(), writer)?;
+        BorshSerialize::serialize(&self.da_slot_hash(), writer)?;
+        BorshSerialize::serialize(&self.da_slot_txs_commitment(), writer)?;
+        BorshSerialize::serialize(&self.l1_fee_rate(), writer)?;
+        BorshSerialize::serialize(&self.compute_blobs(), writer)?;
+        BorshSerialize::serialize(&self.signature().to_vec(), writer)?;
+        BorshSerialize::serialize(&self.deposit_data().to_vec(), writer)?;
+        BorshSerialize::serialize(&self.pub_key().to_vec(), writer)?;
+        BorshSerialize::serialize(&self.timestamp(), writer)
+    }
+
+    // impl<Tx: Clone + BorshSerialize> From<L2Block<'_, Tx>> for SignedSoftConfirmationV1 {
+    //     fn from(input: L2Block<'_, Tx>) -> Self {
+    //         SignedSoftConfirmationV1 {
+    //             l2_height: input.l2_height(),
+    //             hash: input.hash(),
+    //             prev_hash: input.prev_hash(),
+    //             da_slot_height: input.da_slot_height(),
+    //             da_slot_hash: input.da_slot_hash(),
+    //             da_slot_txs_commitment: input.da_slot_txs_commitment(),
+    //             l1_fee_rate: input.l1_fee_rate(),
+    //             txs: input.compute_blobs(),
+    //             signature: input.signature().to_vec(),
+    //             deposit_data: input.deposit_data().to_vec(),
+    //             pub_key: input.pub_key().to_vec(),
+    //             timestamp: input.timestamp(),
+    //         }
+    //     }
+    // }
 }
 
 /// Contains raw transactions and information about the soft confirmation block
@@ -390,45 +425,6 @@ impl<'txs, Tx: Clone + BorshSerialize> SignedSoftConfirmation<'txs, Tx> {
     }
 }
 
-/// Signed version of the `UnsignedSoftConfirmation` used in Genesis
-/// Contains the signature and public key of the sequencer
-#[derive(PartialEq, Eq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
-pub struct SignedSoftConfirmationV1 {
-    l2_height: u64,
-    hash: [u8; 32],
-    prev_hash: [u8; 32],
-    da_slot_height: u64,
-    da_slot_hash: [u8; 32],
-    da_slot_txs_commitment: [u8; 32],
-    l1_fee_rate: u128,
-    txs: Vec<Vec<u8>>,
-    signature: Vec<u8>,
-    deposit_data: Vec<Vec<u8>>,
-    pub_key: Vec<u8>,
-    timestamp: u64,
-}
-
-impl<'txs, Tx: Clone + BorshSerialize> From<SignedSoftConfirmation<'txs, Tx>>
-    for SignedSoftConfirmationV1
-{
-    fn from(input: SignedSoftConfirmation<'txs, Tx>) -> Self {
-        SignedSoftConfirmationV1 {
-            l2_height: input.l2_height,
-            hash: input.hash,
-            prev_hash: input.prev_hash,
-            da_slot_height: input.da_slot_height,
-            da_slot_hash: input.da_slot_hash,
-            da_slot_txs_commitment: input.da_slot_txs_commitment,
-            l1_fee_rate: input.l1_fee_rate,
-            txs: input.blobs.into_owned(),
-            signature: input.signature,
-            deposit_data: input.deposit_data,
-            pub_key: input.pub_key,
-            timestamp: input.timestamp,
-        }
-    }
-}
-
 impl<'txs, Tx: Clone + BorshSerialize> From<L2Block<'_, Tx>> for SignedSoftConfirmation<'txs, Tx> {
     fn from(input: L2Block<'_, Tx>) -> Self {
         SignedSoftConfirmation {
@@ -441,25 +437,6 @@ impl<'txs, Tx: Clone + BorshSerialize> From<L2Block<'_, Tx>> for SignedSoftConfi
             l1_fee_rate: input.l1_fee_rate(),
             blobs: Cow::Owned(input.compute_blobs()),
             txs: Cow::Owned(input.txs.to_vec()),
-            signature: input.signature().to_vec(),
-            deposit_data: input.deposit_data().to_vec(),
-            pub_key: input.pub_key().to_vec(),
-            timestamp: input.timestamp(),
-        }
-    }
-}
-
-impl<Tx: Clone + BorshSerialize> From<L2Block<'_, Tx>> for SignedSoftConfirmationV1 {
-    fn from(input: L2Block<'_, Tx>) -> Self {
-        SignedSoftConfirmationV1 {
-            l2_height: input.l2_height(),
-            hash: input.hash(),
-            prev_hash: input.prev_hash(),
-            da_slot_height: input.da_slot_height(),
-            da_slot_hash: input.da_slot_hash(),
-            da_slot_txs_commitment: input.da_slot_txs_commitment(),
-            l1_fee_rate: input.l1_fee_rate(),
-            txs: input.compute_blobs(),
             signature: input.signature().to_vec(),
             deposit_data: input.deposit_data().to_vec(),
             pub_key: input.pub_key().to_vec(),

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/mod.rs
@@ -92,11 +92,7 @@ where
                 .into_iter()
                 .zip(witnesses)
                 .map(|(confirmation, (state_witness, offchain_witness))| {
-                    (
-                        confirmation.into(),
-                        state_witness.into(),
-                        offchain_witness.into(),
-                    )
+                    (confirmation, state_witness.into(), offchain_witness.into())
                 })
                 .collect();
 

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v1.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v1.rs
@@ -68,7 +68,9 @@ impl<'txs, Da: DaSpec, Tx: BorshSerialize + Clone> BorshSerialize
         BorshSerialize::serialize(&self.preproven_commitments, writer)?;
 
         // Serialize L2Blocks into v1 format
+        BorshSerialize::serialize(&(self.soft_confirmations.len() as u32), writer)?;
         for soft_conf in &self.soft_confirmations {
+            BorshSerialize::serialize(&(soft_conf.len() as u32), writer)?;
             for conf in soft_conf {
                 conf.serialize_v1(writer)?;
             }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v1.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v1.rs
@@ -4,12 +4,12 @@ use borsh::BorshSerialize;
 
 use super::BatchProofCircuitInput;
 use crate::da::{BlobReaderTrait, DaSpec};
-use crate::soft_confirmation::SignedSoftConfirmationV1;
+use crate::soft_confirmation::L2Block;
 use crate::witness::PreFork2Witness;
 use crate::zk::StorageRootHash;
 
 /// Data required to verify a state transition.
-pub struct BatchProofCircuitInputV1<Da: DaSpec> {
+pub struct BatchProofCircuitInputV1<'txs, Da: DaSpec, Tx: BorshSerialize + Clone> {
     /// The state root before the state transition
     pub initial_state_root: StorageRootHash,
     /// The state root after the state transition
@@ -27,7 +27,7 @@ pub struct BatchProofCircuitInputV1<Da: DaSpec> {
     /// Pre-proven commitments L2 ranges which also exist in the current L1 `da_data`.
     pub preproven_commitments: Vec<usize>,
     /// The soft confirmations that are inside the sequencer commitments.
-    pub soft_confirmations: VecDeque<Vec<SignedSoftConfirmationV1>>,
+    pub soft_confirmations: VecDeque<Vec<L2Block<'txs, Tx>>>,
     /// Corresponding witness for the soft confirmations.
     pub state_transition_witnesses: VecDeque<Vec<PreFork2Witness>>,
     /// DA block headers the L2 blocks were constructed on.
@@ -40,7 +40,9 @@ pub struct BatchProofCircuitInputV1<Da: DaSpec> {
     /// The range is inclusive.
     pub sequencer_commitments_range: (u32, u32),
 }
-impl<Da: DaSpec> BorshSerialize for BatchProofCircuitInputV1<Da> {
+impl<'txs, Da: DaSpec, Tx: BorshSerialize + Clone> BorshSerialize
+    for BatchProofCircuitInputV1<'txs, Da, Tx>
+{
     /// Pre fork 1 serialization
     /// An additional [u8; 32] is added to the end of the bitcoin da header
     /// So the genesis fork guest fails to deserialize the header
@@ -64,7 +66,13 @@ impl<Da: DaSpec> BorshSerialize for BatchProofCircuitInputV1<Da> {
         BorshSerialize::serialize(&self.inclusion_proof, writer)?;
         BorshSerialize::serialize(&self.completeness_proof, writer)?;
         BorshSerialize::serialize(&self.preproven_commitments, writer)?;
-        BorshSerialize::serialize(&self.soft_confirmations, writer)?;
+
+        // Serialize L2Blocks into v1 format
+        for soft_conf in &self.soft_confirmations {
+            for conf in soft_conf {
+                conf.serialize_v1(writer)?;
+            }
+        }
         BorshSerialize::serialize(&self.state_transition_witnesses, writer)?;
 
         // for every Da::BlockHeader we serialize it and remove last 32 bytes
@@ -85,7 +93,8 @@ impl<Da: DaSpec> BorshSerialize for BatchProofCircuitInputV1<Da> {
     }
 }
 
-impl<'txs, Da, Tx> From<BatchProofCircuitInput<'txs, Da, Tx>> for BatchProofCircuitInputV1<Da>
+impl<'txs, Da, Tx> From<BatchProofCircuitInput<'txs, Da, Tx>>
+    for BatchProofCircuitInputV1<'txs, Da, Tx>
 where
     Da: DaSpec,
     Tx: Clone + BorshSerialize,
@@ -100,16 +109,8 @@ where
             inclusion_proof: input.inclusion_proof,
             completeness_proof: input.completeness_proof,
             preproven_commitments: input.preproven_commitments,
-            soft_confirmations: input
-                .l2_blocks
-                .into_iter()
-                .map(|confirmations| {
-                    confirmations
-                        .into_iter()
-                        .map(SignedSoftConfirmationV1::from)
-                        .collect()
-                })
-                .collect(),
+            soft_confirmations: input.l2_blocks,
+
             state_transition_witnesses: input
                 .state_transition_witnesses
                 .into_iter()

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v2.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v2.rs
@@ -16,9 +16,13 @@ pub struct BatchProofCircuitInputV2Part2<'txs, Tx: Clone + BorshSerialize>(
 
 impl<'txs, Tx: Clone + BorshSerialize> BorshSerialize for BatchProofCircuitInputV2Part2<'txs, Tx> {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        BorshSerialize::serialize(&(self.0.len() as u32), writer)?;
         for blocks in &self.0 {
-            for (block, _, _) in blocks {
-                block.serialize_v2(writer)?
+            BorshSerialize::serialize(&(blocks.len() as u32), writer)?;
+            for (block, w1, w2) in blocks {
+                block.serialize_v2(writer)?;
+                w1.serialize(writer)?;
+                w2.serialize(writer)?;
             }
         }
         Ok(())

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v2.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v2.rs
@@ -1,27 +1,31 @@
 use std::collections::VecDeque;
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshSerialize;
 
 use crate::da::DaSpec;
-use crate::soft_confirmation::SignedSoftConfirmation;
+use crate::soft_confirmation::L2Block;
 use crate::witness::PreFork2Witness;
 use crate::zk::StorageRootHash;
 
-#[derive(BorshDeserialize, BorshSerialize)]
 /// Second part of the Kumquat elf input
 /// This is going to be read per-need basis to not go out of memory
 /// in the zkvm
 pub struct BatchProofCircuitInputV2Part2<'txs, Tx: Clone + BorshSerialize>(
-    pub  VecDeque<
-        Vec<(
-            SignedSoftConfirmation<'txs, Tx>,
-            PreFork2Witness,
-            PreFork2Witness,
-        )>,
-    >,
+    pub VecDeque<Vec<(L2Block<'txs, Tx>, PreFork2Witness, PreFork2Witness)>>,
 );
 
-#[derive(BorshDeserialize, BorshSerialize)]
+impl<'txs, Tx: Clone + BorshSerialize> BorshSerialize for BatchProofCircuitInputV2Part2<'txs, Tx> {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        for blocks in &self.0 {
+            for (block, _, _) in blocks {
+                block.serialize_v2(writer)?
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(BorshSerialize)]
 // Prevent serde from generating spurious trait bounds. The correct serde bounds are already enforced by the
 // StateTransitionFunction, DA, and Zkvm traits.
 /// First part of the Kumquat elf input


### PR DESCRIPTION
# Description

- Cleanup L2Block and remove all previous structs.
Remove the need to go through previous versionned `UnsignedSoftConfirmation` structs for hashing and `SignedSoftConfirmation` for batch prover input serialization.
Implement `serialize_v1` and `serialize_v2` on `L2Block` to keep backward compatibility with `Genesis` and `Kumquat` forks.
Implement `hash_v1` and `hash_v2` on `L2Header` to keep backward compatibility with `Genesis` and `Kumquat` forks.

- Cleanup Transaction handling. Creation and signing logic is handled in transaction variants 
