### PR TITLE
HOTFIX - Do not return error on unknown function selector for system txs

### DIFF
--- a/.github/actions/install-risc0/action.yml
+++ b/.github/actions/install-risc0/action.yml
@@ -16,5 +16,7 @@ runs:
       run: | 
         curl -L https://risczero.com/install | bash
         export PATH="$PATH:$HOME/.risc0/bin"
-        rzup install
+        rzup install r0vm 2.0.2
+        rzup install cargo-risc0 2.0.2
+        rzup install cpp
         rzup install rust 1.85.0

--- a/.github/actions/install-risc0/action.yml
+++ b/.github/actions/install-risc0/action.yml
@@ -17,6 +17,6 @@ runs:
         curl -L https://risczero.com/install | bash
         export PATH="$PATH:$HOME/.risc0/bin"
         rzup install r0vm 2.0.2
-        rzup install cargo-risc0 2.0.2
+        rzup install cargo-risczero 2.0.2
         rzup install cpp
         rzup install rust 1.85.0

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -104,9 +104,10 @@ async fn update_short_header_proof_from_sys_tx<Da: DaService, DB: SharedLedgerOp
         BridgeContract::depositCall::SELECTOR => {
             tracing::info!("Deposit system tx found inside block");
         }
+        // TODO: https://github.com/chainwayxyz/citrea/issues/2442
         unexpected_selector => {
             tracing::warn!(
-                "Invalid system tx, unexpected function selector: {unexpected_selector:?} , tx input: {:?}, tx hash: {:?}, tx nonce: {:?}", tx.inner().transaction().input(), tx.inner().hash(), tx.inner().transaction().nonce()
+                "Unexpected function selector at system tx: {unexpected_selector:?} , tx input: {:?}, tx hash: {:?}, tx nonce: {:?}", tx.inner().transaction().input(), tx.inner().hash(), tx.inner().transaction().nonce()
             );
         }
     }

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -104,8 +104,10 @@ async fn update_short_header_proof_from_sys_tx<Da: DaService, DB: SharedLedgerOp
         BridgeContract::depositCall::SELECTOR => {
             tracing::info!("Deposit system tx found inside block");
         }
-        _ => {
-            return Err(anyhow!("Invalid system tx"));
+        unexpected_selector => {
+            tracing::warn!(
+                "Invalid system tx, unexpected function selector: {unexpected_selector:?} , tx input: {:?}, tx hash: {:?}, tx nonce: {:?}", tx.inner().transaction().input(), tx.inner().hash(), tx.inner().transaction().nonce()
+            );
         }
     }
 


### PR DESCRIPTION
# Description
We always check for the latest selector because the contracts are compiled, if the incoming selector does not match with the latest versions of selectors we throw error which halted the node
The issue arises because we update the deposit call signature
To fix, we will not return error in that case and just log an informative warning that we got an unexpected function selector

**Tested locally, it works**
**Ran tests locally, they pass**