### PR TITLE
The current timestamp of the block should be strictly greater than thee timestamp of the last block

### DIFF
--- a/crates/l2-block-rule-enforcer/src/hooks.rs
+++ b/crates/l2-block-rule-enforcer/src/hooks.rs
@@ -74,7 +74,7 @@ impl<C: Context, Da: DaSpec> L2BlockRuleEnforcer<C, Da> {
     }
 
     /// Checks that the current block's timestamp.
-    /// This is to make sure that the set timestamp is greater than the last block's timestamp.
+    /// This is to make sure that the set timestamp is strictly greater than the last block's timestamp.
     ///
     /// # Arguments
     ///
@@ -104,7 +104,7 @@ impl<C: Context, Da: DaSpec> L2BlockRuleEnforcer<C, Da> {
     ) -> Result<(), L2BlockHookError> {
         let current_timestamp = l2_block.timestamp();
 
-        if current_timestamp < *last_timestamp {
+        if current_timestamp <= *last_timestamp {
             return Err(L2BlockHookError::TimestampShouldBeGreater);
         }
 


### PR DESCRIPTION
# Description
The current timestamp of the block should be strictly greater than thee timestamp of the last block
