### PR TITLE
Da rpc: Optional hex in MonitoredTxResponse

### DIFF
--- a/bin/citrea/tests/bitcoin/bitcoin_test.rs
+++ b/bin/citrea/tests/bitcoin/bitcoin_test.rs
@@ -186,14 +186,14 @@ impl TestCase for DaMonitoringTest {
         let monitored_tx = sequencer
             .client
             .http_client()
-            .da_get_monitored_transaction(pending_txs[0].txid)
+            .da_get_monitored_transaction(pending_txs[0].txid, false)
             .await?;
         assert_eq!(pending_txs[0], monitored_tx.unwrap());
 
         let non_monitored_tx = sequencer
             .client
             .http_client()
-            .da_get_monitored_transaction(Txid::all_zeros())
+            .da_get_monitored_transaction(Txid::all_zeros(), false)
             .await?;
         assert!(non_monitored_tx.is_none());
 

--- a/bin/citrea/tests/bitcoin/tx_chain.rs
+++ b/bin/citrea/tests/bitcoin/tx_chain.rs
@@ -385,7 +385,7 @@ impl TestSequencerTransactionChaining {
         let monitored_txs = sequencer
             .client
             .http_client()
-            .da_list_monitored_transactions()
+            .da_list_monitored_transactions(false)
             .await?;
 
         assert_eq!(monitored_txs.len(), 2);

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -20,11 +20,11 @@ pub struct MonitoredTxResponse {
     pub prev_txid: Option<Txid>,
     pub next_txid: Option<Txid>,
     pub status: TxStatus,
-    pub hex: String,
+    pub hex: Option<String>,
 }
 
-impl From<(Txid, MonitoredTx)> for MonitoredTxResponse {
-    fn from((txid, tx): (Txid, MonitoredTx)) -> Self {
+impl From<(Txid, MonitoredTx, bool)> for MonitoredTxResponse {
+    fn from((txid, tx, with_hex): (Txid, MonitoredTx, bool)) -> Self {
         let base_fee = if let TxStatus::Pending { base_fee, .. } = tx.status {
             Some(base_fee)
         } else {
@@ -32,7 +32,7 @@ impl From<(Txid, MonitoredTx)> for MonitoredTxResponse {
         };
 
         let raw_tx_bytes = bitcoin::consensus::encode::serialize(&tx.tx);
-        let hex = hex::encode(&raw_tx_bytes);
+        let hex = with_hex.then(|| hex::encode(&raw_tx_bytes));
 
         MonitoredTxResponse {
             txid,
@@ -45,6 +45,12 @@ impl From<(Txid, MonitoredTx)> for MonitoredTxResponse {
             status: tx.status,
             hex,
         }
+    }
+}
+
+impl From<(Txid, MonitoredTx)> for MonitoredTxResponse {
+    fn from((txid, tx): (Txid, MonitoredTx)) -> Self {
+        Self::from((txid, tx, false)) // Defaults to hex verbosity false
     }
 }
 
@@ -121,7 +127,7 @@ impl DaRpcServer for DaRpcServerImpl {
             .monitoring
             .get_monitored_tx(&txid)
             .await
-            .map(|tx| (txid, tx).into()))
+            .map(|tx| (txid, tx, true).into()))
     }
 
     async fn da_get_tx_status(&self, txid: Txid) -> RpcResult<Option<TxStatus>> {

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -20,6 +20,7 @@ pub struct MonitoredTxResponse {
     pub prev_txid: Option<Txid>,
     pub next_txid: Option<Txid>,
     pub status: TxStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hex: Option<String>,
 }
 

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -60,12 +60,16 @@ pub trait DaRpc {
     async fn da_get_pending_transactions(&self) -> RpcResult<Vec<MonitoredTxResponse>>;
 
     #[method(name = "listMonitoredTransactions")]
-    async fn da_list_monitored_transactions(&self) -> RpcResult<Vec<MonitoredTxResponse>>;
+    async fn da_list_monitored_transactions(
+        &self,
+        with_hex: bool,
+    ) -> RpcResult<Vec<MonitoredTxResponse>>;
 
     #[method(name = "getMonitoredTransaction")]
     async fn da_get_monitored_transaction(
         &self,
         txid: Txid,
+        with_hex: bool,
     ) -> RpcResult<Option<MonitoredTxResponse>>;
 
     #[method(name = "getTxStatus")]
@@ -107,27 +111,31 @@ impl DaRpcServer for DaRpcServerImpl {
         Ok(txs)
     }
 
-    async fn da_list_monitored_transactions(&self) -> RpcResult<Vec<MonitoredTxResponse>> {
+    async fn da_list_monitored_transactions(
+        &self,
+        with_hex: bool,
+    ) -> RpcResult<Vec<MonitoredTxResponse>> {
         Ok(self
             .da
             .monitoring
             .get_monitored_txs()
             .await
             .into_iter()
-            .map(Into::into)
+            .map(|(txid, tx)| (txid, tx, with_hex).into())
             .collect::<Vec<_>>())
     }
 
     async fn da_get_monitored_transaction(
         &self,
         txid: Txid,
+        with_hex: bool,
     ) -> RpcResult<Option<MonitoredTxResponse>> {
         Ok(self
             .da
             .monitoring
             .get_monitored_tx(&txid)
             .await
-            .map(|tx| (txid, tx, true).into()))
+            .map(|tx| (txid, tx, with_hex).into()))
     }
 
     async fn da_get_tx_status(&self, txid: Txid) -> RpcResult<Option<TxStatus>> {


### PR DESCRIPTION
# Description

- Only send hex when querying a single tx. Don't send hexes as part of list

## Linked Issues
- Fixes #2450 