### PR TITLE
Batch proof input output changes

### DIFF
--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -315,7 +315,6 @@ impl TestCase for SkipPreprovenCommitmentsTest {
             .map(|response| SequencerCommitment {
                 merkle_root: response.merkle_root,
                 index: response.index.to(),
-                l2_start_block_number: response.l2_start_block_number.to(),
                 l2_end_block_number: response.l2_end_block_number.to(),
             })
             .collect();

--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -177,219 +177,220 @@ async fn basic_prover_test() -> Result<()> {
         .await
 }
 
-#[derive(Default)]
-struct SkipPreprovenCommitmentsTest {
-    task_manager: TaskManager<()>,
-}
+// TODO: Should I remove this?
+// #[derive(Default)]
+// struct SkipPreprovenCommitmentsTest {
+//     task_manager: TaskManager<()>,
+// }
 
-#[async_trait]
-impl TestCase for SkipPreprovenCommitmentsTest {
-    fn test_config() -> TestCaseConfig {
-        TestCaseConfig {
-            with_batch_prover: true,
-            with_full_node: true,
-            ..Default::default()
-        }
-    }
+// #[async_trait]
+// impl TestCase for SkipPreprovenCommitmentsTest {
+//     fn test_config() -> TestCaseConfig {
+//         TestCaseConfig {
+//             with_batch_prover: true,
+//             with_full_node: true,
+//             ..Default::default()
+//         }
+//     }
 
-    fn sequencer_config() -> SequencerConfig {
-        SequencerConfig {
-            min_soft_confirmations_per_commitment: 1,
-            ..Default::default()
-        }
-    }
+//     fn sequencer_config() -> SequencerConfig {
+//         SequencerConfig {
+//             min_soft_confirmations_per_commitment: 1,
+//             ..Default::default()
+//         }
+//     }
 
-    fn scan_l1_start_height() -> Option<u64> {
-        Some(170)
-    }
+//     fn scan_l1_start_height() -> Option<u64> {
+//         Some(170)
+//     }
 
-    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
-        let da = f.bitcoin_nodes.get(0).unwrap();
-        let sequencer = f.sequencer.as_ref().unwrap();
-        let batch_prover = f.batch_prover.as_ref().unwrap();
-        let full_node = f.full_node.as_ref().unwrap();
+//     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+//         let da = f.bitcoin_nodes.get(0).unwrap();
+//         let sequencer = f.sequencer.as_ref().unwrap();
+//         let batch_prover = f.batch_prover.as_ref().unwrap();
+//         let full_node = f.full_node.as_ref().unwrap();
 
-        let da_config = &f.bitcoin_nodes.get(0).unwrap().config;
-        let bitcoin_da_service_config = BitcoinServiceConfig {
-            node_url: format!(
-                "http://127.0.0.1:{}/wallet/{}",
-                da_config.rpc_port,
-                NodeKind::Bitcoin
-            ),
-            node_username: da_config.rpc_user.clone(),
-            node_password: da_config.rpc_password.clone(),
-            network: bitcoin::Network::Regtest,
-            da_private_key: Some(
-                // This is because the prover has a check to make sure that the commitment was
-                // submitted by the sequencer and NOT any other key. Which means that arbitrary keys
-                // CANNOT submit preproven commitments.
-                // Using the sequencer DA private key means that we simulate the fact that the sequencer
-                // somehow resubmitted the same commitment.
-                sequencer
-                    .config()
-                    .rollup
-                    .da
-                    .da_private_key
-                    .as_ref()
-                    .unwrap()
-                    .clone(),
-            ),
-            tx_backup_dir: Self::test_config()
-                .dir
-                .join("tx_backup_dir")
-                .display()
-                .to_string(),
-            monitoring: Default::default(),
-            mempool_space_url: None,
-        };
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+//         let da_config = &f.bitcoin_nodes.get(0).unwrap().config;
+//         let bitcoin_da_service_config = BitcoinServiceConfig {
+//             node_url: format!(
+//                 "http://127.0.0.1:{}/wallet/{}",
+//                 da_config.rpc_port,
+//                 NodeKind::Bitcoin
+//             ),
+//             node_username: da_config.rpc_user.clone(),
+//             node_password: da_config.rpc_password.clone(),
+//             network: bitcoin::Network::Regtest,
+//             da_private_key: Some(
+//                 // This is because the prover has a check to make sure that the commitment was
+//                 // submitted by the sequencer and NOT any other key. Which means that arbitrary keys
+//                 // CANNOT submit preproven commitments.
+//                 // Using the sequencer DA private key means that we simulate the fact that the sequencer
+//                 // somehow resubmitted the same commitment.
+//                 sequencer
+//                     .config()
+//                     .rollup
+//                     .da
+//                     .da_private_key
+//                     .as_ref()
+//                     .unwrap()
+//                     .clone(),
+//             ),
+//             tx_backup_dir: Self::test_config()
+//                 .dir
+//                 .join("tx_backup_dir")
+//                 .display()
+//                 .to_string(),
+//             monitoring: Default::default(),
+//             mempool_space_url: None,
+//         };
+//         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
-        let bitcoin_da_service = Arc::new(
-            BitcoinService::new_with_wallet_check(
-                bitcoin_da_service_config,
-                RollupParams {
-                    reveal_tx_prefix: REVEAL_TX_PREFIX.to_vec(),
-                },
-                tx,
-            )
-            .await
-            .unwrap(),
-        );
+//         let bitcoin_da_service = Arc::new(
+//             BitcoinService::new_with_wallet_check(
+//                 bitcoin_da_service_config,
+//                 RollupParams {
+//                     reveal_tx_prefix: REVEAL_TX_PREFIX.to_vec(),
+//                 },
+//                 tx,
+//             )
+//             .await
+//             .unwrap(),
+//         );
 
-        self.task_manager
-            .spawn(|tk| bitcoin_da_service.clone().run_da_queue(rx, tk));
+//         self.task_manager
+//             .spawn(|tk| bitcoin_da_service.clone().run_da_queue(rx, tk));
 
-        // Generate FINALIZED DA block.
-        da.generate(FINALITY_DEPTH).await?;
+//         // Generate FINALIZED DA block.
+//         da.generate(FINALITY_DEPTH).await?;
 
-        let min_soft_confirmations_per_commitment =
-            sequencer.min_soft_confirmations_per_commitment();
+//         let min_soft_confirmations_per_commitment =
+//             sequencer.min_soft_confirmations_per_commitment();
 
-        for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
-        }
+//         for _ in 0..min_soft_confirmations_per_commitment {
+//             sequencer.client.send_publish_batch_request().await?;
+//         }
 
-        // Wait for blob inscribe tx to be in mempool
-        da.wait_mempool_len(2, None).await?;
+//         // Wait for blob inscribe tx to be in mempool
+//         da.wait_mempool_len(2, None).await?;
 
-        da.generate(FINALITY_DEPTH).await?;
+//         da.generate(FINALITY_DEPTH).await?;
 
-        let finalized_height = da.get_finalized_height(None).await?;
-        batch_prover
-            .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
-            .await?;
+//         let finalized_height = da.get_finalized_height(None).await?;
+//         batch_prover
+//             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
+//             .await?;
 
-        // Wait for batch proof tx to hit mempool
-        da.wait_mempool_len(2, None).await?;
+//         // Wait for batch proof tx to hit mempool
+//         da.wait_mempool_len(2, None).await?;
 
-        da.generate(FINALITY_DEPTH).await?;
-        let _proofs = wait_for_zkproofs(full_node, finalized_height + FINALITY_DEPTH, None, 1)
-            .await
-            .unwrap();
+//         da.generate(FINALITY_DEPTH).await?;
+//         let _proofs = wait_for_zkproofs(full_node, finalized_height + FINALITY_DEPTH, None, 1)
+//             .await
+//             .unwrap();
 
-        // TODO: this test will need refactor
-        // assert!(proofs
-        //     .first()
-        //     .unwrap()
-        //     .proof_output
-        //     .preproven_commitments
-        //     .is_empty());
+//         // TODO: this test will need refactor
+//         // assert!(proofs
+//         //     .first()
+//         //     .unwrap()
+//         //     .proof_output
+//         //     .preproven_commitments
+//         //     .is_empty());
 
-        // Make sure the mempool is mined.
-        da.wait_mempool_len(0, None).await?;
+//         // Make sure the mempool is mined.
+//         da.wait_mempool_len(0, None).await?;
 
-        // Fetch the commitment created from the previous L1 range
-        let commitments: Vec<SequencerCommitment> = full_node
-            .client
-            .http_client()
-            .get_sequencer_commitments_on_slot_by_number(U64::from(finalized_height))
-            .await
-            .unwrap_or_else(|_| {
-                panic!(
-                    "Failed to get sequencer commitments at {}",
-                    finalized_height
-                )
-            })
-            .unwrap_or_else(|| panic!("No sequencer commitments found at {}", finalized_height))
-            .into_iter()
-            .map(|response| SequencerCommitment {
-                merkle_root: response.merkle_root,
-                index: response.index.to(),
-                l2_end_block_number: response.l2_end_block_number.to(),
-            })
-            .collect();
+//         // Fetch the commitment created from the previous L1 range
+//         let commitments: Vec<SequencerCommitment> = full_node
+//             .client
+//             .http_client()
+//             .get_sequencer_commitments_on_slot_by_number(U64::from(finalized_height))
+//             .await
+//             .unwrap_or_else(|_| {
+//                 panic!(
+//                     "Failed to get sequencer commitments at {}",
+//                     finalized_height
+//                 )
+//             })
+//             .unwrap_or_else(|| panic!("No sequencer commitments found at {}", finalized_height))
+//             .into_iter()
+//             .map(|response| SequencerCommitment {
+//                 merkle_root: response.merkle_root,
+//                 index: response.index.to(),
+//                 l2_end_block_number: response.l2_end_block_number.to(),
+//             })
+//             .collect();
 
-        // Send the same commitment that was already proven.
-        bitcoin_da_service
-            .send_transaction_with_fee_rate(
-                DaTxRequest::SequencerCommitment(commitments.first().unwrap().clone()),
-                1,
-            )
-            .await
-            .unwrap();
+//         // Send the same commitment that was already proven.
+//         bitcoin_da_service
+//             .send_transaction_with_fee_rate(
+//                 DaTxRequest::SequencerCommitment(commitments.first().unwrap().clone()),
+//                 1,
+//             )
+//             .await
+//             .unwrap();
 
-        // Wait for the duplicate commitment transaction to be accepted.
-        da.wait_mempool_len(2, None).await?;
+//         // Wait for the duplicate commitment transaction to be accepted.
+//         da.wait_mempool_len(2, None).await?;
 
-        // Trigger a new commitment.
-        for _ in 0..min_soft_confirmations_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
-        }
+//         // Trigger a new commitment.
+//         for _ in 0..min_soft_confirmations_per_commitment {
+//             sequencer.client.send_publish_batch_request().await?;
+//         }
 
-        // Wait for the sequencer commitment to be submitted & accepted.
-        da.wait_mempool_len(4, None).await?;
+//         // Wait for the sequencer commitment to be submitted & accepted.
+//         da.wait_mempool_len(4, None).await?;
 
-        da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height(None).await?;
+//         da.generate(FINALITY_DEPTH).await?;
+//         let finalized_height = da.get_finalized_height(None).await?;
 
-        batch_prover
-            .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
-            .await?;
+//         batch_prover
+//             .wait_for_l1_height(finalized_height, Some(Duration::from_secs(300)))
+//             .await?;
 
-        // Wait for batch proof tx to hit mempool
-        da.wait_mempool_len(2, None).await?;
+//         // Wait for batch proof tx to hit mempool
+//         da.wait_mempool_len(2, None).await?;
 
-        da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height(None).await?;
+//         da.generate(FINALITY_DEPTH).await?;
+//         let finalized_height = da.get_finalized_height(None).await?;
 
-        // Wait for the full node to see all process verify and store all batch proofs
-        full_node.wait_for_l1_height(finalized_height, None).await?;
-        let _proofs = wait_for_zkproofs(
-            full_node,
-            finalized_height,
-            Some(Duration::from_secs(600)),
-            1,
-        )
-        .await
-        .unwrap();
+//         // Wait for the full node to see all process verify and store all batch proofs
+//         full_node.wait_for_l1_height(finalized_height, None).await?;
+//         let _proofs = wait_for_zkproofs(
+//             full_node,
+//             finalized_height,
+//             Some(Duration::from_secs(600)),
+//             1,
+//         )
+//         .await
+//         .unwrap();
 
-        // TODO: this test will need refactor
-        // assert_eq!(
-        //     proofs
-        //         .first()
-        //         .unwrap()
-        //         .proof_output
-        //         .preproven_commitments
-        //         .len(),
-        //     1
-        // );
+//         // TODO: this test will need refactor
+//         // assert_eq!(
+//         //     proofs
+//         //         .first()
+//         //         .unwrap()
+//         //         .proof_output
+//         //         .preproven_commitments
+//         //         .len(),
+//         //     1
+//         // );
 
-        Ok(())
-    }
+//         Ok(())
+//     }
 
-    async fn cleanup(&self) -> Result<()> {
-        self.task_manager.abort().await;
-        Ok(())
-    }
-}
+//     async fn cleanup(&self) -> Result<()> {
+//         self.task_manager.abort().await;
+//         Ok(())
+//     }
+// }
 
-#[tokio::test]
-async fn prover_skips_preproven_commitments_test() -> Result<()> {
-    TestCaseRunner::new(SkipPreprovenCommitmentsTest::default())
-        .set_citrea_path(get_citrea_path())
-        .run()
-        .await
-}
+// #[tokio::test]
+// async fn prover_skips_preproven_commitments_test() -> Result<()> {
+//     TestCaseRunner::new(SkipPreprovenCommitmentsTest::default())
+//         .set_citrea_path(get_citrea_path())
+//         .run()
+//         .await
+// }
 
 struct LocalProvingTest;
 

--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -1,35 +1,30 @@
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use alloy_primitives::{Address, U64};
 use anyhow::bail;
 use async_trait::async_trait;
 use bitcoin::hashes::Hash;
-use bitcoin_da::service::{BitcoinService, BitcoinServiceConfig, FINALITY_DEPTH};
-use bitcoin_da::spec::RollupParams;
+use bitcoin_da::service::FINALITY_DEPTH;
 use bitcoincore_rpc::RpcApi;
 use borsh::BorshDeserialize;
-use citrea_common::tasks::manager::TaskManager;
 use citrea_e2e::config::{
     BatchProverConfig, CitreaMode, LightClientProverConfig, ProverGuestRunConfig, SequencerConfig,
     SequencerMempoolConfig, TestCaseConfig, TestCaseEnv,
 };
 use citrea_e2e::framework::TestFramework;
-use citrea_e2e::node::{BatchProver, FullNode, NodeKind};
+use citrea_e2e::node::{BatchProver, FullNode};
 use citrea_e2e::test_case::{TestCase, TestCaseRunner};
 use citrea_e2e::traits::NodeT;
 use citrea_e2e::Result;
 use citrea_light_client_prover::rpc::LightClientProverRpcClient;
 use citrea_primitives::forks::{fork_from_block_number, get_forks, use_network_forks};
-use citrea_primitives::REVEAL_TX_PREFIX;
 use citrea_stf::runtime::DefaultContext;
 use sov_ledger_rpc::LedgerRpcClient;
 use sov_modules_api::default_signature::K256PublicKey;
 use sov_modules_api::fork::ForkManager;
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{PublicKey, Spec, SpecId};
-use sov_rollup_interface::da::{DaTxRequest, SequencerCommitment};
 use sov_rollup_interface::rpc::{BatchProofResponse, VerifiedBatchProofResponse};
 use sov_rollup_interface::Network;
 use tokio::time::sleep;

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -212,6 +212,10 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         }
     }
 
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(169)
+    }
+
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
         let da = f.bitcoin_nodes.get(0).unwrap();
         let sequencer = f.sequencer.as_ref().unwrap();

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -1318,14 +1318,19 @@ fn create_serialized_fake_receipt_batch_proof(
     malformed_journal: bool,
     last_l1_hash_on_bitcoin_light_client_contract: [u8; 32],
 ) -> Vec<u8> {
+    // TODO: FIXME: Newly added values are wrong
     let batch_proof_output = BatchProofCircuitOutputV3 {
         initial_state_root,
         final_state_root,
         last_l2_height,
         final_soft_confirmation_hash: [0u8; 32],
         state_diff: state_diff.unwrap_or_default(),
-        sequencer_commitment_merkle_roots: vec![],
+        // TODO: Update these values accordingly
+        sequencer_commitment_hashes: vec![],
         last_l1_hash_on_bitcoin_light_client_contract,
+        sequencer_commitment_index_range: (0, 0),
+        previous_commitment_index: None,
+        previous_commitment_hash: None,
     };
     let mut output_serialized = borsh::to_vec(&batch_proof_output).unwrap();
 

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -27,7 +27,7 @@ use sov_ledger_rpc::LedgerRpcClient;
 use sov_rollup_interface::da::{BatchProofMethodId, DaTxRequest};
 use sov_rollup_interface::rpc::BatchProofMethodIdRpcResponse;
 use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
-use sov_rollup_interface::zk::batch_proof::output::CumulativeStateDiff;
+use sov_rollup_interface::zk::batch_proof::output::{BatchProofCircuitOutput, CumulativeStateDiff};
 
 use super::batch_prover_test::wait_for_zkproofs;
 use super::get_citrea_path;
@@ -1318,7 +1318,7 @@ fn create_serialized_fake_receipt_batch_proof(
     last_l1_hash_on_bitcoin_light_client_contract: [u8; 32],
 ) -> Vec<u8> {
     // TODO: FIXME: Newly added values are wrong
-    let batch_proof_output = BatchProofCircuitOutputV3 {
+    let batch_proof_output = BatchProofCircuitOutput::V3(BatchProofCircuitOutputV3 {
         initial_state_root,
         final_state_root,
         last_l2_height,
@@ -1330,7 +1330,7 @@ fn create_serialized_fake_receipt_batch_proof(
         sequencer_commitment_index_range: (0, 0),
         previous_commitment_index: None,
         previous_commitment_hash: None,
-    };
+    });
     let mut output_serialized = borsh::to_vec(&batch_proof_output).unwrap();
 
     // Distorts the output and make it unparsable

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -127,7 +127,6 @@ impl TestCase for LightClientProvingTest {
             .wait_for_l1_height(batch_proof_l1_height, Some(TEN_MINS))
             .await
             .unwrap();
-        println!("sdjhfgasdjhfgasdjhf2");
 
         // Expect light client prover to have generated light client proof
         let lcp = light_client_prover

--- a/bin/citrea/tests/bitcoin/sequencer_commitments.rs
+++ b/bin/citrea/tests/bitcoin/sequencer_commitments.rs
@@ -100,7 +100,6 @@ impl TestCase for LedgerGetCommitmentsProverTest {
 
         assert_eq!(commitments.len(), 1);
 
-        assert_eq!(commitments[0].l2_start_block_number.to::<u64>(), 1);
         assert_eq!(
             commitments[0].l2_end_block_number.to::<u64>(),
             min_soft_confirmations_per_commitment
@@ -177,7 +176,6 @@ impl TestCase for LedgerGetCommitmentsTest {
 
         assert_eq!(commitments.len(), 1);
 
-        assert_eq!(commitments[0].l2_start_block_number.to::<u64>(), 1);
         assert_eq!(
             commitments[0].l2_end_block_number.to::<u64>(),
             min_soft_confirmations_per_commitment
@@ -339,7 +337,6 @@ impl SequencerSendCommitmentsToDaTest {
                 .as_slice(),
         );
 
-        assert_eq!(commitment.l2_start_block_number, start_l2_block);
         assert_eq!(commitment.l2_end_block_number, end_l2_block);
         assert_eq!(commitment.merkle_root, merkle_tree.root().unwrap());
         Ok(())

--- a/bin/citrea/tests/bitcoin/tx_chain.rs
+++ b/bin/citrea/tests/bitcoin/tx_chain.rs
@@ -595,6 +595,7 @@ impl TestCase for TestProverTransactionChaining {
             .await?;
         let txs = &block.txdata;
 
+        // TODO: Why is this very flaky now?
         assert_eq!(txs.len(), 3, "Block should contain exactly 3 transactions");
 
         let _coinbase = &txs[0];

--- a/bin/citrea/tests/mock/mod.rs
+++ b/bin/citrea/tests/mock/mod.rs
@@ -201,7 +201,6 @@ async fn test_all_flow() {
         .unwrap();
     assert_eq!(commitments.len(), 1);
 
-    assert_eq!(commitments[0].l2_start_block_number.to::<u64>(), 1);
     assert_eq!(commitments[0].l2_end_block_number.to::<u64>(), 4);
 
     assert_eq!(commitments[0].l1_height.to::<u64>(), 3);

--- a/bin/citrea/tests/mock/proving.rs
+++ b/bin/citrea/tests/mock/proving.rs
@@ -143,7 +143,6 @@ async fn full_node_verify_proof_and_store() {
         .unwrap();
     assert_eq!(commitments.len(), 1);
 
-    assert_eq!(commitments[0].l2_start_block_number.to::<u64>(), 1);
     assert_eq!(commitments[0].l2_end_block_number.to::<u64>(), 4);
 
     assert_eq!(commitments[0].l1_height.to::<u64>(), 3);
@@ -350,7 +349,6 @@ async fn test_batch_prover_prove_rpc() {
         .unwrap();
     assert_eq!(commitments.len(), 1);
 
-    assert_eq!(commitments[0].l2_start_block_number.to::<u64>(), 1);
     assert_eq!(commitments[0].l2_end_block_number.to::<u64>(), 4);
 
     assert_eq!(commitments[0].l1_height.to::<u64>(), 3);

--- a/bin/citrea/tests/mock/rollback.rs
+++ b/bin/citrea/tests/mock/rollback.rs
@@ -172,7 +172,6 @@ async fn rollback_node(
     rollback_l2_height: u64,
     rollback_l1_height: u64,
     commitment_index: u32,
-    commitment_l2_height: u64,
 ) -> anyhow::Result<()> {
     copy_db_dir_recursive(old_path, new_path).unwrap();
 
@@ -186,7 +185,6 @@ async fn rollback_node(
             rollback_l2_height,
             rollback_l1_height,
             commitment_index,
-            commitment_l2_height,
         )
         .await
         .unwrap();
@@ -329,7 +327,6 @@ async fn test_sequencer_rollback() -> Result<(), anyhow::Error> {
         rollback_l2_height,
         rollback_l1_height,
         rollback_index,
-        rollback_l2_height,
     )
     .await
     .unwrap();
@@ -424,7 +421,6 @@ async fn test_fullnode_rollback() -> Result<(), anyhow::Error> {
         rollback_l2_height,
         rollback_l1_height,
         rollback_index,
-        rollback_l2_height,
     )
     .await
     .unwrap();
@@ -441,7 +437,6 @@ async fn test_fullnode_rollback() -> Result<(), anyhow::Error> {
         rollback_l2_height,
         rollback_l1_height,
         rollback_index,
-        rollback_l2_height,
     )
     .await
     .unwrap();
@@ -549,7 +544,6 @@ async fn test_fullnode_rollback_without_sequencer_rollback() -> Result<(), anyho
         rollback_l2_height,
         rollback_l1_height,
         rollback_index,
-        rollback_l2_height,
     )
     .await
     .unwrap();
@@ -730,7 +724,6 @@ async fn test_batch_prover_rollback() -> Result<(), anyhow::Error> {
         rollback_l2_height,
         rollback_l1_height,
         rollback_index,
-        rollback_l2_height,
     )
     .await
     .unwrap();
@@ -743,7 +736,6 @@ async fn test_batch_prover_rollback() -> Result<(), anyhow::Error> {
         rollback_l2_height,
         rollback_l1_height,
         rollback_index,
-        rollback_l2_height,
     )
     .await
     .unwrap();
@@ -756,7 +748,6 @@ async fn test_batch_prover_rollback() -> Result<(), anyhow::Error> {
         rollback_l2_height,
         rollback_l1_height,
         rollback_index,
-        rollback_l2_height,
     )
     .await
     .unwrap();

--- a/bin/citrea/tests/mock/sequencer_replacement.rs
+++ b/bin/citrea/tests/mock/sequencer_replacement.rs
@@ -124,7 +124,6 @@ async fn test_sequencer_crash_and_replace_full_node() -> Result<(), anyhow::Erro
 
     let commitments = wait_for_commitment(&da_service, 2, Some(Duration::from_secs(60))).await;
     assert_eq!(commitments.len(), 1);
-    assert_eq!(commitments[0].l2_start_block_number, 1);
     assert_eq!(commitments[0].l2_end_block_number, 4);
 
     full_node_task.abort();
@@ -175,7 +174,6 @@ async fn test_sequencer_crash_and_replace_full_node() -> Result<(), anyhow::Erro
     let commitments = wait_for_commitment(&da_service, 3, None).await;
 
     assert_eq!(commitments.len(), 1);
-    assert_eq!(commitments[0].l2_start_block_number, 5);
     assert_eq!(commitments[0].l2_end_block_number, 8);
 
     seq_task.abort();

--- a/bin/cli/src/commands/rollback.rs
+++ b/bin/cli/src/commands/rollback.rs
@@ -17,7 +17,6 @@ pub(crate) async fn rollback(
     l2_target: u64,
     l1_target: u64,
     last_sequencer_commitment_index: u32,
-    last_sequencer_commitment_l2_height: u64,
 ) -> anyhow::Result<()> {
     info!(
         "Rolling back DB at {} down to L2 {}, L1 {}",
@@ -45,7 +44,6 @@ pub(crate) async fn rollback(
             l2_target,
             l1_target,
             last_sequencer_commitment_index,
-            last_sequencer_commitment_l2_height,
         )
         .await?;
 

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -65,9 +65,6 @@ enum Commands {
         /// The target sequencer commitment index to rollback to
         #[arg(long)]
         sequencer_commitment_index: u32,
-        /// The L2 block number at which there was a sequencer commitment that was sent.
-        #[arg(long)]
-        sequencer_commitment_l2_height: u64,
     },
     /// Backup DBs
     RestoreBackup {
@@ -108,7 +105,6 @@ async fn main() -> anyhow::Result<()> {
             l2_target,
             l1_target,
             sequencer_commitment_index,
-            sequencer_commitment_l2_height,
         } => {
             commands::rollback(
                 node_type,
@@ -116,7 +112,6 @@ async fn main() -> anyhow::Result<()> {
                 l2_target,
                 l1_target,
                 sequencer_commitment_index,
-                sequencer_commitment_l2_height,
             )
             .await?;
         }

--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -9,7 +9,7 @@ use citrea_common::da::sync_l1;
 use citrea_common::utils::merge_state_diffs;
 use citrea_common::{BatchProverConfig, ProverGuestRunConfig, RollupPublicKeys};
 use citrea_primitives::compression::compress_blob;
-use citrea_primitives::forks::fork_from_block_number;
+use citrea_primitives::forks::{fork_from_block_number, get_fork2_activation_height};
 use citrea_primitives::MAX_TXBODY_SIZE;
 use prover_services::ParallelProverService;
 use rand::Rng;
@@ -316,16 +316,32 @@ pub(crate) fn break_sequencer_commitments_into_groups<DB: BatchProverLedgerOps>(
 
     let mut range = 0usize..=0usize;
     let mut cumulative_state_diff = StateDiff::new();
+    let first_l2_block_number = if sequencer_commitments[0].index == 0 {
+        // TODO: Handle this better
+        if get_fork2_activation_height() == 0 {
+            1
+        } else {
+            get_fork2_activation_height()
+        }
+    } else {
+        let previous_commitment = ledger_db
+            .get_commitment_by_index(sequencer_commitments[0].index - 1)?
+            .expect("Should exist");
+        previous_commitment.l2_end_block_number + 1
+    };
     for (index, sequencer_commitment) in sequencer_commitments.iter().enumerate() {
         let mut sequencer_commitment_state_diff = StateDiff::new();
-        for l2_height in
-            sequencer_commitment.l2_start_block_number..=sequencer_commitment.l2_end_block_number
-        {
+        let l2_start_block_number = if index == 0 {
+            first_l2_block_number
+        } else {
+            sequencer_commitments[index - 1].l2_end_block_number + 1
+        };
+        for l2_height in l2_start_block_number..=sequencer_commitment.l2_end_block_number {
             let state_diff = ledger_db
                 .get_l2_state_diff(SoftConfirmationNumber(l2_height))?
                 .ok_or(anyhow!(
                     "Could not find state diff for L2 range {}-{}",
-                    sequencer_commitment.l2_start_block_number,
+                    l2_start_block_number,
                     sequencer_commitment.l2_end_block_number
                 ))?;
             sequencer_commitment_state_diff =

--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -9,7 +9,7 @@ use citrea_common::da::sync_l1;
 use citrea_common::utils::merge_state_diffs;
 use citrea_common::{BatchProverConfig, ProverGuestRunConfig, RollupPublicKeys};
 use citrea_primitives::compression::compress_blob;
-use citrea_primitives::forks::{fork_from_block_number, get_fork2_activation_height};
+use citrea_primitives::forks::{fork_from_block_number, get_fork2_activation_height_non_zero};
 use citrea_primitives::MAX_TXBODY_SIZE;
 use prover_services::ParallelProverService;
 use rand::Rng;
@@ -318,11 +318,7 @@ pub(crate) fn break_sequencer_commitments_into_groups<DB: BatchProverLedgerOps>(
     let mut cumulative_state_diff = StateDiff::new();
     let first_l2_block_number = if sequencer_commitments[0].index == 0 {
         // TODO: Handle this better
-        if get_fork2_activation_height() == 0 {
-            1
-        } else {
-            get_fork2_activation_height()
-        }
+        get_fork2_activation_height_non_zero()
     } else {
         let previous_commitment = ledger_db
             .get_commitment_by_index(sequencer_commitments[0].index - 1)?

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use anyhow::{anyhow, Context};
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::{extract_sequencer_commitments, get_da_block_at_height};
-use citrea_common::utils::{check_l2_block_exists, filter_out_proven_commitments};
-use citrea_primitives::forks::fork_from_block_number;
+use citrea_common::utils::check_l2_block_exists;
+use citrea_primitives::forks::{fork_from_block_number, get_fork2_activation_height, FORKS};
 use citrea_stf::runtime::{CitreaRuntime, DefaultContext};
 use prover_services::{ParallelProverService, ProofData};
 use serde::{Deserialize, Serialize};
@@ -95,11 +95,33 @@ where
             l1_height: l1_block.header().height(),
         });
     }
+    // TODO: Make sure commitment indexes are sequential
+
+    // Store commitments by index
+    for commitment in sequencer_commitments {
+        ledger
+            .put_commitment_by_index(&commitment)
+            .expect("Should store commitment");
+    }
+
+    let l2_start_block_number = if sequencer_commitments[0].index == 0 {
+        // If this is the first commitment in fork2, the start l2 height will be fork2 activation height
+        // Start block number should be fork2  activation height
+        get_fork2_activation_height()
+    } else {
+        let previous_commitment_index = sequencer_commitments[0].index - 1;
+        // If this is not the first commitment in fork2, the start l2 height will be the end block number of the previous commitment
+        ledger
+            .get_commitment_by_index(previous_commitment_index)?
+            .expect("There should exist a commitment")
+            .l2_end_block_number
+            + 1
+    };
 
     // If the L2 range does not exist, we break off the local loop getting back to
     // the outer loop / select to make room for other tasks to run.
     // We retry the L1 block there as well.
-    let start_block_number = sequencer_commitments[0].l2_start_block_number;
+    let start_block_number = l2_start_block_number;
     let end_block_number =
         sequencer_commitments[sequencer_commitments.len() - 1].l2_end_block_number;
 
@@ -110,11 +132,6 @@ where
             end_block_number,
         });
     }
-
-    let (mut sequencer_commitments, preproven_commitments) =
-        filter_out_proven_commitments(&ledger, &sequencer_commitments).map_err(|e| {
-            L1ProcessingError::Other(format!("Error filtering out proven commitments: {}", e))
-        })?;
 
     sequencer_commitments.sort();
 
@@ -145,9 +162,16 @@ where
 
     let mut batch_proof_circuit_inputs = Vec::with_capacity(ranges.len());
 
-    for sequencer_commitments_range in ranges {
-        let first_l2_height_of_l1 =
-            sequencer_commitments[*sequencer_commitments_range.start()].l2_start_block_number;
+    for (idx, sequencer_commitments_range) in ranges.iter().enumerate() {
+        let first_l2_height_of_l1 = if idx == 0 {
+            // If at first commitment the start height should be the start block number
+            // Which is end height + 1 of the previous commitment
+            start_block_number
+        } else {
+            // If not at first commitment the start height should be the end height + 1 of the previous commitment in the commitments array
+            sequencer_commitments[*ranges[idx - 1].end()].l2_end_block_number + 1
+        };
+
         let last_l2_height_of_l1 =
             sequencer_commitments[*sequencer_commitments_range.end()].l2_end_block_number;
 
@@ -166,6 +190,7 @@ where
             da_block_headers_of_l2_blocks,
             last_l1_hash_witness,
         ) = get_batch_proof_circuit_input_from_commitments(
+            first_l2_height_of_l1,
             &sequencer_commitments[sequencer_commitments_range.clone()],
             &da_service,
             &ledger,
@@ -209,6 +234,14 @@ where
             )))?
             .prev_hash;
 
+        // TODO: Remove preproven commitments
+        let preproven_commitments = vec![];
+
+        let previous_sequencer_commitment = sequencer_commitments[0]
+            .index
+            .checked_sub(1)
+            .map(|index| ledger.get_commitment_by_index(index)?);
+
         let input = BatchProofCircuitInput {
             initial_state_root,
             da_data: da_data.clone(),
@@ -232,6 +265,7 @@ where
                 .to_vec(),
             cache_prune_l2_heights,
             last_l1_hash_witness,
+            previous_sequencer_commitment,
         };
 
         batch_proof_circuit_inputs.push(input);
@@ -342,6 +376,7 @@ pub(crate) async fn get_batch_proof_circuit_input_from_commitments<
     Da: DaService,
     DB: BatchProverLedgerOps,
 >(
+    first_l2_height_of_commitments: u64,
     sequencer_commitments: &[SequencerCommitment],
     da_service: &Arc<Da>,
     ledger_db: &DB,
@@ -353,9 +388,14 @@ pub(crate) async fn get_batch_proof_circuit_input_from_commitments<
     let mut committed_l2_blocks = VecDeque::with_capacity(sequencer_commitments.len());
     let mut da_block_headers_of_l2_blocks = VecDeque::with_capacity(sequencer_commitments.len());
 
-    for sequencer_commitment in sequencer_commitments.iter() {
+    for (idx, sequencer_commitment) in sequencer_commitments.iter().enumerate() {
         // get the l2 height ranges of each seq_commitments
-        let start_l2 = sequencer_commitment.l2_start_block_number;
+
+        let start_l2 = if idx == 0 {
+            first_l2_height_of_commitments
+        } else {
+            sequencer_commitments[idx - 1].l2_end_block_number + 1
+        };
         let end_l2 = sequencer_commitment.l2_end_block_number;
 
         let soft_confirmations_in_commitment = ledger_db

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Context};
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::{extract_sequencer_commitments, get_da_block_at_height};
 use citrea_common::utils::check_l2_block_exists;
-use citrea_primitives::forks::{fork_from_block_number, get_fork2_activation_height};
+use citrea_primitives::forks::{fork_from_block_number, get_fork2_activation_height_non_zero};
 use citrea_stf::runtime::{CitreaRuntime, DefaultContext};
 use prover_services::{ParallelProverService, ProofData};
 use serde::{Deserialize, Serialize};
@@ -107,11 +107,7 @@ where
     let l2_start_block_number = if sequencer_commitments[0].index == 0 {
         // If this is the first commitment in fork2, the start l2 height will be fork2 activation height
         // Start block number should be fork2  activation height
-        if get_fork2_activation_height() == 0 {
-            1
-        } else {
-            get_fork2_activation_height()
-        }
+        get_fork2_activation_height_non_zero()
     } else {
         let previous_commitment_index = sequencer_commitments[0].index - 1;
         // If this is not the first commitment in fork2, the start l2 height will be the end block number of the previous commitment
@@ -768,11 +764,7 @@ pub(crate) fn save_commitments<DB>(
 {
     for sequencer_commitment in sequencer_commitments.iter() {
         let l2_start_block_number = if sequencer_commitment.index == 0 {
-            if get_fork2_activation_height() == 0 {
-                1
-            } else {
-                get_fork2_activation_height()
-            }
+            get_fork2_activation_height_non_zero()
         } else {
             ledger_db
                 .get_commitment_by_index(sequencer_commitment.index - 1)

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -240,18 +240,18 @@ where
             .prev_hash;
 
         // TODO: Remove preproven commitments
-        let preproven_commitments = vec![];
+        let preproven_commitments = [];
 
         let previous_sequencer_commitment = sequencer_commitments
-            [*sequencer_commitments_range.start() as usize]
-            .index
-            .checked_sub(1)
-            .map(|index| {
-                ledger
-                    .get_commitment_by_index(index)
-                    .expect("Should get commitment")
-                    .expect("Commitment should exist")
-            });
+            [*sequencer_commitments_range.start()]
+        .index
+        .checked_sub(1)
+        .map(|index| {
+            ledger
+                .get_commitment_by_index(index)
+                .expect("Should get commitment")
+                .expect("Commitment should exist")
+        });
 
         let input = BatchProofCircuitInput {
             initial_state_root,
@@ -382,6 +382,7 @@ where
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn get_batch_proof_circuit_input_from_commitments<
     'txs,
     Da: DaService,

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -23,9 +23,7 @@ use sov_rollup_interface::rpc::SoftConfirmationStatus;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::zk::batch_proof::input::v1::BatchProofCircuitInputV1;
 use sov_rollup_interface::zk::batch_proof::input::BatchProofCircuitInput;
-use sov_rollup_interface::zk::batch_proof::output::v1::BatchProofCircuitOutputV1;
-use sov_rollup_interface::zk::batch_proof::output::v2::BatchProofCircuitOutputV2;
-use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
+use sov_rollup_interface::zk::batch_proof::output::BatchProofCircuitOutput;
 use sov_rollup_interface::zk::{Proof, ReceiptType, ZkvmHost};
 use sov_state::Witness;
 use tokio::sync::Mutex;
@@ -711,27 +709,10 @@ where
 
     // l1_height => (tx_id, proof, circuit_output)
     // save proof along with tx id to db, should be queryable by slot number or slot hash
-    let (last_active_spec_id, batch_proof_output) = match Vm::extract_output::<
-        BatchProofCircuitOutputV3,
-    >(&proof)
-    {
-        Ok(output) => (SpecId::Fork2, StoredBatchProofOutput::V3(output)),
-        Err(e) => {
-            info!("Failed to extract post fork 2 output from proof: {:?}. Trying to extract pre fork 2 output", e);
-            match Vm::extract_output::<BatchProofCircuitOutputV2>(&proof) {
-                Ok(output) => (SpecId::Kumquat, StoredBatchProofOutput::V2(output)),
-                Err(e) => {
-                    info!("Failed to extract kumquat fork output from proof: {:?}. Trying to extract genesis fork output", e);
-                    let output = Vm::extract_output::<BatchProofCircuitOutputV1>(&proof)
-                        .expect("Should be able to extract either pre or post fork 1 output");
+    let batch_proof_output = Vm::extract_output::<BatchProofCircuitOutput>(&proof)
+        .map_err(|e| anyhow!("Failed to extract batch proof output from proof: {:?}", e))?;
 
-                    // If we got output of pre fork 1 that means we are in genesis
-                    (SpecId::Genesis, StoredBatchProofOutput::V1(output))
-                }
-            }
-        }
-    };
-
+    let last_active_spec_id = fork_from_block_number(batch_proof_output.last_l2_height()).spec_id;
     let code_commitment = code_commitments_by_spec
         .get(&last_active_spec_id)
         .expect("Proof public input must contain valid spec id");
@@ -747,7 +728,7 @@ where
         l1_height,
         tx_id_u8,
         proof,
-        batch_proof_output,
+        batch_proof_output.into(),
     ) {
         panic!("Failed to put proof data in the ledger db: {}", e);
     }

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -242,19 +242,16 @@ where
         // TODO: Remove preproven commitments
         let preproven_commitments = vec![];
 
-        println!("sequencer commitments: {:?}", sequencer_commitments);
-
-        let previous_sequencer_commitment =
-            sequencer_commitments[0].index.checked_sub(1).map(|index| {
+        let previous_sequencer_commitment = sequencer_commitments
+            [*sequencer_commitments_range.start() as usize]
+            .index
+            .checked_sub(1)
+            .map(|index| {
                 ledger
                     .get_commitment_by_index(index)
                     .expect("Should get commitment")
                     .expect("Commitment should exist")
             });
-        println!(
-            "previous_sequencer_commitment: {:?}",
-            previous_sequencer_commitment
-        );
 
         let input = BatchProofCircuitInput {
             initial_state_root,

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Context};
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::{extract_sequencer_commitments, get_da_block_at_height};
 use citrea_common::utils::check_l2_block_exists;
-use citrea_primitives::forks::{fork_from_block_number, get_fork2_activation_height, FORKS};
+use citrea_primitives::forks::{fork_from_block_number, get_fork2_activation_height};
 use citrea_stf::runtime::{CitreaRuntime, DefaultContext};
 use prover_services::{ParallelProverService, ProofData};
 use serde::{Deserialize, Serialize};
@@ -87,7 +87,7 @@ where
     let (da_data, inclusion_proof, completeness_proof) =
         da_service.extract_relevant_blobs_with_proof(l1_block);
 
-    let sequencer_commitments: Vec<SequencerCommitment> =
+    let mut sequencer_commitments: Vec<SequencerCommitment> =
         extract_sequencer_commitments::<Da>(da_service.clone(), l1_block, &sequencer_da_pub_key);
 
     if sequencer_commitments.is_empty() {
@@ -98,21 +98,26 @@ where
     // TODO: Make sure commitment indexes are sequential
 
     // Store commitments by index
-    for commitment in sequencer_commitments {
+    for commitment in sequencer_commitments.iter() {
         ledger
-            .put_commitment_by_index(&commitment)
+            .put_commitment_by_index(commitment)
             .expect("Should store commitment");
     }
 
     let l2_start_block_number = if sequencer_commitments[0].index == 0 {
         // If this is the first commitment in fork2, the start l2 height will be fork2 activation height
         // Start block number should be fork2  activation height
-        get_fork2_activation_height()
+        if get_fork2_activation_height() == 0 {
+            1
+        } else {
+            get_fork2_activation_height()
+        }
     } else {
         let previous_commitment_index = sequencer_commitments[0].index - 1;
         // If this is not the first commitment in fork2, the start l2 height will be the end block number of the previous commitment
         ledger
-            .get_commitment_by_index(previous_commitment_index)?
+            .get_commitment_by_index(previous_commitment_index)
+            .expect("Ledger should not error out")
             .expect("There should exist a commitment")
             .l2_end_block_number
             + 1
@@ -237,10 +242,19 @@ where
         // TODO: Remove preproven commitments
         let preproven_commitments = vec![];
 
-        let previous_sequencer_commitment = sequencer_commitments[0]
-            .index
-            .checked_sub(1)
-            .map(|index| ledger.get_commitment_by_index(index)?);
+        println!("sequencer commitments: {:?}", sequencer_commitments);
+
+        let previous_sequencer_commitment =
+            sequencer_commitments[0].index.checked_sub(1).map(|index| {
+                ledger
+                    .get_commitment_by_index(index)
+                    .expect("Should get commitment")
+                    .expect("Commitment should exist")
+            });
+        println!(
+            "previous_sequencer_commitment: {:?}",
+            previous_sequencer_commitment
+        );
 
         let input = BatchProofCircuitInput {
             initial_state_root,
@@ -755,12 +769,26 @@ pub(crate) fn save_commitments<DB>(
     DB: BatchProverLedgerOps,
 {
     for sequencer_commitment in sequencer_commitments.iter() {
+        let l2_start_block_number = if sequencer_commitment.index == 0 {
+            if get_fork2_activation_height() == 0 {
+                1
+            } else {
+                get_fork2_activation_height()
+            }
+        } else {
+            ledger_db
+                .get_commitment_by_index(sequencer_commitment.index - 1)
+                .expect("Ledger should not error out")
+                .expect("There should exist a commitment")
+                .l2_end_block_number
+                + 1
+        };
         // Save commitments on prover ledger db
         ledger_db
             .update_commitments_on_da_slot(l1_height, sequencer_commitment.clone())
             .unwrap();
 
-        let l2_start_height = sequencer_commitment.l2_start_block_number;
+        let l2_start_height = l2_start_block_number;
         let l2_end_height = sequencer_commitment.l2_end_block_number;
         for i in l2_start_height..=l2_end_height {
             ledger_db

--- a/crates/bitcoin-da/tests/test_utils.rs
+++ b/crates/bitcoin-da/tests/test_utils.rs
@@ -143,7 +143,6 @@ pub async fn generate_mock_txs(
     let commitment = SequencerCommitment {
         merkle_root: [13; 32],
         index: seq_index,
-        l2_start_block_number: 1002,
         l2_end_block_number: 1100,
     };
     seq_index += 1;
@@ -156,7 +155,6 @@ pub async fn generate_mock_txs(
     let commitment = SequencerCommitment {
         merkle_root: [14; 32],
         index: seq_index,
-        l2_start_block_number: 1101,
         l2_end_block_number: 1245,
     };
     seq_index += 1;
@@ -190,7 +188,6 @@ pub async fn generate_mock_txs(
         .send_transaction(DaTxRequest::SequencerCommitment(SequencerCommitment {
             merkle_root: [15; 32],
             index: seq_index,
-            l2_start_block_number: 1246,
             l2_end_block_number: 1268,
         }))
         .await
@@ -210,7 +207,6 @@ pub async fn generate_mock_txs(
         .send_transaction(DaTxRequest::SequencerCommitment(SequencerCommitment {
             merkle_root: [15; 32],
             index: seq_index,
-            l2_start_block_number: 1246,
             l2_end_block_number: 1268,
         }))
         .await
@@ -219,7 +215,6 @@ pub async fn generate_mock_txs(
     let commitment = SequencerCommitment {
         merkle_root: [15; 32],
         index: seq_index,
-        l2_start_block_number: 1246,
         l2_end_block_number: 1268,
     };
     valid_commitments.push(commitment.clone());

--- a/crates/citrea-stf/src/verifier.rs
+++ b/crates/citrea-stf/src/verifier.rs
@@ -6,6 +6,7 @@ use sov_modules_api::{Context, DaSpec};
 use sov_modules_stf_blueprint::{ApplySequencerCommitmentsOutput, Runtime, StfBlueprint};
 use sov_rollup_interface::zk::batch_proof::input::v3::BatchProofCircuitInputV3Part1;
 use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
+use sov_rollup_interface::zk::batch_proof::output::BatchProofCircuitOutput;
 use sov_rollup_interface::zk::{StorageRootHash, ZkvmGuest};
 use sov_rollup_interface::RefCount;
 use sov_state::codec::{BcsCodec, BorshCodec};
@@ -45,7 +46,7 @@ where
         sequencer_public_key: &[u8],
         sequencer_k256_public_key: &[u8],
         forks: &[Fork],
-    ) -> BatchProofCircuitOutputV3 {
+    ) -> BatchProofCircuitOutput {
         println!("Running sequencer commitments in DA slot");
 
         let mut data: BatchProofCircuitInputV3Part1<Da> = guest.read_from_host();
@@ -104,7 +105,7 @@ where
             )
         };
 
-        BatchProofCircuitOutputV3 {
+        BatchProofCircuitOutput::V3(BatchProofCircuitOutputV3 {
             initial_state_root: data.initial_state_root,
             final_state_root,
             final_soft_confirmation_hash,
@@ -115,7 +116,7 @@ where
             sequencer_commitment_index_range,
             previous_commitment_index,
             previous_commitment_hash,
-        }
+        })
     }
 }
 

--- a/crates/citrea-stf/src/verifier.rs
+++ b/crates/citrea-stf/src/verifier.rs
@@ -76,6 +76,7 @@ where
                 sequencer_k256_public_key,
                 &data.initial_state_root,
                 pre_state.clone(),
+                data.previous_sequencer_commitment,
                 data.sequencer_commitments,
                 data.da_block_headers_of_soft_confirmations,
                 &data.cache_prune_l2_heights,

--- a/crates/citrea-stf/src/verifier.rs
+++ b/crates/citrea-stf/src/verifier.rs
@@ -66,7 +66,10 @@ where
             state_diff,
             last_l2_height,
             final_soft_confirmation_hash,
-            sequencer_commitment_merkle_roots,
+            sequencer_commitment_hashes,
+            sequencer_commitment_index_range,
+            previous_commitment_index,
+            previous_commitment_hash,
             cumulative_state_log,
         } = self
             .app
@@ -107,8 +110,11 @@ where
             final_soft_confirmation_hash,
             state_diff,
             last_l2_height,
-            sequencer_commitment_merkle_roots,
+            sequencer_commitment_hashes,
             last_l1_hash_on_bitcoin_light_client_contract: last_l1_hash,
+            sequencer_commitment_index_range,
+            previous_commitment_index,
+            previous_commitment_hash,
         }
     }
 }

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -5,6 +5,7 @@ pub enum SyncError {
     MissingL2(&'static str, BlockNumber, BlockNumber),
     // Should not retry in this case
     SequencerCommitmentNotFound([u8; 32]),
+    SequencerCommitmentWithIndexNotFound(u32),
     Error(anyhow::Error),
 }
 

--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -105,7 +105,11 @@ where
             if resp.is_success() {
                 tracing::trace!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_success");
             } else {
-                tracing::warn!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_error");
+                match req_method.as_str() {
+                    "eth_sendRawTransaction" => tracing::debug!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_error"),
+                    _ => tracing::warn!(id = ?req_id, method = ?req_method, result = ?resp.as_result(), "rpc_error")
+                }
+
             }
 
             resp

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use alloy_sol_types::SolCall;
@@ -11,12 +11,10 @@ use reth_primitives::TransactionSignedEcRecovered;
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
 use sov_db::ledger_db::SharedLedgerOps;
-use sov_db::schema::types::SoftConfirmationNumber;
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{Context, DaSpec, Spec};
-use sov_rollup_interface::da::SequencerCommitment;
 use sov_rollup_interface::digest::Digest;
-use sov_rollup_interface::rpc::{SoftConfirmationResponse, SoftConfirmationStatus};
+use sov_rollup_interface::rpc::SoftConfirmationResponse;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::stf::StateDiff;

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -28,57 +28,6 @@ pub fn merge_state_diffs(old_diff: StateDiff, new_diff: StateDiff) -> StateDiff 
     new_diff_map.into_iter().collect()
 }
 
-/// Remove proven commitments using the end block number of the L2 range.
-/// This is basically filtering out proven soft confirmations.
-pub fn filter_out_proven_commitments<DB: SharedLedgerOps>(
-    ledger_db: &DB,
-    sequencer_commitments: &[SequencerCommitment],
-) -> anyhow::Result<(Vec<SequencerCommitment>, Vec<usize>)> {
-    filter_out_commitments_by_status(
-        ledger_db,
-        sequencer_commitments,
-        SoftConfirmationStatus::Proven,
-    )
-}
-
-fn filter_out_commitments_by_status<DB: SharedLedgerOps>(
-    ledger_db: &DB,
-    sequencer_commitments: &[SequencerCommitment],
-    exclude_status: SoftConfirmationStatus,
-) -> anyhow::Result<(Vec<SequencerCommitment>, Vec<usize>)> {
-    let mut skipped_commitments = vec![];
-    let mut filtered = vec![];
-    let mut visited_l2_ranges = HashSet::new();
-    for (index, sequencer_commitment) in sequencer_commitments.iter().enumerate() {
-        // Handle commitments which have the same L2 range
-        let current_range = (
-            sequencer_commitment.l2_start_block_number,
-            sequencer_commitment.l2_end_block_number,
-        );
-        if visited_l2_ranges.contains(&current_range) {
-            continue;
-        }
-        visited_l2_ranges.insert(current_range);
-
-        // Check if the commitment was previously finalized.
-        let Some(status) = ledger_db.get_soft_confirmation_status(SoftConfirmationNumber(
-            sequencer_commitment.l2_end_block_number,
-        ))?
-        else {
-            filtered.push(sequencer_commitment.clone());
-            continue;
-        };
-
-        if status != exclude_status {
-            filtered.push(sequencer_commitment.clone());
-        } else {
-            skipped_commitments.push(index);
-        }
-    }
-
-    Ok((filtered, skipped_commitments))
-}
-
 pub fn check_l2_block_exists<DB: SharedLedgerOps>(ledger_db: &DB, l2_height: u64) -> bool {
     let Some(head_l2_height) = ledger_db
         .get_head_soft_confirmation_height()

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -375,10 +375,14 @@ where
                 .ledger_db
                 .get_commitment_by_index(index)?
                 .ok_or(SyncError::SequencerCommitmentWithIndexNotFound(index))?;
-            assert_eq!(
-                sequencer_commitment.serialize_and_calculate_sha_256(),
-                expected_hash
-            );
+
+            if sequencer_commitment.serialize_and_calculate_sha_256() != expected_hash {
+                return Err(anyhow!(
+                    "Proof verification: For a known and verified sequencer commitment. Hash mismatch - expected 0x{} but got 0x{}. Skipping proof.",
+                    hex::encode(sequencer_commitment.serialize_and_calculate_sha_256()),
+                    hex::encode(expected_hash)
+                ).into());
+            }
             let seq_comm_range = (l2_start_height, sequencer_commitment.l2_end_block_number);
 
             let l2_height_before_comm_range = seq_comm_range.0 - 1;

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -8,6 +8,7 @@ use citrea_common::cache::L1BlockCache;
 use citrea_common::da::{extract_sequencer_commitments, extract_zk_proofs, sync_l1};
 use citrea_common::error::SyncError;
 use citrea_common::utils::check_l2_block_exists;
+use citrea_primitives::forks::get_fork2_activation_height;
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
 use sov_db::ledger_db::NodeLedgerOps;
@@ -135,6 +136,13 @@ where
             l1_block,
             &self.sequencer_da_pub_key,
         );
+
+        for commitment in sequencer_commitments.iter() {
+            self.ledger_db
+                .put_commitment_by_index(commitment)
+                .expect("Should save commitment to ledger db");
+        }
+
         let zk_proofs =
             match extract_zk_proofs(self.da_service.clone(), l1_block, &self.prover_da_pub_key)
                 .await
@@ -171,6 +179,9 @@ where
                     SyncError::SequencerCommitmentNotFound(merkle_root) => {
                         error!("Could not process ZK proofs: Sequencer commitment not found for merkle root: 0x{}... skipping...", hex::encode(merkle_root));
                     }
+                    SyncError::SequencerCommitmentWithIndexNotFound(idx) => {
+                        error!("Could not process ZK proofs: Sequencer commitment with index {} not found... skipping...", idx);
+                    }
                 }
             }
         }
@@ -189,6 +200,9 @@ where
                         error!("Could not process sequencer commitments: {}... skipping", e);
                     }
                     SyncError::SequencerCommitmentNotFound(_) => unreachable!("Error irrelevant!"),
+                    SyncError::SequencerCommitmentWithIndexNotFound(_) => {
+                        unreachable!("Error irrelevant!")
+                    }
                 }
             }
         }
@@ -213,7 +227,19 @@ where
         l1_block: &Da::FilteredBlock,
         sequencer_commitment: &SequencerCommitment,
     ) -> Result<(), SyncError> {
-        let start_l2_height = sequencer_commitment.l2_start_block_number;
+        let start_l2_height = if sequencer_commitment.index == 0 {
+            if get_fork2_activation_height() == 0 {
+                1
+            } else {
+                get_fork2_activation_height()
+            }
+        } else {
+            self.ledger_db
+                .get_commitment_by_index(sequencer_commitment.index - 1)?
+                .expect("Commitment must exist")
+                .l2_end_block_number
+                + 1
+        };
         let end_l2_height = sequencer_commitment.l2_end_block_number;
 
         tracing::info!(
@@ -311,7 +337,7 @@ where
                 self.process_fork2_zk_proof(
                     l1_block,
                     output.initial_state_root,
-                    output.sequencer_commitment_merkle_roots.clone(),
+                    output.sequencer_commitment_index_range,
                     proof,
                     StoredBatchProofOutput::from(output),
                 )
@@ -379,12 +405,20 @@ where
         l1_block: &Da::FilteredBlock,
         initial_state_root: [u8; 32],
         // TODO Get sequencer commitments index range from bp output and get merkle roots from there
-        soft_confirmation_merkle_roots: Vec<[u8; 32]>,
+        sequencer_commitment_index_range: (u32, u32),
         raw_proof: Proof,
         batch_proof_output: StoredBatchProofOutput,
     ) -> Result<(), SyncError> {
         // make sure init roots match <- TODO: with proposed changes in issues this will be unnecessary
-        for root in soft_confirmation_merkle_roots {
+        let mut merkle_roots = vec![];
+        for index in sequencer_commitment_index_range.0..=sequencer_commitment_index_range.1 {
+            let sequencer_commitment = self
+                .ledger_db
+                .get_commitment_by_index(index)?
+                .ok_or(SyncError::SequencerCommitmentWithIndexNotFound(index))?;
+            merkle_roots.push(sequencer_commitment.merkle_root);
+        }
+        for root in merkle_roots {
             // make sure sequencer commitment soft confirmation merkle root match
             // since we wouldn't have the sequencer commitment in the ledger db
             // this makes sure the sequencer commitment exists
@@ -476,8 +510,9 @@ where
             .map(|(_, commitment)| commitment)
             .collect();
 
-        let l2_height =
-            filtered_commitments[sequencer_commitments_range.0 as usize].l2_start_block_number;
+        // TODO: THIS VALUE IS SET TEMPORARILY TO 0 AS WE DO NOT USE IT IN TESTS
+        // ALSO THIS FUNCTION WILL EVENTUALLY BE REMOVED WITH FORK2
+        let l2_height = 0;
         // Fetch the block prior to the one at l2_height so compare state roots
 
         let state_root_prior_soft_confirmation = self
@@ -500,7 +535,9 @@ where
             .skip(sequencer_commitments_range.0 as usize)
             .take((sequencer_commitments_range.1 - sequencer_commitments_range.0 + 1) as usize)
         {
-            let l2_start_height = commitment.l2_start_block_number;
+            // TODO: THIS VALUE IS SET TEMPORARILY TO 0 AS WE DO NOT USE IT IN TESTS
+            // ALSO THIS FUNCTION WILL EVENTUALLY BE REMOVED WITH FORK2
+            let l2_start_height = 0;
             let l2_end_height = commitment.l2_end_block_number;
             for i in l2_start_height..=l2_end_height {
                 self.ledger_db.put_l2_block_status(

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -12,7 +12,6 @@ use citrea_primitives::forks::{fork_from_block_number, get_fork2_activation_heig
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
 use sov_db::ledger_db::NodeLedgerOps;
-use sov_db::schema::types::batch_proof::StoredBatchProofOutput;
 use sov_db::schema::types::soft_confirmation::StoredSoftConfirmation;
 use sov_db::schema::types::{SlotNumber, SoftConfirmationNumber};
 use sov_modules_api::{DaSpec, Zkvm};
@@ -131,12 +130,6 @@ where
             l1_block,
             &self.sequencer_da_pub_key,
         );
-
-        for commitment in sequencer_commitments.iter() {
-            self.ledger_db
-                .put_commitment_by_index(commitment)
-                .expect("Should save commitment to ledger db");
-        }
 
         let zk_proofs =
             match extract_zk_proofs(self.da_service.clone(), l1_block, &self.prover_da_pub_key)
@@ -299,6 +292,9 @@ where
             ),
         )?;
 
+        self.ledger_db
+            .put_commitment_by_index(sequencer_commitment)?;
+
         self.ledger_db.set_last_commitment(sequencer_commitment)?;
 
         Ok(())
@@ -347,6 +343,8 @@ where
             Some(idx) => {
                 let previous_sequencer_commitment = self
                     .ledger_db
+                    // TODO: This works for now, but once we generate proofs by taking commitments from mempool
+                    // we will need to store the commitments earlier to process proofs, maybe just process commitments first for that
                     .get_commitment_by_index(idx)?
                     .ok_or(SyncError::SequencerCommitmentWithIndexNotFound(idx))?;
 

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -328,9 +328,8 @@ where
         self.process_fork2_zk_proof(
             l1_block,
             batch_proof_output.initial_state_root(),
-            batch_proof_output.sequencer_commitment_index_range(),
             proof,
-            StoredBatchProofOutput::from(batch_proof_output),
+            batch_proof_output.into(),
         )
     }
 
@@ -338,30 +337,53 @@ where
         &self,
         l1_block: &Da::FilteredBlock,
         initial_state_root: [u8; 32],
-        // TODO Get sequencer commitments index range from bp output and get merkle roots from there
-        sequencer_commitment_index_range: (u32, u32),
         raw_proof: Proof,
-        batch_proof_output: StoredBatchProofOutput,
+        batch_proof_output: BatchProofCircuitOutput,
     ) -> Result<(), SyncError> {
+        let sequencer_commitment_index_range =
+            batch_proof_output.sequencer_commitment_index_range();
         // make sure init roots match <- TODO: with proposed changes in issues this will be unnecessary
-        let mut merkle_roots = vec![];
-        for index in sequencer_commitment_index_range.0..=sequencer_commitment_index_range.1 {
+        let mut l2_start_height = match batch_proof_output.previous_commitment_index() {
+            Some(idx) => {
+                let previous_sequencer_commitment = self
+                    .ledger_db
+                    .get_commitment_by_index(idx)?
+                    .ok_or(SyncError::SequencerCommitmentWithIndexNotFound(idx))?;
+
+                // Check previous sequencer commitment hash
+                if previous_sequencer_commitment.serialize_and_calculate_sha_256()
+                    != batch_proof_output
+                        .previous_commitment_hash()
+                        .expect("If index exists so must hash")
+                {
+                    return Err(anyhow!(
+                        "Proof verification: For a known and verified sequencer commitment. Hash mismatch - expected 0x{} but got 0x{}. Skipping proof.",
+                        hex::encode(previous_sequencer_commitment.serialize_and_calculate_sha_256()),
+                        hex::encode(batch_proof_output.previous_commitment_hash().expect("If index exists so must hash"))
+                    ).into());
+                }
+                previous_sequencer_commitment.l2_end_block_number + 1
+            }
+            // If there is no previous seq comm hash then this must be the first post fork2 commitment
+            None => get_fork2_activation_height_non_zero(),
+        };
+
+        for (index, expected_hash) in (sequencer_commitment_index_range.0
+            ..=sequencer_commitment_index_range.1)
+            .zip(batch_proof_output.sequencer_commitment_hashes())
+        {
+            // Check if hash matches
             let sequencer_commitment = self
                 .ledger_db
                 .get_commitment_by_index(index)?
                 .ok_or(SyncError::SequencerCommitmentWithIndexNotFound(index))?;
-            merkle_roots.push(sequencer_commitment.merkle_root);
-        }
-        for root in merkle_roots {
-            // make sure sequencer commitment soft confirmation merkle root match
-            // since we wouldn't have the sequencer commitment in the ledger db
-            // this makes sure the sequencer commitment exists
-            let seq_comm_range = self
-                .ledger_db
-                .get_l2_range_by_commitment_merkle_root(root)?
-                .ok_or(SyncError::SequencerCommitmentNotFound(root))?;
+            assert_eq!(
+                sequencer_commitment.serialize_and_calculate_sha_256(),
+                expected_hash
+            );
+            let seq_comm_range = (l2_start_height, sequencer_commitment.l2_end_block_number);
 
-            let l2_height_before_comm_range = seq_comm_range.0 .0 - 1;
+            let l2_height_before_comm_range = seq_comm_range.0 - 1;
             let state_root_prior_soft_confirmation = self
                 .ledger_db
                 .get_l2_state_root(l2_height_before_comm_range)?
@@ -380,19 +402,20 @@ where
                 ).into());
             }
 
-            for i in seq_comm_range.0 .0..=seq_comm_range.1 .0 {
+            for i in seq_comm_range.0..=seq_comm_range.1 {
                 self.ledger_db.put_l2_block_status(
                     SoftConfirmationNumber(i),
                     SoftConfirmationStatus::Proven,
                 )?;
             }
+            l2_start_height = sequencer_commitment.l2_end_block_number + 1;
         }
 
         // store in ledger db
         self.ledger_db.update_verified_proof_data(
             l1_block.header().height(),
             raw_proof,
-            batch_proof_output,
+            batch_proof_output.into(),
         )?;
 
         Ok(())

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -8,7 +8,7 @@ use citrea_common::cache::L1BlockCache;
 use citrea_common::da::{extract_sequencer_commitments, extract_zk_proofs, sync_l1};
 use citrea_common::error::SyncError;
 use citrea_common::utils::check_l2_block_exists;
-use citrea_primitives::forks::get_fork2_activation_height;
+use citrea_primitives::forks::get_fork2_activation_height_non_zero;
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
 use sov_db::ledger_db::NodeLedgerOps;
@@ -228,11 +228,7 @@ where
         sequencer_commitment: &SequencerCommitment,
     ) -> Result<(), SyncError> {
         let start_l2_height = if sequencer_commitment.index == 0 {
-            if get_fork2_activation_height() == 0 {
-                1
-            } else {
-                get_fork2_activation_height()
-            }
+            get_fork2_activation_height_non_zero()
         } else {
             self.ledger_db
                 .get_commitment_by_index(sequencer_commitment.index - 1)?

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -378,6 +378,7 @@ where
         &self,
         l1_block: &Da::FilteredBlock,
         initial_state_root: [u8; 32],
+        // TODO Get sequencer commitments index range from bp output and get merkle roots from there
         soft_confirmation_merkle_roots: Vec<[u8; 32]>,
         raw_proof: Proof,
         batch_proof_output: StoredBatchProofOutput,

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -8,7 +8,7 @@ use citrea_common::cache::L1BlockCache;
 use citrea_common::da::{extract_sequencer_commitments, extract_zk_proofs, sync_l1};
 use citrea_common::error::SyncError;
 use citrea_common::utils::check_l2_block_exists;
-use citrea_primitives::forks::get_fork2_activation_height_non_zero;
+use citrea_primitives::forks::{fork_from_block_number, get_fork2_activation_height_non_zero};
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
 use sov_db::ledger_db::NodeLedgerOps;
@@ -20,9 +20,7 @@ use sov_rollup_interface::da::{BlockHeaderTrait, SequencerCommitment};
 use sov_rollup_interface::rpc::SoftConfirmationStatus;
 use sov_rollup_interface::services::da::{DaService, SlotData};
 use sov_rollup_interface::spec::SpecId;
-use sov_rollup_interface::zk::batch_proof::output::v1::BatchProofCircuitOutputV1;
-use sov_rollup_interface::zk::batch_proof::output::v2::BatchProofCircuitOutputV2;
-use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
+use sov_rollup_interface::zk::batch_proof::output::BatchProofCircuitOutput;
 use sov_rollup_interface::zk::{Proof, ZkvmHost};
 use tokio::select;
 use tokio::sync::Mutex;
@@ -40,7 +38,6 @@ where
 {
     ledger_db: DB,
     da_service: Arc<Da>,
-    sequencer_pub_key: Vec<u8>,
     sequencer_da_pub_key: Vec<u8>,
     prover_da_pub_key: Vec<u8>,
     code_commitments_by_spec: HashMap<SpecId, Vm::CodeCommitment>,
@@ -59,7 +56,6 @@ where
     pub fn new(
         ledger_db: DB,
         da_service: Arc<Da>,
-        sequencer_pub_key: Vec<u8>,
         sequencer_da_pub_key: Vec<u8>,
         prover_da_pub_key: Vec<u8>,
         code_commitments_by_spec: HashMap<SpecId, Vm::CodeCommitment>,
@@ -69,7 +65,6 @@ where
         Self {
             ledger_db,
             da_service,
-            sequencer_pub_key,
             sequencer_da_pub_key,
             prover_da_pub_key,
             code_commitments_by_spec,
@@ -320,80 +315,23 @@ where
         );
         tracing::trace!("ZK proof: {:?}", proof);
 
-        // there must be some diff in kumquat and genesis proof verification
-        match Vm::extract_output::<BatchProofCircuitOutputV3>(&proof) {
-            Ok(output) => {
-                let code_commitment = self
-                    .code_commitments_by_spec
-                    .get(&SpecId::Fork2)
-                    .expect("Proof public input must contain valid spec id");
-                Vm::verify(proof.as_slice(), code_commitment)
-                    .map_err(|err| anyhow!("Failed to verify proof: {:?}. Skipping it...", err))?;
+        let batch_proof_output = Vm::extract_output::<BatchProofCircuitOutput>(&proof)
+            .map_err(|e| anyhow!("Failed to extract batch proof output from proof: {:?}", e))?;
+        let spec_id = fork_from_block_number(batch_proof_output.last_l2_height()).spec_id;
+        let code_commitment = self
+            .code_commitments_by_spec
+            .get(&spec_id)
+            .expect("Proof public input must contain valid spec id");
+        Vm::verify(proof.as_slice(), code_commitment)
+            .map_err(|err| anyhow!("Failed to verify proof: {:?}. Skipping it...", err))?;
 
-                self.process_fork2_zk_proof(
-                    l1_block,
-                    output.initial_state_root,
-                    output.sequencer_commitment_index_range,
-                    proof,
-                    StoredBatchProofOutput::from(output),
-                )
-            }
-            Err(e) => {
-                info!("Failed to extract post fork 2 output from proof: {:?}. Trying to extract pre fork 2 output", e);
-                match Vm::extract_output::<BatchProofCircuitOutputV2>(&proof) {
-                    Ok(output) => {
-                        let code_commitment = self
-                            .code_commitments_by_spec
-                            .get(&SpecId::Kumquat)
-                            .expect("Proof public input must contain valid spec id");
-                        Vm::verify(proof.as_slice(), code_commitment).map_err(|err| {
-                            anyhow!("Failed to verify proof: {:?}. Skipping it...", err)
-                        })?;
-
-                        self.process_pre_fork2_zk_proof(
-                            l1_block,
-                            output.da_slot_hash,
-                            output.preproven_commitments.clone(),
-                            output.sequencer_commitments_range,
-                            output.initial_state_root,
-                            proof,
-                            StoredBatchProofOutput::from(output),
-                        )
-                    }
-                    Err(e) => {
-                        info!("Failed to extract kumquat fork output from proof: {:?}. Trying to extract genesis fork output", e);
-                        let output = Vm::extract_output::<BatchProofCircuitOutputV1>(&proof)
-                            .expect("Should be able to extract either pre or post fork 1 output");
-
-                        if output.sequencer_da_public_key != self.sequencer_da_pub_key
-                            || output.sequencer_public_key != self.sequencer_pub_key
-                        {
-                            return Err(anyhow!(
-                                     "Proof verification: Sequencer public key or sequencer da public key mismatch. Skipping proof."
-                            ).into());
-                        }
-
-                        let code_commitment = self
-                            .code_commitments_by_spec
-                            .get(&SpecId::Genesis)
-                            .expect("Proof public input must contain valid spec id");
-                        Vm::verify(proof.as_slice(), code_commitment).map_err(|err| {
-                            anyhow!("Failed to verify proof: {:?}. Skipping it...", err)
-                        })?;
-
-                        self.process_pre_fork2_zk_proof(
-                            l1_block,
-                            output.da_slot_hash,
-                            output.preproven_commitments.clone(),
-                            output.sequencer_commitments_range,
-                            output.initial_state_root,
-                            proof,
-                            StoredBatchProofOutput::from(output),
-                        )
-                    }
-                }
-            }
-        }
+        self.process_fork2_zk_proof(
+            l1_block,
+            batch_proof_output.initial_state_root(),
+            batch_proof_output.sequencer_commitment_index_range(),
+            proof,
+            StoredBatchProofOutput::from(batch_proof_output),
+        )
     }
 
     fn process_fork2_zk_proof(
@@ -450,98 +388,6 @@ where
             }
         }
 
-        // store in ledger db
-        self.ledger_db.update_verified_proof_data(
-            l1_block.header().height(),
-            raw_proof,
-            batch_proof_output,
-        )?;
-
-        Ok(())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn process_pre_fork2_zk_proof(
-        &self,
-        l1_block: &Da::FilteredBlock,
-        da_slot_hash: [u8; 32],
-        preproven_commitments: Vec<usize>,
-        sequencer_commitments_range: (u32, u32),
-        initial_state_root: [u8; 32],
-        raw_proof: Proof,
-        batch_proof_output: StoredBatchProofOutput,
-    ) -> Result<(), SyncError> {
-        // This is the l1 height where the sequencer commitment was read by the prover and proof generated by those commitments
-        // We need to get commitments in this l1 height and set them as proven
-        let l1_height = match self.ledger_db.get_l1_height_of_l1_hash(da_slot_hash)? {
-            Some(l1_height) => l1_height,
-            None => {
-                return Err(anyhow!(
-                    "Proof verification: L1 height not found for l1 hash: {:?}. Skipping proof.",
-                    da_slot_hash
-                )
-                .into());
-            }
-        };
-
-        let mut commitments_on_da_slot =
-            match self.ledger_db.get_commitments_on_da_slot(l1_height)? {
-                Some(commitments) => commitments,
-                None => {
-                    return Err(anyhow!(
-                "Proof verification: No commitments found for l1 height: {}. Skipping proof.",
-                l1_height
-            )
-                    .into());
-                }
-            };
-
-        commitments_on_da_slot.sort();
-
-        let excluded_commitment_indices = preproven_commitments.clone();
-        let filtered_commitments: Vec<SequencerCommitment> = commitments_on_da_slot
-            .into_iter()
-            .enumerate()
-            .filter(|(index, _)| !excluded_commitment_indices.contains(index))
-            .map(|(_, commitment)| commitment)
-            .collect();
-
-        // TODO: THIS VALUE IS SET TEMPORARILY TO 0 AS WE DO NOT USE IT IN TESTS
-        // ALSO THIS FUNCTION WILL EVENTUALLY BE REMOVED WITH FORK2
-        let l2_height = 0;
-        // Fetch the block prior to the one at l2_height so compare state roots
-
-        let state_root_prior_soft_confirmation = self
-            .ledger_db
-            .get_l2_state_root(l2_height - 1)?
-            .ok_or_else(|| {
-            SyncError::MissingL2("L2 height not synced yet", l2_height - 1, l2_height - 1)
-        })?;
-
-        if state_root_prior_soft_confirmation.as_ref() != initial_state_root.as_ref() {
-            return Err(anyhow!(
-                "Proof verification: For a known and verified sequencer commitment. Pre state root mismatch - expected 0x{} but got 0x{}. Skipping proof.",
-                hex::encode(state_root_prior_soft_confirmation),
-                hex::encode(initial_state_root)
-            ).into());
-        }
-
-        for commitment in filtered_commitments
-            .iter()
-            .skip(sequencer_commitments_range.0 as usize)
-            .take((sequencer_commitments_range.1 - sequencer_commitments_range.0 + 1) as usize)
-        {
-            // TODO: THIS VALUE IS SET TEMPORARILY TO 0 AS WE DO NOT USE IT IN TESTS
-            // ALSO THIS FUNCTION WILL EVENTUALLY BE REMOVED WITH FORK2
-            let l2_start_height = 0;
-            let l2_end_height = commitment.l2_end_block_number;
-            for i in l2_start_height..=l2_end_height {
-                self.ledger_db.put_l2_block_status(
-                    SoftConfirmationNumber(i),
-                    SoftConfirmationStatus::Proven,
-                )?;
-            }
-        }
         // store in ledger db
         self.ledger_db.update_verified_proof_data(
             l1_block.header().height(),

--- a/crates/fullnode/src/lib.rs
+++ b/crates/fullnode/src/lib.rs
@@ -86,7 +86,6 @@ where
     let l1_block_handler = L1BlockHandler::new(
         ledger_db,
         da_service,
-        public_keys.sequencer_public_key,
         public_keys.sequencer_da_pub_key,
         public_keys.prover_da_pub_key,
         code_commitments,

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -24,14 +24,19 @@ pub(crate) fn create_mock_batch_proof(
 ) -> MockBlob {
     let batch_proof_method_id = MockCodeCommitment([0u8; 32]);
 
+    //TODO: FIXME The new added values are all wrong
     let bp = BatchProofCircuitOutputV3 {
         initial_state_root,
         final_state_root,
         final_soft_confirmation_hash: [4; 32],
         state_diff: BTreeMap::new(),
         last_l2_height,
-        sequencer_commitment_merkle_roots: vec![],
+        // TODO: Update this
+        sequencer_commitment_hashes: vec![],
         last_l1_hash_on_bitcoin_light_client_contract,
+        sequencer_commitment_index_range: (0, 0),
+        previous_commitment_index: None,
+        previous_commitment_hash: None,
     };
 
     let bp_serialized = borsh::to_vec(&bp).expect("should serialize");
@@ -66,14 +71,19 @@ pub(crate) fn create_serialized_mock_proof(
 ) -> Vec<u8> {
     let batch_proof_method_id = MockCodeCommitment([0u8; 32]);
 
+    //TODO: FIXME The new added values are all wrong
     let bp = BatchProofCircuitOutputV3 {
         initial_state_root,
         final_state_root,
         final_soft_confirmation_hash: [4; 32],
         state_diff: state_diff.unwrap_or_default(),
         last_l2_height,
-        sequencer_commitment_merkle_roots: vec![],
+        // TODO: Update this
+        sequencer_commitment_hashes: vec![],
         last_l1_hash_on_bitcoin_light_client_contract,
+        sequencer_commitment_index_range: (0, 0),
+        previous_commitment_index: None,
+        previous_commitment_hash: None,
     };
 
     let bp_serialized = borsh::to_vec(&bp).expect("should serialize");

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -9,7 +9,7 @@ use sov_modules_api::Zkvm;
 use sov_prover_storage_manager::{Config, ProverStorage, ProverStorageManager};
 use sov_rollup_interface::da::{BatchProofMethodId, BlobReaderTrait, DaVerifier, DataOnDa};
 use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
-use sov_rollup_interface::zk::batch_proof::output::CumulativeStateDiff;
+use sov_rollup_interface::zk::batch_proof::output::{BatchProofCircuitOutput, CumulativeStateDiff};
 use sov_rollup_interface::zk::light_client_proof::input::LightClientCircuitInput;
 use sov_rollup_interface::zk::light_client_proof::output::LightClientCircuitOutput;
 
@@ -25,7 +25,7 @@ pub(crate) fn create_mock_batch_proof(
     let batch_proof_method_id = MockCodeCommitment([0u8; 32]);
 
     //TODO: FIXME The new added values are all wrong
-    let bp = BatchProofCircuitOutputV3 {
+    let bp = BatchProofCircuitOutput::V3(BatchProofCircuitOutputV3 {
         initial_state_root,
         final_state_root,
         final_soft_confirmation_hash: [4; 32],
@@ -37,7 +37,7 @@ pub(crate) fn create_mock_batch_proof(
         sequencer_commitment_index_range: (0, 0),
         previous_commitment_index: None,
         previous_commitment_hash: None,
-    };
+    });
 
     let bp_serialized = borsh::to_vec(&bp).expect("should serialize");
 
@@ -72,7 +72,7 @@ pub(crate) fn create_serialized_mock_proof(
     let batch_proof_method_id = MockCodeCommitment([0u8; 32]);
 
     //TODO: FIXME The new added values are all wrong
-    let bp = BatchProofCircuitOutputV3 {
+    let bp = BatchProofCircuitOutput::V3(BatchProofCircuitOutputV3 {
         initial_state_root,
         final_state_root,
         final_soft_confirmation_hash: [4; 32],
@@ -84,7 +84,7 @@ pub(crate) fn create_serialized_mock_proof(
         sequencer_commitment_index_range: (0, 0),
         previous_commitment_index: None,
         previous_commitment_hash: None,
-    };
+    });
 
     let bp_serialized = borsh::to_vec(&bp).expect("should serialize");
 

--- a/crates/primitives/src/forks.rs
+++ b/crates/primitives/src/forks.rs
@@ -88,11 +88,20 @@ const _CHECK_FORKS: () = {
     }
 };
 
-pub fn get_fork2_activation_height() -> u64 {
+// If fork2 activation height is 0, return 1
+// Because in tests when the first l2 block for the first sequencer commitment is needed
+// Fork2 activation height should be sent
+// If it is 0, it errors out because l2 block 0 is not valid
+// So for only in tests, if fork2 activation height is 0, return 1
+// In production, it will return whatever the activation height is
+pub fn get_fork2_activation_height_non_zero() -> u64 {
     let forks = get_forks();
     let fork = forks
         .iter()
         .find(|f| f.spec_id == SpecId::Fork2)
         .expect("Fork2 should exist");
+    if fork.activation_height == 0 {
+        return 1;
+    }
     fork.activation_height
 }

--- a/crates/primitives/src/forks.rs
+++ b/crates/primitives/src/forks.rs
@@ -87,3 +87,12 @@ const _CHECK_FORKS: () = {
         panic!("FORKS order is invalid")
     }
 };
+
+pub fn get_fork2_activation_height() -> u64 {
+    let forks = get_forks();
+    let fork = forks
+        .iter()
+        .find(|f| f.spec_id == SpecId::Fork2)
+        .expect("Fork2 should exist");
+    fork.activation_height
+}

--- a/crates/prover-services/tests/prover_tests.rs
+++ b/crates/prover-services/tests/prover_tests.rs
@@ -191,6 +191,8 @@ fn make_transition_data(header_hash: MockHash) -> BatchProofCircuitInput<'static
         sequencer_commitments: vec![],
         cache_prune_l2_heights: vec![],
         last_l1_hash_witness: Witness::default(),
+        // Update this after you get the input from this function
+        previous_sequencer_commitment: None,
     }
 }
 

--- a/crates/sequencer/src/commitment/mod.rs
+++ b/crates/sequencer/src/commitment/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::anyhow;
-use citrea_primitives::forks::get_fork2_activation_height;
+use citrea_primitives::forks::get_fork2_activation_height_non_zero;
 use parking_lot::RwLock;
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
@@ -274,11 +274,7 @@ where
             } else {
                 // Submit commitment
                 let l2_start_block_number = if pending_db_comm.index == 0 {
-                    if get_fork2_activation_height() == 0 {
-                        1
-                    } else {
-                        get_fork2_activation_height()
-                    }
+                    get_fork2_activation_height_non_zero()
                 } else {
                     self.ledger_db
                         .get_commitment_by_index(pending_db_comm.index - 1)?

--- a/crates/sequencer/src/commitment/mod.rs
+++ b/crates/sequencer/src/commitment/mod.rs
@@ -193,6 +193,12 @@ where
                         .as_secs_f64(),
                 );
 
+                ledger_db
+                    .put_commitment_by_index(&commitment_c)
+                    .map_err(|_| {
+                        anyhow!("Sequencer: Failed to store sequencer commitment by index")
+                    })?;
+
                 ledger_db.set_last_commitment(&commitment_c).map_err(|_| {
                     anyhow!("Sequencer: Failed to set last sequencer commitment L2 height")
                 })?;

--- a/crates/sequencer/src/commitment/mod.rs
+++ b/crates/sequencer/src/commitment/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::anyhow;
+use citrea_primitives::forks::get_fork2_activation_height;
 use parking_lot::RwLock;
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
@@ -46,10 +47,13 @@ fn load_next_commitment_index<Db: SequencerLedgerOps>(db: &Db) -> u32 {
         .into_iter()
         .map(|s| s.index)
         .max();
+    println!("max_pending: {:?}", max_pending);
     // max index from last commitment:
     let max_last = db.get_last_commitment().unwrap().map(|s| s.index);
+    println!("max_last: {:?}", max_last);
     // maximum of pending and last:
     let max_db = max_pending.max(max_last);
+    println!("max_db: {:?}", max_db);
     if let Some(max_db) = max_db {
         max_db + 1
     } else {
@@ -146,6 +150,9 @@ where
     ) -> anyhow::Result<()> {
         let l2_start = *commitment_info.start();
         let l2_end = *commitment_info.end();
+
+        println!("commitment_index: {:?}", commitment_index);
+        println!("commitment_info: {:?}", commitment_info);
 
         let soft_confirmation_hashes = self
             .ledger_db
@@ -272,7 +279,20 @@ where
                     .delete_pending_commitment(pending_db_comm.index)?;
             } else {
                 // Submit commitment
-                let range = SoftConfirmationNumber(pending_db_comm.l2_start_block_number)
+                let l2_start_block_number = if pending_db_comm.index == 0 {
+                    if get_fork2_activation_height() == 0 {
+                        1
+                    } else {
+                        get_fork2_activation_height()
+                    }
+                } else {
+                    self.ledger_db
+                        .get_commitment_by_index(pending_db_comm.index - 1)?
+                        .unwrap()
+                        .l2_end_block_number
+                        + 1
+                };
+                let range = SoftConfirmationNumber(l2_start_block_number)
                     ..=SoftConfirmationNumber(pending_db_comm.l2_end_block_number);
 
                 self.commit(pending_db_comm.index, range, true).await?;
@@ -302,7 +322,6 @@ where
         Ok(SequencerCommitment {
             merkle_root,
             index: commitment_index,
-            l2_start_block_number: commitment_info.start().0,
             l2_end_block_number: commitment_info.end().0,
         })
     }

--- a/crates/sequencer/src/commitment/mod.rs
+++ b/crates/sequencer/src/commitment/mod.rs
@@ -47,13 +47,10 @@ fn load_next_commitment_index<Db: SequencerLedgerOps>(db: &Db) -> u32 {
         .into_iter()
         .map(|s| s.index)
         .max();
-    println!("max_pending: {:?}", max_pending);
     // max index from last commitment:
     let max_last = db.get_last_commitment().unwrap().map(|s| s.index);
-    println!("max_last: {:?}", max_last);
     // maximum of pending and last:
     let max_db = max_pending.max(max_last);
-    println!("max_db: {:?}", max_db);
     if let Some(max_db) = max_db {
         max_db + 1
     } else {
@@ -150,9 +147,6 @@ where
     ) -> anyhow::Result<()> {
         let l2_start = *commitment_info.start();
         let l2_end = *commitment_info.end();
-
-        println!("commitment_index: {:?}", commitment_index);
-        println!("commitment_info: {:?}", commitment_info);
 
         let soft_confirmation_hashes = self
             .ledger_db

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -661,29 +661,47 @@ impl SequencerLedgerOps for LedgerDB {
     /// Returns start-end L2 heights.
     #[instrument(level = "trace", skip(self), err)]
     fn get_pending_commitments(&self) -> anyhow::Result<Vec<SequencerCommitment>> {
-        let mut iter = self.db.iter::<PendingSequencerCommitment>()?;
-        iter.seek_to_first();
-
-        let mut comms = iter
-            .map(|item| item.map(|item| item.value))
-            .collect::<Result<Vec<_>, _>>()?;
-        // Sort ascending
-        comms.sort();
-
-        Ok(comms)
+        let commitment_indexes = self.db.get::<PendingSequencerCommitment>(&())?;
+        match commitment_indexes {
+            Some(mut commitment_indexes) => {
+                if commitment_indexes.is_empty() {
+                    return Ok(vec![]);
+                }
+                commitment_indexes.sort_unstable();
+                let start = commitment_indexes[0];
+                let end = commitment_indexes[commitment_indexes.len() - 1];
+                self.get_data_range::<SequencerCommitmentByIndex, _, _>(&(start..end))
+            }
+            None => Ok(vec![]),
+        }
     }
 
     /// Put a pending commitment l2 range
     #[instrument(level = "trace", skip(self), err)]
     fn put_pending_commitment(&self, seqcomm: &SequencerCommitment) -> anyhow::Result<()> {
-        self.db
-            .put::<PendingSequencerCommitment>(&seqcomm.index, seqcomm)
+        let pending_commitment_indexes = self.db.get::<PendingSequencerCommitment>(&())?;
+        match pending_commitment_indexes {
+            Some(mut indexes) => {
+                indexes.push(seqcomm.index);
+                self.db.put::<PendingSequencerCommitment>(&(), &indexes)
+            }
+            None => self
+                .db
+                .put::<PendingSequencerCommitment>(&(), &vec![seqcomm.index]),
+        }
     }
 
     /// Delete a pending commitment l2 range
     #[instrument(level = "trace", skip(self), err)]
     fn delete_pending_commitment(&self, index: u32) -> anyhow::Result<()> {
-        self.db.delete::<PendingSequencerCommitment>(&index)
+        let pending_commitment_indexes = self.db.get::<PendingSequencerCommitment>(&())?;
+        match pending_commitment_indexes {
+            Some(mut indexes) => {
+                indexes.retain(|&i| i != index);
+                self.db.put::<PendingSequencerCommitment>(&(), &indexes)
+            }
+            None => Ok(()),
+        }
     }
 
     /// Sets the latest state diff

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -18,9 +18,9 @@ use crate::schema::tables::{
     CommitmentMerkleRoots, CommitmentsByNumber, ExecutedMigrations, L2GenesisStateRoot,
     L2RangeByL1Height, LastPrunedBlock, LastSequencerCommitmentSent, LastStateDiff,
     LightClientProofBySlotNumber, MempoolTxs, PendingProvingSessions, PendingSequencerCommitment,
-    ProofsBySlotNumberV2, ProverLastScannedSlot, ProverStateDiffs, ShortHeaderProofBySlotHash,
-    SlotByHash, SoftConfirmationByHash, SoftConfirmationByNumber, SoftConfirmationStatus,
-    VerifiedBatchProofsBySlotNumber, LEDGER_TABLES,
+    ProofsBySlotNumberV2, ProverLastScannedSlot, ProverStateDiffs, SequencerCommitmentByIndex,
+    ShortHeaderProofBySlotHash, SlotByHash, SoftConfirmationByHash, SoftConfirmationByNumber,
+    SoftConfirmationStatus, VerifiedBatchProofsBySlotNumber, LEDGER_TABLES,
 };
 use crate::schema::types::batch_proof::{
     StoredBatchProof, StoredBatchProofOutput, StoredVerifiedProof,
@@ -501,6 +501,18 @@ impl SharedLedgerOps for LedgerDB {
         root: [u8; 32],
     ) -> anyhow::Result<Option<L2HeightRange>> {
         self.db.get::<CommitmentMerkleRoots>(&root)
+    }
+
+    fn put_commitment_by_index(&self, commitment: &SequencerCommitment) -> anyhow::Result<()> {
+        let mut schema_batch = SchemaBatch::new();
+        schema_batch.put::<SequencerCommitmentByIndex>(&commitment.index, commitment)?;
+        self.db.write_schemas(schema_batch)?;
+
+        Ok(())
+    }
+
+    fn get_commitment_by_index(&self, index: u32) -> anyhow::Result<Option<SequencerCommitment>> {
+        self.db.get::<SequencerCommitmentByIndex>(&index)
     }
 }
 

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -419,7 +419,11 @@ impl SharedLedgerOps for LedgerDB {
     /// Returns last sequencer commitment.
     #[instrument(level = "trace", skip(self), err, ret)]
     fn get_last_commitment(&self) -> anyhow::Result<Option<SequencerCommitment>> {
-        self.db.get::<LastSequencerCommitmentSent>(&())
+        let index = self.db.get::<LastSequencerCommitmentSent>(&())?;
+        match index {
+            Some(index) => self.db.get::<SequencerCommitmentByIndex>(&index),
+            None => Ok(None),
+        }
     }
 
     /// Used by the nodes to record that it has committed a soft confirmations on a given L2 height.
@@ -429,7 +433,7 @@ impl SharedLedgerOps for LedgerDB {
     fn set_last_commitment(&self, seqcomm: &SequencerCommitment) -> Result<(), anyhow::Error> {
         let mut schema_batch = SchemaBatch::new();
 
-        schema_batch.put::<LastSequencerCommitmentSent>(&(), seqcomm)?;
+        schema_batch.put::<LastSequencerCommitmentSent>(&(), &seqcomm.index)?;
         self.db.write_schemas(schema_batch)?;
 
         Ok(())

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
@@ -151,6 +151,12 @@ pub trait SharedLedgerOps {
         &self,
         root: [u8; 32],
     ) -> anyhow::Result<Option<L2HeightRange>>;
+
+    /// Store commitment by index
+    fn put_commitment_by_index(&self, commitment: &SequencerCommitment) -> anyhow::Result<()>;
+
+    /// Get commitment by index
+    fn get_commitment_by_index(&self, index: u32) -> anyhow::Result<Option<SequencerCommitment>>;
 }
 
 /// Node ledger operations

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
@@ -382,7 +382,7 @@ define_table_with_default_codec!(
 
 define_table_with_seek_key_codec!(
     /// Sequencer uses this table to store the last commitment it sent
-    (LastSequencerCommitmentSent) () => SequencerCommitment
+    (LastSequencerCommitmentSent) () => u32
 );
 
 define_table_with_seek_key_codec!(

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
@@ -376,7 +376,8 @@ define_table_with_default_codec!(
 
 define_table_with_default_codec!(
     /// The primary source for in progress sequencer commitments
-    (PendingSequencerCommitment) u32 => SequencerCommitment
+    /// This table is used to store the pending sequencer commitments indexes
+    (PendingSequencerCommitment) () => Vec<u32>
 );
 
 define_table_with_seek_key_codec!(
@@ -397,7 +398,7 @@ define_table_with_default_codec!(
     (SoftConfirmationStatus) SoftConfirmationNumber => sov_rollup_interface::rpc::SoftConfirmationStatus
 );
 
-define_table_with_default_codec!(
+define_table_with_seek_key_codec!(
     /// Index to sequencer commitment mapping
     (SequencerCommitmentByIndex) u32 => SequencerCommitment
 );

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
@@ -69,6 +69,7 @@ pub const SEQUENCER_LEDGER_TABLES: &[&str] = &[
     SlotByHash::table_name(),
     ShortHeaderProofBySlotHash::table_name(),
     CommitmentMerkleRoots::table_name(),
+    SequencerCommitmentByIndex::table_name(),
     // ########
     #[cfg(test)]
     TestTableOld::table_name(),
@@ -93,6 +94,7 @@ pub const FULL_NODE_LEDGER_TABLES: &[&str] = &[
     LastPrunedBlock::table_name(),
     VerifiedBatchProofsBySlotNumber::table_name(),
     CommitmentMerkleRoots::table_name(),
+    SequencerCommitmentByIndex::table_name(),
     #[cfg(test)]
     TestTableOld::table_name(),
     #[cfg(test)]
@@ -118,6 +120,7 @@ pub const BATCH_PROVER_LEDGER_TABLES: &[&str] = &[
     ProverStateDiffs::table_name(),
     LastPrunedBlock::table_name(),
     CommitmentMerkleRoots::table_name(),
+    SequencerCommitmentByIndex::table_name(),
     #[cfg(test)]
     TestTableOld::table_name(),
     #[cfg(test)]
@@ -165,6 +168,7 @@ pub const LEDGER_TABLES: &[&str] = &[
     ProverStateDiffs::table_name(),
     LastPrunedBlock::table_name(),
     CommitmentMerkleRoots::table_name(),
+    SequencerCommitmentByIndex::table_name(),
     #[cfg(test)]
     TestTableOld::table_name(),
     #[cfg(test)]
@@ -391,6 +395,11 @@ define_table_with_seek_key_codec!(
 define_table_with_default_codec!(
     /// Check whether a block is finalized
     (SoftConfirmationStatus) SoftConfirmationNumber => sov_rollup_interface::rpc::SoftConfirmationStatus
+);
+
+define_table_with_default_codec!(
+    /// Index to sequencer commitment mapping
+    (SequencerCommitmentByIndex) u32 => SequencerCommitment
 );
 
 define_table_without_codec!(

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/batch_proof.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/batch_proof.rs
@@ -2,16 +2,18 @@ use std::fmt::Debug;
 
 use alloy_primitives::{U32, U64, U8};
 use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
 use sov_rollup_interface::rpc::{
     BatchProofOutputRpcResponse, BatchProofResponse, SerializableHash, VerifiedBatchProofResponse,
 };
 use sov_rollup_interface::zk::batch_proof::output::v1::BatchProofCircuitOutputV1;
 use sov_rollup_interface::zk::batch_proof::output::v2::BatchProofCircuitOutputV2;
 use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
+use sov_rollup_interface::zk::batch_proof::output::BatchProofCircuitOutput;
 use sov_rollup_interface::zk::Proof;
 
 /// The on-disk format for a state transition.
-#[derive(Debug, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub enum StoredBatchProofOutput {
     /// V1 batch proof output wrapper
     V1(BatchProofCircuitOutputV1),
@@ -38,6 +40,16 @@ impl From<StoredBatchProof> for BatchProofResponse {
             l1_tx_id: value.l1_tx_id,
             proof: value.proof,
             proof_output: BatchProofOutputRpcResponse::from(value.proof_output),
+        }
+    }
+}
+
+impl From<BatchProofCircuitOutput> for StoredBatchProofOutput {
+    fn from(value: BatchProofCircuitOutput) -> Self {
+        match value {
+            BatchProofCircuitOutput::V1(value) => Self::V1(value),
+            BatchProofCircuitOutput::V2(value) => Self::V2(value),
+            BatchProofCircuitOutput::V3(value) => Self::V3(value),
         }
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/lib.rs
@@ -192,7 +192,6 @@ pub use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 pub use sov_rollup_interface::services::da::SlotData;
 pub use sov_rollup_interface::soft_confirmation::L2Block;
 pub use sov_rollup_interface::stf::StateDiff;
-pub use sov_rollup_interface::zk::batch_proof::output::v2::BatchProofCircuitOutputV2;
 pub use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
 pub use sov_rollup_interface::zk::Zkvm;
 pub use sov_rollup_interface::{digest, BasicAddress, RollupAddress};

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -93,9 +93,15 @@ pub struct ApplySequencerCommitmentsOutput {
     /// Last soft confirmation hash
     pub final_soft_confirmation_hash: [u8; 32],
     /// Sequencer commitment hashes
-    pub sequencer_commitment_merkle_roots: Vec<[u8; 32]>,
+    pub sequencer_commitment_hashes: Vec<[u8; 32]>,
+    /// The range of sequencer commitments that were processed.
+    pub sequencer_commitment_index_range: (u32, u32),
     /// Cumulative state log
     pub cumulative_state_log: ReadWriteLog,
+    /// The index of the previous commitment that was given as input in the batch proof
+    pub previous_commitment_index: u64,
+    /// The hash of the previous commitment that was given as input in the batch proof
+    pub previous_commitment_hash: [u8; 32],
 }
 
 impl<C, RT, Da> StfBlueprint<C, Da, RT>
@@ -519,6 +525,7 @@ where
         sequencer_k256_public_key: &[u8],
         initial_state_root: &StorageRootHash,
         pre_state: C::Storage,
+        previous_sequencer_commitment: Option<SequencerCommitment>,
         sequencer_commitments: Vec<SequencerCommitment>,
         slot_headers: VecDeque<Vec<<Da as DaSpec>::BlockHeader>>,
         cache_prune_l2_heights: &[u64],
@@ -526,22 +533,58 @@ where
     ) -> ApplySequencerCommitmentsOutput {
         let mut state_diff = CumulativeStateDiff::default();
 
-        let sequencer_commitment_merkle_roots = sequencer_commitments
+        let sequencer_commitment_hashes = sequencer_commitments
             .iter()
-            .map(|c| c.merkle_root)
+            .map(|c| c.serialize_and_calculate_sha_256())
             .collect::<Vec<_>>();
+
+        let sequencer_commitment_index_range = (
+            sequencer_commitments.first().unwrap().index,
+            sequencer_commitments.last().unwrap().index,
+        );
 
         // Verify these soft confirmations.
         let mut current_state_root = *initial_state_root;
         let mut prev_soft_confirmation_hash: Option<[u8; 32]> = None;
-        let mut last_commitment_end_height: Option<u64> = None;
 
         let group_count: u32 = guest.read_from_host();
 
         assert_eq!(group_count, sequencer_commitments.len() as u32);
 
-        let mut fork_manager =
-            ForkManager::new(forks, sequencer_commitments[0].l2_start_block_number);
+        // Get fork2
+        let fork2 = forks
+            .iter()
+            .find(|f| f.spec_id == SpecId::Fork2)
+            .expect("Fork2 must exist");
+
+        let fork2_activation_height = fork2.activation_height;
+
+        let mut previous_batch_proof_l2_end_height = fork2_activation_height;
+
+        // If there is no previous commitment, then this is the first batch proof
+        // and this should start from proving the first l2 block
+        if let Some(previous_sequencer_commitment) = previous_sequencer_commitment {
+            // The index of the previous commitment should be one less than the first commitment
+            assert_eq!(
+                previous_sequencer_commitment.index + 1,
+                sequencer_commitments[0].index,
+                "Sequencer commitments must be sequential"
+            );
+            // If there exists a previous commitment, then the first l2 block to prove
+            // should be the one after the last commitment
+            previous_batch_proof_l2_end_height = previous_sequencer_commitment.l2_end_block_number;
+        } else {
+            // If this is the first batch proof, then the first commitment idx should be 0
+            assert_eq!(
+                sequencer_commitments[0].index, 0,
+                "First commitment must be index 0"
+            );
+        };
+        let mut current_batch_proof_first_l2_height = previous_batch_proof_l2_end_height + 1;
+        let mut fork_manager = ForkManager::new(forks, current_batch_proof_first_l2_height);
+        let mut sequencer_commitment_l2_start_height = current_batch_proof_first_l2_height;
+
+        let mut last_commitment_end_height = previous_batch_proof_l2_end_height;
 
         // Reuseable log caches
         let mut cumulative_state_log = None;
@@ -552,18 +595,18 @@ where
             sequencer_commitments.into_iter().zip_eq(slot_headers)
         {
             // if the commitment is not sequential, then the proof is invalid.
-            if let Some(end_height) = last_commitment_end_height {
-                assert_eq!(
-                    end_height + 1,
-                    sequencer_commitment.l2_start_block_number,
-                    "Sequencer commitments must be sequential"
-                );
-            }
-            last_commitment_end_height = Some(sequencer_commitment.l2_end_block_number);
+
+            assert_eq!(
+                last_commitment_end_height + 1,
+                sequencer_commitment_l2_start_height,
+                "Sequencer commitments must be sequential"
+            );
+
+            last_commitment_end_height = sequencer_commitment.l2_end_block_number;
 
             // we must verify given DA headers match the commitments
 
-            let mut l2_height = sequencer_commitment.l2_start_block_number;
+            let mut l2_height = sequencer_commitment_l2_start_height;
 
             let state_change_count: u32 = guest.read_from_host();
             let mut soft_confirmation_hashes = Vec::with_capacity(state_change_count as usize);
@@ -682,16 +725,22 @@ where
             );
 
             assert_eq!(sequencer_commitment.l2_end_block_number, l2_height - 1);
+            // Update next sequencer commitment start height
+            sequencer_commitment_l2_start_height = l2_height;
         }
 
         ApplySequencerCommitmentsOutput {
             final_state_root: current_state_root,
             state_diff,
             // There has to be a height
-            last_l2_height: last_commitment_end_height.unwrap(),
+            last_l2_height: last_commitment_end_height,
             final_soft_confirmation_hash: prev_soft_confirmation_hash.unwrap(),
-            sequencer_commitment_merkle_roots,
+            sequencer_commitment_hashes,
+            sequencer_commitment_index_range,
             cumulative_state_log: cumulative_state_log.unwrap(),
+            previous_commitment_index: previous_sequencer_commitment.map(|c| c.index),
+            previous_commitment_hash: previous_sequencer_commitment
+                .map(|c| c.serialize_and_calculate_sha_256()),
         }
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -581,7 +581,6 @@ where
                 )
             } else {
                 // If this is the first batch proof, then the first commitment idx should be 0
-                // TODO: First commitment index is not in 0 parallel_proving_test why?
                 assert_eq!(
                     sequencer_commitments[0].index, 0,
                     "First commitment must be index 0"

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -99,9 +99,9 @@ pub struct ApplySequencerCommitmentsOutput {
     /// Cumulative state log
     pub cumulative_state_log: ReadWriteLog,
     /// The index of the previous commitment that was given as input in the batch proof
-    pub previous_commitment_index: u64,
+    pub previous_commitment_index: Option<u32>,
     /// The hash of the previous commitment that was given as input in the batch proof
-    pub previous_commitment_hash: [u8; 32],
+    pub previous_commitment_hash: Option<[u8; 32]>,
 }
 
 impl<C, RT, Da> StfBlueprint<C, Da, RT>
@@ -563,23 +563,30 @@ where
 
         // If there is no previous commitment, then this is the first batch proof
         // and this should start from proving the first l2 block
-        if let Some(previous_sequencer_commitment) = previous_sequencer_commitment {
-            // The index of the previous commitment should be one less than the first commitment
-            assert_eq!(
-                previous_sequencer_commitment.index + 1,
-                sequencer_commitments[0].index,
-                "Sequencer commitments must be sequential"
-            );
-            // If there exists a previous commitment, then the first l2 block to prove
-            // should be the one after the last commitment
-            previous_batch_proof_l2_end_height = previous_sequencer_commitment.l2_end_block_number;
-        } else {
-            // If this is the first batch proof, then the first commitment idx should be 0
-            assert_eq!(
-                sequencer_commitments[0].index, 0,
-                "First commitment must be index 0"
-            );
-        };
+        let (previous_commitment_index, previous_commitment_hash) =
+            if let Some(previous_sequencer_commitment) = previous_sequencer_commitment {
+                // The index of the previous commitment should be one less than the first commitment
+                assert_eq!(
+                    previous_sequencer_commitment.index + 1,
+                    sequencer_commitments[0].index,
+                    "Sequencer commitments must be sequential"
+                );
+                // If there exists a previous commitment, then the first l2 block to prove
+                // should be the one after the last commitment
+                previous_batch_proof_l2_end_height =
+                    previous_sequencer_commitment.l2_end_block_number;
+                (
+                    Some(previous_sequencer_commitment.index),
+                    Some(previous_sequencer_commitment.serialize_and_calculate_sha_256()),
+                )
+            } else {
+                // If this is the first batch proof, then the first commitment idx should be 0
+                assert_eq!(
+                    sequencer_commitments[0].index, 0,
+                    "First commitment must be index 0"
+                );
+                (None, None)
+            };
         let mut current_batch_proof_first_l2_height = previous_batch_proof_l2_end_height + 1;
         let mut fork_manager = ForkManager::new(forks, current_batch_proof_first_l2_height);
         let mut sequencer_commitment_l2_start_height = current_batch_proof_first_l2_height;
@@ -738,9 +745,8 @@ where
             sequencer_commitment_hashes,
             sequencer_commitment_index_range,
             cumulative_state_log: cumulative_state_log.unwrap(),
-            previous_commitment_index: previous_sequencer_commitment.map(|c| c.index),
-            previous_commitment_hash: previous_sequencer_commitment
-                .map(|c| c.serialize_and_calculate_sha_256()),
+            previous_commitment_index,
+            previous_commitment_hash,
         }
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -581,13 +581,14 @@ where
                 )
             } else {
                 // If this is the first batch proof, then the first commitment idx should be 0
+                // TODO: First commitment index is not in 0 parallel_proving_test why?
                 assert_eq!(
                     sequencer_commitments[0].index, 0,
                     "First commitment must be index 0"
                 );
                 (None, None)
             };
-        let mut current_batch_proof_first_l2_height = previous_batch_proof_l2_end_height + 1;
+        let current_batch_proof_first_l2_height = previous_batch_proof_l2_end_height + 1;
         let mut fork_manager = ForkManager::new(forks, current_batch_proof_first_l2_height);
         let mut sequencer_commitment_l2_start_height = current_batch_proof_first_l2_height;
 

--- a/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
@@ -140,8 +140,6 @@ pub struct SequencerCommitmentResponse {
     pub merkle_root: [u8; 32],
     /// Hex encoded index - absolute order
     pub index: U32,
-    /// Hex encoded Start L2 block's number
-    pub l2_start_block_number: U64,
     /// Hex encoded End L2 block's number
     pub l2_end_block_number: U64,
 }
@@ -439,7 +437,6 @@ pub fn sequencer_commitment_to_response(
         l1_height: U64::from(l1_height),
         merkle_root: commitment.merkle_root,
         index: U32::from(commitment.index),
-        l2_start_block_number: U64::from(commitment.l2_start_block_number),
         l2_end_block_number: U64::from(commitment.l2_end_block_number),
     }
 }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::zk::Proof;
 use crate::{BasicAddress, Network};
@@ -17,10 +18,20 @@ pub struct SequencerCommitment {
     pub merkle_root: [u8; 32],
     /// Absolute order of the sequencer commitment, the first commitment has index 0, the next one has 1...
     pub index: u32,
-    /// Start L2 block's number
-    pub l2_start_block_number: u64,
     /// End L2 block's number
     pub l2_end_block_number: u64,
+}
+
+impl SequencerCommitment {
+    /// Compute sha256 hash
+    pub fn serialize_and_calculate_sha_256(&self) -> [u8; 32] {
+        let serialized =
+            borsh::to_vec(self).expect("Sequencer commitment serialization cannot fail");
+        let mut hasher = Sha256::default();
+        hasher.update(&serialized);
+        let hash = hasher.finalize();
+        hash.into()
+    }
 }
 
 /// A new batch proof method_id starting to be applied from the l2_block_number (inclusive).

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/mod.rs
@@ -64,6 +64,9 @@ pub struct BatchProofCircuitInput<'txs, Da: DaSpec, Tx: Clone + BorshSerialize> 
     pub cache_prune_l2_heights: Vec<u64>,
     /// Witness needed to get the last Bitcoin hash on Bitcoin Light Client contract
     pub last_l1_hash_witness: Witness,
+    /// The last proven sequencer commitment.
+    /// Only applies to V3
+    pub previous_sequencer_commitment: Option<SequencerCommitment>,
 }
 
 impl<'txs, Da, Tx> BatchProofCircuitInput<'txs, Da, Tx>
@@ -156,6 +159,7 @@ where
                 sequencer_commitments: self.sequencer_commitments,
                 cache_prune_l2_heights: self.cache_prune_l2_heights,
                 last_l1_hash_witness: self.last_l1_hash_witness,
+                previous_sequencer_commitment: self.previous_sequencer_commitment,
             },
             BatchProofCircuitInputV3Part2(x),
         )

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v3.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v3.rs
@@ -24,6 +24,10 @@ pub struct BatchProofCircuitInputV3Part2<'txs, Tx: Clone + BorshSerialize>(
 pub struct BatchProofCircuitInputV3Part1<Da: DaSpec> {
     /// The state root before the state transition
     pub initial_state_root: StorageRootHash,
+    /// The sequencer commitment before the first sequencer commitment in the sequencer_commitments vector
+    /// If it is none than this is the first batch proof
+    /// Else the index of the sequencer commitment should be `sequencer_commitments[0].index - 1``
+    pub previous_sequencer_commitment: Option<SequencerCommitment>,
     /// Sequencer commitments being proven
     /// Since `SequencerCommitment` does not have the sequencer's signature,
     /// the light client prover will be doing the signature verification

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/mod.rs
@@ -99,4 +99,22 @@ impl BatchProofCircuitOutput {
             BatchProofCircuitOutput::V3(output) => output.last_l2_height,
         }
     }
+
+    /// Get the previous commitment index
+    pub fn previous_commitment_index(&self) -> Option<u32> {
+        match self {
+            BatchProofCircuitOutput::V1(_) => None,
+            BatchProofCircuitOutput::V2(_) => None,
+            BatchProofCircuitOutput::V3(output) => output.previous_commitment_index,
+        }
+    }
+
+    /// Get the previous commitment hash
+    pub fn previous_commitment_hash(&self) -> Option<[u8; 32]> {
+        match self {
+            BatchProofCircuitOutput::V1(_) => None,
+            BatchProofCircuitOutput::V2(_) => None,
+            BatchProofCircuitOutput::V3(output) => output.previous_commitment_hash,
+        }
+    }
 }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/mod.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use borsh::{BorshDeserialize, BorshSerialize};
+
 use crate::RefCount;
 
 /// Genesis output module
@@ -11,3 +13,90 @@ pub mod v3;
 
 /// State diff produced by the Zk proof
 pub type CumulativeStateDiff = BTreeMap<RefCount<[u8]>, Option<RefCount<[u8]>>>;
+
+/// Versioned Batch Proof Output
+#[derive(Debug, BorshDeserialize, BorshSerialize)]
+pub enum BatchProofCircuitOutput {
+    /// V1 batch proof output
+    V1(v1::BatchProofCircuitOutputV1),
+    /// V2 batch proof output
+    V2(v2::BatchProofCircuitOutputV2),
+    /// V3 batch proof output
+    V3(v3::BatchProofCircuitOutputV3),
+}
+
+impl BatchProofCircuitOutput {
+    /// Get the initial state root
+    pub fn initial_state_root(&self) -> [u8; 32] {
+        match self {
+            BatchProofCircuitOutput::V1(output) => output.initial_state_root,
+            BatchProofCircuitOutput::V2(output) => output.initial_state_root,
+            BatchProofCircuitOutput::V3(output) => output.initial_state_root,
+        }
+    }
+
+    /// Get the final state root
+    pub fn final_state_root(&self) -> [u8; 32] {
+        match self {
+            BatchProofCircuitOutput::V1(output) => output.final_state_root,
+            BatchProofCircuitOutput::V2(output) => output.final_state_root,
+            BatchProofCircuitOutput::V3(output) => output.final_state_root,
+        }
+    }
+
+    /// Get the final soft confirmation hash
+    pub fn final_soft_confirmation_hash(&self) -> [u8; 32] {
+        match self {
+            BatchProofCircuitOutput::V1(_) => [0; 32],
+            BatchProofCircuitOutput::V2(output) => output.final_soft_confirmation_hash,
+            BatchProofCircuitOutput::V3(output) => output.final_soft_confirmation_hash,
+        }
+    }
+
+    /// Get sequencer commitment hashes
+    pub fn sequencer_commitment_hashes(&self) -> Vec<[u8; 32]> {
+        match self {
+            BatchProofCircuitOutput::V1(_) => vec![],
+            BatchProofCircuitOutput::V2(_) => vec![],
+            BatchProofCircuitOutput::V3(output) => output.sequencer_commitment_hashes.clone(),
+        }
+    }
+
+    /// Get sequencer commitment index range
+    pub fn sequencer_commitment_index_range(&self) -> (u32, u32) {
+        match self {
+            BatchProofCircuitOutput::V1(_) => (0, 0),
+            BatchProofCircuitOutput::V2(_) => (0, 0),
+            BatchProofCircuitOutput::V3(output) => output.sequencer_commitment_index_range,
+        }
+    }
+
+    /// Get the last L1 hash on the Bitcoin light client contract
+    pub fn last_l1_hash_on_bitcoin_light_client_contract(&self) -> [u8; 32] {
+        match self {
+            BatchProofCircuitOutput::V1(_) => [0; 32],
+            BatchProofCircuitOutput::V2(_) => [0; 32],
+            BatchProofCircuitOutput::V3(output) => {
+                output.last_l1_hash_on_bitcoin_light_client_contract
+            }
+        }
+    }
+
+    /// Get the state diff produced by the Zk proof
+    pub fn state_diff(&self) -> &CumulativeStateDiff {
+        match self {
+            BatchProofCircuitOutput::V1(output) => &output.state_diff,
+            BatchProofCircuitOutput::V2(output) => &output.state_diff,
+            BatchProofCircuitOutput::V3(output) => &output.state_diff,
+        }
+    }
+
+    /// Get the last L2 height
+    pub fn last_l2_height(&self) -> u64 {
+        match self {
+            BatchProofCircuitOutput::V1(_) => 0,
+            BatchProofCircuitOutput::V2(output) => output.last_l2_height,
+            BatchProofCircuitOutput::V3(output) => output.last_l2_height,
+        }
+    }
+}

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/v3.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/v3.rs
@@ -35,7 +35,7 @@ pub struct BatchProofCircuitOutputV3 {
     /// L1 hashes added to the Bitcoin light client contract
     pub last_l1_hash_on_bitcoin_light_client_contract: [u8; 32],
     /// The index of the previous commitment that was given as input in the batch proof
-    pub previous_commitment_index: Option<u64>,
+    pub previous_commitment_index: Option<u32>,
     /// The hash of the previous commitment that was given as input in the batch proof
     pub previous_commitment_hash: Option<[u8; 32]>,
 }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/v3.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/v3.rs
@@ -28,8 +28,14 @@ pub struct BatchProofCircuitOutputV3 {
     /// The last processed l2 height in the processed sequencer commitments.
     /// This will be 0 for pre fork 1 proofs
     pub last_l2_height: u64,
-    /// Hashes inside sequencer commitmentes that were processed.
-    pub sequencer_commitment_merkle_roots: Vec<[u8; 32]>,
-    /// L1 hashes added to the Bitocin light client contract
+    /// Hashes inside sequencer commitments that were processed.
+    pub sequencer_commitment_hashes: Vec<[u8; 32]>,
+    /// The range of sequencer commitments that were processed.
+    pub sequencer_commitment_index_range: (u32, u32),
+    /// L1 hashes added to the Bitcoin light client contract
     pub last_l1_hash_on_bitcoin_light_client_contract: [u8; 32],
+    /// The index of the previous commitment that was given as input in the batch proof
+    pub previous_commitment_index: Option<u64>,
+    /// The hash of the previous commitment that was given as input in the batch proof
+    pub previous_commitment_hash: Option<[u8; 32]>,
 }

--- a/crates/storage-ops/src/rollback/components/ledger_db/mod.rs
+++ b/crates/storage-ops/src/rollback/components/ledger_db/mod.rs
@@ -17,7 +17,6 @@ pub(crate) fn rollback_ledger_db(
     target_l2: u64,
     target_l1: u64,
     last_sequencer_commitment_index: u32,
-    last_sequencer_commitment_l2_height: u64,
 ) {
     debug!(
         "Rolling back Ledger, down to L2 block {}, L1 block {}",
@@ -31,7 +30,6 @@ pub(crate) fn rollback_ledger_db(
             &ledger_db,
             target_l2,
             last_sequencer_commitment_index,
-            last_sequencer_commitment_l2_height,
         )
     );
     match node_type {

--- a/crates/storage-ops/src/rollback/components/ledger_db/soft_confirmations.rs
+++ b/crates/storage-ops/src/rollback/components/ledger_db/soft_confirmations.rs
@@ -1,6 +1,5 @@
 use sov_db::schema::tables::{LastSequencerCommitmentSent, SoftConfirmationByNumber};
 use sov_db::schema::types::SoftConfirmationNumber;
-use sov_rollup_interface::da::SequencerCommitment;
 use sov_schema_db::{ScanDirection, DB};
 
 use crate::pruning::types::StorageNodeType;
@@ -11,7 +10,6 @@ pub(crate) fn rollback_soft_confirmations(
     ledger_db: &DB,
     target_l2: u64,
     last_sequencer_commitment_index: u32,
-    last_sequencer_commitment_l2_height: u64,
 ) -> anyhow::Result<u64> {
     let mut soft_confirmations = ledger_db.iter_with_direction::<SoftConfirmationByNumber>(
         Default::default(),
@@ -44,14 +42,7 @@ pub(crate) fn rollback_soft_confirmations(
     if matches!(node_type, StorageNodeType::Sequencer)
         || matches!(node_type, StorageNodeType::FullNode)
     {
-        ledger_db.put::<LastSequencerCommitmentSent>(
-            &(),
-            &SequencerCommitment {
-                merkle_root: [0; 32],
-                index: last_sequencer_commitment_index,
-                l2_end_block_number: last_sequencer_commitment_l2_height,
-            },
-        )?;
+        ledger_db.put::<LastSequencerCommitmentSent>(&(), &last_sequencer_commitment_index)?;
     }
 
     Ok(deleted)

--- a/crates/storage-ops/src/rollback/components/ledger_db/soft_confirmations.rs
+++ b/crates/storage-ops/src/rollback/components/ledger_db/soft_confirmations.rs
@@ -49,7 +49,6 @@ pub(crate) fn rollback_soft_confirmations(
             &SequencerCommitment {
                 merkle_root: [0; 32],
                 index: last_sequencer_commitment_index,
-                l2_start_block_number: 0,
                 l2_end_block_number: last_sequencer_commitment_l2_height,
             },
         )?;

--- a/crates/storage-ops/src/rollback/mod.rs
+++ b/crates/storage-ops/src/rollback/mod.rs
@@ -40,7 +40,6 @@ impl Rollback {
         l2_target: u64,
         l1_target: u64,
         last_sequencer_commitment_index: u32,
-        last_sequencer_commitment_l2_height: u64,
     ) -> anyhow::Result<()> {
         info!("Rolling back until L2 {}, L1 {}", l2_target, l1_target);
 
@@ -55,7 +54,6 @@ impl Rollback {
                 l2_target,
                 l1_target,
                 last_sequencer_commitment_index,
-                last_sequencer_commitment_l2_height,
             )
         });
 

--- a/crates/storage-ops/src/rollback/service.rs
+++ b/crates/storage-ops/src/rollback/service.rs
@@ -11,7 +11,6 @@ pub struct RollbackSignal {
     target_l2: u64,
     target_l1: u64,
     last_sequencer_commitment_index: u32,
-    last_commitment_l2_height: u64,
 }
 
 pub struct RollbackService {
@@ -34,7 +33,7 @@ impl RollbackService {
                 },
                 Some(signal) = self.receiver.recv() => {
                     info!("Received signal to rollback to L2 {}, L1 {}", signal.target_l2, signal.target_l1);
-                    if let Err(e) = self.rollback.execute(node_type, signal.current_l2_height, signal.target_l2, signal.target_l1, signal.last_sequencer_commitment_index, signal.last_commitment_l2_height).await {
+                    if let Err(e) = self.rollback.execute(node_type, signal.current_l2_height, signal.target_l2, signal.target_l1, signal.last_sequencer_commitment_index).await {
                         panic!("Could not rollback blocks: {:?}", e);
                     }
                 }

--- a/deny.toml
+++ b/deny.toml
@@ -49,4 +49,5 @@ ignore = [
   "RUSTSEC-2024-0384", # Unmaintained instant crate
   "RUSTSEC-2024-0436", # Unmaintained paste crate
   "RUSTSEC-2025-0012", # Unmaintained backoff crate
+  "RUSTSEC-2025-0014", # Unmaintained humantime crate
 ]


### PR DESCRIPTION
# Description
Adds
-  Previous sequencer commitment to the input of the batch proof (the sequencer commitment with the previous index of the current batch proofs first commitment)
- Sequencer Commitment index range (range of indexes of sequencer commitments proven in the batch proof)
- Index of the previous sequencer commitment that was inputted
- Hash of the previous sequencer commitment that was inputted
Updates
- Instead of outputting sequencer commitment merkle roots we now output sequencer commitment hashes
Removes
- L2 start height from sequencer commitment

With these changes, sequencer and batch prover cannot trick light client prover to prover false state transitions

## Linked Issues
- Fixes #2069 #2019 
