### PR TITLE
Simplify create_txn_env nonce handling

### DIFF
--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -702,11 +702,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .map_err(EthApiError::from)?
             .unwrap_or_default();
 
-        let nonce = if request.nonce.is_some() {
-            None
-        } else {
-            Some(account.nonce)
-        };
+        let nonce = request.nonce.unwrap_or(account.nonce);
         let chain_id = cfg_env.chain_id();
 
         let tx_env = create_txn_env(
@@ -932,11 +928,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .account_info(&request.from.unwrap_or_default(), working_set)
             .unwrap_or_default();
 
-        let nonce = if request.nonce.is_some() {
-            None
-        } else {
-            Some(account.nonce)
-        };
+        let nonce = request.nonce.unwrap_or(account.nonce);
         let chain_id = cfg_env.chain_id();
 
         // create tx env
@@ -1391,11 +1383,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         let mut evm_db = self.get_db(working_set);
 
-        let nonce = if request.nonce.is_some() {
-            None
-        } else {
-            Some(account.nonce)
-        };
+        let nonce = request.nonce.unwrap_or(account.nonce);
         let chain_id = cfg_env.chain_id();
 
         // create tx env

--- a/crates/evm/src/tests/tx_tests.rs
+++ b/crates/evm/src/tests/tx_tests.rs
@@ -85,6 +85,8 @@ fn tx_conversion() {
 fn prepare_call_env_conversion() {
     let from = Address::random();
     let to = Address::random();
+
+    let nonce = 1;
     let request = TransactionRequest {
         from: Some(from),
         to: Some(TxKind::Call(to)),
@@ -94,7 +96,7 @@ fn prepare_call_env_conversion() {
         gas: Some(200),
         value: Some(U256::from(300u64)),
         input: TransactionInput::default(),
-        nonce: Some(1u64),
+        nonce: Some(nonce),
         chain_id: Some(1u64),
         access_list: None,
         transaction_type: Some(2u8),
@@ -106,7 +108,7 @@ fn prepare_call_env_conversion() {
 
     let block_env = BlockEnv::default();
 
-    let tx_env = create_txn_env(&block_env, request, None, None, 1).unwrap();
+    let tx_env = create_txn_env(&block_env, request, None, nonce, 1).unwrap();
     let expected = TxEnv {
         tx_type: TxType::Eip1559 as u8,
         caller: from,
@@ -117,7 +119,7 @@ fn prepare_call_env_conversion() {
         value: U256::from(300u64),
         data: Default::default(),
         chain_id: Some(1u64),
-        nonce: 1u64,
+        nonce,
         access_list: Default::default(),
         blob_hashes: vec![],
         max_fee_per_blob_gas: 0,


### PR DESCRIPTION
# Description

- Pass down non-optional nonce to `create_txn_env`

## Linked Issues
- Fixes #2207 
