### PR TITLE
Fix typos in comments and rename activation to activating

### DIFF
--- a/crates/bitcoin-da/tests/service.rs
+++ b/crates/bitcoin-da/tests/service.rs
@@ -64,7 +64,7 @@ impl TestCase for BitcoinServiceTest {
             assert_eq!(inclusion_proof.wtxids.len(), 33);
             assert_eq!(inclusion_proof.wtxids[1..], block_wtxids[1..]);
             // 2 complete, 2 aggregate proofs with 2 chunks for the first and 3 chunks for the second agg, and 2 method id txs
-            // 4 seqeuncer commitments
+            // 4 sequencer commitments
             assert_eq!(txs.len(), 15);
             // it is >= due to the probability that one of commit transactions ended up
             // with the prefix by chance (reveals are guaranteed to have a certain prefix)

--- a/crates/light-client-prover/src/tests/mod.rs
+++ b/crates/light-client-prover/src/tests/mod.rs
@@ -601,7 +601,7 @@ fn test_new_method_id_txs() {
         vec![(0u64, [0u32; 8]), (10u64, [2u32; 8])]
     );
 
-    // now try activation height < last activationg height and activation height = last activation height
+    // now try activation height < last activating height and activation height = last activation height
     let blob_1 = create_new_method_id_tx(10, [2u32; 8], method_id_upgrade_authority);
     let blob_2 = create_new_method_id_tx(3, [2u32; 8], method_id_upgrade_authority);
 

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/src/lib.rs
@@ -101,7 +101,7 @@ pub fn config_constant(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Derives a [`jsonrpsee`] implementation for the underlying type. Any code relying on this macro
 /// must take jsonrpsee as a dependency with at least the following features enabled: `["macros", "client-core", "server"]`.
 ///
-/// Syntax is identical to `jsonrpsee`'s `#[rpc]` execept that:
+/// Syntax is identical to `jsonrpsee`'s `#[rpc]` except that:
 /// 1. `#[rpc]` is renamed to `#[rpc_gen]` to avoid confusion with `jsonrpsee`'s `#[rpc]`
 /// 2. `#[rpc_gen]` is applied to an `impl` block instead of a trait
 /// 3. `#[method]` is renamed to with `#[rpc_method]` to avoid import confusion and clarify the purpose of the annotation


### PR DESCRIPTION
This PR fixes several typos in comments:

1. Changes "activationg" to "activating" in test_new_method_id_txs() function
2. Fixes formatting in comments about jsonrpsee syntax by changing "except" to "except"

These changes improve code readability and fix minor documentation issues.