### PR TITLE
CLI: Clear fullnode pending proofs and commitments

### DIFF
--- a/bin/cli/src/commands/mod.rs
+++ b/bin/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) use backup::*;
 use citrea_storage_ops::pruning::types::StorageNodeType;
 use clap::ValueEnum;
+pub(crate) use pending::*;
 pub(crate) use prune::*;
 pub(crate) use rollback::*;
 use sov_db::schema::tables::{
@@ -9,6 +10,7 @@ use sov_db::schema::tables::{
 };
 
 mod backup;
+mod pending;
 mod prune;
 mod rollback;
 

--- a/bin/cli/src/commands/pending.rs
+++ b/bin/cli/src/commands/pending.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use sov_db::ledger_db::migrations::utils::drop_column_families;
+use sov_db::rocks_db_config::RocksdbConfig;
+use sov_db::schema::tables::{PendingProofs, PendingSequencerCommitments};
+use tracing::info;
+
+use crate::commands::{cfs_from_node_type, StorageNodeTypeArg};
+
+/// Clear pending commitments and proofs
+/// Use with caution as this can lead to a stuck node. Should be used alongside rollback
+/// TODO remove and properly index so that this can be rolled back by l1 block by mainnet
+pub(crate) async fn clear_pending_proofs_and_commitments(db_path: PathBuf) -> anyhow::Result<()> {
+    info!(
+        "Clearing pending commitments and proofs for DB at {}",
+        db_path.display(),
+    );
+
+    let column_families = cfs_from_node_type(StorageNodeTypeArg::FullNode);
+    drop_column_families(
+        &RocksdbConfig::new(&db_path, None, Some(column_families)),
+        vec![
+            PendingProofs::table_name().to_string(),
+            PendingSequencerCommitments::table_name().to_string(),
+        ],
+    )?;
+    Ok(())
+}

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -81,6 +81,12 @@ enum Commands {
         #[arg(long)]
         backup_id: u32,
     },
+    /// Clear pending commitments and proofs
+    ClearPending {
+        /// The path of the databases to clear
+        #[arg(long)]
+        db_path: PathBuf,
+    },
 }
 
 #[tokio::main]
@@ -123,6 +129,9 @@ async fn main() -> anyhow::Result<()> {
         } => {
             commands::restore_backup(node_kind.to_string(), db_path, backup_path, backup_id)
                 .await?;
+        }
+        Commands::ClearPending { db_path } => {
+            commands::clear_pending_proofs_and_commitments(db_path).await?
         }
     }
 


### PR DESCRIPTION
# Description

- Drop both `PendingSequencerCommitments` and `PendingProofs` column families that will be re-created on next fullnode startup