### PR TITLE
Implement new batch proof verification logic in light client

### DIFF
--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -2216,6 +2216,7 @@ pub(crate) fn create_random_state_diff(size_in_kb: u64) -> BTreeMap<Arc<[u8]>, O
     map
 }
 
+#[allow(clippy::too_many_arguments)]
 fn create_serialized_fake_receipt_batch_proof(
     initial_state_root: [u8; 32],
     final_state_root: [u8; 32],

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -73,6 +73,10 @@ impl TestCase for LightClientProvingTest {
         }
     }
 
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(169)
+    }
+
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
         let da = f.bitcoin_nodes.get(0).unwrap();
         let sequencer = f.sequencer.as_ref().unwrap();

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -1447,7 +1447,6 @@ impl TestCase for UnchainedBatchProofsTest {
     }
 
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
-        println!("start");
         let da = f.bitcoin_nodes.get(0).unwrap();
         let light_client_prover = f.light_client_prover.as_ref().unwrap();
 
@@ -1514,7 +1513,6 @@ impl TestCase for UnchainedBatchProofsTest {
         // first one is chained, second one is unchained, third one can be chained to the second one
         // on the next block, we put another bp that can be chained to the first one in the previous block
         // and the second-third will chain to this one
-        println!("1");
         let fake_sequencer_commitment = SequencerCommitment {
             merkle_root: [0u8; 32],
             index: 1,
@@ -1527,7 +1525,6 @@ impl TestCase for UnchainedBatchProofsTest {
             )
             .await
             .unwrap();
-        println!("2");
         let fake_sequencer_commitment_2 = SequencerCommitment {
             merkle_root: [0u8; 32],
             index: 2,
@@ -1542,7 +1539,6 @@ impl TestCase for UnchainedBatchProofsTest {
                 .await
                 .unwrap(),
         );
-        println!("3");
         let fake_sequencer_commitment_3 = SequencerCommitment {
             merkle_root: [0u8; 32],
             index: 3,
@@ -1571,7 +1567,6 @@ impl TestCase for UnchainedBatchProofsTest {
                 .await
                 .unwrap(),
         );
-        println!("4");
 
         da.wait_mempool_len(8, None).await?;
 
@@ -1629,7 +1624,6 @@ impl TestCase for UnchainedBatchProofsTest {
                 .await
                 .unwrap(),
         );
-        println!("5");
 
         txids.extend(
             bitcoin_da_service
@@ -1637,7 +1631,6 @@ impl TestCase for UnchainedBatchProofsTest {
                 .await
                 .unwrap(),
         );
-        println!("6");
 
         txids.extend(
             bitcoin_da_service
@@ -1646,7 +1639,6 @@ impl TestCase for UnchainedBatchProofsTest {
                 .unwrap(),
         );
         da.wait_mempool_len(14, None).await?;
-        println!("7");
         da.generate_block(
             da.get_new_address(None, None)
                 .await?
@@ -1655,21 +1647,18 @@ impl TestCase for UnchainedBatchProofsTest {
             txids.into_iter().map(|txid| txid.to_string()).collect(),
         )
         .await?;
-        println!("8");
 
         da.generate(FINALITY_DEPTH - 1).await?;
 
         light_client_prover
             .wait_for_l1_height(start_l1_height + FINALITY_DEPTH, None)
             .await?;
-        println!("9");
         let lcp = light_client_prover
             .client
             .http_client()
             .get_light_client_proof_by_l1_height(start_l1_height + FINALITY_DEPTH)
             .await?
             .unwrap();
-        println!("10");
 
         let lcp_output = lcp.light_client_proof_output;
 
@@ -1700,7 +1689,6 @@ impl TestCase for UnchainedBatchProofsTest {
             .send_transaction_with_fee_rate(DaTxRequest::ZKProof(bp4), 1)
             .await
             .unwrap();
-        println!("11");
 
         da.wait_mempool_len(2, None).await?;
 
@@ -1886,6 +1874,303 @@ impl TestCase for UnknownL1HashBatchProofTest {
 #[tokio::test]
 async fn test_unknown_l1_hash_batch_proof_in_light_client() -> Result<()> {
     TestCaseRunner::new(UnknownL1HashBatchProofTest::default())
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
+}
+
+#[derive(Default)]
+struct BatchProofWithMissingCommitmentTest {
+    task_manager: TaskManager<()>,
+}
+
+#[async_trait]
+impl TestCase for BatchProofWithMissingCommitmentTest {
+    fn test_config() -> TestCaseConfig {
+        TestCaseConfig {
+            with_light_client_prover: true,
+            ..Default::default()
+        }
+    }
+
+    fn light_client_prover_config() -> LightClientProverConfig {
+        LightClientProverConfig {
+            enable_recovery: false,
+            initial_da_height: 170,
+            ..Default::default()
+        }
+    }
+
+    fn sequencer_config() -> SequencerConfig {
+        SequencerConfig {
+            min_l2_blocks_per_commitment: 10000,
+            ..Default::default()
+        }
+    }
+
+    async fn cleanup(&self) -> Result<()> {
+        self.task_manager.abort().await;
+        Ok(())
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        let da = f.bitcoin_nodes.get(0).unwrap();
+        let light_client_prover = f.light_client_prover.as_ref().unwrap();
+
+        let da_config = &da.config;
+        let bitcoin_da_service_config = BitcoinServiceConfig {
+            node_url: format!(
+                "http://127.0.0.1:{}/wallet/{}",
+                da_config.rpc_port,
+                NodeKind::Bitcoin
+            ),
+            node_username: da_config.rpc_user.clone(),
+            node_password: da_config.rpc_password.clone(),
+            network: bitcoin::Network::Regtest,
+            da_private_key: Some(
+                // This is the regtest private key of batch prover
+                "56D08C2DDE7F412F80EC99A0A328F76688C904BD4D1435281EFC9270EC8C8707".to_string(),
+            ),
+            tx_backup_dir: Self::test_config()
+                .dir
+                .join("tx_backup_dir")
+                .display()
+                .to_string(),
+            monitoring: Default::default(),
+            mempool_space_url: None,
+        };
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let bitcoin_da_service = Arc::new(
+            BitcoinService::new_with_wallet_check(
+                bitcoin_da_service_config,
+                RollupParams {
+                    reveal_tx_prefix: REVEAL_TX_PREFIX.to_vec(),
+                },
+                tx,
+            )
+            .await
+            .unwrap(),
+        );
+
+        self.task_manager.spawn(TaskType::Secondary, |tk| {
+            bitcoin_da_service.clone().run_da_queue(rx, tk)
+        });
+
+        da.generate(FINALITY_DEPTH).await?;
+
+        let start_l1_height = da.get_finalized_height(None).await?;
+
+        light_client_prover.wait_for_l1_height(170, None).await?;
+
+        let initial_lcp = light_client_prover
+            .client
+            .http_client()
+            .get_light_client_proof_by_l1_height(170)
+            .await?
+            .unwrap();
+
+        let method_id = initial_lcp.light_client_proof_output.batch_proof_method_ids[0]
+            .method_id
+            .into();
+        let genesis_root = initial_lcp.light_client_proof_output.l2_state_root;
+        let l1_hash = da.get_block_hash(171).await?;
+
+        // put 3 bp in a block
+        // first one is chained, second one is unchained, third one can be chained to the second one
+        // on the next block, we put another bp that can be chained to the first one in the previous block
+        // and the second-third will chain to this one
+        let fake_sequencer_commitment = SequencerCommitment {
+            merkle_root: [0u8; 32],
+            index: 1,
+            l2_end_block_number: 100,
+        };
+        let mut txids = bitcoin_da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(fake_sequencer_commitment.clone()),
+                1,
+            )
+            .await
+            .unwrap();
+        let fake_sequencer_commitment_2 = SequencerCommitment {
+            merkle_root: [0u8; 32],
+            index: 2,
+            l2_end_block_number: 200,
+        };
+
+        let fake_sequencer_commitment_3 = SequencerCommitment {
+            merkle_root: [0u8; 32],
+            index: 3,
+            l2_end_block_number: 300,
+        };
+
+        da.wait_mempool_len(2, None).await?;
+
+        let bp1 = create_serialized_fake_receipt_batch_proof(
+            genesis_root,
+            [1u8; 32],
+            100,
+            method_id,
+            None,
+            false,
+            l1_hash.as_raw_hash().to_byte_array(),
+            vec![fake_sequencer_commitment.clone()],
+            None,
+        );
+
+        let bp2 = create_serialized_fake_receipt_batch_proof(
+            [1u8; 32],
+            [2u8; 32],
+            300,
+            method_id,
+            None,
+            false,
+            l1_hash.as_raw_hash().to_byte_array(),
+            vec![
+                fake_sequencer_commitment_2.clone(),
+                fake_sequencer_commitment_3.clone(),
+            ],
+            Some(fake_sequencer_commitment.serialize_and_calculate_sha_256()),
+        );
+
+        txids.extend(
+            bitcoin_da_service
+                .send_transaction_with_fee_rate(DaTxRequest::ZKProof(bp1), 1)
+                .await
+                .unwrap(),
+        );
+
+        txids.extend(
+            bitcoin_da_service
+                .send_transaction_with_fee_rate(DaTxRequest::ZKProof(bp2), 1)
+                .await
+                .unwrap(),
+        );
+
+        da.wait_mempool_len(6, None).await?;
+
+        da.generate_block(
+            da.get_new_address(None, None)
+                .await?
+                .assume_checked()
+                .to_string(),
+            txids.into_iter().map(|txid| txid.to_string()).collect(),
+        )
+        .await?;
+
+        da.generate(FINALITY_DEPTH - 1).await?;
+
+        light_client_prover
+            .wait_for_l1_height(start_l1_height + FINALITY_DEPTH, None)
+            .await?;
+        let lcp = light_client_prover
+            .client
+            .http_client()
+            .get_light_client_proof_by_l1_height(start_l1_height + FINALITY_DEPTH)
+            .await?
+            .unwrap();
+
+        let lcp_output = lcp.light_client_proof_output;
+
+        assert_eq!(lcp_output.l2_state_root, [1u8; 32]);
+        assert_eq!(lcp_output.last_l2_height, U64::from(100));
+        assert_eq!(lcp_output.unchained_batch_proofs_info.len(), 0);
+        assert_eq!(
+            lcp_output
+                .batch_proofs_with_missing_sequencer_commitments
+                .len(),
+            1
+        );
+        assert_eq!(
+            lcp_output.batch_proofs_with_missing_sequencer_commitments[0].initial_state_root,
+            [1u8; 32]
+        );
+        assert_eq!(
+            lcp_output.batch_proofs_with_missing_sequencer_commitments[0].final_state_root,
+            [2u8; 32]
+        );
+        assert_eq!(
+            lcp_output.batch_proofs_with_missing_sequencer_commitments[0].last_l2_height,
+            U64::from(300)
+        );
+        assert_eq!(
+            lcp_output.batch_proofs_with_missing_sequencer_commitments[0]
+                .last_sequencer_commitment_index,
+            U32::from(3)
+        );
+        assert_eq!(
+            lcp_output.batch_proofs_with_missing_sequencer_commitments[0]
+                .missing_commitments
+                .len(),
+            2
+        );
+
+        assert_eq!(
+            lcp_output.batch_proofs_with_missing_sequencer_commitments[0].missing_commitments[0]
+                .index,
+            U32::from(2)
+        );
+        assert_eq!(
+            lcp_output.batch_proofs_with_missing_sequencer_commitments[0].missing_commitments[0]
+                .hash,
+            fake_sequencer_commitment_2.serialize_and_calculate_sha_256()
+        );
+        assert_eq!(
+            lcp_output.batch_proofs_with_missing_sequencer_commitments[0].missing_commitments[1]
+                .index,
+            U32::from(3)
+        );
+
+        let mut missing_txids = bitcoin_da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(fake_sequencer_commitment_2.clone()),
+                1,
+            )
+            .await
+            .unwrap();
+        missing_txids.extend(
+            bitcoin_da_service
+                .send_transaction_with_fee_rate(
+                    DaTxRequest::SequencerCommitment(fake_sequencer_commitment_3.clone()),
+                    1,
+                )
+                .await
+                .unwrap(),
+        );
+
+        da.wait_mempool_len(4, None).await?;
+
+        da.generate(FINALITY_DEPTH).await?;
+
+        light_client_prover
+            .wait_for_l1_height(start_l1_height + 2 * FINALITY_DEPTH, None)
+            .await?;
+
+        let lcp = light_client_prover
+            .client
+            .http_client()
+            .get_light_client_proof_by_l1_height(start_l1_height + 2 * FINALITY_DEPTH)
+            .await?
+            .unwrap();
+
+        let lcp_output = lcp.light_client_proof_output;
+        assert_eq!(lcp_output.unchained_batch_proofs_info.len(), 0);
+        assert_eq!(
+            lcp_output
+                .batch_proofs_with_missing_sequencer_commitments
+                .len(),
+            0
+        );
+        assert_eq!(lcp_output.l2_state_root, [2u8; 32]);
+        assert_eq!(lcp_output.last_l2_height, U64::from(300));
+
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_batch_proof_with_missing_commitments() -> Result<()> {
+    TestCaseRunner::new(BatchProofWithMissingCommitmentTest::default())
         .set_citrea_path(get_citrea_path())
         .run()
         .await

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use alloy_primitives::U64;
+use alloy_primitives::{U32, U64};
 use async_trait::async_trait;
 use bitcoin::hashes::Hash;
 use bitcoin_da::service::{BitcoinService, BitcoinServiceConfig, FINALITY_DEPTH};
@@ -1682,12 +1682,16 @@ impl TestCase for UnchainedBatchProofsTest {
                 BatchProofInfoRpcResponse {
                     initial_state_root: [2; 32],
                     final_state_root: [3; 32],
-                    last_l2_height: U64::from(300)
+                    last_l2_height: U64::from(300),
+                    last_sequencer_commitment_index: U32::from(3),
+                    missing_commitments: vec![]
                 },
                 BatchProofInfoRpcResponse {
                     initial_state_root: [3; 32],
                     final_state_root: [4; 32],
-                    last_l2_height: U64::from(400)
+                    last_l2_height: U64::from(400),
+                    last_sequencer_commitment_index: U32::from(4),
+                    missing_commitments: vec![]
                 }
             ]
         );

--- a/crates/batch-prover/src/da_block_handler.rs
+++ b/crates/batch-prover/src/da_block_handler.rs
@@ -315,7 +315,7 @@ pub(crate) fn break_sequencer_commitments_into_groups<DB: BatchProverLedgerOps>(
 
     let mut range = 0usize..=0usize;
     let mut cumulative_state_diff = StateDiff::new();
-    let first_l2_block_number = if sequencer_commitments[0].index == 0 {
+    let first_l2_block_number = if sequencer_commitments[0].index == 1 {
         // TODO: Handle this better
         get_fork2_activation_height_non_zero()
     } else {

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -95,7 +95,7 @@ where
             .expect("Should store commitment");
     }
 
-    let l2_start_block_number = if sequencer_commitments[0].index == 0 {
+    let l2_start_block_number = if sequencer_commitments[0].index == 1 {
         // If this is the first commitment in fork2, the start l2 height will be fork2 activation height
         // Start block number should be fork2  activation height
         get_fork2_activation_height_non_zero()
@@ -615,7 +615,7 @@ pub(crate) fn save_commitments<DB>(
     DB: BatchProverLedgerOps,
 {
     for sequencer_commitment in sequencer_commitments.iter() {
-        let l2_start_block_number = if sequencer_commitment.index == 0 {
+        let l2_start_block_number = if sequencer_commitment.index == 1 {
             get_fork2_activation_height_non_zero()
         } else {
             ledger_db

--- a/crates/batch-prover/src/proving.rs
+++ b/crates/batch-prover/src/proving.rs
@@ -205,16 +205,21 @@ where
             })?
             .expect("There should be a state root");
 
-        let previous_sequencer_commitment = sequencer_commitments
-            [*sequencer_commitments_range.start()]
-        .index
-        .checked_sub(1)
-        .map(|index| {
-            ledger
-                .get_commitment_by_index(index)
-                .expect("Should get commitment")
-                .expect("Commitment should exist")
-        });
+        let previous_sequencer_commitment =
+        // If first commitment (index == 1) then the previous commitment will be None
+            if sequencer_commitments[*sequencer_commitments_range.start()].index == 1 {
+                None
+            } else {
+                sequencer_commitments[*sequencer_commitments_range.start()]
+                    .index
+                    .checked_sub(1)
+                    .map(|index| {
+                        ledger
+                            .get_commitment_by_index(index)
+                            .expect("Should get commitment")
+                            .expect("Commitment should exist")
+                    })
+            };
 
         let input = BatchProofCircuitInputV3 {
             initial_state_root,

--- a/crates/bitcoin-da/tests/test_utils.rs
+++ b/crates/bitcoin-da/tests/test_utils.rs
@@ -129,7 +129,7 @@ pub async fn generate_mock_txs(
     let mut valid_commitments = vec![];
     let mut valid_proofs = vec![];
     let mut valid_method_ids = vec![];
-    let mut seq_index = 0;
+    let mut seq_index = 1;
 
     // Send method id update tx
     let method_id = BatchProofMethodId {

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -207,7 +207,7 @@ where
         l1_block: &Da::FilteredBlock,
         sequencer_commitment: &SequencerCommitment,
     ) -> Result<(), SyncError> {
-        let start_l2_height = if sequencer_commitment.index == 0 {
+        let start_l2_height = if sequencer_commitment.index == 1 {
             get_fork2_activation_height_non_zero()
         } else {
             self.ledger_db

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -579,7 +579,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
             batch_proof_method_ids,
             witness,
             change_set: storage,
-            last_sequencer_commitment_index: last_sequencer_commitment_index,
+            last_sequencer_commitment_index,
             semi_unstitched: batch_proofs_with_missing_sequencer_commitments,
         }
     }

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -140,6 +140,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
         proof_process
     }
 
+    // TODO: Too many args
     fn process_complete_proof(
         &self,
         proof: &[u8],

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -289,7 +289,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
         // first insert the block hash into the JMT
         BlockHashAccessor::<S>::insert(da_block_header.hash().into(), &mut working_set);
 
-        // Mapping from initial state root to final state root, last L2 height and sequencer commitment range
+        // Mapping from initial state root to final state root, last L2 height and last sequencer commitment index
         let mut initial_to_final = BTreeMap::<[u8; 32], ([u8; 32], u64, u32)>::new();
 
         let (

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -141,7 +141,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
         proof_process
     }
 
-    // TODO: Too many args
+    #[allow(clippy::too_many_arguments)]
     fn process_complete_proof(
         &self,
         proof: &[u8],

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -204,6 +204,19 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
                     *last_l2_state_root = batch_proof_output_final_state_root;
                     *last_l2_height = batch_proof_output_last_l2_height;
                     *last_commitment_index = batch_proof_output_sequencer_commitment_index_range.0;
+
+                    // Do recursive matching for previous state root
+                    recursive_match_state_roots(
+                        fully_unstitched,
+                        &BatchProofInfo::new(
+                            *last_l2_state_root,
+                            *last_l2_state_root,
+                            *last_l2_height,
+                            *last_commitment_index,
+                            None,
+                        ),
+                    );
+                    return Ok(());
                 }
                 // None of the checks match, proof order is wrong, put it to unstitched
                 else if batch_proof_output_sequencer_commitment_index_range.0

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -490,6 +490,18 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
                         }
 
                         for idx in remove_batch_proof_indexes.iter().rev() {
+                            initial_to_final.insert(
+                                batch_proofs_with_missing_sequencer_commitments[*idx]
+                                    .initial_state_root,
+                                (
+                                    batch_proofs_with_missing_sequencer_commitments[*idx]
+                                        .final_state_root,
+                                    batch_proofs_with_missing_sequencer_commitments[*idx]
+                                        .last_l2_height,
+                                    batch_proofs_with_missing_sequencer_commitments[*idx]
+                                        .last_sequencer_commitment_index,
+                                ),
+                            );
                             batch_proofs_with_missing_sequencer_commitments.remove(*idx);
                         }
                     }
@@ -527,9 +539,6 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
 
         let (read_write_log, mut witness) = working_set.checkpoint().freeze();
 
-        // https://github.com/chainwayxyz/citrea/issues/2046
-        // which we don't need in this circuit
-        // maybe create new function or pass argument for state diff building
         let (lcp_state_root_transition, jmt_state_update, _) = storage
             .compute_state_update(&read_write_log, &mut witness, false)
             .expect("jellyfish merkle tree update must succeed");

--- a/crates/light-client-prover/src/circuit/utils.rs
+++ b/crates/light-client-prover/src/circuit/utils.rs
@@ -61,6 +61,17 @@ pub(crate) fn collect_unchained_outputs(
         .collect()
 }
 
+pub(crate) fn prune_batch_proofs_with_missing_commitments(
+    proofs_with_missing_commitments: &mut Vec<BatchProofInfo>,
+    last_l2_height: u64,
+    last_sequencer_commitment_index: u32,
+) {
+    proofs_with_missing_commitments.retain(|bp| {
+        bp.last_l2_height > last_l2_height
+            && bp.last_sequencer_commitment_index > last_sequencer_commitment_index
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/light-client-prover/src/tests/mod.rs
+++ b/crates/light-client-prover/src/tests/mod.rs
@@ -1022,7 +1022,7 @@ fn test_light_client_circuit_verify_chunks() {
             light_client_proof_method_id,
             da_block_header: block_header_1,
             inclusion_proof: [1u8; 32],
-            completeness_proof: vec![blob1, blob2, blob3, blob4],
+            completeness_proof: vec![seq_comm_1_blob, blob1, blob2, blob3, blob4],
             witness: Default::default(),
         },
         l2_genesis_state_root,

--- a/crates/light-client-prover/src/tests/mod.rs
+++ b/crates/light-client-prover/src/tests/mod.rs
@@ -1242,6 +1242,8 @@ fn test_unknown_block_hash_in_batch_proof_not_verified() {
             initial_state_root: [4u8; 32],
             final_state_root: [5u8; 32],
             last_l2_height: 5,
+            last_sequencer_commitment_index: 5,
+            missing_commitments: vec![]
         }],
     );
     assert_eq!(output_2.last_l2_height, 2);

--- a/crates/light-client-prover/src/tests/mod.rs
+++ b/crates/light-client-prover/src/tests/mod.rs
@@ -1064,8 +1064,6 @@ fn test_missing_chunk() {
 
     let seq_comm_1 = create_mock_sequencer_commitment(1, 2);
 
-    let seq_comm_1_blob = create_mock_sequencer_commitment_blob(seq_comm_1.clone());
-
     let serialized_mock_proof = create_serialized_mock_proof(
         l2_genesis_state_root,
         [2u8; 32],

--- a/crates/light-client-prover/src/tests/mod.rs
+++ b/crates/light-client-prover/src/tests/mod.rs
@@ -1,12 +1,10 @@
 pub mod test_utils;
 
-use rand::seq;
 use sov_mock_da::{MockAddress, MockBlob, MockBlockHeader, MockDaSpec, MockDaVerifier};
 use sov_mock_zkvm::MockZkGuest;
 use sov_modules_api::WorkingSet;
 use sov_rollup_interface::da::{BlobReaderTrait, DataOnDa, SequencerCommitment};
 use sov_rollup_interface::zk::light_client_proof::input::LightClientCircuitInput;
-use sov_rollup_interface::zk::light_client_proof::output::BatchProofInfo;
 use sov_rollup_interface::Network;
 use sov_state::{Witness, ZkStorage};
 use tempfile::tempdir;

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -96,6 +96,7 @@ pub(crate) fn create_mock_batch_proof(
     blob
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn create_serialized_mock_proof(
     initial_state_root: [u8; 32],
     final_state_root: [u8; 32],

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -242,34 +242,6 @@ impl NativeCircuitRunner {
         }
     }
 
-    pub fn insert_sequencer_commitment(
-        &self,
-        seq_comm: SequencerCommitment,
-        witness: Option<Witness>,
-    ) {
-        let prover_storage = self
-            .prover_storage_manager
-            .create_storage_for_next_l2_height();
-        let mut working_set = WorkingSet::with_witness(
-            prover_storage.clone(),
-            witness.unwrap_or_default(),
-            Default::default(),
-        );
-        SequencerCommitmentAccessor::<ProverStorage>::insert(
-            seq_comm.index,
-            seq_comm,
-            &mut working_set,
-        );
-        let (read_write_log, mut witness) = working_set.checkpoint().freeze();
-
-        let (_, jmt_state_update, _) = prover_storage
-            .compute_state_update(&read_write_log, &mut witness, false)
-            .expect("jellyfish merkle tree update must succeed");
-
-        prover_storage.commit(&jmt_state_update, &vec![], &ReadWriteLog::default());
-        self.prover_storage_manager.finalize_storage(prover_storage);
-    }
-
     /// Run the circuit with the given input and return the input with its witness filled
     /// that will be used to run the circuit in ZK context
     pub fn run(

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 use rand::{thread_rng, Rng};
 use sov_mock_da::{MockAddress, MockBlob, MockDaSpec, MockDaVerifier};
 use sov_mock_zkvm::{MockCodeCommitment, MockJournal, MockProof, MockZkvm};
-use sov_modules_api::{WorkingSet, Zkvm};
-use sov_modules_core::{ReadWriteLog, Storage};
+use sov_modules_api::Zkvm;
 use sov_prover_storage_manager::{Config, ProverStorage, ProverStorageManager};
 use sov_rollup_interface::da::{
     BatchProofMethodId, BlobReaderTrait, DaVerifier, DataOnDa, SequencerCommitment,
@@ -15,9 +14,7 @@ use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3
 use sov_rollup_interface::zk::batch_proof::output::{BatchProofCircuitOutput, CumulativeStateDiff};
 use sov_rollup_interface::zk::light_client_proof::input::LightClientCircuitInput;
 use sov_rollup_interface::zk::light_client_proof::output::LightClientCircuitOutput;
-use sov_state::Witness;
 
-use crate::circuit::accessors::SequencerCommitmentAccessor;
 use crate::circuit::LightClientProofCircuit;
 
 pub(crate) fn create_mock_sequencer_commitment(index: u32, l2_end: u64) -> SequencerCommitment {

--- a/crates/sequencer/src/commitment/mod.rs
+++ b/crates/sequencer/src/commitment/mod.rs
@@ -55,7 +55,7 @@ fn load_next_commitment_index<Db: SequencerLedgerOps>(db: &Db) -> u32 {
         max_db + 1
     } else {
         // if comms are empty, then index is 0
-        0
+        1
     }
 }
 
@@ -255,7 +255,7 @@ where
                     .delete_pending_commitment(pending_db_comm.index)?;
             } else {
                 // Submit commitment
-                let l2_start_block_number = if pending_db_comm.index == 0 {
+                let l2_start_block_number = if pending_db_comm.index == 1 {
                     get_fork2_activation_height_non_zero()
                 } else {
                     self.ledger_db

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/light_client_proof.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/light_client_proof.rs
@@ -90,6 +90,12 @@ impl From<StoredLightClientProofOutput> for LightClientProofOutputRpcResponse {
                 })
                 .collect(),
             lcp_state_root: value.lcp_state_root,
+            last_sequencer_commitment_index: value.last_sequencer_commitment_index,
+            batch_proofs_with_missing_sequencer_commitments: value
+                .batch_proofs_with_missing_sequencer_commitments
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         }
     }
 }

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/light_client_proof.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/light_client_proof.rs
@@ -49,6 +49,10 @@ pub struct StoredLightClientProofOutput {
     pub last_l2_height: u64,
     /// L2 activation height of the fork and the Method ids of the batch proofs that were verified in the light client proof
     pub batch_proof_method_ids: Vec<(u64, [u32; 8])>,
+    /// The last sequencer commitment index of the last fully stitched and verified batch proof
+    pub last_sequencer_commitment_index: u32,
+    /// Info about batch proof with missing sequencer commitments
+    pub batch_proofs_with_missing_sequencer_commitments: Vec<BatchProofInfo>,
 }
 
 impl From<StoredLightClientProofOutput> for LightClientProofOutputRpcResponse {
@@ -108,6 +112,9 @@ impl From<LightClientCircuitOutput> for StoredLightClientProofOutput {
             last_l2_height: circuit_output.last_l2_height,
             batch_proof_method_ids: circuit_output.batch_proof_method_ids,
             lcp_state_root: circuit_output.lcp_state_root,
+            last_sequencer_commitment_index: circuit_output.last_sequencer_commitment_index,
+            batch_proofs_with_missing_sequencer_commitments: circuit_output
+                .batch_proofs_with_missing_sequencer_commitments,
         }
     }
 }
@@ -130,6 +137,9 @@ impl From<StoredLightClientProofOutput> for LightClientCircuitOutput {
             last_l2_height: db_output.last_l2_height,
             batch_proof_method_ids: db_output.batch_proof_method_ids,
             lcp_state_root: db_output.lcp_state_root,
+            last_sequencer_commitment_index: db_output.last_sequencer_commitment_index,
+            batch_proofs_with_missing_sequencer_commitments: db_output
+                .batch_proofs_with_missing_sequencer_commitments,
         }
     }
 }

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -384,8 +384,8 @@ where
             } else {
                 // If this is the first batch proof, then the first commitment idx should be 0
                 assert_eq!(
-                    sequencer_commitments[0].index, 0,
-                    "First commitment must be index 0"
+                    sequencer_commitments[0].index, 1,
+                    "First commitment must be index 1"
                 );
                 (None, None)
             };

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/light_client_proof/output.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/light_client_proof/output.rs
@@ -23,6 +23,10 @@ pub struct LightClientCircuitOutput {
     pub last_l2_height: u64,
     /// L2 activation height of the fork and the Method ids of the batch proofs that were verified in the light client proof
     pub batch_proof_method_ids: Vec<(u64, [u32; 8])>,
+    /// The last sequencer commitment index of the last fully stitched and verified batch proof
+    pub last_sequencer_commitment_index: u32,
+    /// Info about batch proof with missing sequencer commitments
+    pub batch_proofs_with_missing_sequencer_commitments: Vec<BatchProofInfo>,
 }
 
 /// The batch proof that was not verified in the light client circuit because it was missing another proof for state root chaining
@@ -36,6 +40,10 @@ pub struct BatchProofInfo {
     pub final_state_root: [u8; 32],
     /// The last processed l2 height in the batch proof
     pub last_l2_height: u64,
+    /// The sequencer commitment range of the batch proof
+    pub sequencer_commitment_range: (u32, u32),
+    /// (Commitment index, commitment hash)
+    pub missing_commitments: Vec<(u32, [u8; 32])>,
 }
 
 impl BatchProofInfo {
@@ -44,11 +52,15 @@ impl BatchProofInfo {
         initial_state_root: [u8; 32],
         final_state_root: [u8; 32],
         last_l2_height: u64,
+        sequencer_commitment_range: (u32, u32),
+        missing_commitments: Option<Vec<(u32, [u8; 32])>>,
     ) -> Self {
         Self {
             initial_state_root,
             final_state_root,
             last_l2_height,
+            sequencer_commitment_range,
+            missing_commitments: missing_commitments.unwrap_or_default(),
         }
     }
 }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/light_client_proof/output.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/light_client_proof/output.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 use crate::da::LatestDaState;
 use crate::zk::StorageRootHash;
 
+/// Type for the index and hash of a commitment
+pub type IndexAndHashOfCommitment = (u32, [u8; 32]);
+
 /// The output of light client proof
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize, PartialEq)]
 pub struct LightClientCircuitOutput {
@@ -40,10 +43,10 @@ pub struct BatchProofInfo {
     pub final_state_root: [u8; 32],
     /// The last processed l2 height in the batch proof
     pub last_l2_height: u64,
-    /// The sequencer commitment range of the batch proof
-    pub sequencer_commitment_range: (u32, u32),
+    /// The last processesd batch proofs last commitment's index
+    pub last_sequencer_commitment_index: u32,
     /// (Commitment index, commitment hash)
-    pub missing_commitments: Vec<(u32, [u8; 32])>,
+    pub missing_commitments: Vec<IndexAndHashOfCommitment>,
 }
 
 impl BatchProofInfo {
@@ -52,14 +55,14 @@ impl BatchProofInfo {
         initial_state_root: [u8; 32],
         final_state_root: [u8; 32],
         last_l2_height: u64,
-        sequencer_commitment_range: (u32, u32),
-        missing_commitments: Option<Vec<(u32, [u8; 32])>>,
+        last_sequencer_commitment_index: u32,
+        missing_commitments: Option<Vec<IndexAndHashOfCommitment>>,
     ) -> Self {
         Self {
             initial_state_root,
             final_state_root,
             last_l2_height,
-            sequencer_commitment_range,
+            last_sequencer_commitment_index,
             missing_commitments: missing_commitments.unwrap_or_default(),
         }
     }

--- a/crates/storage-ops/src/tests.rs
+++ b/crates/storage-ops/src/tests.rs
@@ -388,6 +388,8 @@ fn prepare_slots_data(ledger_db: &DB) {
                         last_l2_height: da_slot_height,
                         batch_proof_method_ids: vec![],
                         lcp_state_root: [0; 32],
+                        last_sequencer_commitment_index: 1,
+                        batch_proofs_with_missing_sequencer_commitments: vec![],
                     },
                 },
             )


### PR DESCRIPTION
# Description
At the current state of the pr, if there are missing commitments of a batch proof, info about those batch proofs are added to light client output for later verification as well
## Linked Issues
- Fixes #2020 
