### PR TITLE
Task manager: cancellation strategy on errors

### DIFF
--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -9,7 +9,7 @@ use bitcoin_da::verifier::BitcoinVerifier;
 use citrea_common::backup::{create_backup_rpc_module, BackupManager};
 use citrea_common::config::ProverGuestRunConfig;
 use citrea_common::rpc::register_healthcheck_rpc;
-use citrea_common::tasks::manager::TaskManager;
+use citrea_common::tasks::manager::{TaskManager, TaskType};
 use citrea_common::FullNodeConfig;
 use citrea_primitives::forks::use_network_forks;
 use citrea_primitives::REVEAL_TX_PREFIX;
@@ -142,8 +142,12 @@ impl RollupBlueprint for BitcoinRollup {
             // run only for sequencer and prover
             service.monitoring.restore().await?;
 
-            task_manager.spawn(|tk| Arc::clone(&service).run_da_queue(rx, tk));
-            task_manager.spawn(|tk| Arc::clone(&service.monitoring).run(tk));
+            task_manager.spawn(TaskType::Secondary, |tk| {
+                Arc::clone(&service).run_da_queue(rx, tk)
+            });
+            task_manager.spawn(TaskType::Secondary, |tk| {
+                Arc::clone(&service.monitoring).run(tk)
+            });
         }
 
         Ok(service)

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -10,7 +10,7 @@ use bitcoin_da::spec::RollupParams;
 use bitcoincore_rpc::RpcApi;
 use citrea_batch_prover::rpc::BatchProverRpcClient;
 use citrea_batch_prover::GroupCommitments;
-use citrea_common::tasks::manager::TaskManager;
+use citrea_common::tasks::manager::{TaskManager, TaskType};
 use citrea_e2e::config::{
     BatchProverConfig, CitreaMode, LightClientProverConfig, SequencerConfig,
     SequencerMempoolConfig, TestCaseConfig,
@@ -544,8 +544,9 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
             .unwrap(),
         );
 
-        self.task_manager
-            .spawn(|tk| bitcoin_da_service.clone().run_da_queue(rx, tk));
+        self.task_manager.spawn(TaskType::Secondary, |tk| {
+            bitcoin_da_service.clone().run_da_queue(rx, tk)
+        });
 
         let min_soft_confirmations_per_commitment =
             sequencer.min_soft_confirmations_per_commitment();
@@ -786,8 +787,9 @@ impl TestCase for LightClientUnverifiableBatchProofTest {
             .unwrap(),
         );
 
-        self.task_manager
-            .spawn(|tk| bitcoin_da_service.clone().run_da_queue(rx, tk));
+        self.task_manager.spawn(TaskType::Secondary, |tk| {
+            bitcoin_da_service.clone().run_da_queue(rx, tk)
+        });
 
         da.generate(FINALITY_DEPTH).await?;
         let finalized_height = da.get_finalized_height(None).await?;
@@ -1007,8 +1009,9 @@ impl TestCase for VerifyChunkedTxsInLightClient {
             .unwrap(),
         );
 
-        self.task_manager
-            .spawn(|tk| bitcoin_da_service.clone().run_da_queue(rx, tk));
+        self.task_manager.spawn(TaskType::Secondary, |tk| {
+            bitcoin_da_service.clone().run_da_queue(rx, tk)
+        });
 
         da.generate(FINALITY_DEPTH).await?;
         let finalized_height = da.get_finalized_height(None).await?;

--- a/crates/batch-prover/src/runner.rs
+++ b/crates/batch-prover/src/runner.rs
@@ -44,7 +44,7 @@ where
             .l2_sync_worker
             .take()
             .expect("L2 sync worker should be set");
-        let worker = l2_sync_worker.run(cancellation_token.child_token());
+        let worker = l2_sync_worker.run(cancellation_token.clone());
         tokio::pin!(worker);
 
         loop {

--- a/crates/bitcoin-da/tests/test_utils.rs
+++ b/crates/bitcoin-da/tests/test_utils.rs
@@ -12,7 +12,7 @@ use bitcoin_da::spec::header::HeaderWrapper;
 use bitcoin_da::spec::transaction::TransactionWrapper;
 use bitcoin_da::spec::RollupParams;
 use bitcoincore_rpc::RpcApi;
-use citrea_common::tasks::manager::TaskManager;
+use citrea_common::tasks::manager::{TaskManager, TaskType};
 use citrea_e2e::bitcoin::BitcoinNode;
 use citrea_e2e::config::BitcoinConfig;
 use citrea_e2e::node::NodeKind;
@@ -69,7 +69,9 @@ pub async fn get_service(
     .expect("Error initializing BitcoinService");
 
     let da_service = Arc::new(da_service);
-    task_manager.spawn(|tk| da_service.clone().run_da_queue(rx, tk));
+    task_manager.spawn(TaskType::Secondary, |tk| {
+        da_service.clone().run_da_queue(rx, tk)
+    });
 
     da_service
 }

--- a/crates/common/src/rpc/server.rs
+++ b/crates/common/src/rpc/server.rs
@@ -5,7 +5,7 @@ use jsonrpsee::RpcModule;
 use tokio::sync::oneshot;
 use tracing::{error, info};
 
-use crate::tasks::manager::TaskManager;
+use crate::tasks::manager::{TaskManager, TaskType};
 use crate::RpcConfig;
 
 /// Starts a RPC server with provided rpc methods.
@@ -38,7 +38,7 @@ pub fn start_rpc_server(
         .layer_fn(move |s| super::auth::Auth::new(s, rpc_config.api_key.clone()))
         .layer_fn(super::Logger);
 
-    task_manager.spawn(move |cancellation_token| async move {
+    task_manager.spawn(TaskType::Secondary, move |cancellation_token| async move {
         let server = ServerBuilder::default()
             .max_connections(max_connections)
             .max_subscriptions_per_connection(max_subscriptions_per_connection)

--- a/crates/common/src/tasks/manager.rs
+++ b/crates/common/src/tasks/manager.rs
@@ -95,7 +95,7 @@ impl<T: Send + 'static> TaskManager<T> {
                     return;
                 }
                 _ = handles_check.tick() => {
-                    let all_handles_finished = self.handles.iter().fold(true, |acc, t| acc && t.is_finished());
+                    let all_handles_finished = self.handles.iter().all(|t| t.is_finished());
                     if all_handles_finished {
                         info!("All tasks finished, stopping node");
                         self.abort().await;

--- a/crates/common/src/tasks/manager.rs
+++ b/crates/common/src/tasks/manager.rs
@@ -69,26 +69,27 @@ impl<T: Send + 'static> TaskManager<T> {
         let mut interrupt_signal =
             signal(SignalKind::interrupt()).expect("Failed to create interrupt signal");
 
-        tokio::select! {
-            _ = signal::ctrl_c() => {
-                self.abort().await;
-            }
-            _ = term_signal.recv() => {
-                self.abort().await;
-            },
-            _ = interrupt_signal.recv() => {
-                self.abort().await;
-            }
-            _ = handles_check.tick() => {
-                let mut all_handles_finished = true;
-                for handle in self.handles.iter() {
-                    if !handle.is_finished() {
-                        all_handles_finished = false;
-                    }
-                }
-                if all_handles_finished {
-                    info!("All tasks finished, stopping node");
+        loop {
+            tokio::select! {
+                _ = signal::ctrl_c() => {
                     self.abort().await;
+                    return;
+                }
+                _ = term_signal.recv() => {
+                    self.abort().await;
+                    return;
+                },
+                _ = interrupt_signal.recv() => {
+                    self.abort().await;
+                    return;
+                }
+                _ = handles_check.tick() => {
+                    let all_handles_finished = self.handles.iter().fold(true, |acc, t| acc && t.is_finished());
+                    if all_handles_finished {
+                        info!("All tasks finished, stopping node");
+                        self.abort().await;
+                        return;
+                    }
                 }
             }
         }

--- a/crates/common/src/tasks/manager.rs
+++ b/crates/common/src/tasks/manager.rs
@@ -6,6 +6,7 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 const WAIT_DURATION: u64 = 5; // 5 seconds
 
@@ -60,6 +61,9 @@ impl<T: Send + 'static> TaskManager<T> {
 
     /// Wait for a termination signal and cancel all running tasks
     pub async fn wait_shutdown(&self) {
+        let mut handles_check = tokio::time::interval(Duration::from_secs(1));
+        handles_check.tick().await;
+
         let mut term_signal =
             signal(SignalKind::terminate()).expect("Failed to create termination signal");
         let mut interrupt_signal =
@@ -74,6 +78,18 @@ impl<T: Send + 'static> TaskManager<T> {
             },
             _ = interrupt_signal.recv() => {
                 self.abort().await;
+            }
+            _ = handles_check.tick() => {
+                let mut all_handles_finished = true;
+                for handle in self.handles.iter() {
+                    if !handle.is_finished() {
+                        all_handles_finished = false;
+                    }
+                }
+                if all_handles_finished {
+                    info!("All tasks finished, stopping node");
+                    self.abort().await;
+                }
             }
         }
     }

--- a/crates/common/src/tasks/manager.rs
+++ b/crates/common/src/tasks/manager.rs
@@ -10,6 +10,13 @@ use tracing::info;
 
 const WAIT_DURATION: u64 = 5; // 5 seconds
 
+/// Task type distinguishes between a primary and secondary tasks.
+/// A primary task when finished is able cancel all secondary tasks.
+pub enum TaskType {
+    Primary,
+    Secondary,
+}
+
 /// TaskManager manages tasks spawned using tokio and keeps
 /// track of handles so that these tasks are cancellable.
 /// This provides a way to implement graceful shutdown of our
@@ -34,12 +41,16 @@ impl<T: Send + 'static> TaskManager<T> {
     ///
     /// Tasks are forced to accept a cancellation token so that they can be notified
     /// about the cancellation using the passed token.
-    pub fn spawn<F, Fut>(&mut self, callback: F)
+    pub fn spawn<F, Fut>(&mut self, task_type: TaskType, callback: F)
     where
         F: FnOnce(CancellationToken) -> Fut,
         Fut: Future<Output = T> + Send + 'static,
     {
-        let handle = tokio::spawn(callback(self.child_token()));
+        let cancellation_token = match task_type {
+            TaskType::Primary => self.cancellation_token.clone(),
+            TaskType::Secondary => self.child_token(),
+        };
+        let handle = tokio::spawn(callback(cancellation_token));
         self.handles.push(handle);
     }
 

--- a/crates/fullnode/src/runner.rs
+++ b/crates/fullnode/src/runner.rs
@@ -43,7 +43,7 @@ where
             .l2_sync_worker
             .take()
             .expect("L2 sync worker should be set");
-        let worker = l2_sync_worker.run(cancellation_token.child_token());
+        let worker = l2_sync_worker.run(cancellation_token.clone());
         tokio::pin!(worker);
 
         loop {

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -705,6 +705,8 @@ where
                     if missed_da_blocks_count > 0 {
                         if let Err(e) = self.process_missed_da_blocks(missed_da_blocks_count, &mut last_used_l1_height, l1_fee_rate).await {
                             error!("Sequencer error: {}", e);
+                            // Cancel child tasks
+                            cancellation_token.cancel();
                             // we never want to continue if we have missed blocks
                             return Err(e);
                         }
@@ -735,6 +737,8 @@ where
                     if missed_da_blocks_count > 0 {
                         if let Err(e) = self.process_missed_da_blocks(missed_da_blocks_count, &mut last_used_l1_height, l1_fee_rate).await {
                             error!("Sequencer error: {}", e);
+                            // Cancel child tasks
+                            cancellation_token.cancel();
                             // we never want to continue if we have missed blocks
                             return Err(e);
                         }


### PR DESCRIPTION
# Description

This PR introduces `TaskType::Primary` and `TaskType::Secondary` variants which would help us distinguish between primary and secondary tasks.

- A primary task receives a clone of the parent cancellation token (any parent token clone can cancel all child tasks)
- On an error in the primary task which makes the primary task return (stop), means that all secondary tasks are stopped as well.

The task manager in this case would be looking out tasks and checking of all are finished to stop running the node.