### PR TITLE
Make state_machine module public to enable external access to light client proof output

### DIFF
--- a/crates/sovereign-sdk/rollup-interface/src/lib.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/lib.rs
@@ -18,7 +18,7 @@ mod network;
 mod node;
 /// Specs module
 pub mod spec;
-mod state_machine;
+pub mod state_machine;
 
 #[cfg(not(feature = "native"))]
 pub use std::rc::Rc as RefCount;


### PR DESCRIPTION
# Description

This change makes the `state_machine` module public within the `rollup-interface` crate.  
It allows external crates to access types such as `LightClientCircuitOutput`.