### PR TITLE
Test: Undecompressable data on DA

### DIFF
--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -6,6 +6,8 @@ use alloy_primitives::{U32, U64};
 use async_trait::async_trait;
 use bitcoin::hashes::Hash;
 use bitcoin_da::helpers::parsers::{parse_relevant_transaction, ParsedTransaction};
+use bitcoin_da::spec::RollupParams;
+use bitcoin_da::verifier::BitcoinVerifier;
 use bitcoincore_rpc::RpcApi;
 use citrea_batch_prover::rpc::BatchProverRpcClient;
 use citrea_batch_prover::PartitionMode;
@@ -24,10 +26,14 @@ use citrea_primitives::REVEAL_TX_PREFIX;
 use rand::{thread_rng, Rng};
 use reth_tasks::TaskManager;
 use risc0_zkvm::{FakeReceipt, InnerReceipt, MaybePruned, ReceiptClaim};
+use sov_modules_api::BlobReaderTrait;
+use sov_rollup_interface::da::DaVerifier;
 use sov_rollup_interface::da::{BatchProofMethodId, DaTxRequest, SequencerCommitment};
 use sov_rollup_interface::rpc::BatchProofMethodIdRpcResponse;
+use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
 use sov_rollup_interface::zk::batch_proof::output::{BatchProofCircuitOutput, CumulativeStateDiff};
+use sov_rollup_interface::Network;
 
 use super::batch_prover_test::wait_for_zkproofs;
 use super::get_citrea_path;
@@ -2820,7 +2826,9 @@ pub fn create_serialized_fake_receipt_batch_proof(
     bincode::serialize(&receipt).unwrap()
 }
 
-struct UndecompressableBlobTest;
+struct UndecompressableBlobTest {
+    task_manager: TaskManager,
+}
 
 #[async_trait]
 impl TestCase for UndecompressableBlobTest {
@@ -2849,6 +2857,12 @@ impl TestCase for UndecompressableBlobTest {
             extra_args: vec!["-fallbackfee=0.00001"],
             ..Default::default()
         }
+    }
+
+    async fn cleanup(self) -> Result<()> {
+        self.task_manager
+            .graceful_shutdown_with_timeout(Duration::from_secs(1));
+        Ok(())
     }
 
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
@@ -2885,9 +2899,8 @@ impl TestCase for UndecompressableBlobTest {
         da.generate(DEFAULT_FINALITY_DEPTH).await?;
         let finalized_height = da.get_finalized_height(None).await?;
 
-        let block = da
-            .get_block(&da.get_block_hash(finalized_height).await?)
-            .await?;
+        let block_hash = da.get_block_hash(finalized_height).await?;
+        let block = da.get_block(&block_hash).await?;
 
         let txs: Vec<_> = block
             .txdata
@@ -2903,16 +2916,47 @@ impl TestCase for UndecompressableBlobTest {
             .wait_for_l1_height(finalized_height, None)
             .await?;
 
+        let prover_da_service = spawn_bitcoin_da_service(
+            self.task_manager.executor().clone(),
+            &da.config,
+            Self::test_config().dir,
+            DaServiceKeyKind::BatchProver,
+        )
+        .await;
+        let block = prover_da_service
+            .get_block_by_hash(block_hash.into())
+            .await
+            .unwrap();
+
+        let (mut txs, inclusion_proof, completeness_proof) =
+            prover_da_service.extract_relevant_blobs_with_proof(&block);
+
+        txs.iter_mut().for_each(|t| {
+            t.full_data();
+        });
+
+        let verifier = BitcoinVerifier::new(RollupParams {
+            reveal_tx_prefix: REVEAL_TX_PREFIX.to_vec(),
+            network: Network::Nightly,
+        });
+
+        assert_eq!(
+            verifier.verify_transactions(&block.header, inclusion_proof, completeness_proof,),
+            Ok(txs),
+        );
+
         Ok(())
     }
 }
 
 #[tokio::test]
 async fn test_undecompressable_blob() -> Result<()> {
-    TestCaseRunner::new(UndecompressableBlobTest)
-        .set_citrea_path(get_citrea_path())
-        .run()
-        .await
+    TestCaseRunner::new(UndecompressableBlobTest {
+        task_manager: TaskManager::current(),
+    })
+    .set_citrea_path(get_citrea_path())
+    .run()
+    .await
 }
 
 fn verify_is_non_decompressable(tx: &bitcoin::Transaction) -> bool {

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -1,12 +1,13 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
 use alloy_primitives::{U32, U64};
 use async_trait::async_trait;
 use bitcoin::hashes::Hash;
+use bitcoin::Txid;
 use bitcoin_da::helpers::parsers::{parse_relevant_transaction, ParsedTransaction};
-use bitcoin_da::spec::RollupParams;
+use bitcoin_da::spec::{BitcoinSpec, RollupParams};
 use bitcoin_da::verifier::BitcoinVerifier;
 use bitcoincore_rpc::{Client, RpcApi};
 use citrea_batch_prover::rpc::BatchProverRpcClient;
@@ -26,8 +27,10 @@ use citrea_primitives::REVEAL_TX_PREFIX;
 use rand::{thread_rng, Rng};
 use reth_tasks::TaskManager;
 use risc0_zkvm::{FakeReceipt, InnerReceipt, MaybePruned, ReceiptClaim};
-use sov_modules_api::BlobReaderTrait;
-use sov_rollup_interface::da::{BatchProofMethodId, DaTxRequest, DaVerifier, SequencerCommitment};
+use sov_modules_api::{BlobReaderTrait, DaSpec};
+use sov_rollup_interface::da::{
+    BatchProofMethodId, DaTxRequest, DaVerifier, DataOnDa, SequencerCommitment,
+};
 use sov_rollup_interface::rpc::BatchProofMethodIdRpcResponse;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
@@ -2828,6 +2831,185 @@ struct UndecompressableBlobTest {
     task_manager: TaskManager,
 }
 
+impl UndecompressableBlobTest {
+    fn verify_complete_is_non_decompressable(tx: &bitcoin::Transaction) -> bool {
+        if let Ok(ParsedTransaction::Complete(complete)) = parse_relevant_transaction(tx) {
+            decompress_blob(&complete.body).is_err()
+        } else {
+            false
+        }
+    }
+
+    fn verify_chunked_is_non_decompressable(block: &bitcoin::Block) -> bool {
+        let mut complete_proof = Vec::new();
+
+        for tx in &block.txdata {
+            if let Ok(ParsedTransaction::Aggregate(aggregate)) = parse_relevant_transaction(tx) {
+                complete_proof.extend_from_slice(&aggregate.body);
+            }
+        }
+
+        BitcoinSpec::decompress_chunks(&complete_proof).is_err()
+    }
+
+    async fn send_complete_tx(client: &Client) -> anyhow::Result<(Txid, Txid)> {
+        use std::str::FromStr;
+
+        use bitcoin::secp256k1::SecretKey;
+        use bitcoin_da::helpers::builders::body_builders::{create_inscription_type_0, DaTxs};
+
+        let da_private_key = SecretKey::from_str(PROVER_DA_PUBLIC_KEY).unwrap();
+        let change_address = client.get_new_address(None, None).await?.assume_checked();
+        let utxos = client
+            .list_unspent(None, None, None, None, None)
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+
+        let body = vec![1u8; 64];
+        let DaTxs::Complete { commit, reveal } = create_inscription_type_0(
+            body,
+            &da_private_key,
+            None,
+            utxos,
+            change_address,
+            1,
+            1,
+            bitcoin::Network::Regtest,
+            REVEAL_TX_PREFIX,
+        )?
+        else {
+            panic!("Unexpected result type")
+        };
+
+        let signed_raw_commit_tx = client
+            .sign_raw_transaction_with_wallet(&commit, None, None)
+            .await?;
+
+        Ok((
+            client
+                .send_raw_transaction(&signed_raw_commit_tx.hex)
+                .await?,
+            client
+                .send_raw_transaction(&bitcoin::consensus::encode::serialize(&reveal.tx))
+                .await?,
+        ))
+    }
+
+    async fn send_chunked_tx(client: &Client) -> anyhow::Result<Vec<Txid>> {
+        use std::str::FromStr;
+
+        use bitcoin::consensus::encode;
+        use bitcoin::secp256k1::SecretKey;
+        use bitcoin_da::helpers::builders::body_builders::{create_inscription_type_1, DaTxs};
+        use bitcoincore_rpc::json::SignRawTransactionInput;
+
+        let da_private_key = SecretKey::from_str(PROVER_DA_PUBLIC_KEY).unwrap();
+        let change_address = client.get_new_address(None, None).await?.assume_checked();
+        let utxos = client
+            .list_unspent(None, None, None, None, None)
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+
+        let mut chunks = vec![];
+        for _ in 0..2 {
+            let data = DataOnDa::Chunk(vec![1; 64]);
+            let blob = borsh::to_vec(&data).unwrap();
+            chunks.push(blob)
+        }
+
+        let DaTxs::Chunked {
+            commit_chunks,
+            reveal_chunks,
+            commit,
+            reveal,
+        } = create_inscription_type_1(
+            chunks,
+            &da_private_key,
+            None,
+            utxos,
+            change_address,
+            2,
+            2,
+            bitcoin::Network::Regtest,
+            REVEAL_TX_PREFIX,
+        )?
+        else {
+            panic!("Wrong DaTxs kind");
+        };
+
+        let mut raw_txs = Vec::new();
+
+        let all_tx_map = commit_chunks
+            .iter()
+            .chain(reveal_chunks.iter())
+            .chain([&commit, &reveal.tx].into_iter())
+            .map(|tx| (tx.compute_txid(), tx.clone()))
+            .collect::<HashMap<_, _>>();
+
+        for (commit, reveal) in commit_chunks.into_iter().zip(reveal_chunks) {
+            let mut inputs = vec![];
+
+            for input in commit.input.iter() {
+                if let Some(entry) = all_tx_map.get(&input.previous_output.txid) {
+                    inputs.push(SignRawTransactionInput {
+                        txid: input.previous_output.txid,
+                        vout: input.previous_output.vout,
+                        script_pub_key: entry.output[input.previous_output.vout as usize]
+                            .script_pubkey
+                            .clone(),
+                        redeem_script: None,
+                        amount: Some(entry.output[input.previous_output.vout as usize].value),
+                    });
+                }
+            }
+
+            let signed_raw_commit_tx = client
+                .sign_raw_transaction_with_wallet(&commit, Some(&inputs), None)
+                .await?;
+
+            raw_txs.push(signed_raw_commit_tx.hex);
+
+            let serialized_reveal_tx = encode::serialize(&reveal);
+            raw_txs.push(serialized_reveal_tx);
+        }
+
+        let mut inputs = vec![];
+        for input in commit.input.iter() {
+            if let Some(entry) = all_tx_map.get(&input.previous_output.txid) {
+                inputs.push(SignRawTransactionInput {
+                    txid: input.previous_output.txid,
+                    vout: input.previous_output.vout,
+                    script_pub_key: entry.output[input.previous_output.vout as usize]
+                        .script_pubkey
+                        .clone(),
+                    redeem_script: None,
+                    amount: Some(entry.output[input.previous_output.vout as usize].value),
+                });
+            }
+        }
+        let signed_raw_commit_tx = client
+            .sign_raw_transaction_with_wallet(&commit, Some(&inputs), None)
+            .await?;
+
+        raw_txs.push(signed_raw_commit_tx.hex);
+
+        let serialized_reveal_tx = encode::serialize(&reveal.tx);
+        raw_txs.push(serialized_reveal_tx);
+
+        let mut txids = Vec::new();
+        for raw_tx in raw_txs {
+            let txid = client.send_raw_transaction(&raw_tx).await?;
+            txids.push(txid);
+        }
+
+        Ok(txids)
+    }
+}
+
 #[async_trait]
 impl TestCase for UndecompressableBlobTest {
     fn test_config() -> TestCaseConfig {
@@ -2869,6 +3051,14 @@ impl TestCase for UndecompressableBlobTest {
         let batch_prover = f.batch_prover.as_ref().unwrap();
         let light_client_prover = f.light_client_prover.as_ref().unwrap();
 
+        let prover_da_service = spawn_bitcoin_da_service(
+            self.task_manager.executor().clone(),
+            &da.config,
+            Self::test_config().dir,
+            DaServiceKeyKind::BatchProver,
+        )
+        .await;
+
         let max_l2_blocks_per_commitment = sequencer.max_l2_blocks_per_commitment();
 
         for _ in 0..max_l2_blocks_per_commitment {
@@ -2886,10 +3076,7 @@ impl TestCase for UndecompressableBlobTest {
             .await?;
 
         // Send a complete tx with dummy body
-        let (commit_tx, reveal_tx) =
-            create_complete_tx_with_prefix(&batch_prover.da, vec![1u8; 64]).await?;
-        batch_prover.da.send_raw_transaction(&commit_tx).await?;
-        batch_prover.da.send_raw_transaction(&reveal_tx).await?;
+        Self::send_complete_tx(&batch_prover.da).await?;
 
         // // Wait for batch prover tx and the test reveal tx to be in mempool
         da.wait_mempool_len(4, None).await?;
@@ -2906,21 +3093,14 @@ impl TestCase for UndecompressableBlobTest {
             .collect();
 
         txs.sort_by(|a, b| a.input[0].witness.size().cmp(&b.input[0].witness.size()));
-        assert!(verify_is_non_decompressable(txs[0])); // First tx has `vec![1u8; 64]` body and should be undecompressable
-        assert!(!verify_is_non_decompressable(txs[1])); // Second tx is correct batch prover reveal tx
+        assert!(Self::verify_complete_is_non_decompressable(txs[0])); // First tx has `vec![1u8; 64]` body and should be undecompressable
+        assert!(!Self::verify_complete_is_non_decompressable(txs[1])); // Second tx is correct batch prover reveal tx
 
         // LCP should be able to process it and tick along
         light_client_prover
             .wait_for_l1_height(finalized_height, None)
             .await?;
 
-        let prover_da_service = spawn_bitcoin_da_service(
-            self.task_manager.executor().clone(),
-            &da.config,
-            Self::test_config().dir,
-            DaServiceKeyKind::BatchProver,
-        )
-        .await;
         let block = prover_da_service
             .get_block_by_hash(block_hash.into())
             .await
@@ -2943,6 +3123,43 @@ impl TestCase for UndecompressableBlobTest {
             Ok(txs),
         );
 
+        da.generate(1).await?;
+
+        // Send a chunked tx with dummy body
+        let txids = Self::send_chunked_tx(&batch_prover.da).await?;
+
+        // // Wait for chunked txs to hit the mempool
+        da.wait_mempool_len(txids.len(), None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
+
+        let block_hash = da.get_block_hash(finalized_height).await?;
+        let block = da.get_block(&block_hash).await?;
+
+        assert!(Self::verify_chunked_is_non_decompressable(&block));
+
+        // LCP should be able to process it and tick along
+        light_client_prover
+            .wait_for_l1_height(finalized_height, None)
+            .await?;
+
+        let block = prover_da_service
+            .get_block_by_hash(block_hash.into())
+            .await
+            .unwrap();
+
+        let (mut txs, inclusion_proof, completeness_proof) =
+            prover_da_service.extract_relevant_blobs_with_proof(&block);
+
+        txs.iter_mut().for_each(|t| {
+            t.full_data();
+        });
+
+        assert_eq!(
+            verifier.verify_transactions(&block.header, inclusion_proof, completeness_proof,),
+            Ok(txs),
+        );
+
         Ok(())
     }
 }
@@ -2955,57 +3172,4 @@ async fn test_undecompressable_blob() -> Result<()> {
     .set_citrea_path(get_citrea_path())
     .run()
     .await
-}
-
-pub async fn create_complete_tx_with_prefix(
-    client: &Client,
-    body: Vec<u8>,
-) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
-    use std::str::FromStr;
-
-    use bitcoin::secp256k1::SecretKey;
-    use bitcoin_da::helpers::builders::body_builders::{create_inscription_type_0, DaTxs};
-
-    let da_private_key = SecretKey::from_str(PROVER_DA_PUBLIC_KEY).unwrap();
-    let change_address = client.get_new_address(None, None).await?.assume_checked();
-    let utxos = client
-        .list_unspent(None, None, None, None, None)
-        .await?
-        .into_iter()
-        .map(Into::into)
-        .collect();
-
-    let result = create_inscription_type_0(
-        body,
-        &da_private_key,
-        None,
-        utxos,
-        change_address,
-        1,
-        1,
-        bitcoin::Network::Regtest,
-        REVEAL_TX_PREFIX,
-    )?;
-
-    match result {
-        DaTxs::Complete { commit, reveal } => {
-            let signed_raw_commit_tx = client
-                .sign_raw_transaction_with_wallet(&commit, None, None)
-                .await?;
-
-            Ok((
-                signed_raw_commit_tx.hex,
-                bitcoin::consensus::encode::serialize(&reveal.tx),
-            ))
-        }
-        _ => unreachable!("Unexpected result type"),
-    }
-}
-
-fn verify_is_non_decompressable(tx: &bitcoin::Transaction) -> bool {
-    if let Ok(ParsedTransaction::Complete(complete)) = parse_relevant_transaction(tx) {
-        decompress_blob(&complete.body).is_err()
-    } else {
-        false
-    }
 }

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -5,12 +5,13 @@ use std::time::Duration;
 use alloy_primitives::{U32, U64};
 use async_trait::async_trait;
 use bitcoin::hashes::Hash;
+use bitcoin_da::helpers::parsers::{parse_relevant_transaction, ParsedTransaction};
 use bitcoincore_rpc::RpcApi;
 use citrea_batch_prover::rpc::BatchProverRpcClient;
 use citrea_batch_prover::PartitionMode;
 use citrea_e2e::bitcoin::DEFAULT_FINALITY_DEPTH;
 use citrea_e2e::config::{
-    BatchProverConfig, CitreaMode, LightClientProverConfig, SequencerConfig,
+    BatchProverConfig, BitcoinConfig, CitreaMode, LightClientProverConfig, SequencerConfig,
     SequencerMempoolConfig, TestCaseConfig,
 };
 use citrea_e2e::framework::TestFramework;
@@ -18,6 +19,8 @@ use citrea_e2e::test_case::{TestCase, TestCaseRunner};
 use citrea_e2e::Result;
 use citrea_fullnode::rpc::FullNodeRpcClient;
 use citrea_light_client_prover::rpc::LightClientProverRpcClient;
+use citrea_primitives::compression::decompress_blob;
+use citrea_primitives::REVEAL_TX_PREFIX;
 use rand::{thread_rng, Rng};
 use reth_tasks::TaskManager;
 use risc0_zkvm::{FakeReceipt, InnerReceipt, MaybePruned, ReceiptClaim};
@@ -29,7 +32,9 @@ use sov_rollup_interface::zk::batch_proof::output::{BatchProofCircuitOutput, Cum
 use super::batch_prover_test::wait_for_zkproofs;
 use super::get_citrea_path;
 use crate::bitcoin::batch_prover_test::wait_for_prover_job;
-use crate::bitcoin::utils::{spawn_bitcoin_da_service, DaServiceKeyKind};
+use crate::bitcoin::utils::{
+    create_complete_tx_with_prefix, spawn_bitcoin_da_service, DaServiceKeyKind,
+};
 
 pub const TEN_MINS: Duration = Duration::from_secs(10 * 60);
 
@@ -2813,4 +2818,107 @@ pub fn create_serialized_fake_receipt_batch_proof(
     // Receipt with verifiable claim
     let receipt = InnerReceipt::Fake(fake_receipt);
     bincode::serialize(&receipt).unwrap()
+}
+
+struct UndecompressableBlobTest;
+
+#[async_trait]
+impl TestCase for UndecompressableBlobTest {
+    fn test_config() -> TestCaseConfig {
+        TestCaseConfig {
+            with_batch_prover: true,
+            with_light_client_prover: true,
+            ..Default::default()
+        }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(170)
+    }
+
+    fn light_client_prover_config() -> LightClientProverConfig {
+        LightClientProverConfig {
+            enable_recovery: false,
+            initial_da_height: 171,
+            ..Default::default()
+        }
+    }
+
+    fn bitcoin_config() -> BitcoinConfig {
+        BitcoinConfig {
+            extra_args: vec!["-fallbackfee=0.00001"],
+            ..Default::default()
+        }
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        let da = f.bitcoin_nodes.get(0).unwrap();
+        let sequencer = f.sequencer.as_ref().unwrap();
+        let batch_prover = f.batch_prover.as_ref().unwrap();
+        let light_client_prover = f.light_client_prover.as_ref().unwrap();
+
+        let max_l2_blocks_per_commitment = sequencer.max_l2_blocks_per_commitment();
+
+        for _ in 0..max_l2_blocks_per_commitment {
+            sequencer.client.send_publish_batch_request().await?;
+        }
+
+        // Wait for blob inscribe tx to be in mempool and the fake reveal tx
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+
+        let finalized_height = da.get_finalized_height(None).await?;
+
+        batch_prover
+            .wait_for_l1_height(finalized_height, None)
+            .await?;
+
+        // Send a complete tx with wrong body
+        let (commit_tx, reveal_tx) =
+            create_complete_tx_with_prefix(&batch_prover.da, vec![1u8; 64], REVEAL_TX_PREFIX)
+                .await?;
+        batch_prover.da.send_raw_transaction(&commit_tx).await?;
+        batch_prover.da.send_raw_transaction(&reveal_tx).await?;
+
+        // // Wait for batch prover tx and the test reveal tx to be in mempool
+        da.wait_mempool_len(4, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
+
+        let block = da
+            .get_block(&da.get_block_hash(finalized_height).await?)
+            .await?;
+
+        let txs: Vec<_> = block
+            .txdata
+            .iter()
+            .filter(|tx| tx.input[0].witness.len() == 3)
+            .collect();
+
+        assert!(verify_is_non_decompressable(txs[0])); // First tx has `vec![1u8; 64]` body and should be undecompressable
+        assert!(!verify_is_non_decompressable(txs[1])); // Second tx is correct batch prover reveal tx
+
+        // LCP should be able to process it and tick along
+        light_client_prover
+            .wait_for_l1_height(finalized_height, None)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_undecompressable_blob() -> Result<()> {
+    TestCaseRunner::new(UndecompressableBlobTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
+}
+
+fn verify_is_non_decompressable(tx: &bitcoin::Transaction) -> bool {
+    if let Ok(ParsedTransaction::Complete(complete)) = parse_relevant_transaction(tx) {
+        decompress_blob(&complete.body).is_err()
+    } else {
+        false
+    }
 }

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -3059,6 +3059,11 @@ impl TestCase for UndecompressableBlobTest {
         )
         .await;
 
+        let verifier = BitcoinVerifier::new(RollupParams {
+            reveal_tx_prefix: REVEAL_TX_PREFIX.to_vec(),
+            network: Network::Nightly,
+        });
+
         let max_l2_blocks_per_commitment = sequencer.max_l2_blocks_per_commitment();
 
         for _ in 0..max_l2_blocks_per_commitment {
@@ -3078,7 +3083,7 @@ impl TestCase for UndecompressableBlobTest {
         // Send a complete tx with dummy body
         Self::send_complete_tx(&batch_prover.da).await?;
 
-        // // Wait for batch prover tx and the test reveal tx to be in mempool
+        // Wait for batch prover tx and the test reveal tx to be in mempool
         da.wait_mempool_len(4, None).await?;
         da.generate(DEFAULT_FINALITY_DEPTH).await?;
         let finalized_height = da.get_finalized_height(None).await?;
@@ -3101,6 +3106,20 @@ impl TestCase for UndecompressableBlobTest {
             .wait_for_l1_height(finalized_height, None)
             .await?;
 
+        // LCP should have processed the proof and skipped the fake complete proof
+        let lcp_output = light_client_prover
+            .client
+            .http_client()
+            .get_light_client_proof_by_l1_height(finalized_height)
+            .await?
+            .unwrap()
+            .light_client_proof_output;
+        assert_eq!(lcp_output.last_sequencer_commitment_index.to::<u32>(), 1);
+        assert_eq!(
+            lcp_output.last_l2_height.to::<u64>(),
+            max_l2_blocks_per_commitment
+        );
+
         let block = prover_da_service
             .get_block_by_hash(block_hash.into())
             .await
@@ -3113,11 +3132,6 @@ impl TestCase for UndecompressableBlobTest {
             t.full_data();
         });
 
-        let verifier = BitcoinVerifier::new(RollupParams {
-            reveal_tx_prefix: REVEAL_TX_PREFIX.to_vec(),
-            network: Network::Nightly,
-        });
-
         assert_eq!(
             verifier.verify_transactions(&block.header, inclusion_proof, completeness_proof,),
             Ok(txs),
@@ -3125,11 +3139,25 @@ impl TestCase for UndecompressableBlobTest {
 
         da.generate(1).await?;
 
+        for _ in 0..max_l2_blocks_per_commitment {
+            sequencer.client.send_publish_batch_request().await?;
+        }
+
+        // Wait for blob inscribe tx to be in mempool
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+
+        let finalized_height = da.get_finalized_height(None).await?;
+
+        batch_prover
+            .wait_for_l1_height(finalized_height, None)
+            .await?;
+
         // Send a chunked tx with dummy body
         let txids = Self::send_chunked_tx(&batch_prover.da).await?;
 
-        // // Wait for chunked txs to hit the mempool
-        da.wait_mempool_len(txids.len(), None).await?;
+        // // Wait for batch prover tx and chunked txs to hit the mempool
+        da.wait_mempool_len(txids.len() + 2, None).await?;
         da.generate(DEFAULT_FINALITY_DEPTH).await?;
         let finalized_height = da.get_finalized_height(None).await?;
 
@@ -3142,6 +3170,20 @@ impl TestCase for UndecompressableBlobTest {
         light_client_prover
             .wait_for_l1_height(finalized_height, None)
             .await?;
+
+        // LCP should have processed the proof and skipped the fake chunked proof
+        let lcp_output = light_client_prover
+            .client
+            .http_client()
+            .get_light_client_proof_by_l1_height(finalized_height)
+            .await?
+            .unwrap()
+            .light_client_proof_output;
+        assert_eq!(lcp_output.last_sequencer_commitment_index.to::<u32>(), 2);
+        assert_eq!(
+            lcp_output.last_l2_height.to::<u64>(),
+            max_l2_blocks_per_commitment * 2
+        );
 
         let block = prover_da_service
             .get_block_by_hash(block_hash.into())

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -27,8 +27,7 @@ use rand::{thread_rng, Rng};
 use reth_tasks::TaskManager;
 use risc0_zkvm::{FakeReceipt, InnerReceipt, MaybePruned, ReceiptClaim};
 use sov_modules_api::BlobReaderTrait;
-use sov_rollup_interface::da::DaVerifier;
-use sov_rollup_interface::da::{BatchProofMethodId, DaTxRequest, SequencerCommitment};
+use sov_rollup_interface::da::{BatchProofMethodId, DaTxRequest, DaVerifier, SequencerCommitment};
 use sov_rollup_interface::rpc::BatchProofMethodIdRpcResponse;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
@@ -2962,9 +2961,10 @@ pub async fn create_complete_tx_with_prefix(
     client: &Client,
     body: Vec<u8>,
 ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+    use std::str::FromStr;
+
     use bitcoin::secp256k1::SecretKey;
     use bitcoin_da::helpers::builders::body_builders::{create_inscription_type_0, DaTxs};
-    use std::str::FromStr;
 
     let da_private_key = SecretKey::from_str(PROVER_DA_PUBLIC_KEY).unwrap();
     let change_address = client.get_new_address(None, None).await?.assume_checked();

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -8,7 +8,7 @@ use bitcoin::hashes::Hash;
 use bitcoin_da::helpers::parsers::{parse_relevant_transaction, ParsedTransaction};
 use bitcoin_da::spec::RollupParams;
 use bitcoin_da::verifier::BitcoinVerifier;
-use bitcoincore_rpc::RpcApi;
+use bitcoincore_rpc::{Client, RpcApi};
 use citrea_batch_prover::rpc::BatchProverRpcClient;
 use citrea_batch_prover::PartitionMode;
 use citrea_e2e::bitcoin::DEFAULT_FINALITY_DEPTH;
@@ -37,10 +37,9 @@ use sov_rollup_interface::Network;
 
 use super::batch_prover_test::wait_for_zkproofs;
 use super::get_citrea_path;
+use super::utils::PROVER_DA_PUBLIC_KEY;
 use crate::bitcoin::batch_prover_test::wait_for_prover_job;
-use crate::bitcoin::utils::{
-    create_complete_tx_with_prefix, spawn_bitcoin_da_service, DaServiceKeyKind,
-};
+use crate::bitcoin::utils::{spawn_bitcoin_da_service, DaServiceKeyKind};
 
 pub const TEN_MINS: Duration = Duration::from_secs(10 * 60);
 
@@ -2889,8 +2888,7 @@ impl TestCase for UndecompressableBlobTest {
 
         // Send a complete tx with dummy body
         let (commit_tx, reveal_tx) =
-            create_complete_tx_with_prefix(&batch_prover.da, vec![1u8; 64], REVEAL_TX_PREFIX)
-                .await?;
+            create_complete_tx_with_prefix(&batch_prover.da, vec![1u8; 64]).await?;
         batch_prover.da.send_raw_transaction(&commit_tx).await?;
         batch_prover.da.send_raw_transaction(&reveal_tx).await?;
 
@@ -2958,6 +2956,50 @@ async fn test_undecompressable_blob() -> Result<()> {
     .set_citrea_path(get_citrea_path())
     .run()
     .await
+}
+
+pub async fn create_complete_tx_with_prefix(
+    client: &Client,
+    body: Vec<u8>,
+) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+    use bitcoin::secp256k1::SecretKey;
+    use bitcoin_da::helpers::builders::body_builders::{create_inscription_type_0, DaTxs};
+    use std::str::FromStr;
+
+    let da_private_key = SecretKey::from_str(PROVER_DA_PUBLIC_KEY).unwrap();
+    let change_address = client.get_new_address(None, None).await?.assume_checked();
+    let utxos = client
+        .list_unspent(None, None, None, None, None)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+
+    let result = create_inscription_type_0(
+        body,
+        &da_private_key,
+        None,
+        utxos,
+        change_address,
+        1,
+        1,
+        bitcoin::Network::Regtest,
+        REVEAL_TX_PREFIX,
+    )?;
+
+    match result {
+        DaTxs::Complete { commit, reveal } => {
+            let signed_raw_commit_tx = client
+                .sign_raw_transaction_with_wallet(&commit, None, None)
+                .await?;
+
+            Ok((
+                signed_raw_commit_tx.hex,
+                bitcoin::consensus::encode::serialize(&reveal.tx),
+            ))
+        }
+        _ => unreachable!("Unexpected result type"),
+    }
 }
 
 fn verify_is_non_decompressable(tx: &bitcoin::Transaction) -> bool {

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -2902,12 +2902,13 @@ impl TestCase for UndecompressableBlobTest {
         let block_hash = da.get_block_hash(finalized_height).await?;
         let block = da.get_block(&block_hash).await?;
 
-        let txs: Vec<_> = block
+        let mut txs: Vec<_> = block
             .txdata
             .iter()
             .filter(|tx| tx.input[0].witness.len() == 3)
             .collect();
 
+        txs.sort_by(|a, b| a.input[0].witness.size().cmp(&b.input[0].witness.size()));
         assert!(verify_is_non_decompressable(txs[0])); // First tx has `vec![1u8; 64]` body and should be undecompressable
         assert!(!verify_is_non_decompressable(txs[1])); // Second tx is correct batch prover reveal tx
 

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -2863,7 +2863,7 @@ impl TestCase for UndecompressableBlobTest {
             sequencer.client.send_publish_batch_request().await?;
         }
 
-        // Wait for blob inscribe tx to be in mempool and the fake reveal tx
+        // Wait for blob inscribe tx to be in mempool
         da.wait_mempool_len(2, None).await?;
         da.generate(DEFAULT_FINALITY_DEPTH).await?;
 
@@ -2873,7 +2873,7 @@ impl TestCase for UndecompressableBlobTest {
             .wait_for_l1_height(finalized_height, None)
             .await?;
 
-        // Send a complete tx with wrong body
+        // Send a complete tx with dummy body
         let (commit_tx, reveal_tx) =
             create_complete_tx_with_prefix(&batch_prover.da, vec![1u8; 64], REVEAL_TX_PREFIX)
                 .await?;

--- a/bin/citrea/tests/bitcoin/utils.rs
+++ b/bin/citrea/tests/bitcoin/utils.rs
@@ -1,12 +1,8 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Arc;
 
-use bitcoin::secp256k1::SecretKey;
-use bitcoin_da::helpers::builders::body_builders::{create_inscription_type_0, DaTxs};
 use bitcoin_da::service::{BitcoinService, BitcoinServiceConfig};
 use bitcoin_da::spec::RollupParams;
-use bitcoincore_rpc::{Client, RpcApi};
 use citrea_e2e::config::BitcoinConfig;
 use citrea_e2e::node::NodeKind;
 use citrea_primitives::REVEAL_TX_PREFIX;
@@ -20,9 +16,9 @@ pub(super) enum DaServiceKeyKind {
     Other(String),
 }
 
-const SEQUENCER_DA_PUBLIC_KEY: &str =
+pub const SEQUENCER_DA_PUBLIC_KEY: &str =
     "E9873D79C6D87DC0FB6A5778633389F4453213303DA61F20BD67FC233AA33262";
-const PROVER_DA_PUBLIC_KEY: &str =
+pub(super) const PROVER_DA_PUBLIC_KEY: &str =
     "56D08C2DDE7F412F80EC99A0A328F76688C904BD4D1435281EFC9270EC8C8707";
 
 pub(super) async fn spawn_bitcoin_da_service(
@@ -69,45 +65,4 @@ pub(super) async fn spawn_bitcoin_da_service(
         .spawn_with_graceful_shutdown_signal(|tk| bitcoin_da_service.clone().run_da_queue(rx, tk));
 
     bitcoin_da_service
-}
-
-pub async fn create_complete_tx_with_prefix(
-    client: &Client,
-    body: Vec<u8>,
-    prefix: &[u8],
-) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
-    let da_private_key = SecretKey::from_str(PROVER_DA_PUBLIC_KEY).unwrap();
-    let change_address = client.get_new_address(None, None).await?.assume_checked();
-    let utxos = client
-        .list_unspent(None, None, None, None, None)
-        .await?
-        .into_iter()
-        .map(Into::into)
-        .collect();
-
-    let result = create_inscription_type_0(
-        body,
-        &da_private_key,
-        None,
-        utxos,
-        change_address,
-        1,
-        1,
-        bitcoin::Network::Regtest,
-        prefix,
-    )?;
-
-    match result {
-        DaTxs::Complete { commit, reveal } => {
-            let signed_raw_commit_tx = client
-                .sign_raw_transaction_with_wallet(&commit, None, None)
-                .await?;
-
-            Ok((
-                signed_raw_commit_tx.hex,
-                bitcoin::consensus::encode::serialize(&reveal.tx),
-            ))
-        }
-        _ => unreachable!("Unexpected result type"),
-    }
 }

--- a/bin/citrea/tests/bitcoin/utils.rs
+++ b/bin/citrea/tests/bitcoin/utils.rs
@@ -1,8 +1,12 @@
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 
+use bitcoin::secp256k1::SecretKey;
+use bitcoin_da::helpers::builders::body_builders::{create_inscription_type_0, DaTxs};
 use bitcoin_da::service::{BitcoinService, BitcoinServiceConfig};
 use bitcoin_da::spec::RollupParams;
+use bitcoincore_rpc::{Client, RpcApi};
 use citrea_e2e::config::BitcoinConfig;
 use citrea_e2e::node::NodeKind;
 use citrea_primitives::REVEAL_TX_PREFIX;
@@ -16,6 +20,11 @@ pub(super) enum DaServiceKeyKind {
     Other(String),
 }
 
+const SEQUENCER_DA_PUBLIC_KEY: &str =
+    "E9873D79C6D87DC0FB6A5778633389F4453213303DA61F20BD67FC233AA33262";
+const PROVER_DA_PUBLIC_KEY: &str =
+    "56D08C2DDE7F412F80EC99A0A328F76688C904BD4D1435281EFC9270EC8C8707";
+
 pub(super) async fn spawn_bitcoin_da_service(
     task_executor: TaskExecutor,
     da_config: &BitcoinConfig,
@@ -23,12 +32,8 @@ pub(super) async fn spawn_bitcoin_da_service(
     kind: DaServiceKeyKind,
 ) -> Arc<BitcoinService> {
     let da_private_key = match kind {
-        DaServiceKeyKind::Sequencer => {
-            "E9873D79C6D87DC0FB6A5778633389F4453213303DA61F20BD67FC233AA33262".to_string()
-        }
-        DaServiceKeyKind::BatchProver => {
-            "56D08C2DDE7F412F80EC99A0A328F76688C904BD4D1435281EFC9270EC8C8707".to_string()
-        }
+        DaServiceKeyKind::Sequencer => SEQUENCER_DA_PUBLIC_KEY.to_string(),
+        DaServiceKeyKind::BatchProver => PROVER_DA_PUBLIC_KEY.to_string(),
         DaServiceKeyKind::Other(key) => key,
     };
 
@@ -64,4 +69,45 @@ pub(super) async fn spawn_bitcoin_da_service(
         .spawn_with_graceful_shutdown_signal(|tk| bitcoin_da_service.clone().run_da_queue(rx, tk));
 
     bitcoin_da_service
+}
+
+pub async fn create_complete_tx_with_prefix(
+    client: &Client,
+    body: Vec<u8>,
+    prefix: &[u8],
+) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+    let da_private_key = SecretKey::from_str(PROVER_DA_PUBLIC_KEY).unwrap();
+    let change_address = client.get_new_address(None, None).await?.assume_checked();
+    let utxos = client
+        .list_unspent(None, None, None, None, None)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+
+    let result = create_inscription_type_0(
+        body,
+        &da_private_key,
+        None,
+        utxos,
+        change_address,
+        1,
+        1,
+        bitcoin::Network::Regtest,
+        prefix,
+    )?;
+
+    match result {
+        DaTxs::Complete { commit, reveal } => {
+            let signed_raw_commit_tx = client
+                .sign_raw_transaction_with_wallet(&commit, None, None)
+                .await?;
+
+            Ok((
+                signed_raw_commit_tx.hex,
+                bitcoin::consensus::encode::serialize(&reveal.tx),
+            ))
+        }
+        _ => unreachable!("Unexpected result type"),
+    }
 }

--- a/crates/batch-prover/src/prover.rs
+++ b/crates/batch-prover/src/prover.rs
@@ -6,7 +6,7 @@ use citrea_common::utils::merge_state_diffs;
 use citrea_common::{BatchProverConfig, ProverGuestRunConfig};
 use citrea_primitives::compression::compress_blob;
 use citrea_primitives::forks::fork_from_block_number;
-use citrea_primitives::MAX_TXBODY_SIZE;
+use citrea_primitives::MAX_TX_BODY_SIZE;
 use citrea_stf::runtime::{CitreaRuntime, DefaultContext};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -406,7 +406,7 @@ where
                 compress_blob(&serialized_diff).expect("Diff compression cannot fail");
 
             // check state diff threshold
-            if compressed_diff.len() > MAX_TXBODY_SIZE {
+            if compressed_diff.len() > MAX_TX_BODY_SIZE {
                 cumulative_state_diff = commitment_state_diff;
                 state.add_partition(i - 1, PartitionReason::StateDiff)?;
                 continue;
@@ -909,7 +909,7 @@ mod tests {
 
     use citrea_common::BatchProverConfig;
     use citrea_primitives::forks::FORKS;
-    use citrea_primitives::MAX_TXBODY_SIZE;
+    use citrea_primitives::MAX_TX_BODY_SIZE;
     use prover_services::{ParallelProverService, ProofGenMode};
     use sov_db::ledger_db::{BatchProverLedgerOps, LedgerDB, SharedLedgerOps};
     use sov_db::rocks_db_config::RocksdbConfig;
@@ -1145,8 +1145,8 @@ mod tests {
             &prover.ledger_db,
             vec![
                 (1, 0),
-                (2, MAX_TXBODY_SIZE * 2 / 3),
-                (3, MAX_TXBODY_SIZE * 2 / 3),
+                (2, MAX_TX_BODY_SIZE * 2 / 3),
+                (3, MAX_TX_BODY_SIZE * 2 / 3),
             ],
         );
 

--- a/crates/bitcoin-da/src/helpers/builders/body_builders.rs
+++ b/crates/bitcoin-da/src/helpers/builders/body_builders.rs
@@ -42,7 +42,7 @@ pub(crate) enum RawTxData {
 
 /// This is a list of txs we need to send to DA
 #[derive(Serialize, Clone)]
-pub(crate) enum DaTxs {
+pub enum DaTxs {
     Complete {
         commit: Transaction, // unsigned
         reveal: TxWithId,

--- a/crates/bitcoin-da/src/helpers/builders/body_builders.rs
+++ b/crates/bitcoin-da/src/helpers/builders/body_builders.rs
@@ -31,7 +31,7 @@ pub(crate) enum RawTxData {
     /// compress(borsh(DataOnDa::Complete(Proof)))
     Complete(Vec<u8>),
     /// let compressed = compress(borsh(Proof))
-    /// let chunks = compressed.chunks(MAX_TXBODY_SIZE)
+    /// let chunks = compressed.chunks(MAX_TX_BODY_SIZE)
     /// [borsh(DataOnDa::Chunk(chunk)) for chunk in chunks]
     Chunks(Vec<Vec<u8>>),
     /// borsh(DataOnDa::BatchProofMethodId(MethodId))

--- a/crates/bitcoin-da/tests/test_utils.rs
+++ b/crates/bitcoin-da/tests/test_utils.rs
@@ -16,7 +16,7 @@ use citrea_e2e::bitcoin::BitcoinNode;
 use citrea_e2e::config::BitcoinConfig;
 use citrea_e2e::node::NodeKind;
 use citrea_e2e::traits::NodeT;
-use citrea_primitives::{MAX_TXBODY_SIZE, REVEAL_TX_PREFIX};
+use citrea_primitives::{MAX_TX_BODY_SIZE, REVEAL_TX_PREFIX};
 use reth_tasks::TaskExecutor;
 use sov_rollup_interface::da::{BatchProofMethodId, DaTxRequest, SequencerCommitment};
 use sov_rollup_interface::services::da::DaService;
@@ -177,7 +177,7 @@ pub async fn generate_mock_txs(
         .expect("Failed to send transaction");
 
     // Invoke chunked zk proof generation with 2 chunks
-    let size = MAX_TXBODY_SIZE + 1500;
+    let size = MAX_TX_BODY_SIZE + 1500;
     let blob = (0..size).map(|_| rand::random::<u8>()).collect::<Vec<u8>>();
 
     valid_proofs.push(blob.clone());
@@ -227,7 +227,7 @@ pub async fn generate_mock_txs(
         .expect("Failed to send transaction");
 
     // Invoke chunked zk proof generation with 3 chunks
-    let size = MAX_TXBODY_SIZE * 2 + 2500;
+    let size = MAX_TX_BODY_SIZE * 2 + 2500;
     let blob = (0..size).map(|_| rand::random::<u8>()).collect::<Vec<u8>>();
 
     valid_proofs.push(blob.clone());

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -11,9 +11,9 @@ pub const MIN_BASE_FEE_PER_GAS: u64 = 10_000_000; // 0.01 gwei
 
 /// Maximum size of a bitcoin transaction body in bytes
 #[cfg(feature = "testing")]
-pub const MAX_TXBODY_SIZE: usize = 39700;
+pub const MAX_TX_BODY_SIZE: usize = 39700;
 #[cfg(not(feature = "testing"))]
-pub const MAX_TXBODY_SIZE: usize = 397000;
+pub const MAX_TX_BODY_SIZE: usize = 397000;
 
 /// SHA-256 hash of "citrea" string
 /// Used as the default tx merkle root when the block has no transactions

--- a/crates/sequencer/src/commitment/controller.rs
+++ b/crates/sequencer/src/commitment/controller.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use anyhow::ensure;
 use citrea_common::utils::merge_state_diffs;
 use citrea_primitives::compression::compress_blob;
-use citrea_primitives::MAX_TXBODY_SIZE;
+use citrea_primitives::MAX_TX_BODY_SIZE;
 use parking_lot::Mutex;
 use sov_db::ledger_db::SequencerLedgerOps;
 use sov_db::schema::types::L2BlockNumber;
@@ -15,7 +15,7 @@ use super::service::CommitmentRange;
 // Based on the test runs, brotli is able to compress the state diff 58% to 70%,
 // with an average of 66% for both empty and full blocks. This is a super safe
 // estimation of 50% compression.
-const SAFE_MAX_UNCOMPRESSED_TXBODY_SIZE: usize = MAX_TXBODY_SIZE * 2;
+const SAFE_MAX_UNCOMPRESSED_TXBODY_SIZE: usize = MAX_TX_BODY_SIZE * 2;
 
 /// Keeps track of the accumulated state diff ever since the last committed L2 block.
 struct AccumulatedStateDiff {
@@ -145,7 +145,7 @@ where
             }
 
             let compressed_state_diff = compress_blob(&uncompressed_state_diff).unwrap();
-            if compressed_state_diff.len() > MAX_TXBODY_SIZE {
+            if compressed_state_diff.len() > MAX_TX_BODY_SIZE {
                 debug!("Enough state diff size to submit commitment");
                 return Ok(Some(L2BlockNumber(l2_start)..=L2BlockNumber(l2_height)));
             }


### PR DESCRIPTION
# Description

- Send an undecompressable tx to bitcoin da and make sure that light client prover is able to process the block and ignores the tx

## Linked Issues
- Fixes #2325 