### PR TITLE
Disable tracing when re-executing txs in witness gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,6 +1883,7 @@ dependencies = [
  "tokio-util",
  "tower 0.4.13",
  "tracing",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]

--- a/crates/batch-prover/Cargo.toml
+++ b/crates/batch-prover/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 sha2 = { workspace = true }


### PR DESCRIPTION
# Description

Seeing logs from tx re-execution when generating witnesses is confusing and unnecessary IMO. We can shut it off.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
