### PR TITLE
Fix vscode build (missing cfg feature guard)

### DIFF
--- a/bin/citrea/tests/bitcoin/mod.rs
+++ b/bin/citrea/tests/bitcoin/mod.rs
@@ -8,6 +8,7 @@ mod utils;
 pub mod backup;
 pub mod bitcoin_test;
 pub mod fork;
+#[cfg(feature = "testing")]
 pub mod full_node;
 pub mod guest_cycles;
 pub mod sequencer_commitments;


### PR DESCRIPTION
# Description

test full_node.rs uses `test_send_separate_chunk_transaction_with_fee_rate` which is defined for `feature = "testing"` only.