### PR TITLE
Fix test_chain_proof_by_commitment_index flakiness

### DIFF
--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -1831,7 +1831,7 @@ impl TestCase for ChainProofByCommitmentIndex {
             .unwrap();
 
         let bp = create_serialized_fake_receipt_batch_proof(
-            genesis_state_root,
+            [1u8; 32], // The state root of the previous commitment
             300,
             method_ids[0].method_id.into(),
             None,


### PR DESCRIPTION
# Description
Made a mistake on the test, second batch proof had the genesis state root as initial state root while it should have had the  previous commitments state root

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
