### PR TITLE
Test non segwit tx commitment in short_proof.rs

### DIFF
--- a/crates/bitcoin-da/src/spec/short_proof.rs
+++ b/crates/bitcoin-da/src/spec/short_proof.rs
@@ -300,5 +300,65 @@ mod test {
                 ShortHeaderProofVerificationError::InvalidHeaderHash
             )
         }
+
+        // non segwit wrong tx commitment: 1 txs
+        {
+            // One-Transaction Non-SegWit Block
+            // First TX: Coinbase Transaction
+            let block = hex::decode("0200000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000").unwrap();
+            let block: bitcoin::Block = bitcoin::consensus::deserialize(block.as_slice()).unwrap();
+
+            let block = BitcoinBlock {
+                header: HeaderWrapper::new(
+                    block.header,
+                    block.txdata.len() as u32,
+                    882547,
+                    [1; 32],
+                ),
+                txdata: block.txdata.into_iter().map(Into::into).collect(),
+            };
+
+            let proof = BitcoinService::block_to_short_header_proof(block);
+
+            assert_eq!(
+                proof.verify().unwrap_err(),
+                ShortHeaderProofVerificationError::WrongTxCommitment {
+                    expected: [0; 32],
+                    actual: [1; 32]
+                }
+            )
+        }
+
+        // non segwit wrong tx commitment: 2 txs
+        {
+            // Two-Transaction Non-SegWit Block
+            // First TX: Coinbase Transaction
+            // Second TX: Fake input, send to random P2PKH address
+            let block = hex::decode("02000000000000000000000000000000000000000000000000000000000000000000000018bb1f1245be6597df2f463399e391738f4650b88c66ed7a1a1f2a7ad472b0b229ab5f49ffff001d1dac2b7c0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac0000000001000000010e9ef4d565fa2b404cd1e1cd5b7bb4c083151d647536fdecf7895f3acf7ca852000000000151ffffffff0180969800000000001976a9140123456789abcdef0123456789abcdef0123456788ac00000000").unwrap();
+            let block: bitcoin::Block = bitcoin::consensus::deserialize(block.as_slice()).unwrap();
+
+            let block = BitcoinBlock {
+                header: HeaderWrapper::new(
+                    block.header,
+                    block.txdata.len() as u32,
+                    882547,
+                    [0; 32],
+                ),
+                txdata: block.txdata.into_iter().map(Into::into).collect(),
+            };
+
+            let proof = BitcoinService::block_to_short_header_proof(block);
+
+            assert_eq!(
+                proof.verify().unwrap_err(),
+                ShortHeaderProofVerificationError::WrongTxCommitment {
+                    expected: [
+                        24, 187, 31, 18, 69, 190, 101, 151, 223, 47, 70, 51, 153, 227, 145, 115,
+                        143, 70, 80, 184, 140, 102, 237, 122, 26, 31, 42, 122, 212, 114, 176, 178
+                    ],
+                    actual: [0; 32]
+                }
+            )
+        }
     }
 }

--- a/crates/bitcoin-da/src/spec/short_proof.rs
+++ b/crates/bitcoin-da/src/spec/short_proof.rs
@@ -303,17 +303,21 @@ mod test {
 
         // non segwit wrong tx commitment: 1 txs
         {
+            // Verify with no segwit and only coinbase always expects tx commitment to be [0; 32]
+
             // One-Transaction Non-SegWit Block
             // First TX: Coinbase Transaction
-            let block = hex::decode("0200000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000").unwrap();
+            let block = hex::decode("030000008f6bf399c264ffb224b370a895774da700aee298ee64c30800000000000000005c759d40b6682c185028ae9b352ab1a7039828881c550cee0476d8077beb7b36c796bd55150815181470b5290101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff64039e9d05e4b883e5bda9e7a59ee4bb99e9b1bcfabe6d6de1f60d022c2ad500bf897d07d85cef56c7e4323f24e89cd19bdfda0e4325ec6a10000000f09f909f4d696e65642062792067756f68756100000000000000000000000000000000000000000000d51e00000100f90295000000001976a914c825a1ecf2a6830c4401620c3a16f1995057c2ab88ac896bb334").unwrap();
             let block: bitcoin::Block = bitcoin::consensus::deserialize(block.as_slice()).unwrap();
+
+            assert_eq!(1, block.txdata.len());
 
             let block = BitcoinBlock {
                 header: HeaderWrapper::new(
                     block.header,
                     block.txdata.len() as u32,
-                    882547,
-                    [1; 32],
+                    368030,
+                    [1; 32], // MUST BE [0; 32]
                 ),
                 txdata: block.txdata.into_iter().map(Into::into).collect(),
             };
@@ -331,18 +335,23 @@ mod test {
 
         // non segwit wrong tx commitment: 2 txs
         {
+            // Verify with no segwit and coinbase and a tx always expects tx commitment to be the merkle root of the block
+
             // Two-Transaction Non-SegWit Block
             // First TX: Coinbase Transaction
             // Second TX: Fake input, send to random P2PKH address
-            let block = hex::decode("02000000000000000000000000000000000000000000000000000000000000000000000018bb1f1245be6597df2f463399e391738f4650b88c66ed7a1a1f2a7ad472b0b229ab5f49ffff001d1dac2b7c0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac0000000001000000010e9ef4d565fa2b404cd1e1cd5b7bb4c083151d647536fdecf7895f3acf7ca852000000000151ffffffff0180969800000000001976a9140123456789abcdef0123456789abcdef0123456788ac00000000").unwrap();
+            let block = hex::decode("03000000855d154359b794c6ba2c5586cf6278eee5bd658faa954200000000000000000035e95b187fb0d5175f681c2a1c499c3c91a0781c91679545a1fcabba2cd7cd801b04bd5515081518aa8afeaf0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff25035b9d05384d2f040f04bd550894251c009a0500000f5b4254434368696e612e636f6d5d20000000000100f90295000000001976a9142c30a6aaac6d96687291475d7d52f4b469f665a688ac0000000001000000018651ed89909def949ee3e05631bb332f339f4c667b0af7e2d94e7940a4568a21000000006a473044022059c947c745d94d1019990f39b2c938c9ce3e79fe9a650cff01589ec3b5ed2c2c02206dcff5e15ae6aa9c7d44308f16963dd5ad1dd3229e923c9de3ae1c14f6f91a02012102163e80de410646145142636833d8a92de4bb5c99e49bd52be5346fb1030628d4ffffffff0250ac6002000000001976a9145ca26d65ee83f441ef98b624763a305d50eb36cf88aca0860100000000001976a914838eb1034b719f9c47ab853aee63d505e4176a8388ac00000000").unwrap();
             let block: bitcoin::Block = bitcoin::consensus::deserialize(block.as_slice()).unwrap();
 
+            assert_eq!(2, block.txdata.len());
+
+            let original_merkle_root = block.header.merkle_root;
             let block = BitcoinBlock {
                 header: HeaderWrapper::new(
                     block.header,
                     block.txdata.len() as u32,
-                    882547,
-                    [0; 32],
+                    367963,
+                    [0; 32], // MUST BE block.header.merkle_root
                 ),
                 txdata: block.txdata.into_iter().map(Into::into).collect(),
             };
@@ -352,10 +361,7 @@ mod test {
             assert_eq!(
                 proof.verify().unwrap_err(),
                 ShortHeaderProofVerificationError::WrongTxCommitment {
-                    expected: [
-                        24, 187, 31, 18, 69, 190, 101, 151, 223, 47, 70, 51, 153, 227, 145, 115,
-                        143, 70, 80, 184, 140, 102, 237, 122, 26, 31, 42, 122, 212, 114, 176, 178
-                    ],
+                    expected: original_merkle_root.to_byte_array(),
                     actual: [0; 32]
                 }
             )


### PR DESCRIPTION
# Description

Sad path for these lines:

https://app.codecov.io/gh/chainwayxyz/citrea/pull/2353/blob/crates/bitcoin-da/src/spec/short_proof.rs?dropdown=coverage#L58

https://app.codecov.io/gh/chainwayxyz/citrea/pull/2353/blob/crates/bitcoin-da/src/spec/short_proof.rs?dropdown=coverage#L77

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/2329