### PR TITLE
Corrected typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Citrea Kumquat upgrade will go live on testnet at block 5546000, activating many
   - BLOBBASEFEE returns 1 always as blob transactions are not supported.
   - KZG precompile is not activated.
 - Offchain smart contracts.
-  - Smart contract bytecodes are not commited to the state any more, reducing transaction costs when deploying smart contracts.
+  - Smart contract bytecodes are not committed to the state any more, reducing transaction costs when deploying smart contracts.
 - Reduced diff size estimation by accounting for brotli compression discount, resulting in lower transaction costs for all transactions.
 - Light client proofs are activated.
   - Succinct ZK proofs for any actor to know Citrea's final state trustlessly by verifying a single ZK proof.
@@ -24,7 +24,7 @@ For a detailed list of changes, see auto generated changelog at [v0.6.0 release 
 
 ## v0.5.5 (2024-12-9)
 - 100 wei constant priority fee suggestion from nodes. ([#1561](https://github.com/chainwayxyz/citrea/pull/1561))
-- Sequencer checks compressed diff size of a commitment before commiting. ([#1349](https://github.com/chainwayxyz/citrea/pull/1349) and [#1557](https://github.com/chainwayxyz/citrea/pull/1557))
+- Sequencer checks compressed diff size of a commitment before committing. ([#1349](https://github.com/chainwayxyz/citrea/pull/1349) and [#1557](https://github.com/chainwayxyz/citrea/pull/1557))
 - `prover_prove` RPC method now available. ([#1335](https://github.com/chainwayxyz/citrea/pull/1335))
 - Prover can now prove locally. ([#1326](https://github.com/chainwayxyz/citrea/pull/1326))
 - Prover, sequencer and node configs can now be passed through environment variables. ([#1320](https://github.com/chainwayxyz/citrea/pull/1320))

--- a/crates/soft-confirmation-rule-enforcer/README.md
+++ b/crates/soft-confirmation-rule-enforcer/README.md
@@ -5,4 +5,4 @@ Implementation of Citrea's soft confirmaiton rules as a Sovereign SDK Module.
 This module can be used in any [`State Transition Function`](../citrea-stf/README.md) to enforce two rules:
 
 - **Block Count Rule**: A sequencer cannot publish more L2 blocks on a single L1 block than the amount set by the rollup.
-- **Fee Rate Rule**: Between two consecutive L2 blocks, a sequencer cannot increase or decrease the L1 fee rate more thant the amount set by the rollup.
+- **Fee Rate Rule**: Between two consecutive L2 blocks, a sequencer cannot increase or decrease the L1 fee rate more than, that the amount set by the rollup.

--- a/crates/sovereign-sdk/module-system/README.md
+++ b/crates/sovereign-sdk/module-system/README.md
@@ -14,7 +14,7 @@ and a powerful templating system for implementing complex state transitions.
 The basic building block of the Module System is a `module`. Modules are structs in Rust, and are _required_ to implement the `Module` trait.
 You can find a complete tutorial showing how to implement a custom module [here](../examples/simple-nft-module/README.md).
 Modules typically live in their own crates (you can find a template [here](./module-implementations/module-template/)) so that they're easily
-re-usable. A typical struct definition for a module looks something like this:
+reusable. A typical struct definition for a module looks something like this:
 
 ```rust
 #[derive(ModuleInfo)]

--- a/docs/run-testnet.md
+++ b/docs/run-testnet.md
@@ -98,7 +98,7 @@ There is three different ways to run a Citra full node: using a [pre-built binar
 
 Before continueuing we suggest creating a `citrea/` directory and executing these commands in that directory.
 
-#### Step 1.1: Download neccessary files
+#### Step 1.1: Download necessary files
 
 Go to this [webpage](https://github.com/chainwayxyz/citrea/releases) and download latest binary for your operating system under "Assets" section.
 


### PR DESCRIPTION
Changes made in:

- /CHANGELOG.md ("commited" → "committed")

- /CHANGELOG.md ("commiting" → "committing")

- /crates/sovereign-sdk/module-system/README.md ("re-usable" → "reusable")

- /crates/soft-confirmation-rule-enforcer/README.md ("thant" → "than, that")

- /docs/run-testnet.md ("neccessary" → "necessary")
