### PR TITLE
Add missing bitcoin regtest light client prover config

### DIFF
--- a/resources/configs/bitcoin-regtest/light_client_prover_config.toml
+++ b/resources/configs/bitcoin-regtest/light_client_prover_config.toml
@@ -1,3 +1,4 @@
+initial_da_height = 1
 proving_mode = "execute"
 proof_sampling_number = 500
 enable_recovery = true

--- a/resources/configs/bitcoin-regtest/light_client_prover_rollup_config.toml
+++ b/resources/configs/bitcoin-regtest/light_client_prover_rollup_config.toml
@@ -26,3 +26,4 @@ enable_subscriptions = false
 [runner]
 sequencer_client_url = "http://0.0.0.0:12345"
 include_tx_body = false
+scan_l1_start_height = 1


### PR DESCRIPTION
# Description

Fixes :
```
./target/debug/citrea --dev --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/light_client_prover_rollup_config.toml --light-client-prover resources/configs/bitcoin-regtest/light_client_prover_config.toml --genesis-paths resources/genesis/bitcoin-regtest

Error: Failed to read prover configuration from the config file

Caused by:
    TOML parse error at line 1, column 1
      |
    1 | proving_mode = "execute"
      | ^^^^^^^^^^^^^^^^^^^^^^^^
    missing field `initial_da_height`
```

&&

```
./target/debug/citrea --dev --da-layer bitcoin --rollup-config-path resources/configs/bitcoin-regtest/light_client_prover_rollup_config.toml --light-client-prover resources/configs/bitcoin-regtest/light_client_prover_config.toml --genesis-paths resources/genesis/bitcoin-regtest
2025-06-10T07:30:07.733281Z  INFO citrea: Starting node on Nightly
2025-06-10T07:30:07.736802Z ERROR citrea: error=Failed to read rollup configuration from the config file
Error: Failed to read rollup configuration from the config file

Caused by:
    TOML parse error at line 26, column 1
       |
    26 | [runner]
       | ^^^^^^^^
    missing field `scan_l1_start_height`
```