### PR TITLE
Clean up build requirements for e2e tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -248,7 +248,7 @@ jobs:
 
   uniswap:
     runs-on: ubicloud-standard-2
-    needs: build-
+    needs: build
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
@@ -290,7 +290,7 @@ jobs:
 
   web3_py:
     runs-on: ubicloud-standard-2
-    needs: build-
+    needs: build
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
@@ -319,7 +319,7 @@ jobs:
 
   ethers_js:
     runs-on: ubicloud-standard-2
-    needs: build-
+    needs: build
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,8 +64,6 @@ env:
   RUSTFLAGS: -D warnings
   FOUNDRY_PROFILE: ci
   TEST_BITCOIN_DOCKER: "bitcoin/bitcoin:29.0"
-  CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
-  CITREA_CLI_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea-cli
 
 # Automatically cancels a job if a new commit if pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>
@@ -76,8 +74,8 @@ concurrency:
   cancel-in-progress: ${{ (github.ref != 'refs/heads/nightly') && (github.ref != 'refs/heads/devnet-freeze') && (github.ref != 'refs/heads/main') }}
 
 jobs:
-  build-test:
-    name: build-tests
+  build:
+    name: build
     runs-on: ubicloud-standard-30
     timeout-minutes: 60
     if: github.event.pull_request.draft == false
@@ -103,11 +101,11 @@ jobs:
           key: "eth-tests-1c23e3c"
           path: crates/evm/ethereum-tests
       - name: Build citrea
-        run: make build-test
+        run: make build
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: citrea-test-build
+          name: citrea-build
           path: |
             target/debug/citrea
             target/debug/citrea-cli
@@ -250,7 +248,7 @@ jobs:
 
   uniswap:
     runs-on: ubicloud-standard-2
-    needs: build-test
+    needs: build-
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
@@ -260,7 +258,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: citrea-test-build
+          name: citrea-build
           path: target/debug
       - name: Make citrea executable
         run: chmod +x target/debug/citrea
@@ -292,7 +290,7 @@ jobs:
 
   web3_py:
     runs-on: ubicloud-standard-2
-    needs: build-test
+    needs: build-
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
@@ -303,7 +301,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: citrea-test-build
+          name: citrea-build
           path: target/debug
       - name: Make citrea executable
         run: chmod +x target/debug/citrea
@@ -321,7 +319,7 @@ jobs:
 
   ethers_js:
     runs-on: ubicloud-standard-2
-    needs: build-test
+    needs: build-
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
@@ -331,7 +329,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: citrea-test-build
+          name: citrea-build
           path: target/debug
       - name: Make citrea executable
         run: chmod +x target/debug/citrea
@@ -398,6 +396,8 @@ jobs:
           TEST_BITCOIN_DOCKER: 1
           PARALLEL_PROOF_LIMIT: 1
           TEST_OUT_DIR: ${{ runner.temp }}/test
+          CITREA_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea
+          CITREA_CLI_E2E_TEST_BINARY: ${{ github.workspace }}/target/debug/citrea-cli
       - name: Upload e2e test dir
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -224,7 +224,7 @@ jobs:
         continue-on-error: true
         run: docker load < /tmp/docker/bitcoin.tar
       - name: Run coverage
-        run: make coverage-ci
+        run: make coverage
         env:
           RUST_BACKTRACE: 1
           TEST_BITCOIN_DOCKER: 1
@@ -389,7 +389,7 @@ jobs:
         continue-on-error: true
         run: docker load < /tmp/docker/bitcoin.tar
       - name: Run nextest
-        run: make test-ci
+        run: make test
         env:
           RUST_BACKTRACE: 1
           RISC0_DEV_MODE: 1 # This is needed to generate mock proofs and verify them

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -352,7 +352,6 @@ jobs:
   nextest:
     needs:
       - docker-setup
-      - build-test
     name: nextest
     runs-on: ubicloud-standard-30
     timeout-minutes: 60
@@ -391,15 +390,6 @@ jobs:
       - name: Load Docker image
         continue-on-error: true
         run: docker load < /tmp/docker/bitcoin.tar
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: citrea-test-build
-          path: target/debug
-      - name: Make citrea executable
-        run: chmod +x target/debug/citrea
-      - name: Make citrea-cli executable
-        run: chmod +x target/debug/citrea-cli
       - name: Run nextest
         run: make test-ci
         env:
@@ -418,7 +408,6 @@ jobs:
   system-contracts:
     strategy:
       fail-fast: true
-
     name: Foundry project
     runs-on: ubicloud-standard-2
     if: github.event.pull_request.draft == false
@@ -447,7 +436,6 @@ jobs:
   check_genesis_files:
     strategy:
       fail-fast: true
-
     name: Check Genesis Files
     runs-on: ubicloud-standard-2
     if: github.event.pull_request.draft == false

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build: ## Build the project
 	@cargo build
 
 .PHONY: build-test
-build-test: $(EF_TESTS_DIR) ## Build the project
+build-test: ## Build the project
 	@cargo build --locked $(TEST_FEATURES)
 
 build-reproducible: build-sp1 ## Build the project in release mode with reproducible guest builds
@@ -56,8 +56,8 @@ test-ci:
 coverage-ci: $(EF_TESTS_DIR)
 	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo llvm-cov --locked --lcov --output-path lcov.info nextest -j10 --workspace --all-features
 
-test: build-test ## Runs test suite using next test
-	TEST_SKIP_GUEST_BUILD=1 $(MAKE) test-ci -- $(filter-out $@,$(MAKECMDGOALS))
+test: $(EF_TESTS_DIR) ## Runs test suite using next test
+	$(MAKE) test-ci -- $(filter-out $@,$(MAKECMDGOALS))
 
 coverage: coverage-ci ## Coverage in lcov format
 

--- a/Makefile
+++ b/Makefile
@@ -46,16 +46,11 @@ clean-all: clean clean-node clean-txs
 test-legacy: ## Runs test suite with output from tests printed
 	@cargo test -- --nocapture -Zunstable-options --report-time
 
-test-ci:
+test: $(EF_TESTS_DIR) ## Runs test suite using nextest
 	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo nextest run -j15 --locked --workspace --all-features --no-fail-fast $(filter-out $@,$(MAKECMDGOALS))
 
-coverage-ci: $(EF_TESTS_DIR)
+coverage: $(EF_TESTS_DIR) ## Coverage in lcov format
 	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo llvm-cov --locked --lcov --output-path lcov.info nextest -j10 --workspace --all-features
-
-test: $(EF_TESTS_DIR) ## Runs test suite using next test
-	$(MAKE) test-ci -- $(filter-out $@,$(MAKECMDGOALS))
-
-coverage: coverage-ci ## Coverage in lcov format
 
 coverage-html: ## Coverage in HTML format
 	cargo llvm-cov --locked --all-features --html nextest --workspace --all-features

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,11 @@ test: $(EF_TESTS_DIR) ## Runs test suite using nextest
 	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo nextest run -j15 --locked --workspace --all-features --no-fail-fast $(filter-out $@,$(MAKECMDGOALS))
 
 coverage: $(EF_TESTS_DIR) ## Coverage in lcov format
-	RISC0_DEV_MODE=1 PARALLEL_PROOF_LIMIT=1 cargo llvm-cov --locked --lcov --output-path lcov.info nextest -j10 --workspace --all-features
+	CITREA_CLI_E2E_TEST_BINARY=$(CURDIR)/target/llvm-cov-target/debug/citrea-cli \
+	CITREA_E2E_TEST_BINARY=$(CURDIR)/target/llvm-cov-target/debug/citrea \
+	RISC0_DEV_MODE=1 \
+	PARALLEL_PROOF_LIMIT=1 \
+	cargo llvm-cov --locked --lcov --output-path lcov.info nextest -j10 --workspace --all-features
 
 coverage-html: ## Coverage in HTML format
 	cargo llvm-cov --locked --all-features --html nextest --workspace --all-features

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,6 @@ build-sp1:
 build: ## Build the project
 	@cargo build
 
-.PHONY: build-test
-build-test: ## Build the project
-	@cargo build --locked $(TEST_FEATURES)
-
 build-reproducible: build-sp1 ## Build the project in release mode with reproducible guest builds
 	REPR_GUEST_BUILD=1 cargo build --release --locked
 


### PR DESCRIPTION
# Description

- Follow up of https://github.com/chainwayxyz/citrea/pull/2302
- Remove the need for `build-test` altogether. Use binary outputted by `nextest` and `coverage` and pass its path down to `citrea-e2e`
- Remove the dependency on `build` job for `coverage` and `nextest` CI jobs
- Remove local duplicate compilation on `make test` 
- Remove `test-ci` and `coverage-ci` makefile targets since they were in place to bypass this redundant compilation and are not needed anymore. Simply restored to `test` and `coverage`.