### PR TITLE
Fix empty partitions causing prover panic

### DIFF
--- a/crates/batch-prover/src/prover.rs
+++ b/crates/batch-prover/src/prover.rs
@@ -215,6 +215,10 @@ where
         info!("Got {} pending commitment(s)", commitments.len());
 
         let partitions = self.create_partitions(&mut commitments, mode)?;
+        if partitions.is_empty() {
+            debug!("No provable commitments found");
+            return Ok(vec![]);
+        }
 
         let mut proving_jobs = Vec::with_capacity(partitions.len());
         for partition in partitions {


### PR DESCRIPTION
# Description
When `create_partitions` return an empty vec (for example due to `filter_unsynced_commitments`), `watch_proving_jobs` was causing the panic:
```
2025-05-01T12:56:43.182052Z ERROR panic: thread 'tokio-runtime-worker' panicked at 'received empty jobs list': crates/batch-prover/src/prover.rs:499
```
Returning early on empty partitions vec to fix it.
