### PR TITLE
fix l1 hash output test flakiness

### DIFF
--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -828,14 +828,19 @@ impl TestCase for L1HashOutputTest {
         let batch_prover = f.batch_prover.as_ref().unwrap();
 
         sequencer.client.send_publish_batch_request().await?;
-        let start_l1_height = da.get_finalized_height(None).await?;
-
         sequencer.client.wait_for_l2_block(1, None).await?;
 
-        da.generate(100).await?;
+        let start_l1_height = da.get_finalized_height(None).await?;
 
-        tokio::time::sleep(Duration::from_secs(10)).await;
+        da.generate(50).await?;
+
+        // We need to generate 2 L2 blocks here with some delay due to the fact that
+        // L1 syncing of sequencer is asynchronously happenning, and it might be the
+        // case that it saw 20 missing L1 blocks while DA was still generating blocks,
+        // which would prevent further updating the missing DA blocks, hence the second L2 block
+        tokio::time::sleep(Duration::from_secs(1)).await;
         sequencer.client.send_publish_batch_request().await?;
+        tokio::time::sleep(Duration::from_secs(1)).await;
         sequencer.client.send_publish_batch_request().await?;
 
         // Wait for blob inscribe tx to be in mempool
@@ -846,7 +851,6 @@ impl TestCase for L1HashOutputTest {
         let finalized_height = da.get_finalized_height(None).await?;
 
         let zkp = wait_for_proving_finish(batch_prover, finalized_height, None).await?;
-
         assert_eq!(zkp.len(), 1);
 
         let l1_hash = zkp[0]
@@ -856,8 +860,7 @@ impl TestCase for L1HashOutputTest {
             .expect("Should exist")
             .0;
 
-        let hash_from_rpc = sequencer.da.get_block_hash(start_l1_height + 100).await?;
-
+        let hash_from_rpc = sequencer.da.get_block_hash(start_l1_height + 50).await?;
         assert_eq!(hash_from_rpc.as_raw_hash().to_byte_array(), l1_hash);
 
         // part 2
@@ -892,7 +895,6 @@ impl TestCase for L1HashOutputTest {
         let finalized_height = da.get_finalized_height(None).await?;
 
         let zkp_prev = wait_for_proving_finish(batch_prover, finalized_height - 1, None).await?;
-
         assert_eq!(zkp_prev.len(), 1);
 
         let prev_l1_hash = zkp_prev[0]
@@ -901,12 +903,10 @@ impl TestCase for L1HashOutputTest {
             .clone()
             .expect("Should exist")
             .0;
-
         assert_ne!(prev_l1_hash, l1_hash);
 
         let zkp_last = wait_for_proving_finish(batch_prover, finalized_height, None).await?;
-
-        assert_eq!(zkp.len(), 1);
+        assert_eq!(zkp_last.len(), 1);
 
         let new_l1_hash = zkp_last[0]
             .proof_output


### PR DESCRIPTION
# Description

The test was flaky mainly due to 2 reasons:
- Sequencer missing da blocks tracking is asynchronous, and when sequencer sees some amount of da blocks missing, even though in the next tick there are more da blocks missing, it doesn't allow updating missing da blocks until the previous ones are processed. So it is likely the case it saw 20 DA blocks missing initially (test slept for 10 seconds at this point but it wasn't meaningful since it can't update its missing da blocks), and then an L2 block is produced, and before actually updating the test updating the missed da blocks value on the next da block tick, second L2 block is produced, hence, sequencer is now stuck with 20 L2 blocks, producing no commitments. The error seen relevant to this was: `Timeout waiting for mempool to reach length 2`. This is fixed by sleeping also in between 2 L2 block productions. It was passing mostly so far due to the fact that `send_publish_batch_request` is sleeping 100ms by default, and the default citrea-e2e default for da check interval is 100ms as well.
- It could also be the case that sequencer initially saw 60 DA blocks missing, causing it to generate a commitment for L2 blocks 1-61. Even if it correctly catches up the last 40 DA blocks, its not gonna produce a second commitment. Now the problem is the following check:
  ```rust
  let hash_from_rpc = sequencer.da.get_block_hash(start_l1_height + 100).await?;
  assert_eq!(hash_from_rpc.as_raw_hash().to_byte_array(), l1_hash);
  ```
  This assert check will fail because the end commitment L1 height is not +100 but +60. This is fixed by generating 50 DA blocks instead of 100.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
