### PR TITLE
For non segwit blocks the witness root is txs merkle root

### DIFF
--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -1128,8 +1128,7 @@ impl DaService for BitcoinService {
             })
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
-        let coinbase_tx = block.tx[0].clone();
-        let commitment_idx = coinbase_tx.vout.iter().rev().position(|output| {
+        let commitment_idx = block.tx[0].vout.iter().rev().position(|output| {
             output
                 .script_pub_key
                 .script()
@@ -1139,9 +1138,9 @@ impl DaService for BitcoinService {
         });
 
         let witness_root = match commitment_idx {
-            Some(idx) => calculate_witness_root(&txs),
+            Some(_idx) => calculate_witness_root(&txs),
             // If block is not a segwit block, then the witness root should be the header merkle root
-            None => header.merkle_root(),
+            None => header.merkle_root.as_raw_hash().to_byte_array(),
         };
 
         Ok(BitcoinBlock {

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -1140,7 +1140,7 @@ impl DaService for BitcoinService {
         let witness_root = match commitment_idx {
             Some(_idx) => calculate_witness_root(&txs),
             // If block is not a segwit block, then the witness root should be the header merkle root
-            None => header.merkle_root.as_raw_hash().to_byte_array(),
+            None => header.merkle_root.to_byte_array(),
         };
 
         Ok(BitcoinBlock {


### PR DESCRIPTION
# Description
When implementing reorg syncer @eyusufatik and I realized there is a bug in verifying short header proofs, turns out we made a mistake at non segwit block witness roots, it should be txs merkle root.

## Linked Issues
- Fixes #2110 


