### PR TITLE
Impl rename for ModuleInfo (short module name)

### DIFF
--- a/bin/citrea/tests/mock/evm/mod.rs
+++ b/bin/citrea/tests/mock/evm/mod.rs
@@ -298,7 +298,7 @@ fn check_proof(acc_proof: &EIP1186AccountProofResponse, account_address: Address
             .expect("Account proof must be valid");
     } else if acc_proof.account_proof[0] == Bytes::from("fork2") {
         dbg!("verify proof acc fork2");
-        let account_key = [b"Evm/i/", account_address.as_slice()].concat();
+        let account_key = [b"E/i/", account_address.as_slice()].concat();
         let account_hash = KeyHash::with::<sha2::Sha256>(account_key.clone());
 
         if acc_proof.account_proof.len() == 3 {
@@ -352,7 +352,7 @@ fn check_proof(acc_proof: &EIP1186AccountProofResponse, account_address: Address
                 None
             };
 
-            let index_key = [b"Evm/t/", account_idx.to_le_bytes().as_slice()].concat();
+            let index_key = [b"E/a/", account_idx.to_le_bytes().as_slice()].concat();
             let index_hash = KeyHash::with::<sha2::Sha256>(index_key.clone());
 
             let acc_proof: jmt::proof::SparseMerkleProof<sha2::Sha256> =
@@ -403,7 +403,7 @@ fn check_proof(acc_proof: &EIP1186AccountProofResponse, account_address: Address
                 let arr = hasher.finalize();
                 U256::from_le_slice(&arr)
             };
-            let storage_key = [b"Evm/S/".as_slice(), kaddr.as_le_slice()].concat();
+            let storage_key = [b"E/S/".as_slice(), kaddr.as_le_slice()].concat();
             let key_hash = KeyHash::with::<sha2::Sha256>(storage_key.clone());
 
             let proved_value = if storage_proof.proof[2] == Bytes::from("y") {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -73,6 +73,7 @@ type AccountId = u64;
 /// The citrea-evm module provides compatibility with the EVM.
 // #[cfg_attr(feature = "native", derive(sov_modules_api::ModuleCallJsonSchema))]
 #[derive(ModuleInfo, Clone)]
+#[module(rename = "E")]
 pub struct Evm<C: sov_modules_api::Context> {
     /// The address of the evm module.
     #[address]

--- a/crates/l2-block-rule-enforcer/src/lib.rs
+++ b/crates/l2-block-rule-enforcer/src/lib.rs
@@ -29,6 +29,7 @@ struct RuleEnforcerData {
 }
 
 #[derive(ModuleInfo, Clone)]
+#[module(rename = "L")]
 pub struct L2BlockRuleEnforcer<C: Context, Da: DaSpec> {
     /// Address of the L2BlockRuleEnforcer module.
     #[address]

--- a/crates/sovereign-sdk/module-system/module-implementations/sov-accounts/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/module-implementations/sov-accounts/src/lib.rs
@@ -48,6 +48,7 @@ impl StateValueCodec<Account> for BorshCodec {
 /// A module responsible for managing accounts on the rollup.
 #[cfg_attr(feature = "native", derive(sov_modules_api::ModuleCallJsonSchema))]
 #[derive(ModuleInfo, Clone)]
+#[module(rename = "A")]
 pub struct Accounts<C: Context> {
     /// The address of the sov-accounts module.
     #[address]


### PR DESCRIPTION
# Description

Note: merge after https://github.com/chainwayxyz/citrea/pull/2084

- [x] Implement rename
- [x] Rename modules (Evm -> E, L2BlockRuleEnforcer -> L, sov Accounts -> A)
- [x] Fix eth_getProof again

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/2061
