### PR TITLE
De-duplicate usage of ValidationError IncorrectInclusionProof variant

### DIFF
--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -42,7 +42,7 @@ pub enum ValidationError {
     BlobContentWasModified,
     IncorrectCompletenessProof,
     RelevantTxNotInProof,
-    IncorrectInclusionProof,
+    IncorrectTxidCommitment,
     IncorrectWitnessCommitment,
     FailedToCalculateMerkleRoot,
     RelevantTxNotFoundInBlock,
@@ -227,7 +227,7 @@ impl DaVerifier for BitcoinVerifier {
 
         // Check that the tx root in the block header matches the tx root in the inclusion proof.
         if block_header.merkle_root() != claimed_root {
-            return Err(ValidationError::IncorrectInclusionProof);
+            return Err(ValidationError::IncorrectTxidCommitment);
         }
 
         Ok(blobs)

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -43,6 +43,7 @@ pub enum ValidationError {
     IncorrectCompletenessProof,
     RelevantTxNotInProof,
     IncorrectInclusionProof,
+    IncorrectWitnessCommitment,
     FailedToCalculateMerkleRoot,
     RelevantTxNotFoundInBlock,
     InvalidBlockHash,
@@ -209,7 +210,7 @@ impl DaVerifier for BitcoinVerifier {
                 commitment_idx = coinbase_tx.output.len() - commitment_idx - 1; // The index is reversed
                 let script_pubkey = coinbase_tx.output[commitment_idx].script_pubkey.as_bytes();
                 if script_pubkey[6..38] != commitment {
-                    return Err(ValidationError::IncorrectInclusionProof);
+                    return Err(ValidationError::IncorrectWitnessCommitment);
                 }
 
                 if merkle_root != block_header.txs_commitment {

--- a/crates/bitcoin-da/tests/verifier.rs
+++ b/crates/bitcoin-da/tests/verifier.rs
@@ -138,7 +138,7 @@ impl TestCase for BitcoinVerifierTest {
                     inclusion_proof,
                     completeness_proof.clone(),
                 ),
-                Err(ValidationError::IncorrectInclusionProof),
+                Err(ValidationError::IncorrectWitnessCommitment),
             );
         }
 
@@ -186,7 +186,7 @@ impl TestCase for BitcoinVerifierTest {
                     inclusion_proof,
                     completeness_proof.clone(),
                 ),
-                Err(ValidationError::IncorrectInclusionProof),
+                Err(ValidationError::IncorrectWitnessCommitment),
             );
         }
 
@@ -250,7 +250,7 @@ impl TestCase for BitcoinVerifierTest {
             ip.wtxids[1] = [16; 32];
             assert_eq!(
                 verifier.verify_transactions(&block.header, ip, completeness_proof.clone(),),
-                Err(ValidationError::IncorrectInclusionProof),
+                Err(ValidationError::IncorrectWitnessCommitment),
             );
         }
 
@@ -295,7 +295,7 @@ impl TestCase for BitcoinVerifierTest {
                     inclusion_proof,
                     completeness_proof.clone(),
                 ),
-                Err(ValidationError::IncorrectInclusionProof),
+                Err(ValidationError::IncorrectWitnessCommitment),
             );
         }
 


### PR DESCRIPTION
# Description

- De-duplicate usage of `IncorrectInclusionProof` and introduce new `IncorrectWitnessCommitment` `ValidationError` variant
- Update tests accordingly.
- Explicit non-coverage of :
```
if block_header.merkle_root() != claimed_root {
            return Err(ValidationError::IncorrectInclusionProof);
        }
```

## Linked Issues
- Pre-req to #2327 