### PR TITLE
Do not check `humantime` crate in cargo deny

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          command: "--exclude humantime check"
+          command: check
 
   coverage:
     needs:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          command: check
+          command: "--exclude humantime check"
 
   coverage:
     needs:

--- a/deny.toml
+++ b/deny.toml
@@ -49,4 +49,5 @@ ignore = [
   "RUSTSEC-2024-0384", # Unmaintained instant crate
   "RUSTSEC-2024-0436", # Unmaintained paste crate
   "RUSTSEC-2025-0012", # Unmaintained backoff crate
+  "RUSTSEC-2025-0014", # Unmaintained humantime crate
 ]


### PR DESCRIPTION
# Description
`humantime` library is not maintained for over 4 years now so cargo deny is rightfully erroring out, however since it comes from some reth crate we cannot get rid of it just yet so we can exclude it for now

