### PR TITLE
Propagate coverage env to citrea-e2e

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -194,7 +194,6 @@ jobs:
   coverage:
     needs:
       - docker-setup
-      - build-test
     runs-on: ubicloud-standard-30
     if: github.event.pull_request.draft == false
     steps:
@@ -224,16 +223,8 @@ jobs:
           path: /tmp/docker
           key: ${{ runner.os }}-docker-${{ env.TEST_BITCOIN_DOCKER }}
       - name: Load Docker image
+        continue-on-error: true
         run: docker load < /tmp/docker/bitcoin.tar
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: citrea-test-build
-          path: target/debug
-      - name: Make citrea executable
-        run: chmod +x target/debug/citrea
-      - name: Make citrea-cli executable
-        run: chmod +x target/debug/citrea-cli
       - name: Run coverage
         run: make coverage-ci
         env:
@@ -242,6 +233,8 @@ jobs:
           RISC0_DEV_MODE: 1 # This is needed to generate mock proofs and verify them
           PARALLEL_PROOF_LIMIT: 1
           TEST_OUT_DIR: ${{ runner.temp }}/coverage
+          CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/llvm-cov-target/debug/citrea
+          CITREA_CLI_E2E_TEST_BINARY: ${{ github.workspace }}/target/llvm-cov-target/debug/citrea-cli
       - name: Upload e2e test dir
         if: always()
         uses: actions/upload-artifact@v4
@@ -396,6 +389,7 @@ jobs:
           path: /tmp/docker
           key: ${{ runner.os }}-docker-${{ env.TEST_BITCOIN_DOCKER }}
       - name: Load Docker image
+        continue-on-error: true
         run: docker load < /tmp/docker/bitcoin.tar
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # The release tag of https://github.com/ethereum/tests to use for EF tests
 EF_TESTS_URL := https://github.com/ethereum/tests/archive/refs/tags/v16.0.tar.gz
 EF_TESTS_DIR := crates/evm/ethereum-tests
-CITREA_E2E_TEST_BINARY := $(CURDIR)/target/debug/citrea
 PARALLEL_PROOF_LIMIT := 1
 TEST_FEATURES := --features testing
 BATCH_OUT_PATH := resources/guests/risc0/
@@ -54,13 +53,13 @@ test-legacy: ## Runs test suite with output from tests printed
 test-ci:
 	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo nextest run -j15 --locked --workspace --all-features --no-fail-fast $(filter-out $@,$(MAKECMDGOALS))
 
-coverage-ci:
+coverage-ci: $(EF_TESTS_DIR)
 	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo llvm-cov --locked --lcov --output-path lcov.info nextest -j10 --workspace --all-features
 
 test: build-test ## Runs test suite using next test
 	TEST_SKIP_GUEST_BUILD=1 $(MAKE) test-ci -- $(filter-out $@,$(MAKECMDGOALS))
 
-coverage: build-test coverage-ci ## Coverage in lcov format
+coverage: coverage-ci ## Coverage in lcov format
 
 coverage-html: ## Coverage in HTML format
 	cargo llvm-cov --locked --all-features --html nextest --workspace --all-features

--- a/bin/cli/tests/mod.rs
+++ b/bin/cli/tests/mod.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_placeholder() {
+        assert_eq!(40 + 2, 42);
+    }
+}


### PR DESCRIPTION
# Description

- Propagate coverage env to citrea-e2e with companion PR https://github.com/chainwayxyz/citrea-e2e/pull/96
- Remove build-test dependency. We need to use same binary shared between nextest and spawned via citrea-e2e so name mangling matches and we hit coverage. This has the additional benefits of reducing CI dependencies, start running coverage straight away and remove the need for additional build step.
- Add tests folder with placeholder to `citrea-cli` so it gets compiled by nextest alongside main `citrea` binary
- Remove setting `CITREA_E2E_TEST_BINARY` as this would override CI env and is handled by test framework `.set_citrea_path(get_citrea_path())`
