### PR TITLE
Cleanup ledger db & remove last commitment table

### DIFF
--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -281,8 +281,6 @@ where
         self.ledger_db
             .put_commitment_by_index(sequencer_commitment)?;
 
-        self.ledger_db.set_last_commitment(sequencer_commitment)?;
-
         Ok(())
     }
 

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -243,12 +243,7 @@ impl SharedLedgerOps for LedgerDB {
             None => (l2_height, l2_height),
         };
 
-        let mut schema_batch = SchemaBatch::new();
-
-        schema_batch.put::<L2RangeByL1Height>(&l1_height, &new_range)?;
-        self.db.write_schemas(schema_batch)?;
-
-        Ok(())
+        self.db.put::<L2RangeByL1Height>(&l1_height, &new_range)
     }
 
     #[instrument(level = "trace", skip(self), err, ret)]
@@ -288,12 +283,7 @@ impl SharedLedgerOps for LedgerDB {
         height: L2BlockNumber,
         status: sov_rollup_interface::rpc::L2BlockStatus,
     ) -> Result<(), anyhow::Error> {
-        let mut schema_batch = SchemaBatch::new();
-
-        schema_batch.put::<L2BlockStatus>(&height, &status)?;
-        self.db.write_schemas(schema_batch)?;
-
-        Ok(())
+        self.db.put::<L2BlockStatus>(&height, &status)
     }
 
     /// Saves a l2 block status for a given L1 height
@@ -302,9 +292,7 @@ impl SharedLedgerOps for LedgerDB {
         &self,
         height: L2BlockNumber,
     ) -> Result<Option<sov_rollup_interface::rpc::L2BlockStatus>, anyhow::Error> {
-        let status = self.db.get::<L2BlockStatus>(&height)?;
-
-        Ok(status)
+        self.db.get::<L2BlockStatus>(&height)
     }
 
     /// Gets the commitments in the da slot with given height if any
@@ -340,12 +328,7 @@ impl SharedLedgerOps for LedgerDB {
     #[instrument(level = "trace", skip_all, err, ret)]
     fn set_l2_genesis_state_root(&self, state_root: &StorageRootHash) -> anyhow::Result<()> {
         let buf = bincode::serialize(state_root)?;
-        let mut schema_batch = SchemaBatch::new();
-        schema_batch.put::<L2GenesisStateRoot>(&(), &buf)?;
-
-        self.db.write_schemas(schema_batch)?;
-
-        Ok(())
+        self.db.put::<L2GenesisStateRoot>(&(), &buf)
     }
 
     /// Get the state root by L2 height
@@ -421,12 +404,7 @@ impl SharedLedgerOps for LedgerDB {
     /// For a full node the last commitment is set when a commitment is read from a finalized DA layer block.
     #[instrument(level = "trace", skip(self), err, ret)]
     fn set_last_commitment(&self, seqcomm: &SequencerCommitment) -> Result<(), anyhow::Error> {
-        let mut schema_batch = SchemaBatch::new();
-
-        schema_batch.put::<LastSequencerCommitmentSent>(&(), &seqcomm.index)?;
-        self.db.write_schemas(schema_batch)?;
-
-        Ok(())
+        self.db.put::<LastSequencerCommitmentSent>(&(), &seqcomm.index)
     }
 
     /// Get the last scanned slot by the prover
@@ -439,12 +417,7 @@ impl SharedLedgerOps for LedgerDB {
     /// Called by the prover.
     #[instrument(level = "trace", skip(self), err, ret)]
     fn set_last_scanned_l1_height(&self, l1_height: SlotNumber) -> anyhow::Result<()> {
-        let mut schema_batch = SchemaBatch::new();
-
-        schema_batch.put::<ProverLastScannedSlot>(&(), &l1_height)?;
-        self.db.write_schemas(schema_batch)?;
-
-        Ok(())
+        self.db.put::<ProverLastScannedSlot>(&(), &l1_height)
     }
 
     #[instrument(level = "trace", skip(self), err, ret)]
@@ -455,12 +428,7 @@ impl SharedLedgerOps for LedgerDB {
     /// Set the last pruned L2 block number
     #[instrument(level = "trace", skip(self), err, ret)]
     fn set_last_pruned_l2_height(&self, l2_height: u64) -> anyhow::Result<()> {
-        let mut schema_batch = SchemaBatch::new();
-
-        schema_batch.put::<LastPrunedBlock>(&(), &l2_height)?;
-        self.db.write_schemas(schema_batch)?;
-
-        Ok(())
+        self.db.put::<LastPrunedBlock>(&(), &l2_height)
     }
 
     /// Gets all executed migrations.
@@ -498,11 +466,7 @@ impl SharedLedgerOps for LedgerDB {
     }
 
     fn put_commitment_by_index(&self, commitment: &SequencerCommitment) -> anyhow::Result<()> {
-        let mut schema_batch = SchemaBatch::new();
-        schema_batch.put::<SequencerCommitmentByIndex>(&commitment.index, commitment)?;
-        self.db.write_schemas(schema_batch)?;
-
-        Ok(())
+        self.db.put::<SequencerCommitmentByIndex>(&commitment.index, commitment)
     }
 
     fn get_commitment_by_index(&self, index: u32) -> anyhow::Result<Option<SequencerCommitment>> {

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -15,10 +15,9 @@ use crate::rocks_db_config::RocksdbConfig;
 use crate::schema::tables::TestTableNew;
 use crate::schema::tables::{
     CommitmentMerkleRoots, CommitmentsByNumber, ExecutedMigrations, L2BlockByHash, L2BlockByNumber,
-    L2BlockStatus, L2GenesisStateRoot, L2RangeByL1Height, LastPrunedBlock,
-    LastSequencerCommitmentSent, LastStateDiff, LightClientProofBySlotNumber, MempoolTxs,
-    PendingProvingSessions, PendingSequencerCommitment, ProofsBySlotNumberV2,
-    ProverLastScannedSlot, ProverStateDiffs, SequencerCommitmentByIndex,
+    L2BlockStatus, L2GenesisStateRoot, L2RangeByL1Height, LastPrunedBlock, LastStateDiff,
+    LightClientProofBySlotNumber, MempoolTxs, PendingProvingSessions, PendingSequencerCommitment,
+    ProofsBySlotNumberV2, ProverLastScannedSlot, ProverStateDiffs, SequencerCommitmentByIndex,
     ShortHeaderProofBySlotHash, SlotByHash, VerifiedBatchProofsBySlotNumber, LEDGER_TABLES,
 };
 use crate::schema::types::batch_proof::{
@@ -141,6 +140,16 @@ impl LedgerDB {
         }
     }
 
+    fn put_l2_block(
+        &self,
+        l2_block: &StoredL2Block,
+        l2_block_number: &L2BlockNumber,
+        schema_batch: &mut SchemaBatch,
+    ) -> Result<(), anyhow::Error> {
+        schema_batch.put::<L2BlockByNumber>(l2_block_number, l2_block)?;
+        schema_batch.put::<L2BlockByHash>(&l2_block.hash, l2_block_number)
+    }
+
     /// Write raw rocksdb WriteBatch
     pub fn write(&self, batch: WriteBatch) -> anyhow::Result<()> {
         self.db.write(batch)
@@ -161,17 +170,6 @@ impl SharedLedgerOps for LedgerDB {
     /// Returns the inner DB instance
     fn inner(&self) -> Arc<DB> {
         self.db.clone()
-    }
-
-    #[instrument(level = "trace", skip(self, schema_batch), err, ret)]
-    fn put_l2_block(
-        &self,
-        l2_block: &StoredL2Block,
-        l2_block_number: &L2BlockNumber,
-        schema_batch: &mut SchemaBatch,
-    ) -> Result<(), anyhow::Error> {
-        schema_batch.put::<L2BlockByNumber>(l2_block_number, l2_block)?;
-        schema_batch.put::<L2BlockByHash>(&l2_block.hash, l2_block_number)
     }
 
     /// Commits a l2 block to the database by inserting its transactions and batches before
@@ -388,23 +386,17 @@ impl SharedLedgerOps for LedgerDB {
         self.db.get::<L2BlockByNumber>(number)
     }
 
-    /// Get the most recent committed batch
-    /// Returns last sequencer commitment.
+    /// Returns the commitment with highest index.
     #[instrument(level = "trace", skip(self), err, ret)]
     fn get_last_commitment(&self) -> anyhow::Result<Option<SequencerCommitment>> {
-        let index = self.db.get::<LastSequencerCommitmentSent>(&())?;
-        match index {
-            Some(index) => self.db.get::<SequencerCommitmentByIndex>(&index),
-            None => Ok(None),
-        }
-    }
+        let mut iter = self.db.iter::<SequencerCommitmentByIndex>()?;
+        iter.seek_to_last();
 
-    /// Used by the nodes to record that it has committed a soft confirmations on a given L2 height.
-    /// For a sequencer, the last commitment is set when the block is produced.
-    /// For a full node the last commitment is set when a commitment is read from a finalized DA layer block.
-    #[instrument(level = "trace", skip(self), err, ret)]
-    fn set_last_commitment(&self, seqcomm: &SequencerCommitment) -> Result<(), anyhow::Error> {
-        self.db.put::<LastSequencerCommitmentSent>(&(), &seqcomm.index)
+        match iter.next() {
+            Some(Ok(item)) => Ok(Some(item.value)),
+            Some(Err(e)) => Err(e),
+            _ => Ok(None),
+        }
     }
 
     /// Get the last scanned slot by the prover
@@ -466,7 +458,8 @@ impl SharedLedgerOps for LedgerDB {
     }
 
     fn put_commitment_by_index(&self, commitment: &SequencerCommitment) -> anyhow::Result<()> {
-        self.db.put::<SequencerCommitmentByIndex>(&commitment.index, commitment)
+        self.db
+            .put::<SequencerCommitmentByIndex>(&commitment.index, commitment)
     }
 
     fn get_commitment_by_index(&self, index: u32) -> anyhow::Result<Option<SequencerCommitment>> {

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -143,11 +143,11 @@ impl LedgerDB {
     fn put_l2_block(
         &self,
         l2_block: &StoredL2Block,
-        l2_block_number: &L2BlockNumber,
         schema_batch: &mut SchemaBatch,
     ) -> Result<(), anyhow::Error> {
-        schema_batch.put::<L2BlockByNumber>(l2_block_number, l2_block)?;
-        schema_batch.put::<L2BlockByHash>(&l2_block.hash, l2_block_number)
+        let l2_block_number = L2BlockNumber(l2_block.height);
+        schema_batch.put::<L2BlockByNumber>(&l2_block_number, l2_block)?;
+        schema_batch.put::<L2BlockByHash>(&l2_block.hash, &l2_block_number)
     }
 
     /// Write raw rocksdb WriteBatch
@@ -216,11 +216,7 @@ impl SharedLedgerOps for LedgerDB {
             timestamp: l2_block.timestamp(),
             tx_merkle_root: l2_block.tx_merkle_root(),
         };
-        self.put_l2_block(
-            &l2_block_to_store,
-            &L2BlockNumber(height),
-            &mut schema_batch,
-        )?;
+        self.put_l2_block(&l2_block_to_store, &mut schema_batch)?;
 
         self.db.write_schemas(schema_batch)?;
 

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
@@ -6,7 +6,6 @@ use sov_rollup_interface::block::L2Block;
 use sov_rollup_interface::da::SequencerCommitment;
 use sov_rollup_interface::stf::StateDiff;
 use sov_rollup_interface::zk::{Proof, StorageRootHash};
-use sov_schema_db::SchemaBatch;
 
 use crate::schema::types::batch_proof::{StoredBatchProof, StoredBatchProofOutput};
 use crate::schema::types::l2_block::StoredL2Block;
@@ -22,14 +21,6 @@ pub trait SharedLedgerOps {
 
     /// Returns the inner DB instance
     fn inner(&self) -> Arc<sov_schema_db::DB>;
-
-    /// Put L2 block to db
-    fn put_l2_block(
-        &self,
-        l2_block: &StoredL2Block,
-        l2_block_number: &L2BlockNumber,
-        schema_batch: &mut SchemaBatch,
-    ) -> Result<()>;
 
     /// Commits a l2 block to the database by inserting its transactions and batches before
     fn commit_l2_block(
@@ -97,9 +88,6 @@ pub trait SharedLedgerOps {
     /// Gets all l2 blocks by numbers
 
     fn get_l2_block_by_number(&self, number: &L2BlockNumber) -> Result<Option<StoredL2Block>>;
-
-    /// Used by the sequencer to record that it has committed to soft confirmations on a given L2 height
-    fn set_last_commitment(&self, seqcomm: &SequencerCommitment) -> Result<()>;
 
     /// Get the most recent committed batch
     /// Returns last sequencer commitment.

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
@@ -54,7 +54,6 @@ pub const SEQUENCER_LEDGER_TABLES: &[&str] = &[
     L2GenesisStateRoot::table_name(),
     LastStateDiff::table_name(),
     PendingSequencerCommitment::table_name(),
-    LastSequencerCommitmentSent::table_name(),
     L2BlockStatus::table_name(),
     CommitmentsByNumber::table_name(),
     MempoolTxs::table_name(),
@@ -87,7 +86,6 @@ pub const FULL_NODE_LEDGER_TABLES: &[&str] = &[
     ShortHeaderProofBySlotHash::table_name(),
     L2RangeByL1Height::table_name(),
     L2GenesisStateRoot::table_name(),
-    LastSequencerCommitmentSent::table_name(),
     L2BlockStatus::table_name(),
     ProverLastScannedSlot::table_name(),
     CommitmentsByNumber::table_name(),
@@ -155,7 +153,6 @@ pub const LEDGER_TABLES: &[&str] = &[
     LastStateDiff::table_name(),
     LightClientProofBySlotNumber::table_name(),
     PendingSequencerCommitment::table_name(),
-    LastSequencerCommitmentSent::table_name(),
     ProverLastScannedSlot::table_name(),
     L2BlockStatus::table_name(),
     ShortHeaderProofBySlotHash::table_name(),
@@ -378,11 +375,6 @@ define_table_with_default_codec!(
     /// The primary source for in progress sequencer commitments
     /// This table is used to store the pending sequencer commitments indexes
     (PendingSequencerCommitment) () => Vec<u32>
-);
-
-define_table_with_seek_key_codec!(
-    /// Sequencer uses this table to store the last commitment it sent
-    (LastSequencerCommitmentSent) () => u32
 );
 
 define_table_with_seek_key_codec!(


### PR DESCRIPTION
# Description

- Some put operations was being done as SchemaBatch even though it was a single write. There is no need for ledger db to do that, even though under the hood sov DB is already doing a SchemaBatch write for single puts.
- Carried put_l2_block trait fn to be an inner fn as its only used by ledger db itself.
- Removed LastSequencerCommitmentSent table to avoid unnecessary double writes. The name first suggested to me that this is a table where we track the last commitment that is sent to DA, but the usage of this table rather suggests that it is the commitment that has the highest index. Hence, I completely removed this table and implemented get_last_commitment fn by reading the last element in the SequencerCommitmentsByIndex table.
 
One bug that existed most likely due to confusion of having 2 such tables and set_last_commitment fn taking full commitment as input even though just index would have sufficed, on resubmitting pending commitments in sequencer, if submission was complete, we only saved the index to LastSequencerCommitmentSent table, but didnt save the actual commitment to SequencerCommitmentsByIndex table. Fixed that as well.

Also on rollback, we weren't pruning the SequencerCommitmentsByIndex table. Fixed that.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
