### PR TITLE
Convert wrapping_sub to saturating_sub in verify_forks

### DIFF
--- a/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/fork/mod.rs
@@ -56,7 +56,7 @@ pub const fn verify_forks(forks: &[Fork]) -> bool {
             }
         } else {
             // Validate spec_id increase by 1, and activation height is strictly greater than the previous fork
-            if (fork.spec_id as u8).wrapping_sub(forks[i - 1].spec_id as u8) != 1
+            if (fork.spec_id as u8).saturating_sub(forks[i - 1].spec_id as u8) != 1
                 || fork.activation_height <= forks[i - 1].activation_height
             {
                 return false;


### PR DESCRIPTION
# Description

If SpecId ever reaches 255 variants, wrapping_sub check might evaluate to true due to wrapping_sub(0 - 255)= 1. Minor issue.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
