### PR TITLE
Enable test no capture through an env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test-ci:
 	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo nextest run $(no_capture_param) --locked --workspace --all-features --no-fail-fast $(filter-out $@,$(MAKECMDGOALS))
 
 coverage-ci:
-	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo llvm-cov --locked --lcov --output-path lcov.info nextest -j10 --workspace --all-features
+	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo llvm-cov --locked --lcov --output-path lcov.info nextest --workspace --all-features
 
 test: build-test ## Runs test suite using next test
 	TEST_SKIP_GUEST_BUILD=1 $(MAKE) test-ci -- $(filter-out $@,$(MAKECMDGOALS))

--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,12 @@ clean-docker:
 
 clean-all: clean clean-node clean-txs
 
-test-legacy: ## Runs test suite with output from tests printed
-	@cargo test -- --nocapture -Zunstable-options --report-time
-
+no_capture_param =
+ifdef TEST_NO_CAPTURE
+	no_capture_param = --no-capture
+endif
 test-ci:
-	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo nextest run -j15 --locked --workspace --all-features --no-fail-fast $(filter-out $@,$(MAKECMDGOALS))
+	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo nextest run $(no_capture_param) --locked --workspace --all-features --no-fail-fast $(filter-out $@,$(MAKECMDGOALS))
 
 coverage-ci:
 	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo llvm-cov --locked --lcov --output-path lcov.info nextest -j10 --workspace --all-features


### PR DESCRIPTION
# Description

This removes the need for `make test-legacy` which is badly named IMO.

Also enables us to use existing `make test/test-ci` to filter for a specific test while also showing the test logs with `--no-capture`.

## Usage:
```
TEST_NO_CAPTURE=1 make test basic_prover_test
```
where `basic_prover_test` is an example but can be any test filter

## Alternatives

We can use the following syntax to pass additional parameters to tests which are invoked through `make test`

```
make test -- --retries 0 --no-capture test_sequencer_sends_commitments_to_da_layer
```
In this case `retries` and `no-capture` are additional params passed down to `cargo nextest run` 

But since we had `make test-legacy`, this tells me that maybe it is just easier to have an env var since people did not know how to show logs using `cargo nextest`