### PR TITLE
Fix citrea-test image proving

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -33,6 +33,7 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           rustup install 1.81.0
           rustup default 1.81.0
+          rustup toolchain install 1.81-x86_64-unknown-linux-gnu
 
       - name: Install risc0
         uses: ./.github/actions/install-risc0
@@ -42,7 +43,8 @@ jobs:
       - name: Build Project
         id: build
         run: |
-          if ${{ github.event_name == 'workflow_dispatch' && inputs.testing == 'true' }} || ${{ github.ref == 'refs/heads/nightly' }}; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" -a "${{ inputs.testing }}" = "true" ] || [ "${{ github.ref }}" = "refs/heads/nightly" ]; then
+            echo "Building with testing features"
             cargo build --features testing
             echo "image_name=citrea-test" >> $GITHUB_OUTPUT
           else
@@ -54,6 +56,7 @@ jobs:
         run: |
           cp target/debug/citrea docker/build-push/nightly/citrea
           chmod +x docker/build-push/nightly/citrea
+          cp $(which r0vm) docker/build-push/nightly/r0vm
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/docker/build-push/nightly/Dockerfile
+++ b/docker/build-push/nightly/Dockerfile
@@ -8,5 +8,6 @@ RUN apt-get update && \
 WORKDIR /app
 
 COPY citrea /app/citrea
+COPY r0vm /usr/local/bin
 
 ENTRYPOINT ["./citrea"]


### PR DESCRIPTION
# Description

- Fixes https://github.com/chainwayxyz/citrea/issues/2032 by installing missing `1.81-x86_64-unknown-linux-gnu` toolchain
- Copy r0vm from host
- Fixes workflow dispatch to properly resolving testing feature

## Linked Issues
- Fixes #2032
- Fixes https://github.com/chainwayxyz/citrea-e2e/issues/78