### PR TITLE
remove bls precompiles for now

### DIFF
--- a/crates/evm/src/evm/handler.rs
+++ b/crates/evm/src/evm/handler.rs
@@ -322,6 +322,20 @@ impl<SPEC: Spec, EXT: CitreaExternalExt, DB: Database> CitreaHandler<SPEC, EXT, 
             p.remove(&u64_to_address(0x0A))
                 .expect("point eval should be removed");
 
+            // remove BLS related precompiles until we fix
+            // revm-precompile blst feature compilation for risc0zkv
+            p.remove(&u64_to_address(0x0b));
+            p.remove(&u64_to_address(0x0c));
+            p.remove(&u64_to_address(0x0d));
+            p.remove(&u64_to_address(0x0e));
+            p.remove(&u64_to_address(0x0f));
+            p.remove(&u64_to_address(0x10));
+            p.remove(&u64_to_address(0x11));
+            // TODO: once revm precompile is updated
+            // remvoe these as EIP now defined 0xb to 0x11
+            p.remove(&u64_to_address(0x12));
+            p.remove(&u64_to_address(0x13));
+
             precompiles.extend([P256VERIFY]);
 
             precompiles


### PR DESCRIPTION
# Description
I can't get revm-precompile with blst feature to compile to risc0 zkvm. so to remove discrepancies between native and zk citrea-evm, we'll remove blst from the precompiles map.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
