### PR TITLE
Tone down sequencer RPC Logger logging level

### DIFF
--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -102,10 +102,15 @@ where
         let service = self.0.clone();
         async move {
             let resp = service.call(req).await;
+
             if resp.is_success() {
                 tracing::trace!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_success");
             } else {
-                tracing::warn!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_error");
+                match req_method.as_str() {
+                    "eth_sendRawTransaction" => tracing::debug!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_error"),
+                    _ => tracing::warn!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_error")
+                }
+
             }
 
             resp

--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -102,7 +102,6 @@ where
         let service = self.0.clone();
         async move {
             let resp = service.call(req).await;
-
             if resp.is_success() {
                 tracing::trace!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_success");
             } else {


### PR DESCRIPTION
# Description

- `eth_sendRawTransaction` RPC response has lots of valid, non-warn level reason to fail, such as Tx `already known` or `insufficient funds for gas`, etc.
This reduces sequencer logs warn level clutter
