### PR TITLE
Groth16 light client proofs with host-side verification

### DIFF
--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -164,34 +164,24 @@ where
             self.da_service.extract_relevant_blobs_with_proof(&l1_block);
 
         let previous_l1_height = l1_height - 1;
-        let (assumption, light_client_proof_journal, l2_last_height, light_client_proof_output) =
-            match self
-                .ledger_db
-                .get_light_client_proof_data_by_l1_height(previous_l1_height)?
-            {
-                Some(data) => {
-                    let db_output = data.light_client_proof_output;
-                    let output = LightClientCircuitOutput::from(db_output);
-
-                    // TODO: instead of serializing the output
-                    // we should just store and push the serialized proof as outputted from the circuit
-                    // that way modifications are less error prone
-                    (
-                        Some(data.proof),
-                        Some(borsh::to_vec(&output)?),
-                        output.last_l2_height,
-                        Some(output),
-                    )
-                }
-                None => {
-                    // first time proving a light client proof
-                    tracing::warn!(
-                        "Creating initial light client proof on L1 block #{}",
-                        l1_height
-                    );
-                    (None, None, 0, None)
-                }
-            };
+        let (previous_lcp_proof, l2_last_height, previous_lcp_output) = match self
+            .ledger_db
+            .get_light_client_proof_data_by_l1_height(previous_l1_height)?
+        {
+            Some(data) => {
+                let db_output = data.light_client_proof_output;
+                let output = LightClientCircuitOutput::from(db_output);
+                (Some(data.proof), output.last_l2_height, Some(output))
+            }
+            None => {
+                // first time proving a light client proof
+                tracing::warn!(
+                    "Creating initial light client proof on L1 block #{}",
+                    l1_height
+                );
+                (None, 0, None)
+            }
+        };
 
         let storage = self.storage_manager.create_storage_for_next_l2_height();
 
@@ -201,7 +191,7 @@ where
             Default::default(),
             da_data,
             l1_block.header().clone(),
-            light_client_proof_output,
+            previous_lcp_output,
             self.network.get_l2_genesis_root(),
             self.network.initial_batch_proof_method_ids(),
             &self.network.batch_prover_da_public_key(),
@@ -227,19 +217,11 @@ where
             completeness_proof,
             da_block_header: l1_block.header().clone(),
             light_client_proof_method_id: light_client_proof_code_commitment.clone().into(),
-            previous_light_client_proof_journal: light_client_proof_journal,
+            previous_light_client_proof: previous_lcp_proof,
             witness: result.witness,
         };
 
-        let proof = self
-            .prove(
-                light_client_elf,
-                circuit_input,
-                // light client proofs are succinct, we can make use of assumption APIs
-                // if assumption is None, pass empty vector
-                assumption.map(|a| vec![a]).unwrap_or_default(),
-            )
-            .await?;
+        let proof = self.prove(light_client_elf, circuit_input, vec![]).await?;
 
         let circuit_output = Vm::extract_output::<LightClientCircuitOutput>(&proof)
             .expect("Should deserialize valid proof");

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -199,7 +199,7 @@ where
         let result = self.circuit.run_l1_block(
             storage,
             Default::default(),
-            da_data.clone(),
+            da_data,
             l1_block.header().clone(),
             light_client_proof_output,
             self.network.get_l2_genesis_root(),

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -277,13 +277,11 @@ where
         circuit_input: LightClientCircuitInput<<Da as DaService>::Spec>,
         assumptions: Vec<Vec<u8>>,
     ) -> Result<Proof, anyhow::Error> {
-        let prover_service = self.prover_service.as_ref();
         let data = ProofData {
             input: borsh::to_vec(&circuit_input)?,
             assumptions,
             elf: light_client_elf,
         };
-
-        prover_service.prove(data, ReceiptType::Succinct).await
+        self.prover_service.prove(data, ReceiptType::Groth16).await
     }
 }

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -169,8 +169,7 @@ where
             .get_light_client_proof_data_by_l1_height(previous_l1_height)?
         {
             Some(data) => {
-                let db_output = data.light_client_proof_output;
-                let output = LightClientCircuitOutput::from(db_output);
+                let output = LightClientCircuitOutput::from(data.light_client_proof_output);
                 (Some(data.proof), output.last_l2_height, Some(output))
             }
             None => {

--- a/crates/light-client-prover/src/tests/mod.rs
+++ b/crates/light-client-prover/src/tests/mod.rs
@@ -892,7 +892,7 @@ fn test_unverifiable_batch_proofs() {
 }
 
 #[test]
-#[should_panic = "Assumption proof verification failed!"]
+#[should_panic = "Previous light client proof is invalid"]
 fn test_unverifiable_prev_light_client_proof() {
     let db_dir = tempdir().unwrap();
     let native_circuit_runner = NativeCircuitRunner::new(db_dir.path().to_path_buf());

--- a/crates/light-client-prover/src/tests/mod.rs
+++ b/crates/light-client-prover/src/tests/mod.rs
@@ -72,7 +72,7 @@ fn test_light_client_circuit_valid_da_valid_data() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1.clone(),
             inclusion_proof: [1u8; 32],
@@ -136,7 +136,7 @@ fn test_light_client_circuit_valid_da_valid_data() {
 
     let input_2 = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(mock_output_1_serialized),
+            previous_light_client_proof: Some(mock_output_1_serialized),
             da_block_header: block_header_2,
             light_client_proof_method_id,
             inclusion_proof: [1u8; 32],
@@ -221,7 +221,7 @@ fn test_light_client_circuit_commitment_chaining() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1.clone(),
             inclusion_proof: [1u8; 32],
@@ -307,7 +307,7 @@ fn test_previous_commitment_not_set_should_not_transition() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1,
             inclusion_proof: [1u8; 32],
@@ -371,7 +371,7 @@ fn test_batch_proof_with_missing_commitment_not_set_should_not_transition() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1,
             inclusion_proof: [1u8; 32],
@@ -448,7 +448,7 @@ fn test_wrong_order_da_blocks_should_still_work() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1,
             inclusion_proof: [1u8; 32],
@@ -527,7 +527,7 @@ fn create_unchainable_outputs_then_chain_them_on_next_block() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1.clone(),
             inclusion_proof: [1u8; 32],
@@ -612,7 +612,7 @@ fn create_unchainable_outputs_then_chain_them_on_next_block() {
 
     let input_2 = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(mock_output_1_ser),
+            previous_light_client_proof: Some(mock_output_1_ser),
             light_client_proof_method_id,
             da_block_header: block_header_2,
             inclusion_proof: [1u8; 32],
@@ -690,7 +690,7 @@ fn test_header_chain_proof_height_and_hash() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1.clone(),
             inclusion_proof: [1u8; 32],
@@ -755,7 +755,7 @@ fn test_header_chain_proof_height_and_hash() {
 
     let input_2 = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(prev_lcp_out),
+            previous_light_client_proof: Some(prev_lcp_out),
             da_block_header: block_header_2,
             light_client_proof_method_id,
             inclusion_proof: [1u8; 32],
@@ -844,7 +844,7 @@ fn test_unverifiable_batch_proofs() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1,
             inclusion_proof: [1u8; 32],
@@ -936,7 +936,7 @@ fn test_unverifiable_prev_light_client_proof() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1,
             inclusion_proof: [1u8; 32],
@@ -988,7 +988,7 @@ fn test_unverifiable_prev_light_client_proof() {
 
     let input_2 = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(prev_lcp_out),
+            previous_light_client_proof: Some(prev_lcp_out),
             da_block_header: block_header_2,
             light_client_proof_method_id,
             inclusion_proof: [1u8; 32],
@@ -1050,7 +1050,7 @@ fn test_new_method_id_txs() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1,
             inclusion_proof: [1u8; 32],
@@ -1097,7 +1097,7 @@ fn test_new_method_id_txs() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(create_prev_lcp_serialized(output_1, true)),
+            previous_light_client_proof: Some(create_prev_lcp_serialized(output_1, true)),
             light_client_proof_method_id,
             da_block_header: block_header_2,
             inclusion_proof: [1u8; 32],
@@ -1142,7 +1142,7 @@ fn test_new_method_id_txs() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(create_prev_lcp_serialized(output_2, true)),
+            previous_light_client_proof: Some(create_prev_lcp_serialized(output_2, true)),
             light_client_proof_method_id,
             da_block_header: block_header_3,
             inclusion_proof: [1u8; 32],
@@ -1229,7 +1229,7 @@ fn test_unverifiable_batch_proof_is_ignored() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1,
             inclusion_proof: [1u8; 32],
@@ -1358,7 +1358,7 @@ fn test_light_client_circuit_verify_chunks() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1,
             inclusion_proof: [1u8; 32],
@@ -1490,7 +1490,7 @@ fn test_missing_chunk() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1,
             // Blob2 is not present
@@ -1584,7 +1584,7 @@ fn test_malicious_aggregate_should_not_work() {
     // First block has the two chunks
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1.clone(),
             inclusion_proof: [1u8; 32],
@@ -1636,7 +1636,7 @@ fn test_malicious_aggregate_should_not_work() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(create_prev_lcp_serialized(output, true)),
+            previous_light_client_proof: Some(create_prev_lcp_serialized(output, true)),
             light_client_proof_method_id,
             da_block_header: block_header_2,
             inclusion_proof: [1u8; 32],
@@ -1709,7 +1709,7 @@ fn test_malicious_aggregate_should_not_work() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(create_prev_lcp_serialized(output, true)),
+            previous_light_client_proof: Some(create_prev_lcp_serialized(output, true)),
             light_client_proof_method_id,
             da_block_header: block_header_3,
             inclusion_proof: [1u8; 32],
@@ -1795,7 +1795,7 @@ fn test_unknown_block_hash_in_batch_proof_not_verified() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1.clone(),
             inclusion_proof: [1u8; 32],
@@ -1867,7 +1867,7 @@ fn test_unknown_block_hash_in_batch_proof_not_verified() {
 
     let input_2 = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(mock_output_1_serialized),
+            previous_light_client_proof: Some(mock_output_1_serialized),
             da_block_header: block_header_2,
             light_client_proof_method_id,
             inclusion_proof: [1u8; 32],
@@ -1936,7 +1936,7 @@ fn test_light_client_circuit_verify_sequencer_commitment() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1.clone(),
             inclusion_proof: [1u8; 32],
@@ -1986,7 +1986,7 @@ fn test_light_client_circuit_verify_sequencer_commitment() {
 
     let input2 = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(mock_output_1_serialized),
+            previous_light_client_proof: Some(mock_output_1_serialized),
             light_client_proof_method_id,
             da_block_header: block_header_2,
             inclusion_proof: [1u8; 32],
@@ -2062,7 +2062,7 @@ fn wrong_pubkey_sequencer_commitment_should_not_work() {
 
     let input = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: None,
+            previous_light_client_proof: None,
             light_client_proof_method_id,
             da_block_header: block_header_1.clone(),
             inclusion_proof: [1u8; 32],
@@ -2112,7 +2112,7 @@ fn wrong_pubkey_sequencer_commitment_should_not_work() {
 
     let input2: LightClientCircuitInput<MockDaSpec> = native_circuit_runner.run(
         LightClientCircuitInput {
-            previous_light_client_proof_journal: Some(mock_output_1_serialized),
+            previous_light_client_proof: Some(mock_output_1_serialized),
             light_client_proof_method_id,
             da_block_header: block_header_2,
             inclusion_proof: [1u8; 32],

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -169,10 +169,17 @@ pub(crate) fn create_prev_lcp_serialized(
     is_valid: bool,
 ) -> Vec<u8> {
     let serialized = borsh::to_vec(&output).expect("should serialize");
-    match is_valid {
+    let mock_journal = match is_valid {
         true => borsh::to_vec(&MockJournal::Verifiable(serialized)).unwrap(),
         false => borsh::to_vec(&MockJournal::Unverifiable(serialized)).unwrap(),
-    }
+    };
+    let mock_proof = MockProof {
+        program_id: output.light_client_proof_method_id.into(),
+        is_valid,
+        log: mock_journal,
+    };
+    let proof = mock_proof.encode_to_vec();
+    proof
 }
 
 pub(crate) fn create_new_method_id_tx(
@@ -272,7 +279,10 @@ impl NativeCircuitRunner {
         let prev_lcp_output = input
             .previous_light_client_proof
             .clone()
-            .map(|j| MockZkvm::deserialize_output(&j).unwrap());
+            .map(|proof| {
+                let journal = MockZkvm::extract_raw_output(&proof).unwrap();
+                MockZkvm::deserialize_output(&journal).unwrap()
+            });
 
         let da_verifier = MockDaVerifier {};
 

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -270,7 +270,7 @@ impl NativeCircuitRunner {
             .create_storage_for_next_l2_height();
 
         let prev_lcp_output = input
-            .previous_light_client_proof_journal
+            .previous_light_client_proof
             .clone()
             .map(|j| MockZkvm::deserialize_output(&j).unwrap());
 

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -178,8 +178,8 @@ pub(crate) fn create_prev_lcp_serialized(
         is_valid,
         log: mock_journal,
     };
-    let proof = mock_proof.encode_to_vec();
-    proof
+
+    mock_proof.encode_to_vec()
 }
 
 pub(crate) fn create_new_method_id_tx(
@@ -276,13 +276,10 @@ impl NativeCircuitRunner {
             .prover_storage_manager
             .create_storage_for_next_l2_height();
 
-        let prev_lcp_output = input
-            .previous_light_client_proof
-            .clone()
-            .map(|proof| {
-                let journal = MockZkvm::extract_raw_output(&proof).unwrap();
-                MockZkvm::deserialize_output(&journal).unwrap()
-            });
+        let prev_lcp_output = input.previous_light_client_proof.clone().map(|proof| {
+            let journal = MockZkvm::extract_raw_output(&proof).unwrap();
+            MockZkvm::deserialize_output(&journal).unwrap()
+        });
 
         let da_verifier = MockDaVerifier {};
 

--- a/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
+++ b/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
@@ -163,7 +163,7 @@ impl sov_rollup_interface::zk::Zkvm for MockZkvm {
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         Self::verify(serialized_proof, code_commitment)?;
-        Ok(T::deserialize(&mut &serialized_proof[33..])?)
+        Ok(Self::deserialize_output(&serialized_proof[37..])?)
     }
 }
 
@@ -277,7 +277,7 @@ impl sov_rollup_interface::zk::Zkvm for MockZkGuest {
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         Self::verify(serialized_proof, code_commitment)?;
-        Ok(T::deserialize(&mut &serialized_proof[33..])?)
+        Ok(Self::deserialize_output(&serialized_proof[37..])?)
     }
 }
 

--- a/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
+++ b/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
@@ -163,7 +163,7 @@ impl sov_rollup_interface::zk::Zkvm for MockZkvm {
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         Self::verify(serialized_proof, code_commitment)?;
-        Ok(Self::deserialize_output(&serialized_proof[37..])?)
+        Self::deserialize_output(&serialized_proof[37..])
     }
 }
 
@@ -277,7 +277,7 @@ impl sov_rollup_interface::zk::Zkvm for MockZkGuest {
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         Self::verify(serialized_proof, code_commitment)?;
-        Ok(Self::deserialize_output(&serialized_proof[37..])?)
+        Self::deserialize_output(&serialized_proof[37..])
     }
 }
 

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/light_client_proof/input.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/light_client_proof/input.rs
@@ -14,9 +14,9 @@ pub struct LightClientCircuitInput<Da: DaSpec> {
     pub da_block_header: Da::BlockHeader,
     /// Light client proof method id
     pub light_client_proof_method_id: [u32; 8],
-    /// Light client proof output
+    /// Previous light client proof
     /// Optional because the first light client proof doesn't have a previous proof
-    pub previous_light_client_proof_journal: Option<Vec<u8>>,
+    pub previous_light_client_proof: Option<Vec<u8>>,
     /// Witness for the light client state
     pub witness: Witness,
 }


### PR DESCRIPTION
# Description

Switched to groth16 proofs for lcp and using host side verification api for verifying previous light client proof. 

Host-side verification seems to add about 23M total cycles per proof.

## Linked Issues
- Fixes #2308 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
