### PR TITLE
Add TEST_SKIP_GUEST_BUILD env to skip re-building guests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ test-ci:
 	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo nextest run -j15 --locked --workspace --all-features --no-fail-fast $(filter-out $@,$(MAKECMDGOALS))
 
 coverage-ci:
-	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo llvm-cov --locked --lcov --output-path lcov.info nextest -j10 --workspace --all-features 
+	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo llvm-cov --locked --lcov --output-path lcov.info nextest -j10 --workspace --all-features
 
 test: build-test ## Runs test suite using next test
-	$(MAKE) test-ci -- $(filter-out $@,$(MAKECMDGOALS))
+	TEST_SKIP_GUEST_BUILD=1 $(MAKE) test-ci -- $(filter-out $@,$(MAKECMDGOALS))
 
 coverage: build-test coverage-ci ## Coverage in lcov format
 

--- a/guests/risc0/batch-proof/build.rs
+++ b/guests/risc0/batch-proof/build.rs
@@ -12,6 +12,12 @@ fn main() {
     println!("cargo:rerun-if-env-changed=SEQUENCER_PUBLIC_KEY");
     println!("cargo:rerun-if-env-changed=SEQUENCER_DA_PUB_KEY");
 
+    println!("cargo:rerun-if-env-changed=TEST_SKIP_GUEST_BUILD");
+    if let Ok("1" | "true") = std::env::var("TEST_SKIP_GUEST_BUILD").as_deref() {
+        println!("cargo:warning=Skipping guest build in test. Exiting");
+        return;
+    }
+
     match std::env::var("SKIP_GUEST_BUILD") {
         Ok(value) => match value.as_str() {
             "1" | "true" => {

--- a/guests/risc0/light-client-proof/build.rs
+++ b/guests/risc0/light-client-proof/build.rs
@@ -13,6 +13,11 @@ fn main() {
     println!("cargo:rerun-if-env-changed=BATCH_PROOF_METHOD_ID");
     println!("cargo:rerun-if-env-changed=PROVER_DA_PUB_KEY");
 
+    println!("cargo:rerun-if-env-changed=TEST_SKIP_GUEST_BUILD");
+    if let Ok("1" | "true") = std::env::var("TEST_SKIP_GUEST_BUILD").as_deref() {
+        println!("cargo:warning=Skipping guest build in test. Exiting");
+        return;
+    }
     match std::env::var("SKIP_GUEST_BUILD") {
         Ok(value) => match value.as_str() {
             "1" | "true" => {


### PR DESCRIPTION
# Description

- Test that need proving cannot be built using `SKIP_GUEST_BUILD` or they will fail on ELF error. Even if they were previously built.
- There are some valid use cases for not re-building existing elfs, such as when we only change test itself.
- Introduces new `TEST_SKIP_GUEST_BUILD` that exit guest builds early and keep existing elfs as they are.

Be mindful that guests need to be built once first and this should only really be used when no source code has been changed.

---

Without any env var, rebuilding ELF, 26s build time : 
```
./test.sh basic_prover_test                               
   Compiling citrea-risc0-batch-proof v0.6.0 (/Users/jouz0/CHAINWAY/citrea/guests/risc0/batch-proof)
   Compiling citrea-risc0-light-client v0.6.0 (/Users/jouz0/CHAINWAY/citrea/guests/risc0/light-client-proof)
light-client-proof-bitcoin: Starting build for riscv32im-risc0-zkvm-elfoof(build), citrea-risc0-light-client(build)                                                                       
batch-proof-bitcoin: Starting build for riscv32im-risc0-zkvm-elf
light-client-proof-bitcoin:    Compiling citrea-risc0-batch-proof v0.6.0 (/Users/jouz0/CHAINWAY/citrea/guests/risc0/batch-proof)
batch-proof-bitcoin:     Finished `release` profile [optimized] target(s) in 0.31s
batch-proof-mock: Starting build for riscv32im-risc0-zkvm-elf
batch-proof-mock:     Finished `release` profile [optimized] target(s) in 0.28s
warning: citrea-risc0-batch-proof@0.6.0: SKIP_GUEST_BUILD not set. Defaulting to performing guest build.
warning: citrea-risc0-batch-proof@0.6.0: Building with testing feature
warning: citrea-risc0-batch-proof@0.6.0: Guest code is not built in docker
batch-proof-bitcoin: Starting build for riscv32im-risc0-zkvm-elfatch_proof(test), citrea-risc0-batch-proof, citrea-risc0-light-client(build)                                              
   Compiling citrea-light-client-prover v0.6.0 (/Users/jouz0/CHAINWAY/citrea/crates/light-client-prover)
batch-proof-bitcoin:     Finished `release` profile [optimized] target(s) in 0.40s, citrea-light-client-prover, citrea-risc0-light-client(build)                                          
batch-proof-mock: Starting build for riscv32im-risc0-zkvm-elf
batch-proof-mock:     Finished `release` profile [optimized] target(s) in 0.28s
light-client-proof-bitcoin: warning: citrea-risc0-batch-proof@0.6.0: SKIP_GUEST_BUILD not set. Defaulting to performing guest build.
light-client-proof-bitcoin: warning: citrea-risc0-batch-proof@0.6.0: Building with testing feature
light-client-proof-bitcoin: warning: citrea-risc0-batch-proof@0.6.0: Guest code is not built in docker
light-client-proof-bitcoin:    Compiling citrea-light-client-prover v0.6.0 (/Users/jouz0/CHAINWAY/citrea/crates/light-client-prover)
light-client-proof-bitcoin:    Compiling light-client-proof-bitcoin v0.6.0 (/Users/jouz0/CHAINWAY/citrea/guests/risc0/light-client-proof/bitcoin)
light-client-proof-bitcoin:     Finished `release` profile [optimized] target(s) in 10.23s                                                                                                
light-client-proof-mock: Starting build for riscv32im-risc0-zkvm-elf
light-client-proof-mock:    Compiling citrea-risc0-batch-proof v0.6.0 (/Users/jouz0/CHAINWAY/citrea/guests/risc0/batch-proof)
batch-proof-bitcoin: Starting build for riscv32im-risc0-zkvm-elf
batch-proof-bitcoin:     Finished `release` profile [optimized] target(s) in 0.27s
batch-proof-mock: Starting build for riscv32im-risc0-zkvm-elf
batch-proof-mock:     Finished `release` profile [optimized] target(s) in 0.24s
light-client-proof-mock: warning: citrea-risc0-batch-proof@0.6.0: SKIP_GUEST_BUILD not set. Defaulting to performing guest build.
light-client-proof-mock: warning: citrea-risc0-batch-proof@0.6.0: Building with testing feature
light-client-proof-mock: warning: citrea-risc0-batch-proof@0.6.0: Guest code is not built in docker
light-client-proof-mock:    Compiling citrea-light-client-prover v0.6.0 (/Users/jouz0/CHAINWAY/citrea/crates/light-client-prover)
light-client-proof-mock:    Compiling light-client-proof-mock v0.6.0 (/Users/jouz0/CHAINWAY/citrea/guests/risc0/light-client-proof/mock)
light-client-proof-mock:     Finished `release` profile [optimized] target(s) in 7.70s
warning: citrea-risc0-light-client@0.6.0: SKIP_GUEST_BUILD not set. Defaulting to performing guest build.
warning: citrea-risc0-light-client@0.6.0: Guest code is not built in docker
   Compiling citrea v0.6.0 (/Users/jouz0/CHAINWAY/citrea/bin/citrea)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 26.34s
────────────
 Nextest run ID aaae9441-a587-4e15-86b0-3e89c78f7817 with nextest profile: default
    Starting 1 test across 49 binaries (394 tests skipped)
       START             citrea::bitcoin_e2e bitcoin::batch_prover_test::basic_prover_test

running 1 test
2025-03-21T14:15:24.985029Z  INFO citrea_e2e::bitcoin: Bitcoin debug.log available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmplJNkAu/SCxnU4ZZse/bitcoin/0/regtest/debug.log
Bitcoin Core starting
2025-03-21T14:15:26.751461Z  INFO citrea_e2e::node: sequencer stdout logs available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmplJNkAu/SCxnU4ZZse/sequencer/stdout.log
2025-03-21T14:15:26.753646Z  INFO citrea_e2e::node: batch-prover stdout logs available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmplJNkAu/SCxnU4ZZse/batch-prover/stdout.log
2025-03-21T14:15:26.754018Z  INFO citrea_e2e::node: full-node stdout logs available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmplJNkAu/SCxnU4ZZse/full-node/stdout.log
StateDiff: size 1680, compressed 1026
2025-03-21T14:15:43.337254Z  INFO citrea_e2e::framework: Stopping framework...
2025-03-21T14:15:43.338972Z  INFO citrea_e2e::framework: Successfully stopped sequencer
2025-03-21T14:15:43.340921Z  INFO citrea_e2e::framework: Successfully stopped batch_prover
2025-03-21T14:15:43.341768Z  INFO citrea_e2e::framework: Successfully stopped full_node
2025-03-21T14:15:43.342453Z  INFO citrea_e2e::framework: Successfully stopped bitcoin nodes
test bitcoin::batch_prover_test::basic_prover_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 31 filtered out; finished in 18.37s

        PASS [  18.398s] citrea::bitcoin_e2e bitcoin::batch_prover_test::basic_prover_test
────────────
     Summary [  18.401s] 1 test run: 1 passed, 394 skipped
     
 ```
 
 Without new `TEST_SKIP_GUEST_BUILD` env var, not rebuilding ELF, 6s build time 
 ```
➜  citrea git:(test-skip-guest-build) TEST_SKIP_GUEST_BUILD=1 ./test.sh basic_prover_test
   Compiling citrea-risc0-batch-proof v0.6.0 (/Users/jouz0/CHAINWAY/citrea/guests/risc0/batch-proof)
   Compiling citrea-risc0-light-client v0.6.0 (/Users/jouz0/CHAINWAY/citrea/guests/risc0/light-client-proof)
warning: citrea-risc0-batch-proof@0.6.0: Skipping guest build in test. Exiting
   Compiling citrea-light-client-prover v0.6.0 (/Users/jouz0/CHAINWAY/citrea/crates/light-client-prover)
warning: citrea-risc0-light-client@0.6.0: Skipping guest build in test. Exiting
   Compiling citrea v0.6.0 (/Users/jouz0/CHAINWAY/citrea/bin/citrea)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 6.85s
────────────
 Nextest run ID dfbb8731-8279-4df6-a66f-8b68622d8974 with nextest profile: default
    Starting 1 test across 49 binaries (394 tests skipped)
       START             citrea::bitcoin_e2e bitcoin::batch_prover_test::basic_prover_test

running 1 test
2025-03-21T14:16:01.446805Z  INFO citrea_e2e::bitcoin: Bitcoin debug.log available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmpFk7n80/LfIQu5nTvk/bitcoin/0/regtest/debug.log
Bitcoin Core starting
2025-03-21T14:16:03.556426Z  INFO citrea_e2e::node: sequencer stdout logs available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmpFk7n80/LfIQu5nTvk/sequencer/stdout.log
2025-03-21T14:16:03.558734Z  INFO citrea_e2e::node: batch-prover stdout logs available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmpFk7n80/LfIQu5nTvk/batch-prover/stdout.log
2025-03-21T14:16:03.559148Z  INFO citrea_e2e::node: full-node stdout logs available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmpFk7n80/LfIQu5nTvk/full-node/stdout.log
StateDiff: size 1680, compressed 1022
2025-03-21T14:16:20.148839Z  INFO citrea_e2e::framework: Stopping framework...
2025-03-21T14:16:20.151176Z  INFO citrea_e2e::framework: Successfully stopped sequencer
2025-03-21T14:16:20.153848Z  INFO citrea_e2e::framework: Successfully stopped batch_prover
2025-03-21T14:16:20.154985Z  INFO citrea_e2e::framework: Successfully stopped full_node
2025-03-21T14:16:20.155565Z  INFO citrea_e2e::framework: Successfully stopped bitcoin nodes
test bitcoin::batch_prover_test::basic_prover_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 31 filtered out; finished in 18.72s

        PASS [  18.757s] citrea::bitcoin_e2e bitcoin::batch_prover_test::basic_prover_test
────────────
     Summary [  18.758s] 1 test run: 1 passed, 394 skipped
```

With `SKIP_GUEST_BUILD`, failing with `ERROR panic: thread 'tokio-runtime-worker' panicked at 'Proof creation must not fail: Elf parse error: Could not read bytes in range [0x0, 0x10)'`
```
➜  citrea git:(test-skip-guest-build) SKIP_GUEST_BUILD=1 ./test.sh basic_prover_test
   Compiling citrea-risc0-batch-proof v0.6.0 (/Users/jouz0/CHAINWAY/citrea/guests/risc0/batch-proof)
   Compiling citrea-risc0-light-client v0.6.0 (/Users/jouz0/CHAINWAY/citrea/guests/risc0/light-client-proof)
warning: citrea-risc0-batch-proof@0.6.0: Skipping guest build
   Compiling citrea-light-client-prover v0.6.0 (/Users/jouz0/CHAINWAY/citrea/crates/light-client-prover)
warning: citrea-risc0-light-client@0.6.0: Skipping guest build
   Compiling citrea v0.6.0 (/Users/jouz0/CHAINWAY/citrea/bin/citrea)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 9.70s
────────────
 Nextest run ID 01c9115d-0015-4a94-ac7b-a5e77c2c3fa4 with nextest profile: default
    Starting 1 test across 49 binaries (394 tests skipped)
       START             citrea::bitcoin_e2e bitcoin::batch_prover_test::basic_prover_test

running 1 test
2025-03-21T14:16:46.812789Z  INFO citrea_e2e::bitcoin: Bitcoin debug.log available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmpr8uUyx/G9RUuAYyPA/bitcoin/0/regtest/debug.log
Bitcoin Core starting
2025-03-21T14:16:48.993196Z  INFO citrea_e2e::node: sequencer stdout logs available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmpr8uUyx/G9RUuAYyPA/sequencer/stdout.log
2025-03-21T14:16:48.996058Z  INFO citrea_e2e::node: batch-prover stdout logs available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmpr8uUyx/G9RUuAYyPA/batch-prover/stdout.log
2025-03-21T14:16:48.996448Z  INFO citrea_e2e::node: full-node stdout logs available at : /var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmpr8uUyx/G9RUuAYyPA/full-node/stdout.log
test bitcoin::batch_prover_test::basic_prover_test has been running for over 60 seconds
  Cancelling due to interrupt: 1 test still running
Initiating shutdown...
batch-prover logs (last 50 lines):
tailing path : "/var/folders/1x/jyc845yx04jbwh__4n4s6kq40000gp/T/.tmpr8uUyx/G9RUuAYyPA/batch-prover/stdout.log"
2025-03-21T14:16:50.871988Z  INFO citrea: Starting node on Nightly
2025-03-21T14:16:51.108260Z  INFO sov_schema_db: Opened RocksDB. rocksdb_name="ledger-db"
2025-03-21T14:16:51.116485Z  INFO sov_schema_db: Opened RocksDB. rocksdb_name="state-db"
2025-03-21T14:16:51.122529Z  INFO sov_schema_db: Opened RocksDB. rocksdb_name="native-db"
2025-03-21T14:16:51.128998Z  INFO citrea::rollup: No history detected. Initializing chain...
2025-03-21T14:16:51.139129Z  INFO citrea::rollup: Chain initialization is done. Genesis root: 0x0d4df27fd99ab1df21528bf8833531e5a15c6f2b2bd4f5f9d6499e327e49c6fb
2025-03-21T14:16:51.139275Z  INFO prover_services::parallel: Prover is configured to execute proving
2025-03-21T14:16:51.139710Z  INFO citrea_common::l2: Starting L2 height: 1
2025-03-21T14:16:51.139939Z  INFO citrea_common::rpc::server: Starting RPC server at 127.0.0.1:49503 
2025-03-21T14:16:51.141160Z  INFO citrea_common::da: Starting to sync from L1 height 170
2025-03-21T14:16:51.141192Z  INFO citrea_common::l2: Starting to sync from L2 height 1
2025-03-21T14:16:52.142219Z  INFO citrea_batch_prover::da_block_handler: No sequencer commitment found at height 170
2025-03-21T14:16:52.142619Z  INFO citrea_batch_prover::da_block_handler: No sequencer commitment found at height 171
2025-03-21T14:16:53.553405Z  INFO citrea_common::l2: Running l2 block batch #1 with hash: 0xf4384a1294cc67c9301c90465992b19ae3bae93eab6a760e266615962acfd889
2025-03-21T14:16:53.553818Z  INFO citrea_common::utils: Initialize Bitcoin Light Client contract system tx found inside block
2025-03-21T14:16:53.553939Z  INFO citrea_common::utils: setBlockInfo system tx found inside block
2025-03-21T14:16:53.554191Z  INFO citrea_common::utils: Initialize Bridge contract system tx found inside block
2025-03-21T14:16:53.571631Z  INFO citrea_common::l2: New State Root after l2 block #1 is: 0xc007a7e92c289438ac9178792d7afd3738d0c8a8b1c94be338abab95e1a4c550
2025-03-21T14:16:53.571665Z  INFO citrea_common::l2: Running l2 block batch #2 with hash: 0xe0c0f7f068e700fd43810bd0d2c5b8cb68ed64b2d1018dcf15f976ee747dca9a
2025-03-21T14:16:53.575039Z  INFO citrea_common::l2: New State Root after l2 block #2 is: 0x3ef2af1f874caad4d8f7c3c3c23f890febc5b13ddf8a2d5959801a579c0fbced
2025-03-21T14:16:53.575137Z  INFO citrea_common::l2: Running l2 block batch #3 with hash: 0x75d3ca0e30b1feae53e10464cf7062462b764c8d1d7e75119ce3a1b2aa24765c
2025-03-21T14:16:53.578358Z  INFO citrea_common::l2: New State Root after l2 block #3 is: 0x0bcfe34d3a96b5d1157875c190009e52af602202e1eec30a49ad231c21333508
2025-03-21T14:16:53.578448Z  INFO citrea_common::l2: Running l2 block batch #4 with hash: 0xba4c731dbcd4c00d139f3bbc12940f7487f16063f953235484875eae12c27e7f
2025-03-21T14:16:53.581759Z  INFO citrea_common::l2: New State Root after l2 block #4 is: 0xe73401908e65b683dfd9a13e0bbf68c9796cd035e7ae076ab585153bda9cbb2b
2025-03-21T14:16:56.142693Z  INFO citrea_batch_prover::da_block_handler: No sequencer commitment found at height 172
2025-03-21T14:16:56.143258Z  INFO citrea_batch_prover::da_block_handler: No sequencer commitment found at height 173
2025-03-21T14:16:56.143648Z  INFO citrea_batch_prover::da_block_handler: No sequencer commitment found at height 174
2025-03-21T14:16:56.143975Z  INFO citrea_batch_prover::da_block_handler: No sequencer commitment found at height 175
2025-03-21T14:16:56.190423Z  INFO citrea_batch_prover::proving: Providing input for batch proof circuit for L1 block at height: 176, L2 range #1-#4
2025-03-21T14:16:56.209816Z  INFO citrea_batch_prover::da_block_handler: Processing 1 sequencer commitments at height 176
2025-03-21T14:16:56.209891Z  INFO citrea_batch_prover::proving: Proving state transition with ELF of spec: Fork2
2025-03-21T14:16:56.209964Z  INFO citrea_risc0_adapter::host: Added hint to guest with size 46083
2025-03-21T14:16:56.210049Z  INFO prover_services::parallel: Starting proving task 0
2025-03-21T14:16:56.210616Z  INFO citrea_risc0_adapter::host: Starting risc0 proving
2025-03-21T14:16:57.342709Z ERROR panic: thread 'tokio-runtime-worker' panicked at 'Proof creation must not fail: Elf parse error: Could not read bytes in range [0x0, 0x10)': /Users/jouz0/CHAINWAY/citrea/crates/prover-services/src/parallel/mod.rs:131
```
