### PR TITLE
Mempool txs per sec metric fix

### DIFF
--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -7,7 +7,7 @@ use once_cell::sync::Lazy;
 pub struct SequencerMetrics {
     #[metric(describe = "How many transactions are currently in the mempool")]
     pub mempool_txs: Gauge,
-    #[metric(describe = "How many transactions are currently in the mempool")]
+    #[metric(describe = "An ever increasing transactions count into the mempool")]
     pub mempool_txs_inc: Counter,
     #[metric(describe = "The duration of dry running transactions")]
     pub dry_run_execution: Histogram,

--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -1,4 +1,4 @@
-use metrics::{Gauge, Histogram};
+use metrics::{Counter, Gauge, Histogram};
 use metrics_derive::Metrics;
 use once_cell::sync::Lazy;
 
@@ -7,6 +7,8 @@ use once_cell::sync::Lazy;
 pub struct SequencerMetrics {
     #[metric(describe = "How many transactions are currently in the mempool")]
     pub mempool_txs: Gauge,
+    #[metric(describe = "How many transactions are currently in the mempool")]
+    pub mempool_txs_inc: Counter,
     #[metric(describe = "The duration of dry running transactions")]
     pub dry_run_execution: Histogram,
     #[metric(describe = "The duration of executing block transactions")]

--- a/crates/sequencer/src/rpc.rs
+++ b/crates/sequencer/src/rpc.rs
@@ -126,6 +126,7 @@ impl<DB: SequencerLedgerOps + Send + Sync + 'static> SequencerRpcServer
             tracing::warn!("Failed to insert mempool tx into db: {:?}", e);
         } else {
             SEQUENCER_METRICS.mempool_txs.increment(1);
+            SEQUENCER_METRICS.mempool_txs_inc.increment(1);
         }
 
         Ok(hash)

--- a/resources/grafana/sequencer.dashboard.json
+++ b/resources/grafana/sequencer.dashboard.json
@@ -505,7 +505,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(sequencer_mempool_txs[$__rate_interval])",
+          "expr": "rate(sequencer_mempool_txs_inc[1s])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",


### PR DESCRIPTION
# Description

1. New metric added `mempool_txs_inc`
2. Use an ever increasing counter for mempool transactions so that we are able to calculate the rate of change properly.
3. Use 1s interval to calculate the rate of change. If `No data` is shown, then we don't have at least 2 data points to calculate the rate of change then we should change this to 2s.

## Linked Issues
- Fixes #1916 