### PR TITLE
Correct verbosity handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ brotli = "7"
 byteorder = { version = "1.5.0", default-features = false }
 bytes = { version = "1.10.0", default-features = false }
 chrono = { version = "0.4.39", default-features = false }
-clap = { version = "4.5.23", features = ["derive"] }
+clap = { version = "4.5.23", features = ["derive", "env"] }
 const-hex = "1.14"
 constmuck = "1.1"
 crypto-bigint = "0.5.5"

--- a/bin/citrea/src/cli.rs
+++ b/bin/citrea/src/cli.rs
@@ -54,7 +54,7 @@ pub(crate) struct Args {
     pub(crate) light_client_prover: Option<Option<String>>,
 
     /// Logging verbosity
-    #[arg(long, short = 'v', action = clap::ArgAction::Count, default_value = "0")]
+    #[arg(long, short = 'v', action = clap::ArgAction::Count, default_value = "0", env = "CITREA_VERBOSITY")]
     pub(crate) verbose: u8,
     /// Logging verbosity
     #[arg(long, short = 'q', action)]

--- a/bin/citrea/src/cli.rs
+++ b/bin/citrea/src/cli.rs
@@ -54,7 +54,7 @@ pub(crate) struct Args {
     pub(crate) light_client_prover: Option<Option<String>>,
 
     /// Logging verbosity
-    #[arg(long, short = 'v', action = clap::ArgAction::Count, default_value = "2")]
+    #[arg(long, short = 'v', action = clap::ArgAction::Count, default_value = "0")]
     pub(crate) verbose: u8,
     /// Logging verbosity
     #[arg(long, short = 'q', action)]

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -50,11 +50,8 @@ async fn main() -> anyhow::Result<()> {
         args.verbose = 0;
     }
     let logging_level = match args.verbose {
-        0 => tracing::Level::ERROR,
-        1 => tracing::Level::WARN,
-        2 => tracing::Level::INFO,
-        3 => tracing::Level::DEBUG,
-        4 => tracing::Level::TRACE,
+        1 => tracing::Level::DEBUG,
+        2 => tracing::Level::TRACE,
         _ => tracing::Level::INFO,
     };
     initialize_logging(logging_level);


### PR DESCRIPTION
# Description

The default verbosity for our nodes is `INFO` which has a value of 2. However, the verbosity flag counts the `v`s and we decide the verbosity based on the number of `v`s which starts from 0 for ERROR all the way up to TRACE.
However, our initial verbosity is 2, which means that when we pass `-v` or `--verbose`, that should indicate that we'd like to increase verbosity STARTING from `INFO` which takes us to `DEBUG`.

This PR means that:
- Passing `-v` enables debug logging
- Passing `-vv` enables trace logging