### PR TITLE
Add --all-features to make lint-fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ lint:  ## cargo check and clippy. Skip clippy on guest code since it's not suppo
 
 lint-fix:  ## dprint fmt, cargo fmt, fix and clippy. Skip clippy on guest code since it's not supported by risc0
 	dprint fmt
-	cargo fix --allow-dirty
-	SKIP_GUEST_BUILD=1 cargo clippy --fix --allow-dirty
+	cargo fix --allow-dirty --all-features
+	SKIP_GUEST_BUILD=1 cargo clippy --fix --allow-dirty --all-features
 	cargo +nightly fmt --all
 
 check-features: ## Checks that project compiles with all combinations of features.


### PR DESCRIPTION
# Description

Latest nightly `make lint-fix` cmd fails due to missing `--testing` feature. Fixes it.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
