### PR TITLE
fix: missing one args for docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - RPC_MAX_SUBSCRIPTIONS_PER_CONNECTION=10
       - SEQUENCER_CLIENT_URL=https://rpc.testnet.citrea.xyz
       - INCLUDE_TX_BODY=false
+      - SCAN_L1_START_HEIGHT=45496
       - SYNC_BLOCKS_COUNT=10
       - RUST_LOG=info
       - JSON_LOGS=1


### PR DESCRIPTION
##  Bug Fix: Missing `SCAN_L1_START_HEIGHT` Caused Runtime Panic

### Description

Fixes an issue where the application panicked during startup due to a missing environment variable in the Docker Compose configuration.

### Root Cause

The `SCAN_L1_START_HEIGHT` environment variable was not defined in `docker-compose.yml`, which led to the following runtime error:

`thread 'main' panicked at 'Runner config is missing': /citrea/src/rollup/mod.rs:298`

### Fix

Added the missing environment variable in the Docker Compose file:

```yaml
- SCAN_L1_START_HEIGHT=45496
```

### Testing

- Confirmed locally that the application now starts successfully.
- Chain begins syncing without errors.

