### PR TITLE
Update ProverLastScannedSlot on rollback

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -110,6 +110,7 @@ jobs:
           name: citrea-test-build
           path: |
             target/debug/citrea
+            target/debug/citrea-cli
             target/debug/**/methods.rs
           retention-days: 1
 
@@ -231,6 +232,8 @@ jobs:
           path: target/debug
       - name: Make citrea executable
         run: chmod +x target/debug/citrea
+      - name: Make citrea-cli executable
+        run: chmod +x target/debug/citrea-cli
       - name: Run coverage
         run: make coverage-ci
         env:
@@ -401,6 +404,8 @@ jobs:
           path: target/debug
       - name: Make citrea executable
         run: chmod +x target/debug/citrea
+      - name: Make citrea-cli executable
+        run: chmod +x target/debug/citrea-cli
       - name: Run nextest
         run: make test-ci
         env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,6 +64,8 @@ env:
   RUSTFLAGS: -D warnings
   FOUNDRY_PROFILE: ci
   TEST_BITCOIN_DOCKER: "bitcoin/bitcoin:28.0"
+  CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
+  CITREA_CLI_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea-cli
 
 # Automatically cancels a job if a new commit if pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>
@@ -235,7 +237,6 @@ jobs:
           RUST_BACKTRACE: 1
           TEST_BITCOIN_DOCKER: 1
           RISC0_DEV_MODE: 1 # This is needed to generate mock proofs and verify them
-          CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
           PARALLEL_PROOF_LIMIT: 1
           TEST_OUT_DIR: ${{ runner.temp }}/coverage
       - name: Upload e2e test dir
@@ -406,7 +407,6 @@ jobs:
           RUST_BACKTRACE: 1
           RISC0_DEV_MODE: 1 # This is needed to generate mock proofs and verify them
           TEST_BITCOIN_DOCKER: 1
-          CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
           PARALLEL_PROOF_LIMIT: 1
           TEST_OUT_DIR: ${{ runner.temp }}/test
       - name: Upload e2e test dir

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=629d43c#629d43cbbfade0e6795467826557e0901a1c9206"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=9e76552#9e7655202657dd2e500c779030210e1edd26a8cd"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ alloy-eips = { version = "0.4.2", default-features = false }
 alloy-consensus = { version = "0.4.2", default-features = false, features = ["serde", "serde-bincode-compat"] }
 alloy-network = { version = "0.4.2", default-features = false }
 
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "629d43c" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "9e76552" }
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "0fe8a8b" }

--- a/bin/citrea/tests/bitcoin/mod.rs
+++ b/bin/citrea/tests/bitcoin/mod.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 pub mod batch_prover_test;
 pub mod light_client_test;
+pub mod rollback;
 mod utils;
 // pub mod mempool_accept;
 pub mod backup;
@@ -25,6 +26,22 @@ pub(super) fn get_citrea_path() -> PathBuf {
                 .join("target")
                 .join("debug")
                 .join("citrea")
+        },
+        PathBuf::from,
+    )
+}
+
+pub(super) fn get_citrea_cli_path() -> PathBuf {
+    std::env::var("CITREA_CLI_E2E_TEST_BINARY").map_or_else(
+        |_| {
+            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            manifest_dir
+                .ancestors()
+                .nth(2)
+                .expect("Failed to find workspace root")
+                .join("target")
+                .join("debug")
+                .join("citrea-cli")
         },
         PathBuf::from,
     )

--- a/bin/citrea/tests/bitcoin/rollback.rs
+++ b/bin/citrea/tests/bitcoin/rollback.rs
@@ -1,0 +1,103 @@
+use async_trait::async_trait;
+use bitcoincore_rpc::RpcApi;
+use citrea_e2e::{
+    config::TestCaseConfig,
+    framework::TestFramework,
+    test_case::{TestCase, TestCaseRunner},
+    traits::Restart,
+    Result,
+};
+use sov_ledger_rpc::LedgerRpcClient;
+
+use super::{get_citrea_cli_path, get_citrea_path};
+
+struct RollBackFullNodeSlots;
+
+#[async_trait]
+impl TestCase for RollBackFullNodeSlots {
+    fn test_config() -> TestCaseConfig {
+        TestCaseConfig {
+            with_full_node: true,
+            with_citrea_cli: true,
+            ..Default::default()
+        }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(150)
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        let da = f.bitcoin_nodes.get_mut(0).unwrap();
+        let sequencer = f.sequencer.as_ref().unwrap();
+        let full_node = f.full_node.as_mut().unwrap();
+        let citrea_cli = f.citrea_cli.as_ref().unwrap();
+
+        sequencer.client.send_publish_batch_request().await?;
+
+        let mined_blocks = 10;
+        da.generate(mined_blocks).await?;
+
+        let da_height = da.get_block_count().await?;
+        assert_eq!(da_height, f.initial_da_height + mined_blocks);
+
+        let finalized_height = da.get_finalized_height(None).await?;
+
+        full_node.wait_for_l1_height(finalized_height, None).await?;
+
+        let last_scanned_l1_height: u64 = full_node
+            .client
+            .http_client()
+            .get_last_scanned_l1_height()
+            .await
+            .unwrap()
+            .to();
+        assert_eq!(last_scanned_l1_height, finalized_height);
+
+        // Rollback full node to initial_da_height
+        full_node.wait_until_stopped().await?;
+
+        let v = citrea_cli
+            .run(
+                "rollback",
+                &[
+                    "--node-type",
+                    "full-node",
+                    "--db-path",
+                    full_node.config.rollup.storage.path.to_str().unwrap(),
+                    "--l2-target",
+                    "1",
+                    "--l1-target",
+                    &f.initial_da_height.to_string(),
+                    "--sequencer-commitment-index",
+                    "0",
+                ],
+            )
+            .await?;
+        for l in v.split("\n") {
+            println!("{}", l);
+        }
+
+        full_node.start(None, None).await?;
+
+        let last_scanned_l1_height: u64 = full_node
+            .client
+            .http_client()
+            .get_last_scanned_l1_height()
+            .await
+            .unwrap()
+            .to();
+        assert_eq!(last_scanned_l1_height, f.initial_da_height);
+
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_rollback_fullnode_slots() -> Result<()> {
+    TestCaseRunner::new(RollBackFullNodeSlots)
+        .set_citrea_path(get_citrea_path())
+        .set_citrea_cli_path(get_citrea_cli_path())
+        .run()
+        .await
+}

--- a/bin/citrea/tests/bitcoin/rollback.rs
+++ b/bin/citrea/tests/bitcoin/rollback.rs
@@ -52,6 +52,19 @@ impl TestCase for RollBackFullNodeSlots {
             .to();
         assert_eq!(last_scanned_l1_height, finalized_height);
 
+        // Check that full node restarts from finalized_height
+        full_node.wait_until_stopped().await?;
+        full_node.start(None, None).await?;
+
+        let last_scanned_l1_height: u64 = full_node
+            .client
+            .http_client()
+            .get_last_scanned_l1_height()
+            .await
+            .unwrap()
+            .to();
+        assert_eq!(last_scanned_l1_height, finalized_height);
+
         // Rollback full node to initial_da_height
         full_node.wait_until_stopped().await?;
 
@@ -72,9 +85,6 @@ impl TestCase for RollBackFullNodeSlots {
                 ],
             )
             .await?;
-        for l in v.split("\n") {
-            println!("{}", l);
-        }
 
         full_node.start(None, None).await?;
 

--- a/bin/citrea/tests/bitcoin/rollback.rs
+++ b/bin/citrea/tests/bitcoin/rollback.rs
@@ -68,7 +68,7 @@ impl TestCase for RollBackFullNodeSlots {
         // Rollback full node to initial_da_height
         full_node.wait_until_stopped().await?;
 
-        let v = citrea_cli
+        citrea_cli
             .run(
                 "rollback",
                 &[

--- a/bin/citrea/tests/bitcoin/rollback.rs
+++ b/bin/citrea/tests/bitcoin/rollback.rs
@@ -1,12 +1,10 @@
 use async_trait::async_trait;
 use bitcoincore_rpc::RpcApi;
-use citrea_e2e::{
-    config::TestCaseConfig,
-    framework::TestFramework,
-    test_case::{TestCase, TestCaseRunner},
-    traits::Restart,
-    Result,
-};
+use citrea_e2e::config::TestCaseConfig;
+use citrea_e2e::framework::TestFramework;
+use citrea_e2e::test_case::{TestCase, TestCaseRunner};
+use citrea_e2e::traits::Restart;
+use citrea_e2e::Result;
 use sov_ledger_rpc::LedgerRpcClient;
 
 use super::{get_citrea_cli_path, get_citrea_path};

--- a/crates/storage-ops/src/rollback/components/ledger_db/mod.rs
+++ b/crates/storage-ops/src/rollback/components/ledger_db/mod.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use l2_blocks::rollback_l2_blocks;
 use slots::{rollback_light_client_slots, rollback_slots};
+use sov_db::schema::tables::ProverLastScannedSlot;
+use sov_db::schema::types::SlotNumber;
 use tracing::debug;
 
 use crate::log_result_or_error;
 use crate::pruning::types::StorageNodeType;
-use sov_db::schema::tables::ProverLastScannedSlot;
-use sov_db::schema::types::SlotNumber;
 
 mod l2_blocks;
 mod slots;

--- a/crates/storage-ops/src/rollback/components/ledger_db/mod.rs
+++ b/crates/storage-ops/src/rollback/components/ledger_db/mod.rs
@@ -6,6 +6,8 @@ use tracing::debug;
 
 use crate::log_result_or_error;
 use crate::pruning::types::StorageNodeType;
+use sov_db::schema::tables::ProverLastScannedSlot;
+use sov_db::schema::types::SlotNumber;
 
 mod l2_blocks;
 mod slots;
@@ -43,6 +45,7 @@ pub(crate) fn rollback_ledger_db(
             log_result_or_error!("slots", rollback_slots(node_type, &ledger_db, target_l1,));
         }
     }
+    let _ = ledger_db.put::<ProverLastScannedSlot>(&(), &SlotNumber(target_l1));
 
     let _ = ledger_db.flush();
 }


### PR DESCRIPTION
# Description

- Set `ProverLastScannedSlot` to `target_l1` height on rollback.
- Prevent rolling back l1 data but continue syncing on previous highest l1 block

## Testing
- Add `RollBackFullNodeSlots` which rollback to `initial_da_height` and make sure start l1 height after restart is correct