### PR TITLE
Break commitments if indices are not consecutive

### DIFF
--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -356,6 +356,21 @@ pub(crate) fn break_sequencer_commitments_into_groups<DB: BatchProverLedgerOps>(
         let commitment_spec =
             fork_from_block_number(sequencer_commitment.l2_end_block_number).spec_id;
 
+        // If commitment indices are not consecutive, split them into separate groups
+        if index != 0 && sequencer_commitment.index != sequencer_commitments[index - 1].index + 1 {
+            tracing::info!(
+                "Adding range: {:?} due to non consecutive commitments. Prev index = {}, current index = {}",
+                range,
+                sequencer_commitments[index - 1].index,
+                sequencer_commitment.index
+            );
+            result_range.push(*range.start()..=(index - 1));
+            // Reset the cumulative state diff to be equal to the current commitment state diff
+            cumulative_state_diff = sequencer_commitment_state_diff;
+            range = index..=index;
+            continue;
+        }
+
         if commitment_spec != current_spec || state_diff_threshold_reached {
             tracing::info!(
                 "Adding range: {:?} due to spec change: {} due to state diff threshold: {}",

--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -367,7 +367,7 @@ pub(crate) fn break_sequencer_commitments_into_groups<DB: BatchProverLedgerOps>(
                 sequencer_commitments[index - 1].index,
                 sequencer_commitment.index
             );
-            result_range.push(*range.start()..=(index - 1));
+            result_range.push(range);
             // Reset the cumulative state diff to be equal to the current commitment state diff
             cumulative_state_diff = sequencer_commitment_state_diff;
             range = index..=index;

--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -357,6 +357,9 @@ pub(crate) fn break_sequencer_commitments_into_groups<DB: BatchProverLedgerOps>(
             fork_from_block_number(sequencer_commitment.l2_end_block_number).spec_id;
 
         // If commitment indices are not consecutive, split them into separate groups
+        // The check is done here so that the current commitment's state diff is still calculated
+        // as the new commulative diff as part of the new group, that is, in case the commitments are not
+        // consecutive.
         if index != 0 && sequencer_commitment.index != sequencer_commitments[index - 1].index + 1 {
             tracing::info!(
                 "Adding range: {:?} due to non consecutive commitments. Prev index = {}, current index = {}",

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -132,11 +132,11 @@ where
         });
     }
 
-    sequencer_commitments.sort();
-
     if sequencer_commitments.is_empty() {
         return Err(L1ProcessingError::DuplicateCommitments { l1_height });
     }
+
+    sequencer_commitments.sort_by_key(|c| c.index);
 
     let da_block_header_of_commitments: <<Da as DaService>::Spec as DaSpec>::BlockHeader =
         l1_block.header().clone();

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -136,7 +136,7 @@ where
         return Err(L1ProcessingError::DuplicateCommitments { l1_height });
     }
 
-    sequencer_commitments.sort_by_key(|c| c.index);
+    sequencer_commitments.sort();
 
     let da_block_header_of_commitments: <<Da as DaService>::Spec as DaSpec>::BlockHeader =
         l1_block.header().clone();

--- a/crates/common/src/da.rs
+++ b/crates/common/src/da.rs
@@ -131,7 +131,7 @@ where
 
     // Make sure all sequencer commitments are stored in ascending order.
     // We sort before checking ranges to prevent substraction errors.
-    sequencer_commitments.sort_by_key(|c| c.index);
+    sequencer_commitments.sort();
 
     sequencer_commitments
 }

--- a/crates/common/src/da.rs
+++ b/crates/common/src/da.rs
@@ -131,7 +131,7 @@ where
 
     // Make sure all sequencer commitments are stored in ascending order.
     // We sort before checking ranges to prevent substraction errors.
-    sequencer_commitments.sort();
+    sequencer_commitments.sort_by_key(|c| c.index);
 
     sequencer_commitments
 }


### PR DESCRIPTION
# Description

- Sort sequencer commitments by index so that when prover tries to break them up, the commitment indices are in consecutive order.
- Also check when grouping commitments, for the previous commitment to come consecutively before the current one. In that case, they belong to the same group. Otherwise, they don't and they need to be broken into two separate groups.