### PR TITLE
make sure maximum 256 block hashes end up in the diff

### DIFF
--- a/crates/evm/src/evm/db.rs
+++ b/crates/evm/src/evm/db.rs
@@ -38,9 +38,7 @@ impl<'a, C: sov_modules_api::Context> EvmDb<'a, C> {
 
     #[cfg(feature = "native")]
     pub(crate) fn override_block_hash(&mut self, number: u64, hash: B256) {
-        self.evm
-            .latest_block_hashes
-            .set(&number, &hash, self.working_set);
+        self.evm.blockhash_set(number, &hash, self.working_set);
     }
 
     #[cfg(feature = "native")]
@@ -111,13 +109,10 @@ impl<C: sov_modules_api::Context> Database for EvmDb<'_, C> {
         // no need to check block number ranges
         // revm already checks it
 
-        let block_hash = self
+        Ok(self
             .evm
-            .latest_block_hashes
-            .get(&number, self.working_set)
-            .unwrap_or(B256::ZERO);
-
-        Ok(block_hash)
+            .blockhash_get(number, self.working_set)
+            .expect("Block hash does not exist for range checked by revm"))
     }
 }
 

--- a/crates/evm/src/hooks.rs
+++ b/crates/evm/src/hooks.rs
@@ -54,8 +54,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let last_block_hash = sealed_parent_block.header.hash();
 
         // since we know the previous state root only here, we can set the last block hash
-        self.latest_block_hashes
-            .set(&parent_block_number, &last_block_hash, working_set);
+        self.blockhash_set(parent_block_number, &last_block_hash, working_set);
 
         let cfg = self
             .cfg
@@ -102,8 +101,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .expect("Head block should always be set");
 
         let parent_block_hash = self
-            .latest_block_hashes
-            .get(&parent_block.header.number, working_set)
+            .blockhash_get(parent_block.header.number, working_set)
             .expect("Should have parent block hash");
 
         let expected_block_number = parent_block.header.number + 1;

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1977,8 +1977,8 @@ fn get_pending_block_env<C: sov_modules_api::Context>(
         .last(&mut working_set.accessory_state())
         .expect("Head block must be set");
 
-    evm.latest_block_hashes.set(
-        &latest_block.header.number,
+    evm.blockhash_set(
+        latest_block.header.number,
         &latest_block.header.hash(),
         working_set,
     );

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -425,7 +425,7 @@ fn begin_l2_block_hook_appends_last_block_hashes() {
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
 
     assert_eq!(
-        evm.latest_block_hashes.get(&257, &mut working_set).unwrap(),
+        evm.blockhash_get(257, &mut working_set).unwrap(),
         evm.blocks
             .get(257, &mut working_set.accessory_state())
             .unwrap()


### PR DESCRIPTION
# Description
Right now our batch proof diffs would include as many block hashes as blocks in that proof. which is uncompresable data.
This PR limits the maximum number of block hashes in the diff to 256 (as this is the number of blocks we must supply to evm)

## Linked Issues
Fixes #2188 
