### PR TITLE
Fix make install-risc0 command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,10 @@ install-dev-tools:  ## Installs all necessary cargo helpers
 	$(MAKE) install-sp1
 
 install-risc0:
-	curl -L https://risczero.com/install | bash
-	source ~/.bashrc
-	source ~/.zshrc
-	rzup install
+	curl -L https://risczero.com/install | bash && \
+	([ -f $$HOME/.bashrc ] && source $$HOME/.bashrc || true) && \
+	([ -f $$HOME/.zshrc ] && source $$HOME/.zshrc || true) && \
+	rzup install && \
 	rzup install rust 1.85.0
 
 install-sp1: ## Install necessary SP1 toolchain


### PR DESCRIPTION
# Description
I am using zsh and I had an issue when running make install-risc0, this pr fixes it

Issue I faced is because we first source bash and then try to source zsh, but source bash errors out and stops the process
now it silently errors out and continues to the next option
```
ercecanbekture@Erces-MacBook-Pro-2 newcitrea % make install-risc0
curl -L https://risczero.com/install | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    15    0    15    0     0     43      0 --:--:-- --:--:-- --:--:--    43
100  5947  100  5947    0     0   4578      0  0:00:01  0:00:01 --:--:--  7452
→ Starting rzup installation...
→ Downloading rzup...
######################################################################## 100.0%
→ Configuring shell...
✓ Installation complete! rzup is installed in /Users/ercecanbekture/.risc0/bin

To get started:
1. Restart your shell or run:
   source "/Users/ercecanbekture/.zshrc"
2. Verify the installation:
   rzup --help

source ~/.bashrc
/bin/sh: /Users/ercecanbekture/.bashrc: No such file or directory
make: *** [install-risc0] Error 1
```