### PR TITLE
Fix bitcoin-da test_mempool_accept error message on packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-rpc"
 version = "0.18.0"
-source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=ca3cfa2#ca3cfa2a2a6fac070d1a6116db1a3894b8fd5415"
+source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=0fe8a8b#0fe8a8b8811b9891b37fec2a305f1af6b324111f"
 dependencies = [
  "async-trait",
  "bitcoincore-rpc-json",
@@ -1384,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-rpc-json"
 version = "0.18.0"
-source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=ca3cfa2#ca3cfa2a2a6fac070d1a6116db1a3894b8fd5415"
+source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=0fe8a8b#0fe8a8b8811b9891b37fec2a305f1af6b324111f"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ alloy-network = { version = "0.4.2", default-features = false }
 citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "7b392a2" }
 
 [patch.crates-io]
-bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "ca3cfa2" }
+bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "0fe8a8b" }
 
 [profile.release]
 opt-level = 3

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -623,12 +623,15 @@ impl BitcoinService {
             if let TestMempoolAcceptResult {
                 allowed: Some(false) | None,
                 reject_reason,
+                package_error,
                 ..
             } = res
             {
                 bail!(
                     "{}",
-                    reject_reason.unwrap_or("[testmempoolaccept] Unknown rejection".to_string())
+                    reject_reason
+                        .or(package_error)
+                        .unwrap_or("[testmempoolaccept] Unknown rejection".to_string())
                 )
             }
         }


### PR DESCRIPTION
# Description

- Uses updated bitcoincore-rpc rev with additional `TestMempoolAcceptResult` fields
- Uses `package_error` when present and `reject_reason` is None

## Linked Issues
- Fixes #2143

Result when allowed: None and reject_reason: None

```
results : [TestMempoolAcceptResult { txid: a3826d41058fc097d32598135b8bac38a4ead95a543e2d4915075eb28c9dd1fa, wtxid: ae5b543aa8308e7f30dc3b7fb5eeb7bafc2c7feedf208b40ea1b1a055d5613b2, allowed: None, reject_reason: None, reject_details: None, package_error: Some("package-mempool-limits, possibly too many unconfirmed ancestors [limit: 25]"), vsize: None, fees: None }, TestMempoolAcceptResult { txid: 2f97dd5097bede7e669acf187cc8d0b5b56dea393e9d9d336394fc5cdcbbbdfb, wtxid: 00be9776965702c99fbd93e92c76c5255ee500737d96c78b3b8acb2a9a331602, allowed: None, reject_reason: None, reject_details: None, package_error: Some("package-mempool-limits, possibly too many unconfirmed ancestors [limit: 25]"), vsize: None, fees: None }]
2025-03-21T09:01:15.458583Z ERROR bitcoin_da::service: error=package-mempool-limits, possibly too many unconfirmed ancestors [limit: 25]
2025-03-21T09:01:15.458600Z ERROR bitcoin_da::service: Failed to send transaction to DA layer e=package-mempool-limits, possibly too many unconfirmed ancestors [limit: 25]
```

