### PR TITLE
Configurable L2 block range limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "citrea"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-batch-prover"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-cli"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "citrea-common",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-common"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-evm"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-fullnode"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-light-client-prover"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-primitives"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy-eips",
  "brotli",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-risc0-adapter"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-sequencer"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-stf"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-storage-ops"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "futures",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-rpc"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "prover-services"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "soft-confirmation-rule-enforcer"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "borsh",
  "chrono",
@@ -7803,7 +7803,7 @@ dependencies = [
 
 [[package]]
 name = "sov-accounts"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "borsh",
  "jsonrpsee",
@@ -7819,7 +7819,7 @@ dependencies = [
 
 [[package]]
 name = "sov-db"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -7842,7 +7842,7 @@ dependencies = [
 
 [[package]]
 name = "sov-ledger-rpc"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -7858,7 +7858,7 @@ dependencies = [
 
 [[package]]
 name = "sov-mock-da"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7880,7 +7880,7 @@ dependencies = [
 
 [[package]]
 name = "sov-mock-zkvm"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7890,7 +7890,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-api"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -7922,7 +7922,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-core"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -7946,7 +7946,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-macros"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7966,7 +7966,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-rollup-blueprint"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7986,7 +7986,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-stf-blueprint"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8004,7 +8004,7 @@ dependencies = [
 
 [[package]]
 name = "sov-prover-storage-manager"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8020,7 +8020,7 @@ dependencies = [
 
 [[package]]
 name = "sov-rollup-interface"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "sov-schema-db"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -8060,7 +8060,7 @@ dependencies = [
 
 [[package]]
 name = "sov-state"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "alloy-rlp",
  "anyhow",

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -216,13 +216,14 @@ where
         _ => None,
     };
 
-    let rpc_module = rollup_blueprint.setup_rpc(
+    let rpc_module = rollup_blueprint.create_rpc_methods(
         &prover_storage,
-        ledger_db.clone(),
-        da_service.clone(),
+        &ledger_db,
+        &da_service,
         sequencer_client_url,
         soft_confirmation_rx,
         &backup_manager,
+        rollup_config.rpc.clone(),
     )?;
 
     match node_type {

--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -10,7 +10,7 @@ use citrea_common::backup::{create_backup_rpc_module, BackupManager};
 use citrea_common::config::ProverGuestRunConfig;
 use citrea_common::rpc::register_healthcheck_rpc;
 use citrea_common::tasks::manager::TaskManager;
-use citrea_common::FullNodeConfig;
+use citrea_common::{FullNodeConfig, RpcConfig};
 use citrea_primitives::forks::use_network_forks;
 use citrea_primitives::{TO_BATCH_PROOF_PREFIX, TO_LIGHT_CLIENT_PREFIX};
 use citrea_risc0_adapter::host::Risc0BonsaiHost;
@@ -71,6 +71,7 @@ impl RollupBlueprint for BitcoinRollup {
         sequencer_client_url: Option<String>,
         soft_confirmation_rx: Option<broadcast::Receiver<u64>>,
         backup_manager: &Arc<BackupManager>,
+        rpc_config: RpcConfig,
     ) -> Result<jsonrpsee::RpcModule<()>, anyhow::Error> {
         // unused inside register RPC
         let sov_sequencer = Address::new([0; 32]);
@@ -80,7 +81,7 @@ impl RollupBlueprint for BitcoinRollup {
             Self::NativeRuntime,
             Self::NativeContext,
             Self::DaService,
-        >(storage, ledger_db, da_service, sov_sequencer)?;
+        >(storage, ledger_db, da_service, sov_sequencer, rpc_config)?;
 
         crate::eth::register_ethereum::<Self::DaService>(
             da_service.clone(),

--- a/bin/citrea/src/rollup/mock.rs
+++ b/bin/citrea/src/rollup/mock.rs
@@ -6,7 +6,7 @@ use citrea_common::backup::{create_backup_rpc_module, BackupManager};
 use citrea_common::config::ProverGuestRunConfig;
 use citrea_common::rpc::register_healthcheck_rpc;
 use citrea_common::tasks::manager::TaskManager;
-use citrea_common::FullNodeConfig;
+use citrea_common::{FullNodeConfig, RpcConfig};
 use citrea_primitives::forks::use_network_forks;
 // use citrea_sp1::host::SP1Host;
 use citrea_risc0_adapter::host::Risc0BonsaiHost;
@@ -56,6 +56,7 @@ impl RollupBlueprint for MockDemoRollup {
         sequencer_client_url: Option<String>,
         soft_confirmation_rx: Option<broadcast::Receiver<u64>>,
         backup_manager: &Arc<BackupManager>,
+        rpc_config: RpcConfig,
     ) -> Result<jsonrpsee::RpcModule<()>, anyhow::Error> {
         // TODO set the sequencer address
         let sequencer = Address::new([0; 32]);
@@ -64,7 +65,7 @@ impl RollupBlueprint for MockDemoRollup {
             Self::NativeRuntime,
             Self::NativeContext,
             Self::DaService,
-        >(storage, ledger_db, da_service, sequencer)?;
+        >(storage, ledger_db, da_service, sequencer, rpc_config)?;
 
         crate::eth::register_ethereum::<Self::DaService>(
             da_service.clone(),

--- a/bin/citrea/src/rollup/mod.rs
+++ b/bin/citrea/src/rollup/mod.rs
@@ -126,26 +126,6 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
         })
     }
 
-    /// Setup the RPC server
-    fn setup_rpc(
-        &self,
-        prover_storage: &ProverStorage<SnapshotManager>,
-        ledger_db: LedgerDB,
-        da_service: Arc<<Self as RollupBlueprint>::DaService>,
-        sequencer_client_url: Option<String>,
-        soft_confirmation_rx: Option<broadcast::Receiver<u64>>,
-        backup_manager: &Arc<BackupManager>,
-    ) -> Result<RpcModule<()>> {
-        self.create_rpc_methods(
-            prover_storage,
-            &ledger_db,
-            &da_service,
-            sequencer_client_url,
-            soft_confirmation_rx,
-            backup_manager,
-        )
-    }
-
     /// Creates a new sequencer
     #[instrument(level = "trace", skip_all)]
     #[allow(clippy::type_complexity, clippy::too_many_arguments)]

--- a/bin/citrea/src/test_rpc.rs
+++ b/bin/citrea/src/test_rpc.rs
@@ -82,7 +82,8 @@ fn test_helper(
             .await
             .unwrap();
         let addr = server.local_addr().unwrap();
-        let server_rpc_module = sov_ledger_rpc::server::create_rpc_module::<LedgerDB>(ledger_db);
+        let server_rpc_module =
+            sov_ledger_rpc::server::create_rpc_module::<LedgerDB>(ledger_db, Default::default());
         let _server_handle = server.start(server_rpc_module);
 
         let rpc_config = RpcConfig {

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -154,13 +154,14 @@ pub async fn start_rollup(
         None
     };
     let rpc_module = mock_demo_rollup
-        .setup_rpc(
+        .create_rpc_methods(
             &prover_storage,
-            ledger_db.clone(),
-            da_service.clone(),
+            &ledger_db,
+            &da_service,
             sequencer_client_url,
             soft_confirmation_rx,
             &backup_manager,
+            rollup_config.rpc.clone(),
         )
         .expect("RPC module setup should work");
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use citrea_storage_ops::pruning::PruningConfig;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use sov_ledger_rpc::server::LedgerRpcServerConfig;
 
 pub trait FromEnv: Sized {
     fn from_env() -> anyhow::Result<Self>;
@@ -83,6 +84,14 @@ pub struct RpcConfig {
     pub max_subscriptions_per_connection: u32,
     /// API key for protected JSON-RPC methods
     pub api_key: Option<String>,
+}
+
+impl From<RpcConfig> for LedgerRpcServerConfig {
+    fn from(val: RpcConfig) -> Self {
+        LedgerRpcServerConfig {
+            max_l2_blocks_per_request: val.batch_requests_limit,
+        }
+    }
 }
 
 impl FromEnv for RpcConfig {

--- a/crates/sovereign-sdk/full-node/sov-ledger-rpc/src/server.rs
+++ b/crates/sovereign-sdk/full-node/sov-ledger-rpc/src/server.rs
@@ -15,16 +15,32 @@ use crate::{HexHash, HexStateRoot, LedgerRpcServer};
 
 const LEDGER_RPC_ERROR: &str = "LEDGER_RPC_ERROR";
 
+/// LedgerRpcServerConfig
+#[derive(Clone, Debug)]
+pub struct LedgerRpcServerConfig {
+    /// The maximum number of l2 blocks that can be requested in a single RPC range query
+    pub max_l2_blocks_per_request: u32,
+}
+
+impl Default for LedgerRpcServerConfig {
+    fn default() -> Self {
+        Self {
+            max_l2_blocks_per_request: 20,
+        }
+    }
+}
+
 fn to_ledger_rpc_error(err: impl ToString) -> ErrorObjectOwned {
     to_jsonrpsee_error_object(LEDGER_RPC_ERROR, err)
 }
 pub struct LedgerRpcServerImpl<T> {
     ledger: T,
+    config: LedgerRpcServerConfig,
 }
 
 impl<T> LedgerRpcServerImpl<T> {
-    pub fn new(ledger: T) -> Self {
-        Self { ledger }
+    pub fn new(ledger: T, config: LedgerRpcServerConfig) -> Self {
+        Self { ledger, config }
     }
 }
 
@@ -55,6 +71,12 @@ where
         start: U64,
         end: U64,
     ) -> RpcResult<Vec<Option<SoftConfirmationResponse>>> {
+        if (end - start).to::<u32>() > self.config.max_l2_blocks_per_request {
+            return Err(to_ledger_rpc_error(format!(
+                "requested batch range too large. Max: {}",
+                self.config.max_l2_blocks_per_request
+            )));
+        }
         self.ledger
             .get_soft_confirmations_range(start.to(), end.to())
             .map_err(to_ledger_rpc_error)
@@ -164,10 +186,13 @@ where
     }
 }
 
-pub fn create_rpc_module<T>(ledger: T) -> RpcModule<LedgerRpcServerImpl<T>>
+pub fn create_rpc_module<T>(
+    ledger: T,
+    config: LedgerRpcServerConfig,
+) -> RpcModule<LedgerRpcServerImpl<T>>
 where
     T: LedgerRpcProvider + Send + Sync + 'static,
 {
-    let server = LedgerRpcServerImpl::new(ledger);
+    let server = LedgerRpcServerImpl::new(ledger, config);
     LedgerRpcServer::into_rpc(server)
 }

--- a/crates/sovereign-sdk/full-node/sov-ledger-rpc/tests/empty_ledger.rs
+++ b/crates/sovereign-sdk/full-node/sov-ledger-rpc/tests/empty_ledger.rs
@@ -11,7 +11,7 @@ use tempfile::tempdir;
 async fn rpc_server() -> (jsonrpsee::server::ServerHandle, SocketAddr) {
     let dir = tempdir().unwrap();
     let db = LedgerDB::with_config(&RocksdbConfig::new(dir.path(), None, None)).unwrap();
-    let rpc_module = create_rpc_module::<LedgerDB>(db);
+    let rpc_module = create_rpc_module::<LedgerDB>(db, Default::default());
 
     let server = jsonrpsee::server::ServerBuilder::default()
         .build("127.0.0.1:0")

--- a/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use citrea_common::backup::BackupManager;
 use citrea_common::tasks::manager::TaskManager;
-use citrea_common::{FullNodeConfig, ProverGuestRunConfig};
+use citrea_common::{FullNodeConfig, ProverGuestRunConfig, RpcConfig};
 use prover_services::ParallelProverService;
 use sov_db::ledger_db::LedgerDB;
 use sov_db::rocks_db_config::RocksdbConfig;
@@ -74,6 +74,7 @@ pub trait RollupBlueprint: Sized + Send + Sync {
     ) -> HashMap<SpecId, <Self::Vm as Zkvm>::CodeCommitment>;
 
     /// Creates RPC methods for the rollup.
+    #[allow(clippy::too_many_arguments)]
     fn create_rpc_methods(
         &self,
         storage: &ProverStorage<SnapshotManager>,
@@ -82,6 +83,7 @@ pub trait RollupBlueprint: Sized + Send + Sync {
         sequencer_client_url: Option<String>,
         soft_confirmation_rx: Option<broadcast::Receiver<u64>>,
         backup_manager: &Arc<BackupManager>,
+        rpc_config: RpcConfig,
     ) -> Result<jsonrpsee::RpcModule<()>, anyhow::Error>;
 
     /// Creates GenesisConfig from genesis files.

--- a/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/runtime_rpc.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-rollup-blueprint/src/runtime_rpc.rs
@@ -1,3 +1,4 @@
+use citrea_common::RpcConfig;
 use sov_db::ledger_db::LedgerDB;
 use sov_modules_api::{Context, Spec};
 use sov_modules_stf_blueprint::Runtime as RuntimeTrait;
@@ -10,6 +11,7 @@ pub fn register_rpc<RT, C, Da>(
     ledger_db: &LedgerDB,
     _da_service: &Da,
     _sequencer: C::Address,
+    rpc_config: RpcConfig,
 ) -> Result<jsonrpsee::RpcModule<()>, anyhow::Error>
 where
     RT: RuntimeTrait<C, <Da as DaService>::Spec> + Send + Sync + 'static,
@@ -23,6 +25,7 @@ where
     {
         rpc_methods.merge(sov_ledger_rpc::server::create_rpc_module::<LedgerDB>(
             ledger_db.clone(),
+            rpc_config.into(),
         ))?;
     }
 

--- a/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
@@ -444,12 +444,6 @@ pub enum SoftConfirmationStatus {
 /// A LedgerRpcProvider provides a way to query the ledger for information about slots, batches, transactions, and events.
 #[cfg(feature = "native")]
 pub trait LedgerRpcProvider {
-    /// Get a list of soft confirmations by id. The IDs need not be ordered.
-    fn get_soft_confirmations(
-        &self,
-        batch_ids: &[SoftConfirmationIdentifier],
-    ) -> Result<Vec<Option<SoftConfirmationResponse>>, anyhow::Error>;
-
     /// Get soft confirmation
     fn get_soft_confirmation(
         &self,

--- a/guests/risc0/batch-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-evm"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-primitives"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "alloy-eips",
  "brotli",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-risc0-adapter"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "bincode",
  "borsh",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-stf"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "borsh",
  "citrea-evm",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "soft-confirmation-rule-enforcer"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "borsh",
  "serde",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "sov-accounts"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "borsh",
  "serde",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-api"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-core"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-macros"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-stf-blueprint"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "sov-rollup-interface"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "sov-state"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "alloy-rlp",
  "anyhow",

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.lock
@@ -611,7 +611,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "citrea-light-client-prover"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "borsh",
  "sov-modules-api",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-primitives"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "alloy-eips",
  "brotli",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "citrea-risc0-adapter"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "bincode",
  "borsh",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-api"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-core"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-stf-blueprint"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "sov-rollup-interface"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "sov-state"
-version = "0.6.0"
+version = "0.6.11"
 dependencies = [
  "alloy-rlp",
  "anyhow",


### PR DESCRIPTION
# Description

- Remove `MAX_BATCHES_PER_REQUEST` and `MAX_L2_BLOCK_PER_REQUEST` constants and make it configurable using existing `RpcConfig` `batch_requests_limit`
- Add batch validation at the RPC server layer
- Remove redundants `get_l2_blocks` and `setup_rpc` methods

## Linked Issues
- Fixes #2232