### PR TITLE
read ALL_FORKS from env in zk

### DIFF
--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -288,7 +288,6 @@ where
                     input,
                     assumptions: vec![],
                     elf,
-                    is_post_genesis_batch: current_spec > SpecId::Genesis,
                 })
                 .await;
         }

--- a/crates/batch-prover/tests/prover_tests.rs
+++ b/crates/batch-prover/tests/prover_tests.rs
@@ -31,7 +31,6 @@ async fn test_successful_prover_execution() {
             input: borsh::to_vec(&make_transition_data(header_hash)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
 
@@ -72,7 +71,6 @@ async fn test_parallel_proofs_equal_to_limit() {
             input: borsh::to_vec(&make_transition_data(header_hash_1)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
     // 2nd proof
@@ -82,7 +80,6 @@ async fn test_parallel_proofs_equal_to_limit() {
             input: borsh::to_vec(&make_transition_data(header_hash_2)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
 
@@ -128,7 +125,6 @@ async fn test_parallel_proofs_higher_than_limit() {
             input: borsh::to_vec(&make_transition_data(header_hash_1)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
     // 2nd proof
@@ -138,7 +134,6 @@ async fn test_parallel_proofs_higher_than_limit() {
             input: borsh::to_vec(&make_transition_data(header_hash_2)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
     // 3rd proof
@@ -148,7 +143,6 @@ async fn test_parallel_proofs_higher_than_limit() {
             input: borsh::to_vec(&make_transition_data(header_hash_3)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
     // 4th proof
@@ -158,7 +152,6 @@ async fn test_parallel_proofs_higher_than_limit() {
             input: borsh::to_vec(&make_transition_data(header_hash_4)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
     // 5th proof
@@ -168,7 +161,6 @@ async fn test_parallel_proofs_higher_than_limit() {
             input: borsh::to_vec(&make_transition_data(header_hash_5)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
 
@@ -236,7 +228,6 @@ async fn test_multiple_parallel_proof_run() {
             input: borsh::to_vec(&make_transition_data(header_hash_1)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
     // 2nd proof
@@ -246,7 +237,6 @@ async fn test_multiple_parallel_proof_run() {
             input: borsh::to_vec(&make_transition_data(header_hash_2)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
 
@@ -272,7 +262,6 @@ async fn test_multiple_parallel_proof_run() {
             input: borsh::to_vec(&make_transition_data(header_hash_3)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
     // 2nd proof
@@ -282,7 +271,6 @@ async fn test_multiple_parallel_proof_run() {
             input: borsh::to_vec(&make_transition_data(header_hash_4)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
     // 3rd proof
@@ -292,7 +280,6 @@ async fn test_multiple_parallel_proof_run() {
             input: borsh::to_vec(&make_transition_data(header_hash_5)).unwrap(),
             assumptions: vec![],
             elf: vec![],
-            is_post_genesis_batch: false,
         })
         .await;
 

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -473,7 +473,6 @@ where
                 input: borsh::to_vec(&circuit_input)?,
                 assumptions,
                 elf: light_client_elf,
-                is_post_genesis_batch: false,
             })
             .await;
 

--- a/crates/prover-services/src/lib.rs
+++ b/crates/prover-services/src/lib.rs
@@ -41,7 +41,4 @@ pub struct ProofData {
 
     /// The ELF binary to be used
     pub elf: Elf,
-
-    /// Flag to indicate whether the elf is for post genesis fork of batch proof
-    pub is_post_genesis_batch: bool,
 }

--- a/crates/risc0/src/host.rs
+++ b/crates/risc0/src/host.rs
@@ -132,7 +132,7 @@ impl ZkvmHost for Risc0BonsaiHost {
         #[cfg(feature = "testing")]
         {
             if self.network == Network::TestNetworkWithForks {
-                env.env_var("ALL_FORK", "1");
+                env.env_var("ALL_FORKS", "1");
             }
         }
 

--- a/crates/risc0/src/host.rs
+++ b/crates/risc0/src/host.rs
@@ -113,13 +113,7 @@ impl ZkvmHost for Risc0BonsaiHost {
 
     /// Only with_proof = true is supported.
     /// Proofs are created on the Bonsai API.
-    fn run(
-        &mut self,
-        elf: Vec<u8>,
-        with_proof: bool,
-        // TODO: remove this when risc0 fixes its env.env_var bug
-        _is_post_genesis_batch: bool,
-    ) -> Result<Proof, anyhow::Error> {
+    fn run(&mut self, elf: Vec<u8>, with_proof: bool) -> Result<Proof, anyhow::Error> {
         if !with_proof {
             if std::env::var("RISC0_PROVER") == Ok("bonsai".to_string()) {
                 panic!("Bonsai prover requires with_proof to be true");
@@ -137,15 +131,8 @@ impl ZkvmHost for Risc0BonsaiHost {
 
         #[cfg(feature = "testing")]
         {
-            if _is_post_genesis_batch {
-                let all_forks_flag = if self.network == Network::TestNetworkWithForks {
-                    1u32
-                } else {
-                    0u32
-                };
-
-                env.write(&all_forks_flag)
-                    .expect("Writing testing all forks flag should not fail");
+            if self.network == Network::TestNetworkWithForks {
+                env.env_var("ALL_FORK", "1");
             }
         }
 

--- a/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
+++ b/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
@@ -195,7 +195,6 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvm {
         &mut self,
         _elf: Vec<u8>,
         _with_proof: bool,
-        _: bool,
     ) -> Result<sov_rollup_interface::zk::Proof, anyhow::Error> {
         let (tx, rx) = mpsc::channel();
 

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
@@ -40,12 +40,7 @@ pub trait ZkvmHost: Zkvm + Clone {
     /// This runs the guest binary compiled for the zkVM target, optionally
     /// creating a SNARK of correct execution. Running the true guest binary comes
     /// with some mild performance overhead and is not as easy to debug as [`simulate_with_hints`](ZkvmHost::simulate_with_hints).
-    fn run(
-        &mut self,
-        elf: Vec<u8>,
-        with_proof: bool,
-        is_post_genesis_batch: bool,
-    ) -> Result<Proof, anyhow::Error>;
+    fn run(&mut self, elf: Vec<u8>, with_proof: bool) -> Result<Proof, anyhow::Error>;
 
     /// Extracts public input and receipt from the proof.
     fn extract_output<T: BorshDeserialize>(proof: &Proof) -> Result<T, Self::Error>;

--- a/guests/risc0/batch-proof/bitcoin/Cargo.toml
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.toml
@@ -22,7 +22,7 @@ sov-rollup-interface = { path = "../../../../crates/sovereign-sdk/rollup-interfa
 sov-state = { path = "../../../../crates/sovereign-sdk/module-system/sov-state" }
 
 [features]
-testing = ["citrea-primitives/testing"]
+testing = ["citrea-primitives/testing", "risc0-zkvm-platform/sys-getenv"]
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }

--- a/guests/risc0/batch-proof/bitcoin/src/bin/batch_proof_bitcoin.rs
+++ b/guests/risc0/batch-proof/bitcoin/src/bin/batch_proof_bitcoin.rs
@@ -92,9 +92,8 @@ const FORKS: &[Fork] = match NETWORK {
 fn get_forks() -> &'static [Fork] {
     #[cfg(feature = "testing")]
     {
-        let all_forks_flag: u32 = risc0_zkvm::guest::env::read();
-        println!("All forks: {all_forks_flag}");
-        if all_forks_flag == 1 {
+        if std::env::var("ALL_FORKS").is_ok() {
+            println!("Enabling ALL_FORKS");
             return &ALL_FORKS;
         }
     }

--- a/guests/risc0/batch-proof/mock/Cargo.toml
+++ b/guests/risc0/batch-proof/mock/Cargo.toml
@@ -22,7 +22,7 @@ sov-rollup-interface = { path = "../../../../crates/sovereign-sdk/rollup-interfa
 sov-state = { path = "../../../../crates/sovereign-sdk/module-system/sov-state" }
 
 [features]
-testing = ["citrea-primitives/testing"]
+testing = ["citrea-primitives/testing", "risc0-zkvm-platform/sys-getenv"]
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }

--- a/guests/risc0/batch-proof/mock/src/bin/batch_proof_mock.rs
+++ b/guests/risc0/batch-proof/mock/src/bin/batch_proof_mock.rs
@@ -39,9 +39,8 @@ const FORKS: &[Fork] = &NIGHTLY_FORKS;
 fn get_forks() -> &'static [Fork] {
     #[cfg(feature = "testing")]
     {
-        let all_forks_flag: u32 = risc0_zkvm::guest::env::read();
-        println!("All forks: {all_forks_flag}");
-        if all_forks_flag == 1 {
+        if std::env::var("ALL_FORKS").is_ok() {
+            println!("Enabling ALL_FORKS");
             return &citrea_primitives::forks::ALL_FORKS;
         }
     }


### PR DESCRIPTION
# Description

risc0 fixed reading environment variable bug in earlier versions. We no longer need to have this is_post_fork boolean variable to pass in the flag as input.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
