### PR TITLE
Fix lack of precompiles in simulation queries

### DIFF
--- a/crates/evm/src/evm/handler.rs
+++ b/crates/evm/src/evm/handler.rs
@@ -240,8 +240,7 @@ where
         self.inspector.create_end(context, inputs, outcome)
     }
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
-        // why not  self.inspector.selfdestruct(contract, target, value) ?
-        (&mut self.inspector as &mut dyn Inspector<DB>).selfdestruct(contract, target, value)
+        self.inspector.selfdestruct(contract, target, value)
     }
 }
 

--- a/crates/evm/src/evm/handler.rs
+++ b/crates/evm/src/evm/handler.rs
@@ -198,19 +198,15 @@ where
     I: Inspector<DB>,
 {
     fn initialize_interp(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
-        println!("initialize_interp");
         self.inspector.initialize_interp(interp, context)
     }
     fn step(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
-        println!("step");
         self.inspector.step(interp, context)
     }
     fn step_end(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
-        println!("step_end");
         self.inspector.step_end(interp, context)
     }
     fn log(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>, log: &Log) {
-        println!("log");
         self.inspector.log(interp, context, log)
     }
     fn call(
@@ -218,7 +214,6 @@ where
         context: &mut EvmContext<DB>,
         inputs: &mut CallInputs,
     ) -> Option<CallOutcome> {
-        println!("call");
         self.inspector.call(context, inputs)
     }
     fn call_end(
@@ -227,7 +222,6 @@ where
         inputs: &CallInputs,
         outcome: CallOutcome,
     ) -> CallOutcome {
-        println!("call_end");
         self.inspector.call_end(context, inputs, outcome)
     }
     fn create(
@@ -235,7 +229,6 @@ where
         context: &mut EvmContext<DB>,
         inputs: &mut CreateInputs,
     ) -> Option<CreateOutcome> {
-        println!("create");
         self.inspector.create(context, inputs)
     }
     fn create_end(
@@ -244,7 +237,6 @@ where
         inputs: &CreateInputs,
         outcome: CreateOutcome,
     ) -> CreateOutcome {
-        println!("create_end");
         self.inspector.create_end(context, inputs, outcome)
     }
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {

--- a/crates/evm/src/evm/handler.rs
+++ b/crates/evm/src/evm/handler.rs
@@ -198,15 +198,19 @@ where
     I: Inspector<DB>,
 {
     fn initialize_interp(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
+        println!("initialize_interp");
         self.inspector.initialize_interp(interp, context)
     }
     fn step(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
+        println!("step");
         self.inspector.step(interp, context)
     }
     fn step_end(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
+        println!("step_end");
         self.inspector.step_end(interp, context)
     }
     fn log(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>, log: &Log) {
+        println!("log");
         self.inspector.log(interp, context, log)
     }
     fn call(
@@ -214,6 +218,7 @@ where
         context: &mut EvmContext<DB>,
         inputs: &mut CallInputs,
     ) -> Option<CallOutcome> {
+        println!("call");
         self.inspector.call(context, inputs)
     }
     fn call_end(
@@ -222,6 +227,7 @@ where
         inputs: &CallInputs,
         outcome: CallOutcome,
     ) -> CallOutcome {
+        println!("call_end");
         self.inspector.call_end(context, inputs, outcome)
     }
     fn create(
@@ -229,6 +235,7 @@ where
         context: &mut EvmContext<DB>,
         inputs: &mut CreateInputs,
     ) -> Option<CreateOutcome> {
+        println!("create");
         self.inspector.create(context, inputs)
     }
     fn create_end(
@@ -237,9 +244,11 @@ where
         inputs: &CreateInputs,
         outcome: CreateOutcome,
     ) -> CreateOutcome {
+        println!("create_end");
         self.inspector.create_end(context, inputs, outcome)
     }
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
+        // why not  self.inspector.selfdestruct(contract, target, value) ?
         (&mut self.inspector as &mut dyn Inspector<DB>).selfdestruct(contract, target, value)
     }
 }

--- a/crates/evm/src/evm/handler.rs
+++ b/crates/evm/src/evm/handler.rs
@@ -310,12 +310,12 @@ where
     Box::new(f)
 }
 
-struct CitreaHandler<SPEC, EXT, DB> {
+pub(crate) struct CitreaHandler<SPEC, EXT, DB> {
     _phantom: std::marker::PhantomData<(SPEC, EXT, DB)>,
 }
 
 impl<SPEC: Spec, EXT: CitreaExternalExt, DB: Database> CitreaHandler<SPEC, EXT, DB> {
-    fn load_precompiles() -> ContextPrecompiles<DB> {
+    pub(crate) fn load_precompiles() -> ContextPrecompiles<DB> {
         fn our_precompiles<SPEC: Spec, DB: Database>() -> ContextPrecompiles<DB> {
             let mut precompiles = revm::handler::mainnet::load_precompiles::<SPEC, DB>();
 

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -598,14 +598,15 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .balance;
         let tx_env = prepare_call_env(&block_env, &mut cfg_env, request, cap_to_balance)?;
 
-        let result = match inspect_no_citrea_handle(
+        let result = match inspect_with_citrea_handle(
             evm_db,
             cfg_env,
             block_env,
             tx_env,
+            0,
             TracingInspector::new(TracingInspectorConfig::none()),
         ) {
-            Ok(result) => result.result,
+            Ok((result, _)) => result.result,
             Err(err) => {
                 return Err(EthApiError::from(err).into());
             }
@@ -709,17 +710,21 @@ impl<C: sov_modules_api::Context> Evm<C> {
         // can consume the list since we're not using the request anymore
         let initial = request.access_list.take().unwrap_or_default();
 
+        // TODO: update here.
         let precompiles = get_precompiles(cfg_env.handler_cfg.spec_id);
         let mut inspector = AccessListInspector::new(initial, from, to, precompiles);
 
-        let result = inspect_no_citrea_handle(
-            &mut evm_db,
+        let (result, _) = inspect_with_citrea_handle(
+            evm_db,
             cfg_env.clone(),
             block_env.clone(),
             tx_env,
+            0,
             &mut inspector,
         )
         .map_err(EthApiError::from)?;
+
+        println!("result: {:?}", result);
 
         match result.result {
             ExecutionResult::Halt { reason, .. } => Err(match reason {
@@ -733,6 +738,8 @@ impl<C: sov_modules_api::Context> Evm<C> {
         }?;
 
         let access_list = inspector.into_access_list();
+
+        println!("access_list: {:?}", access_list);
 
         request.access_list = Some(access_list.clone());
 
@@ -939,12 +946,13 @@ impl<C: sov_modules_api::Context> Evm<C> {
                     let mut tx_env = tx_env.clone();
                     tx_env.gas_limit = MIN_TRANSACTION_GAS;
 
-                    let res = inspect_with_citrea_handle_no_inspectors(
+                    let res = inspect_with_citrea_handle(
                         self.get_db(working_set),
                         cfg_env.clone(),
                         block_env.clone(),
                         tx_env.clone(),
                         l1_fee_rate,
+                        TracingInspector::new(TracingInspectorConfig::none()),
                     );
 
                     if let Ok((res, tx_info)) = res {
@@ -988,12 +996,13 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let evm_db = self.get_db(working_set);
 
         // execute the call without writing to db
-        let result = inspect_with_citrea_handle_no_inspectors(
+        let result = inspect_with_citrea_handle(
             evm_db,
             cfg_env.clone(),
             block_env.clone(),
             tx_env.clone(),
             l1_fee_rate,
+            TracingInspector::new(TracingInspectorConfig::none()),
         );
 
         // Exceptional case: init used too much gas, we need to increase the gas limit and try
@@ -1067,12 +1076,13 @@ impl<C: sov_modules_api::Context> Evm<C> {
         if optimistic_gas_limit < highest_gas_limit {
             tx_env.gas_limit = optimistic_gas_limit;
             // (result, env) = executor::transact(&mut db, env)?;
-            let curr_result = inspect_with_citrea_handle_no_inspectors(
+            let curr_result = inspect_with_citrea_handle(
                 self.get_db(working_set),
                 cfg_env.clone(),
                 block_env.clone(),
                 tx_env.clone(),
                 l1_fee_rate,
+                TracingInspector::new(TracingInspectorConfig::none()),
             );
             let (curr_result, tx_info) = match curr_result {
                 Ok(result) => result,
@@ -1109,12 +1119,13 @@ impl<C: sov_modules_api::Context> Evm<C> {
             tx_env.gas_limit = mid_gas_limit;
 
             let evm_db = self.get_db(working_set);
-            let result = inspect_with_citrea_handle_no_inspectors(
+            let result = inspect_with_citrea_handle(
                 evm_db,
                 cfg_env.clone(),
                 block_env.clone(),
                 tx_env.clone(),
                 l1_fee_rate,
+                TracingInspector::new(TracingInspectorConfig::none()),
             );
 
             // Exceptional case: init used too much gas, we need to increase the gas limit and try
@@ -1866,7 +1877,14 @@ fn map_out_of_gas_err<C: sov_modules_api::Context>(
     let req_gas_limit = tx_env.gas_limit;
     tx_env.gas_limit = block_env.gas_limit.saturating_to();
 
-    match inspect_with_citrea_handle_no_inspectors(db, cfg_env, block_env, tx_env, l1_fee_rate) {
+    match inspect_with_citrea_handle(
+        db,
+        cfg_env,
+        block_env,
+        tx_env,
+        l1_fee_rate,
+        TracingInspector::new(TracingInspectorConfig::none()),
+    ) {
         Ok((res, _tx_info)) => match res.result {
             ExecutionResult::Success { .. } => {
                 // transaction succeeded by manually increasing the gas limit to

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -49,7 +49,7 @@ use crate::conversions::{create_tx_env, sealed_block_to_block_env};
 use crate::evm::call::{create_txn_env, prepare_call_env};
 use crate::evm::db::EvmDb;
 use crate::evm::primitive_types::{Receipt, SealedBlock, TransactionSignedAndRecovered};
-use crate::handler::{diff_size_send_eth_eoa, TxInfo};
+use crate::handler::{diff_size_send_eth_eoa, TracingCitreaExternal, TxInfo};
 use crate::rpc_helpers::*;
 use crate::{
     citrea_spec_id_to_evm_spec_id, BloomFilter, Evm, EvmChainConfig, FilterBlockOption, FilterError,
@@ -603,8 +603,10 @@ impl<C: sov_modules_api::Context> Evm<C> {
             cfg_env,
             block_env,
             tx_env,
-            0,
-            TracingInspector::new(TracingInspectorConfig::none()),
+            &mut TracingCitreaExternal::new(
+                TracingInspector::new(TracingInspectorConfig::none()),
+                0,
+            ),
         ) {
             Ok((result, _)) => result.result,
             Err(err) => {
@@ -712,14 +714,15 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         // TODO: update here.
         let precompiles = get_precompiles(cfg_env.handler_cfg.spec_id);
-        let mut inspector = AccessListInspector::new(initial, from, to, precompiles);
+        let inspector = AccessListInspector::new(initial, from, to, precompiles);
+
+        let mut inspector = TracingCitreaExternal::new(inspector, 0);
 
         let (result, _) = inspect_with_citrea_handle(
             evm_db,
             cfg_env.clone(),
             block_env.clone(),
             tx_env,
-            0,
             &mut inspector,
         )
         .map_err(EthApiError::from)?;
@@ -737,7 +740,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             ExecutionResult::Success { .. } => Ok(()),
         }?;
 
-        let access_list = inspector.into_access_list();
+        let access_list = inspector.inspector.into_access_list();
 
         println!("access_list: {:?}", access_list);
 
@@ -951,8 +954,10 @@ impl<C: sov_modules_api::Context> Evm<C> {
                         cfg_env.clone(),
                         block_env.clone(),
                         tx_env.clone(),
-                        l1_fee_rate,
-                        TracingInspector::new(TracingInspectorConfig::none()),
+                        &mut TracingCitreaExternal::new(
+                            TracingInspector::new(TracingInspectorConfig::none()),
+                            l1_fee_rate,
+                        ),
                     );
 
                     if let Ok((res, tx_info)) = res {
@@ -1001,8 +1006,10 @@ impl<C: sov_modules_api::Context> Evm<C> {
             cfg_env.clone(),
             block_env.clone(),
             tx_env.clone(),
-            l1_fee_rate,
-            TracingInspector::new(TracingInspectorConfig::none()),
+            &mut TracingCitreaExternal::new(
+                TracingInspector::new(TracingInspectorConfig::none()),
+                l1_fee_rate,
+            ),
         );
 
         // Exceptional case: init used too much gas, we need to increase the gas limit and try
@@ -1081,8 +1088,10 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 cfg_env.clone(),
                 block_env.clone(),
                 tx_env.clone(),
-                l1_fee_rate,
-                TracingInspector::new(TracingInspectorConfig::none()),
+                &mut TracingCitreaExternal::new(
+                    TracingInspector::new(TracingInspectorConfig::none()),
+                    l1_fee_rate,
+                ),
             );
             let (curr_result, tx_info) = match curr_result {
                 Ok(result) => result,
@@ -1124,8 +1133,10 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 cfg_env.clone(),
                 block_env.clone(),
                 tx_env.clone(),
-                l1_fee_rate,
-                TracingInspector::new(TracingInspectorConfig::none()),
+                &mut TracingCitreaExternal::new(
+                    TracingInspector::new(TracingInspectorConfig::none()),
+                    l1_fee_rate,
+                ),
             );
 
             // Exceptional case: init used too much gas, we need to increase the gas limit and try
@@ -1882,8 +1893,10 @@ fn map_out_of_gas_err<C: sov_modules_api::Context>(
         cfg_env,
         block_env,
         tx_env,
-        l1_fee_rate,
-        TracingInspector::new(TracingInspectorConfig::none()),
+        &mut TracingCitreaExternal::new(
+            TracingInspector::new(TracingInspectorConfig::none()),
+            l1_fee_rate,
+        ),
     ) {
         Ok((res, _tx_info)) => match res.result {
             ExecutionResult::Success { .. } => {

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -32,8 +32,8 @@ use reth_rpc_eth_types::error::{
 };
 use reth_rpc_types_compat::block::from_primitive_with_hash;
 use revm::primitives::{
-    BlobExcessGasAndPrice, BlockEnv, CfgEnvWithHandlerCfg, EVMError, ExecutionResult, HaltReason,
-    InvalidTransaction, TransactTo,
+    spec_to_generic, BlobExcessGasAndPrice, BlockEnv, CfgEnvWithHandlerCfg, EVMError,
+    ExecutionResult, HaltReason, InvalidTransaction, SpecId, TransactTo,
 };
 use revm::{Database, DatabaseCommit};
 use revm_inspectors::access_list::AccessListInspector;
@@ -49,7 +49,10 @@ use crate::conversions::{create_tx_env, sealed_block_to_block_env};
 use crate::evm::call::{create_txn_env, prepare_call_env};
 use crate::evm::db::EvmDb;
 use crate::evm::primitive_types::{Receipt, SealedBlock, TransactionSignedAndRecovered};
-use crate::handler::{diff_size_send_eth_eoa, TracingCitreaExternal, TxInfo};
+use crate::handler::{
+    citrea_handle_register, diff_size_send_eth_eoa, CitreaExternal, CitreaHandler,
+    TracingCitreaExternal, TxInfo,
+};
 use crate::rpc_helpers::*;
 use crate::{
     citrea_spec_id_to_evm_spec_id, BloomFilter, Evm, EvmChainConfig, FilterBlockOption, FilterError,
@@ -709,11 +712,14 @@ impl<C: sov_modules_api::Context> Evm<C> {
             from.create(account.nonce)
         };
 
+        let precompiles = spec_to_generic!(evm_spec_id, {
+            CitreaHandler::<SPEC, CitreaExternal, EvmDb<C>>::load_precompiles()
+        });
+
+        let precompiles = precompiles.addresses().copied();
+
         // can consume the list since we're not using the request anymore
         let initial = request.access_list.take().unwrap_or_default();
-
-        // TODO: update here.
-        let precompiles = get_precompiles(cfg_env.handler_cfg.spec_id);
         let inspector = AccessListInspector::new(initial, from, to, precompiles);
 
         let mut inspector = TracingCitreaExternal::new(inspector, 0);

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -50,8 +50,7 @@ use crate::evm::call::{create_txn_env, prepare_call_env};
 use crate::evm::db::EvmDb;
 use crate::evm::primitive_types::{Receipt, SealedBlock, TransactionSignedAndRecovered};
 use crate::handler::{
-    citrea_handle_register, diff_size_send_eth_eoa, CitreaExternal, CitreaHandler,
-    TracingCitreaExternal, TxInfo,
+    diff_size_send_eth_eoa, CitreaExternal, CitreaHandler, TracingCitreaExternal, TxInfo,
 };
 use crate::rpc_helpers::*;
 use crate::{

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -727,8 +727,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
         )
         .map_err(EthApiError::from)?;
 
-        println!("result: {:?}", result);
-
         match result.result {
             ExecutionResult::Halt { reason, .. } => Err(match reason {
                 HaltReason::NonceOverflow => RpcInvalidTransactionError::NonceMaxValue,
@@ -741,8 +739,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
         }?;
 
         let access_list = inspector.inspector.into_access_list();
-
-        println!("access_list: {:?}", access_list);
 
         request.access_list = Some(access_list.clone());
 

--- a/crates/evm/src/rpc_helpers/tracing_utils.rs
+++ b/crates/evm/src/rpc_helpers/tracing_utils.rs
@@ -431,10 +431,3 @@ pub(crate) fn caller_gas_allowance(balance: U256, value: U256, gas_price: U256) 
         // This will be 0 if gas price is 0. It is fine, because we check it before.
         .unwrap_or_default())
 }
-
-/// Returns the addresses of the precompiles corresponding to the SpecId.
-#[inline]
-pub(crate) fn get_precompiles(spec_id: SpecId) -> impl IntoIterator<Item = Address> {
-    let spec = PrecompileSpecId::from_spec_id(spec_id);
-    Precompiles::new(spec).addresses().copied()
-}

--- a/crates/evm/src/rpc_helpers/tracing_utils.rs
+++ b/crates/evm/src/rpc_helpers/tracing_utils.rs
@@ -13,7 +13,6 @@ use revm_inspectors::tracing::js::JsInspector;
 use revm_inspectors::tracing::{
     FourByteInspector, TracingInspector, TracingInspectorConfig, TransactionContext,
 };
-use sov_modules_api::default_context::DefaultContext;
 
 use crate::db::DBError;
 use crate::evm::db::immutable::EvmDbRef;
@@ -359,16 +358,15 @@ pub(crate) fn inspect_with_citrea_handle<'a, C, I>(
     config_env: CfgEnvWithHandlerCfg,
     block_env: BlockEnv,
     tx_env: TxEnv,
-    l1_fee_rate: u128,
-    inspector: I,
+    ext: &mut I,
 ) -> Result<(ResultAndState, TxInfo), EVMError<DBError>>
 where
     C: sov_modules_api::Context,
-    I: Inspector<EvmDb<'a, DefaultContext>>,
+    I: Inspector<EvmDb<'a, C>>,
+    I: CitreaExternalExt,
 {
     let tmp_hash: TxHash = b"hash_of_an_ephemeral_transaction".into();
 
-    let mut ext = TracingCitreaExternal::new(inspector, l1_fee_rate);
     ext.set_current_tx_hash(tmp_hash);
 
     let mut evm = revm::Evm::builder()
@@ -378,6 +376,7 @@ where
         .with_block_env(block_env)
         .with_tx_env(tx_env)
         .append_handler_register_box(citrea_handle_register())
+        .append_handler_register(inspector_handle_register)
         .build();
 
     let result_and_state = evm.transact()?;

--- a/crates/evm/src/rpc_helpers/tracing_utils.rs
+++ b/crates/evm/src/rpc_helpers/tracing_utils.rs
@@ -6,8 +6,7 @@ use alloy_rpc_types_trace::geth::{
 use reth_primitives::revm_primitives::TxEnv;
 use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
 use reth_rpc_eth_types::error::{EthApiError, EthResult, RpcInvalidTransactionError};
-use revm::precompile::{PrecompileSpecId, Precompiles};
-use revm::primitives::{Address, BlockEnv, CfgEnvWithHandlerCfg, EVMError, ResultAndState, SpecId};
+use revm::primitives::{BlockEnv, CfgEnvWithHandlerCfg, EVMError, ResultAndState};
 use revm::{inspector_handle_register, Inspector};
 use revm_inspectors::tracing::js::JsInspector;
 use revm_inspectors::tracing::{

--- a/crates/evm/src/rpc_helpers/tracing_utils.rs
+++ b/crates/evm/src/rpc_helpers/tracing_utils.rs
@@ -7,20 +7,18 @@ use reth_primitives::revm_primitives::TxEnv;
 use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
 use reth_rpc_eth_types::error::{EthApiError, EthResult, RpcInvalidTransactionError};
 use revm::precompile::{PrecompileSpecId, Precompiles};
-use revm::primitives::db::Database;
 use revm::primitives::{Address, BlockEnv, CfgEnvWithHandlerCfg, EVMError, ResultAndState, SpecId};
 use revm::{inspector_handle_register, Inspector};
 use revm_inspectors::tracing::js::JsInspector;
 use revm_inspectors::tracing::{
     FourByteInspector, TracingInspector, TracingInspectorConfig, TransactionContext,
 };
+use sov_modules_api::default_context::DefaultContext;
 
 use crate::db::DBError;
 use crate::evm::db::immutable::EvmDbRef;
 use crate::evm::db::EvmDb;
-use crate::handler::{
-    citrea_handle_register, CitreaExternal, CitreaExternalExt, TracingCitreaExternal, TxInfo,
-};
+use crate::handler::{citrea_handle_register, CitreaExternalExt, TracingCitreaExternal, TxInfo};
 use crate::rpc_helpers::*;
 
 pub(crate) fn trace_call<C: sov_modules_api::Context>(
@@ -356,45 +354,26 @@ where
     evm.transact()
 }
 
-/// Executes the [Env] against the given [Database] without committing state changes.
-pub(crate) fn inspect_no_citrea_handle<DB, I>(
-    db: DB,
-    config_env: CfgEnvWithHandlerCfg,
-    block_env: BlockEnv,
-    tx_env: TxEnv,
-    inspector: I,
-) -> Result<ResultAndState, EVMError<DB::Error>>
-where
-    DB: Database,
-    <DB as Database>::Error: Into<EthApiError>,
-    I: Inspector<DB>,
-{
-    let mut evm = revm::Evm::builder()
-        .with_db(db)
-        .with_external_context(inspector)
-        .with_cfg_env_with_handler_cfg(config_env)
-        .with_block_env(block_env)
-        .with_tx_env(tx_env)
-        .append_handler_register(inspector_handle_register)
-        .build();
-
-    evm.transact()
-}
-
-pub(crate) fn inspect_with_citrea_handle_no_inspectors<C: sov_modules_api::Context>(
-    db: EvmDb<'_, C>,
+pub(crate) fn inspect_with_citrea_handle<'a, C, I>(
+    db: EvmDb<'a, C>,
     config_env: CfgEnvWithHandlerCfg,
     block_env: BlockEnv,
     tx_env: TxEnv,
     l1_fee_rate: u128,
-) -> Result<(ResultAndState, TxInfo), EVMError<DBError>> {
+    inspector: I,
+) -> Result<(ResultAndState, TxInfo), EVMError<DBError>>
+where
+    C: sov_modules_api::Context,
+    I: Inspector<EvmDb<'a, DefaultContext>>,
+{
     let tmp_hash: TxHash = b"hash_of_an_ephemeral_transaction".into();
-    let mut ext = CitreaExternal::new(l1_fee_rate);
+
+    let mut ext = TracingCitreaExternal::new(inspector, l1_fee_rate);
     ext.set_current_tx_hash(tmp_hash);
 
     let mut evm = revm::Evm::builder()
         .with_db(db)
-        .with_external_context(&mut ext)
+        .with_external_context(ext)
         .with_cfg_env_with_handler_cfg(config_env)
         .with_block_env(block_env)
         .with_tx_env(tx_env)


### PR DESCRIPTION
# Description
On endpoints such as 

- eth_call
- eth_createAccessList
- eth_estimateGas

Uses citrea evm handler so that everything works the same with normal transaction execution.

## Linked Issues
Fixes #2183 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
