### PR TITLE
Fix try_from slice for K256PublicKey

### DIFF
--- a/crates/evm/src/tests/sys_tx_tests.rs
+++ b/crates/evm/src/tests/sys_tx_tests.rs
@@ -1058,7 +1058,7 @@ fn test_wcbtc() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Fork2,
-        sequencer_pub_key: vec![],
+        sequencer_pub_key: [1; 33].as_slice().try_into().unwrap(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1128,7 +1128,7 @@ fn test_wcbtc() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Fork2,
-        sequencer_pub_key: vec![],
+        sequencer_pub_key: [1; 33].as_slice().try_into().unwrap(),
         l1_fee_rate,
         timestamp: 0,
     };

--- a/crates/sovereign-sdk/module-system/sov-keys/src/default_signature.rs
+++ b/crates/sovereign-sdk/module-system/sov-keys/src/default_signature.rs
@@ -132,11 +132,8 @@ impl TryFrom<&[u8]> for K256PublicKey {
     type Error = anyhow::Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let mut public = [0u8; 33];
-        public.copy_from_slice(value);
         Ok(Self {
-            pub_key: k256::ecdsa::VerifyingKey::from_sec1_bytes(&public)
-                .map_err(anyhow::Error::msg)?,
+            pub_key: k256::ecdsa::VerifyingKey::from_sec1_bytes(value)?,
         })
     }
 }


### PR DESCRIPTION
# Description

- fixes try_from slice for k256 pubkey. even though provided slice was invalid, filling it with 0 during copy process might make it look like it is valid and might cause some unwanted trouble

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
