### PR TITLE
RPC: Add `da_get_monitored_transaction`

### DIFF
--- a/bin/citrea/tests/bitcoin/bitcoin_test.rs
+++ b/bin/citrea/tests/bitcoin/bitcoin_test.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use anyhow::bail;
 use async_trait::async_trait;
+use bitcoin::hashes::Hash;
 use bitcoin::{Amount, Txid};
 use bitcoin_da::monitoring::TxStatus;
 use bitcoin_da::rpc::DaRpcClient;
@@ -181,6 +182,20 @@ impl TestCase for DaMonitoringTest {
             .da_get_tx_status(mempool0[0])
             .await?;
         assert!(matches!(tx_status, Some(TxStatus::Pending { .. })));
+
+        let monitored_tx = sequencer
+            .client
+            .http_client()
+            .da_get_monitored_transaction(pending_txs[0].txid)
+            .await?;
+        assert_eq!(pending_txs[0], monitored_tx.unwrap());
+
+        let non_monitored_tx = sequencer
+            .client
+            .http_client()
+            .da_get_monitored_transaction(Txid::all_zeros())
+            .await?;
+        assert!(non_monitored_tx.is_none());
 
         da.generate(1).await?;
 

--- a/bin/citrea/tests/bitcoin/tx_chain.rs
+++ b/bin/citrea/tests/bitcoin/tx_chain.rs
@@ -385,7 +385,7 @@ impl TestSequencerTransactionChaining {
         let monitored_txs = sequencer
             .client
             .http_client()
-            .da_get_monitored_transactions()
+            .da_list_monitored_transactions()
             .await?;
 
         assert_eq!(monitored_txs.len(), 2);

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -10,7 +10,7 @@ use crate::fee::BumpFeeMethod;
 use crate::monitoring::{MonitoredTx, TxStatus};
 use crate::service::BitcoinService;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MonitoredTxResponse {
     pub txid: Txid,
     pub vsize: usize,
@@ -53,8 +53,14 @@ pub trait DaRpc {
     #[method(name = "getPendingTransactions")]
     async fn da_get_pending_transactions(&self) -> RpcResult<Vec<MonitoredTxResponse>>;
 
-    #[method(name = "getMonitoredTransactions")]
-    async fn da_get_monitored_transactions(&self) -> RpcResult<Vec<MonitoredTxResponse>>;
+    #[method(name = "listMonitoredTransactions")]
+    async fn da_list_monitored_transactions(&self) -> RpcResult<Vec<MonitoredTxResponse>>;
+
+    #[method(name = "getMonitoredTransaction")]
+    async fn da_get_monitored_transaction(
+        &self,
+        txid: Txid,
+    ) -> RpcResult<Option<MonitoredTxResponse>>;
 
     #[method(name = "getTxStatus")]
     async fn da_get_tx_status(&self, txid: Txid) -> RpcResult<Option<TxStatus>>;
@@ -95,7 +101,7 @@ impl DaRpcServer for DaRpcServerImpl {
         Ok(txs)
     }
 
-    async fn da_get_monitored_transactions(&self) -> RpcResult<Vec<MonitoredTxResponse>> {
+    async fn da_list_monitored_transactions(&self) -> RpcResult<Vec<MonitoredTxResponse>> {
         Ok(self
             .da
             .monitoring
@@ -104,6 +110,20 @@ impl DaRpcServer for DaRpcServerImpl {
             .into_iter()
             .map(Into::into)
             .collect::<Vec<_>>())
+    }
+
+    async fn da_get_monitored_transaction(
+        &self,
+        txid: Txid,
+    ) -> RpcResult<Option<MonitoredTxResponse>> {
+        Ok(self
+            .da
+            .monitoring
+            .get_monitored_txs()
+            .await
+            .get(&txid)
+            .map(ToOwned::to_owned)
+            .map(|tx| (txid, tx).into()))
     }
 
     async fn da_get_tx_status(&self, txid: Txid) -> RpcResult<Option<TxStatus>> {

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -119,10 +119,8 @@ impl DaRpcServer for DaRpcServerImpl {
         Ok(self
             .da
             .monitoring
-            .get_monitored_txs()
+            .get_monitored_tx(&txid)
             .await
-            .get(&txid)
-            .map(ToOwned::to_owned)
             .map(|tx| (txid, tx).into()))
     }
 


### PR DESCRIPTION
# Description

- Add `da_get_monitored_transaction` to get a single `MonitoredTx` by id.
- rename `da_get_monitored_transactions` to `da_list_monitored_transactions`

## Linked Issues
- Fixes #2452 