### PR TITLE
Increase L1 sync speed

### DIFF
--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -24,7 +24,7 @@ use sov_rollup_interface::services::da::{DaService, SlotData};
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::zk::ZkvmHost;
 use tokio::select;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -50,7 +50,7 @@ where
     elfs_by_spec: HashMap<SpecId, Vec<u8>>,
     l1_block_cache: Arc<Mutex<L1BlockCache<Da>>>,
     skip_submission_until_l1: u64,
-    pending_l1_blocks: Arc<Mutex<VecDeque<<Da as DaService>::FilteredBlock>>>,
+    pending_l1_blocks: VecDeque<<Da as DaService>::FilteredBlock>,
     backup_manager: Arc<BackupManager>,
 }
 
@@ -87,12 +87,14 @@ where
             elfs_by_spec,
             skip_submission_until_l1,
             l1_block_cache,
-            pending_l1_blocks: Arc::new(Mutex::new(VecDeque::new())),
+            pending_l1_blocks: VecDeque::new(),
             backup_manager,
         }
     }
 
     pub async fn run(mut self, start_l1_height: u64, cancellation_token: CancellationToken) {
+        let (l1_sender, mut l1_receiver) = mpsc::channel(10);
+
         if self.prover_config.enable_recovery {
             if let Err(e) = self.check_and_recover_ongoing_proving_sessions().await {
                 error!("Failed to recover ongoing proving sessions: {:?}", e);
@@ -107,7 +109,7 @@ where
         let l1_sync_worker = sync_l1(
             start_l1_height,
             self.da_service.clone(),
-            self.pending_l1_blocks.clone(),
+            l1_sender,
             self.l1_block_cache.clone(),
             BATCH_PROVER_METRICS.scan_l1_block.clone(),
         );
@@ -123,6 +125,9 @@ where
                     return;
                 }
                 _ = &mut l1_sync_worker => {},
+                Some(l1_block) = l1_receiver.recv() => {
+                    self.pending_l1_blocks.push_back(l1_block);
+                }
                 _ = interval.tick() => {
                     let _l1_guard = backup_manager.start_l1_processing().await;
                     if let Err(e) = self.process_l1_block().await {
@@ -134,10 +139,9 @@ where
     }
 
     async fn process_l1_block(&mut self) -> Result<(), anyhow::Error> {
-        let mut pending_l1_blocks = self.pending_l1_blocks.lock().await;
-
-        while !pending_l1_blocks.is_empty() {
-            let l1_block = pending_l1_blocks
+        while !self.pending_l1_blocks.is_empty() {
+            let l1_block = self
+                .pending_l1_blocks
                 .front()
                 .expect("Pending l1 blocks cannot be empty");
             // work on the first unprocessed l1 block
@@ -171,7 +175,7 @@ where
 
                 BATCH_PROVER_METRICS.current_l1_block.set(l1_height as f64);
 
-                pending_l1_blocks.pop_front();
+                self.pending_l1_blocks.pop_front();
                 continue;
             }
 
@@ -197,7 +201,7 @@ where
 
                         BATCH_PROVER_METRICS.current_l1_block.set(l1_height as f64);
 
-                        pending_l1_blocks.pop_front();
+                        self.pending_l1_blocks.pop_front();
                         continue;
                     }
                     L1ProcessingError::DuplicateCommitments { l1_height } => {
@@ -216,7 +220,7 @@ where
 
                         BATCH_PROVER_METRICS.current_l1_block.set(l1_height as f64);
 
-                        pending_l1_blocks.pop_front();
+                        self.pending_l1_blocks.pop_front();
                         continue;
                     }
                     L1ProcessingError::L2RangeMissing {
@@ -276,7 +280,7 @@ where
 
             BATCH_PROVER_METRICS.current_l1_block.set(l1_height as f64);
 
-            pending_l1_blocks.pop_front();
+            self.pending_l1_blocks.pop_front();
         }
         Ok(())
     }

--- a/crates/common/src/da.rs
+++ b/crates/common/src/da.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -9,9 +8,9 @@ use metrics::Histogram;
 use sov_rollup_interface::da::{BlockHeaderTrait, SequencerCommitment};
 use sov_rollup_interface::services::da::{DaService, SlotData};
 use sov_rollup_interface::zk::Proof;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tokio::time::sleep;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 use crate::cache::L1BlockCache;
 
@@ -19,7 +18,7 @@ use crate::cache::L1BlockCache;
 pub async fn sync_l1<Da>(
     mut start_from: u64,
     da_service: Arc<Da>,
-    block_queue: Arc<Mutex<VecDeque<Da::FilteredBlock>>>,
+    l1_sender: mpsc::Sender<Da::FilteredBlock>,
     l1_block_cache: Arc<Mutex<L1BlockCache<Da>>>,
     l1_block_scan_histogram: Histogram,
 ) where
@@ -56,13 +55,12 @@ pub async fn sync_l1<Da>(
                     }
                 };
 
-            let mut queue = block_queue.lock().await;
-
-            if queue.len() < 10 {
-                queue.push_back(l1_block.clone());
-            } else {
-                debug!("Block queue is full, will try later...");
-                break;
+            let l1_height = l1_block.header().height();
+            if let Err(e) = l1_sender.send(l1_block).await {
+                error!(
+                    "Failed to notify about new L1 block at height {:?} because: {:?}",
+                    l1_height, e
+                );
             }
 
             // we know this won't change the for loop range

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -22,7 +22,7 @@ use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::zk::batch_proof::output::BatchProofCircuitOutput;
 use sov_rollup_interface::zk::{Proof, ZkvmHost};
 use tokio::select;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -41,7 +41,7 @@ where
     prover_da_pub_key: Vec<u8>,
     code_commitments_by_spec: HashMap<SpecId, Vm::CodeCommitment>,
     l1_block_cache: Arc<Mutex<L1BlockCache<Da>>>,
-    pending_l1_blocks: Arc<Mutex<VecDeque<<Da as DaService>::FilteredBlock>>>,
+    pending_l1_blocks: VecDeque<<Da as DaService>::FilteredBlock>,
     backup_manager: Arc<BackupManager>,
 }
 
@@ -68,7 +68,7 @@ where
             prover_da_pub_key,
             code_commitments_by_spec,
             l1_block_cache,
-            pending_l1_blocks: Arc::new(Mutex::new(VecDeque::new())),
+            pending_l1_blocks: VecDeque::new(),
             backup_manager,
         }
     }
@@ -77,10 +77,11 @@ where
         let mut interval = tokio::time::interval(Duration::from_secs(1));
         interval.tick().await;
 
+        let (l1_sender, mut l1_receiver) = mpsc::channel(10);
         let l1_sync_worker = sync_l1(
             start_l1_height,
             self.da_service.clone(),
-            self.pending_l1_blocks.clone(),
+            l1_sender,
             self.l1_block_cache.clone(),
             FULLNODE_METRICS.scan_l1_block.clone(),
         );
@@ -93,6 +94,9 @@ where
                     return;
                 }
                 _ = &mut l1_sync_worker => {},
+                Some(l1_block) = l1_receiver.recv() => {
+                    self.pending_l1_blocks.push_back(l1_block);
+                }
                 _ = interval.tick() => {
                     self.process_l1_block().await
                 },
@@ -102,9 +106,8 @@ where
 
     async fn process_l1_block(&mut self) {
         let _l1_lock = self.backup_manager.start_l1_processing().await;
-        let mut pending_l1_blocks = self.pending_l1_blocks.lock().await;
 
-        let Some(l1_block) = pending_l1_blocks.front() else {
+        let Some(l1_block) = self.pending_l1_blocks.front() else {
             return;
         };
 
@@ -199,7 +202,7 @@ where
 
         FULLNODE_METRICS.current_l1_block.set(l1_height as f64);
 
-        pending_l1_blocks.pop_front();
+        self.pending_l1_blocks.pop_front();
     }
 
     async fn process_sequencer_commitment(

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -20,7 +20,7 @@ use sov_rollup_interface::zk::light_client_proof::output::LightClientCircuitOutp
 use sov_rollup_interface::zk::{Proof, ReceiptType, ZkvmHost};
 use sov_rollup_interface::Network;
 use tokio::select;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
@@ -50,7 +50,7 @@ where
     light_client_proof_code_commitments: HashMap<SpecId, Vm::CodeCommitment>,
     light_client_proof_elfs: HashMap<SpecId, Vec<u8>>,
     l1_block_cache: Arc<Mutex<L1BlockCache<Da>>>,
-    queued_l1_blocks: Arc<Mutex<VecDeque<<Da as DaService>::FilteredBlock>>>,
+    queued_l1_blocks: VecDeque<<Da as DaService>::FilteredBlock>,
     backup_manager: Arc<BackupManager>,
     circuit: LightClientProofCircuit<ProverStorage, Da::Spec, Vm>,
 }
@@ -84,7 +84,7 @@ where
             light_client_proof_code_commitments,
             light_client_proof_elfs,
             l1_block_cache: Arc::new(Mutex::new(L1BlockCache::new())),
-            queued_l1_blocks: Arc::new(Mutex::new(VecDeque::new())),
+            queued_l1_blocks: VecDeque::new(),
             backup_manager,
             circuit: LightClientProofCircuit::new(),
         }
@@ -105,6 +105,7 @@ where
         //         .clear_pending_proving_sessions()
         //         .expect("Failed to clear pending proving sessions");
         // }
+        let (l1_sender, mut l1_receiver) = mpsc::channel(10);
         let start_l1_height = match last_l1_height_scanned {
             StartVariant::LastScanned(height) => height + 1, // last scanned block + 1
             StartVariant::FromBlock(height) => height,       // first block to scan
@@ -112,7 +113,7 @@ where
         let l1_sync_worker = sync_l1(
             start_l1_height,
             self.da_service.clone(),
-            self.queued_l1_blocks.clone(),
+            l1_sender,
             self.l1_block_cache.clone(),
             LIGHT_CLIENT_METRICS.scan_l1_block.clone(),
         );
@@ -129,6 +130,9 @@ where
                     return;
                 }
                 _ = &mut l1_sync_worker => {},
+                Some(l1_block) = l1_receiver.recv() => {
+                    self.queued_l1_blocks.push_back(l1_block);
+                }
                 _ = interval.tick() => {
                     let _l1_guard = backup_manager.start_l1_processing().await;
                     if let Err(e) = self.process_queued_l1_blocks().await {
@@ -141,11 +145,11 @@ where
 
     async fn process_queued_l1_blocks(&mut self) -> Result<(), anyhow::Error> {
         loop {
-            let Some(l1_block) = self.queued_l1_blocks.lock().await.front().cloned() else {
+            let Some(l1_block) = self.queued_l1_blocks.front().cloned() else {
                 break;
             };
             self.process_l1_block(l1_block).await?;
-            self.queued_l1_blocks.lock().await.pop_front();
+            self.queued_l1_blocks.pop_front();
         }
 
         Ok(())


### PR DESCRIPTION
# Description

I noticed while running the nodes including full node and batch prover that the L1 sync speed was quite slow especially on the batch prover. This is because `pending_l1_blocks` was behind a Mutex where DA block handler and the L1 syncer had a  read/write lock contention on the Mutex.

The reason we wanted to have this is because we did not want pending l1 blocks to grow beyond limits when trying to process those blocks. The better lock-free solution was to use a bounded channel whose limit is 10 blocks similar to how the we previously manually did with the lock + check on the size.

This lock-free approach led to a much faster L1 sync.

On my other PRs, i had to wait for a while (> 5 minutes) until the batch prover found block ~ 1000 at which there was a commitment to prove. However, with this new version, the sync took seconds to reach to the desired block.