### PR TITLE
Fix pre state root verification

### DIFF
--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -106,10 +106,7 @@ impl TestCase for BasicProverTest {
 
         let min_l2_blocks_per_commitment = sequencer.min_l2_blocks_per_commitment();
 
-        for _ in 0..min_l2_blocks_per_commitment {
-            sequencer.client.send_publish_batch_request().await?;
-        }
-        for _ in 0..min_l2_blocks_per_commitment {
+        for _ in 0..min_l2_blocks_per_commitment * 2 {
             sequencer.client.send_publish_batch_request().await?;
         }
 
@@ -122,6 +119,7 @@ impl TestCase for BasicProverTest {
         batch_prover
             .wait_for_l1_height(finalized_height, None)
             .await?;
+        full_node.wait_for_l1_height(finalized_height, None).await?;
 
         // Wait for batch proof tx to hit mempool
         da.wait_mempool_len(2, None).await?;
@@ -152,6 +150,26 @@ impl TestCase for BasicProverTest {
                 compressed_state_diff.len()
             );
         }
+
+        // Generate proof against seqcom not starting from genesis
+        for _ in 0..min_l2_blocks_per_commitment * 2 {
+            sequencer.client.send_publish_batch_request().await?;
+        }
+
+        // Wait for blob inscribe tx to be in mempool
+        da.wait_mempool_len(4, None).await?;
+        da.generate(FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
+
+        batch_prover
+            .wait_for_l1_height(finalized_height, None)
+            .await?;
+        // Wait for batch proof tx to hit mempool
+        da.wait_mempool_len(2, None).await?;
+
+        da.generate(FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(finalized_height, None).await?;
 
         Ok(())
     }

--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -109,9 +109,12 @@ impl TestCase for BasicProverTest {
         for _ in 0..min_l2_blocks_per_commitment {
             sequencer.client.send_publish_batch_request().await?;
         }
+        for _ in 0..min_l2_blocks_per_commitment {
+            sequencer.client.send_publish_batch_request().await?;
+        }
 
         // Wait for blob inscribe tx to be in mempool
-        da.wait_mempool_len(2, None).await?;
+        da.wait_mempool_len(4, None).await?;
 
         da.generate(FINALITY_DEPTH).await?;
         let finalized_height = da.get_finalized_height(None).await?;


### PR DESCRIPTION
# Description

- Add tests with proof over a sequencer commitment range with multiple commitments
- Lift initial_state_root assertion out of sequencer commitment index range loop. 
- Single initial_state_root assertion against previous commitment `l2_end_block_number` 

Fixes #2170 