### PR TITLE
Refactor verify_tx_merkle_root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,6 +2589,7 @@ dependencies = [
  "alloy-eips",
  "brotli",
  "rs_merkle",
+ "sha2 0.10.8",
  "sov-rollup-interface",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10083,6 +10083,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
+ "sha2 0.10.8",
  "sov-modules-api",
  "sov-modules-core",
  "sov-state",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,7 +2406,6 @@ dependencies = [
  "reth-primitives",
  "reth-tasks",
  "rocksdb",
- "rs_merkle",
  "serde",
  "serde_json",
  "sov-db",
@@ -2589,6 +2588,7 @@ version = "0.7.2"
 dependencies = [
  "alloy-eips",
  "brotli",
+ "rs_merkle",
  "sov-rollup-interface",
 ]
 

--- a/crates/citrea-stf/tests/blueprint.rs
+++ b/crates/citrea-stf/tests/blueprint.rs
@@ -122,8 +122,7 @@ fn create_l2_block(
         EMPTY_TX_ROOT,
         10 * (height - 1),
     );
-    let digest = header.compute_digest::<<DefaultContext as sov_modules_api::Spec>::Hasher>();
-    let hash = Into::<[u8; 32]>::into(digest);
+    let hash = header.compute_digest();
     let signature = sequencer_private_key.sign(&hash);
     let signature = borsh::to_vec(&signature).unwrap();
     let l2_block = L2Block {
@@ -175,8 +174,7 @@ fn test_wrong_l2_block_signature() {
     let random_private_key = K256PrivateKey::generate();
 
     let header = L2Header::new(2, [0; 32], [0; 32], 128u128, EMPTY_TX_ROOT, 10);
-    let digest = header.compute_digest::<<DefaultContext as sov_modules_api::Spec>::Hasher>();
-    let hash = Into::<[u8; 32]>::into(digest);
+    let hash = header.compute_digest();
     let signature = random_private_key.sign(&hash);
     let signature = borsh::to_vec(&signature).unwrap();
 
@@ -202,8 +200,7 @@ fn test_wrong_l2_block_hash() {
     let sequencer_public_key = sequencer_private_key.pub_key();
 
     let header = L2Header::new(2, [0; 32], [0; 32], 128u128, EMPTY_TX_ROOT, 10);
-    let digest = header.compute_digest::<<DefaultContext as sov_modules_api::Spec>::Hasher>();
-    let hash = Into::<[u8; 32]>::into(digest);
+    let hash = header.compute_digest();
     let signature = sequencer_private_key.sign(&hash);
     let signature = borsh::to_vec(&signature).unwrap();
     let l2_block = L2Block {
@@ -227,8 +224,7 @@ fn test_wrong_l2_tx_merkle_root() {
     let sequencer_public_key = sequencer_private_key.pub_key();
 
     let header = L2Header::new(2, [0; 32], [0; 32], 128u128, [100; 32], 10);
-    let digest = header.compute_digest::<<DefaultContext as sov_modules_api::Spec>::Hasher>();
-    let hash = Into::<[u8; 32]>::into(digest);
+    let hash = header.compute_digest();
     let signature = sequencer_private_key.sign(&hash);
     let signature = borsh::to_vec(&signature).unwrap();
     let l2_block = L2Block {
@@ -918,8 +914,7 @@ fn test_panic_l2_block_processing_failure() {
         EMPTY_TX_ROOT,
         20, // Use proper timestamp
     );
-    let digest = header.compute_digest::<<DefaultContext as sov_modules_api::Spec>::Hasher>();
-    let hash = Into::<[u8; 32]>::into(digest);
+    let hash = header.compute_digest();
     let signature = sequencer_private_key.sign(&hash);
     let signature = borsh::to_vec(&signature).unwrap();
     let fake_block = L2Block {
@@ -1001,8 +996,7 @@ fn test_panic_l2_block_timestamp_validation_failure() {
         block_cache[2].1.tx_merkle_root(),
         0, // wrong timestamp (should be greater than previous block's timestamp)
     );
-    let digest = header.compute_digest::<<DefaultContext as sov_modules_api::Spec>::Hasher>();
-    let hash = Into::<[u8; 32]>::into(digest);
+    let hash = header.compute_digest();
     let signature = sequencer_private_key.sign(&hash);
     let signature = borsh::to_vec(&signature).unwrap();
     let corrupted_l2_block = L2Block {
@@ -1104,8 +1098,7 @@ fn test_panic_l2_block_prev_hash_failure() {
         block_cache[2].1.tx_merkle_root(),
         block_cache[2].1.timestamp(), // Use a later timestamp to avoid TimestampShouldBeGreater error
     );
-    let digest = header.compute_digest::<<DefaultContext as sov_modules_api::Spec>::Hasher>();
-    let hash = Into::<[u8; 32]>::into(digest);
+    let hash = header.compute_digest();
     let signature = sequencer_private_key.sign(&hash);
     let signature = borsh::to_vec(&signature).unwrap();
     let corrupted_l2_block = L2Block {
@@ -1189,8 +1182,7 @@ fn test_panic_state_root_assertion_failure() {
         EMPTY_TX_ROOT,
         0,
     );
-    let digest = header.compute_digest::<<DefaultContext as sov_modules_api::Spec>::Hasher>();
-    let hash = Into::<[u8; 32]>::into(digest);
+    let hash = header.compute_digest();
     let signature = sequencer_private_key.sign(&hash);
     let signature = borsh::to_vec(&signature).unwrap();
     let corrupted_l2_block = L2Block {
@@ -1444,8 +1436,7 @@ fn test_panic_state_root_mismatch_assertion() {
         EMPTY_TX_ROOT,
         0,
     );
-    let digest = header.compute_digest::<<DefaultContext as sov_modules_api::Spec>::Hasher>();
-    let hash = Into::<[u8; 32]>::into(digest);
+    let hash = header.compute_digest();
     let signature = sequencer_private_key.sign(&hash);
     let signature = borsh::to_vec(&signature).unwrap();
     let problematic_block = L2Block {

--- a/crates/citrea-stf/tests/blueprint.rs
+++ b/crates/citrea-stf/tests/blueprint.rs
@@ -182,7 +182,7 @@ fn test_wrong_l2_block_signature() {
         header: SignedL2Header::new(header, hash, signature),
         txs: vec![],
     };
-    let result = stf_blueprint.verify_l2_block(&l2_block, &sequencer_public_key);
+    let result = stf_blueprint.verify_l2_block(&l2_block, &sequencer_public_key, SpecId::Fork3);
 
     assert!(matches!(
         result,
@@ -207,7 +207,7 @@ fn test_wrong_l2_block_hash() {
         header: SignedL2Header::new(header, [0; 32], signature),
         txs: vec![],
     };
-    let result = stf_blueprint.verify_l2_block(&l2_block, &sequencer_public_key);
+    let result = stf_blueprint.verify_l2_block(&l2_block, &sequencer_public_key, SpecId::Fork3);
     assert!(matches!(
         result,
         Err(StateTransitionError::L2BlockError(
@@ -231,7 +231,7 @@ fn test_wrong_l2_tx_merkle_root() {
         header: SignedL2Header::new(header, [0; 32], signature),
         txs: vec![],
     };
-    let result = stf_blueprint.verify_l2_block(&l2_block, &sequencer_public_key);
+    let result = stf_blueprint.verify_l2_block(&l2_block, &sequencer_public_key, SpecId::Fork3);
     assert!(matches!(
         result,
         Err(StateTransitionError::L2BlockError(

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -28,7 +28,6 @@ metrics = { workspace = true }
 reth-primitives = { workspace = true }
 reth-tasks = { workspace = true }
 rocksdb = { workspace = true }
-rs_merkle = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/common/src/l2.rs
+++ b/crates/common/src/l2.rs
@@ -5,6 +5,7 @@ use alloy_primitives::U64;
 use anyhow::{bail, Context as _};
 use backoff::exponential::ExponentialBackoffBuilder;
 use backoff::future::retry as retry_backoff;
+use citrea_primitives::merkle::compute_tx_hashes;
 use citrea_primitives::types::L2BlockHash;
 use citrea_stf::runtime::CitreaRuntime;
 use jsonrpsee::core::client::Error as JsonrpseeError;
@@ -25,7 +26,7 @@ use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
 use tracing::{debug, error, info, warn};
 
-use crate::utils::{compute_tx_hashes, decode_sov_tx_and_update_short_header_proofs};
+use crate::utils::decode_sov_tx_and_update_short_header_proofs;
 
 pub struct ProcessL2BlockResult {
     pub l2_height: u64,
@@ -122,7 +123,7 @@ pub async fn process_l2_block<Da: DaService, DB: SharedLedgerOps>(
 
     storage_manager.finalize_storage(l2_block_result.change_set);
 
-    let tx_hashes = compute_tx_hashes::<DefaultContext>(&l2_block.txs, current_spec);
+    let tx_hashes = compute_tx_hashes(&l2_block.txs);
     let tx_bodies = if include_tx_body { tx_bodies } else { None };
 
     ledger_db.commit_l2_block(l2_block, tx_hashes, tx_bodies)?;

--- a/crates/common/src/l2.rs
+++ b/crates/common/src/l2.rs
@@ -123,7 +123,7 @@ pub async fn process_l2_block<Da: DaService, DB: SharedLedgerOps>(
 
     storage_manager.finalize_storage(l2_block_result.change_set);
 
-    let tx_hashes = compute_tx_hashes(&l2_block.txs);
+    let tx_hashes = compute_tx_hashes(&l2_block.txs, current_spec);
     let tx_bodies = if include_tx_body { tx_bodies } else { None };
 
     ledger_db.commit_l2_block(l2_block, tx_hashes, tx_bodies)?;

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -13,6 +13,7 @@ sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface" }
 # 3rd-party deps
 alloy-eips = { workspace = true }
 brotli = { workspace = true }
+rs_merkle = { workspace = true }
 
 [features]
 testing = ["sov-rollup-interface/testing"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -14,6 +14,7 @@ sov-rollup-interface = { path = "../sovereign-sdk/rollup-interface" }
 alloy-eips = { workspace = true }
 brotli = { workspace = true }
 rs_merkle = { workspace = true }
+sha2 = { workspace = true }
 
 [features]
 testing = ["sov-rollup-interface/testing"]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -2,6 +2,7 @@ pub mod basefee;
 pub mod compression;
 mod constants;
 pub mod forks;
+pub mod merkle;
 pub mod types;
 
 pub use constants::*;

--- a/crates/primitives/src/merkle.rs
+++ b/crates/primitives/src/merkle.rs
@@ -1,27 +1,60 @@
-use rs_merkle::algorithms::Sha256;
+use rs_merkle::algorithms::Sha256 as Sha256WithoutSeparator;
 use rs_merkle::MerkleTree;
+use sha2::digest::{Digest, FixedOutput};
+use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::transaction::Transaction;
 
 use crate::EMPTY_TX_ROOT;
 
-pub fn compute_tx_hashes(txs: &[Transaction]) -> Vec<[u8; 32]> {
-    txs.iter().map(|tx| tx.compute_digest()).collect()
+pub fn compute_tx_hashes(txs: &[Transaction], spec: SpecId) -> Vec<[u8; 32]> {
+    let digest_fn = if spec >= SpecId::Fork3 {
+        |tx: &Transaction| {
+            // rehash with separator
+            let hash = tx.compute_digest();
+            let mut hasher = sha2::Sha256::new_with_prefix([0]);
+            hasher.update(hash);
+            <[u8; 32]>::from(hasher.finalize_fixed())
+        }
+    } else {
+        |tx: &Transaction| tx.compute_digest()
+    };
+    txs.iter().map(digest_fn).collect()
 }
 
-pub fn compute_tx_merkle_root(tx_hashes: &[[u8; 32]]) -> [u8; 32] {
+pub fn compute_tx_merkle_root(tx_hashes: &[[u8; 32]], spec: SpecId) -> [u8; 32] {
     if tx_hashes.is_empty() {
         return EMPTY_TX_ROOT;
     }
 
-    MerkleTree::<Sha256>::from_leaves(tx_hashes)
-        .root()
-        .expect("Couldn't compute merkle root")
+    #[derive(Clone)]
+    pub struct Sha256WithSeparator {}
+
+    impl rs_merkle::Hasher for Sha256WithSeparator {
+        type Hash = [u8; 32];
+
+        fn hash(data: &[u8]) -> [u8; 32] {
+            let mut hasher = sha2::Sha256::new_with_prefix([1]);
+
+            hasher.update(data);
+            <[u8; 32]>::from(hasher.finalize_fixed())
+        }
+    }
+
+    if spec >= SpecId::Fork3 {
+        MerkleTree::<Sha256WithSeparator>::from_leaves(tx_hashes)
+            .root()
+            .expect("Couldn't compute merkle root")
+    } else {
+        MerkleTree::<Sha256WithoutSeparator>::from_leaves(tx_hashes)
+            .root()
+            .expect("Couldn't compute merkle root")
+    }
 }
 
-pub fn verify_tx_merkle_root(txs: &[Transaction], root: [u8; 32]) -> bool {
+pub fn verify_tx_merkle_root(txs: &[Transaction], root: [u8; 32], spec: SpecId) -> bool {
     // Calculate tx hashes for merkle root
-    let tx_hashes = compute_tx_hashes(txs);
-    let tx_merkle_root = compute_tx_merkle_root(&tx_hashes);
+    let tx_hashes = compute_tx_hashes(txs, spec);
+    let tx_merkle_root = compute_tx_merkle_root(&tx_hashes, spec);
 
-    tx_merkle_root != root
+    tx_merkle_root == root
 }

--- a/crates/primitives/src/merkle.rs
+++ b/crates/primitives/src/merkle.rs
@@ -1,0 +1,27 @@
+use rs_merkle::algorithms::Sha256;
+use rs_merkle::MerkleTree;
+use sov_rollup_interface::transaction::Transaction;
+
+use crate::EMPTY_TX_ROOT;
+
+pub fn compute_tx_hashes(txs: &[Transaction]) -> Vec<[u8; 32]> {
+    txs.iter().map(|tx| tx.compute_digest()).collect()
+}
+
+pub fn compute_tx_merkle_root(tx_hashes: &[[u8; 32]]) -> [u8; 32] {
+    if tx_hashes.is_empty() {
+        return EMPTY_TX_ROOT;
+    }
+
+    MerkleTree::<Sha256>::from_leaves(tx_hashes)
+        .root()
+        .expect("Couldn't compute merkle root")
+}
+
+pub fn verify_tx_merkle_root(txs: &[Transaction], root: [u8; 32]) -> bool {
+    // Calculate tx hashes for merkle root
+    let tx_hashes = compute_tx_hashes(txs);
+    let tx_merkle_root = compute_tx_merkle_root(&tx_hashes);
+
+    tx_merkle_root != root
+}

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -9,7 +9,6 @@ use anyhow::{anyhow, bail};
 use backoff::future::retry as retry_backoff;
 use backoff::ExponentialBackoffBuilder;
 use citrea_common::backup::BackupManager;
-use citrea_common::utils::{compute_tx_hashes, compute_tx_merkle_root};
 use citrea_common::{InitParams, RollupPublicKeys, SequencerConfig};
 use citrea_evm::system_events::{create_system_transactions, SystemEvent};
 use citrea_evm::{
@@ -19,6 +18,7 @@ use citrea_evm::{
 };
 use citrea_primitives::basefee::calculate_next_block_base_fee;
 use citrea_primitives::forks::fork_from_block_number;
+use citrea_primitives::merkle::{compute_tx_hashes, compute_tx_merkle_root};
 use citrea_primitives::types::L2BlockHash;
 use citrea_stf::runtime::{CitreaRuntime, DefaultContext};
 use parking_lot::Mutex;
@@ -536,8 +536,8 @@ where
             .finalize_l2_block(active_fork_spec, working_set, prestate);
 
         // Calculate tx hashes for merkle root
-        let tx_hashes = compute_tx_hashes::<DefaultContext>(&txs, active_fork_spec);
-        let tx_merkle_root = compute_tx_merkle_root(&tx_hashes)?;
+        let tx_hashes = compute_tx_hashes(&txs);
+        let tx_merkle_root = compute_tx_merkle_root(&tx_hashes);
 
         // create the l2 block header
         let header = L2Header::new(
@@ -894,8 +894,7 @@ where
     /// # Returns
     /// A signed L2 block header
     fn sign_l2_block_header(&mut self, header: L2Header) -> anyhow::Result<SignedL2Header> {
-        let digest = header.compute_digest::<<DefaultContext as sov_modules_api::Spec>::Hasher>();
-        let hash = Into::<[u8; 32]>::into(digest);
+        let hash = header.compute_digest();
 
         let signature = self.sov_tx_signer_priv_key.sign(&hash);
         let signature = borsh::to_vec(&signature)?;

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -536,8 +536,8 @@ where
             .finalize_l2_block(active_fork_spec, working_set, prestate);
 
         // Calculate tx hashes for merkle root
-        let tx_hashes = compute_tx_hashes(&txs);
-        let tx_merkle_root = compute_tx_merkle_root(&tx_hashes);
+        let tx_hashes = compute_tx_hashes(&txs, active_fork_spec);
+        let tx_merkle_root = compute_tx_merkle_root(&tx_hashes, active_fork_spec);
 
         // create the l2 block header
         let header = L2Header::new(

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/default_context.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/default_context.rs
@@ -28,7 +28,6 @@ impl Spec for DefaultContext {
     type Storage = ProverStorage;
     type PrivateKey = K256PrivateKey;
     type PublicKey = K256PublicKey;
-    type Hasher = sha2::Sha256;
     type Signature = K256Signature;
 }
 
@@ -76,7 +75,6 @@ impl Spec for ZkDefaultContext {
     #[cfg(feature = "native")]
     type PrivateKey = K256PrivateKey;
     type PublicKey = K256PublicKey;
-    type Hasher = sha2::Sha256;
     type Signature = K256Signature;
 }
 

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/utils.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/utils.rs
@@ -3,7 +3,7 @@ use sov_modules_core::{Context, Spec};
 use sov_rollup_interface::digest::Digest;
 
 pub fn generate_address<C: Context>(key: &str) -> <C as Spec>::Address {
-    let hash: [u8; 32] = <C as Spec>::Hasher::digest(key.as_bytes()).into();
+    let hash: [u8; 32] = sha2::Sha256::digest(key.as_bytes()).into();
     C::Address::from(hash)
 }
 

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/common/bytes.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/common/bytes.rs
@@ -150,7 +150,7 @@ impl ModulePrefix {
     /// Returns the hash of the combined prefix.
     pub fn hash<C: Context>(&self) -> [u8; 32] {
         let combined_prefix = self.combine_prefix();
-        let mut hasher = C::Hasher::new();
+        let mut hasher = sha2::Sha256::new();
         hasher.update(combined_prefix);
         hasher.finalize().into()
     }

--- a/crates/sovereign-sdk/module-system/sov-modules-core/src/module/spec.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-core/src/module/spec.rs
@@ -3,8 +3,6 @@
 use core::fmt::Debug;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use digest::typenum::U32;
-use digest::Digest;
 use sov_keys::error::KeyError;
 use sov_keys::{PublicKey, Signature};
 use sov_rollup_interface::spec::SpecId;
@@ -64,9 +62,6 @@ pub trait Spec: BorshDeserialize + BorshSerialize {
     /// The public key used for digital signatures
     #[cfg(not(all(feature = "native", feature = "std")))]
     type PublicKey: PublicKey;
-
-    /// The hasher preferred by the rollup, such as Sha256 or Poseidon.
-    type Hasher: Digest<OutputSize = U32>;
 
     /// The digital signature scheme used by the rollup
     #[cfg(all(feature = "native", feature = "std"))]

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
@@ -23,6 +23,7 @@ path = "tests/all_tests.rs"
 sov-modules-api = { path = "../sov-modules-api", features = ["native"] }
 sov-modules-core = { path = "../sov-modules-core" }
 sov-state = { path = "../sov-state" }
+sha2 = { workspace = true }
 
 borsh = { workspace = true }
 jsonrpsee = { workspace = true, features = ["macros", "http-client", "server"] }
@@ -30,7 +31,10 @@ serde = { workspace = true }
 trybuild = "1.0"
 
 [dependencies]
-jsonrpsee = { workspace = true, features = ["http-client", "server"], optional = true }
+jsonrpsee = { workspace = true, features = [
+    "http-client",
+    "server",
+], optional = true }
 proc-macro2 = "1.0"
 quote = "1.0"
 serde_json = { workspace = true }

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/Cargo.toml
@@ -45,4 +45,10 @@ default = ["native"]
 native = ["jsonrpsee"]
 
 [package.metadata.cargo-udeps.ignore]
-development = ["borsh", "sov-modules-api", "sov-modules-core", "sov-state"]
+development = [
+    "borsh",
+    "sov-modules-api",
+    "sov-modules-core",
+    "sov-state",
+    "sha2",
+]

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/tests/module_info/parse.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/tests/module_info/parse.rs
@@ -64,7 +64,7 @@ fn main() {
     );
 
     use sov_modules_api::digest::Digest;
-    let mut hasher = <C as sov_modules_api::Spec>::Hasher::new();
+    let mut hasher = sha2::Sha256::new();
     // hasher.update("trybuild000::test_module/TestStruct/".as_bytes());
     hasher.update("TestStruct/".as_bytes());
     let hash: [u8; 32] = hasher.finalize().into();

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -146,7 +146,7 @@
 //! ```
 
 use borsh::BorshDeserialize;
-use citrea_primitives::EMPTY_TX_ROOT;
+use citrea_primitives::merkle::verify_tx_merkle_root;
 use rs_merkle::algorithms::Sha256;
 use rs_merkle::{MerkleProof, MerkleTree};
 #[cfg(feature = "native")]
@@ -157,7 +157,7 @@ use sov_modules_api::fork::Fork;
 use sov_modules_api::hooks::{
     ApplyL2BlockHooks, FinalizeHook, HookL2BlockInfo, SlotHooks, TxHooks,
 };
-use sov_modules_api::{native_debug, Context, DaSpec, DispatchCall, Genesis, Spec, WorkingSet};
+use sov_modules_api::{native_debug, Context, DaSpec, DispatchCall, Genesis, WorkingSet};
 use sov_rollup_interface::block::{L2Block, SignedL2Header};
 use sov_rollup_interface::da::SequencerCommitment;
 use sov_rollup_interface::fork::ForkManager;
@@ -278,11 +278,13 @@ where
     ) -> Result<(), StateTransitionError> {
         let l2_header = &l2_block.header;
 
-        verify_tx_merkle_root::<C>(l2_block)
-            .map_err(|_| StateTransitionError::L2BlockError(L2BlockError::InvalidTxMerkleRoot))?;
+        if !verify_tx_merkle_root(&l2_block.txs, l2_block.tx_merkle_root()) {
+            return Err(StateTransitionError::L2BlockError(
+                L2BlockError::InvalidTxMerkleRoot,
+            ));
+        }
 
-        let expected_hash =
-            Into::<[u8; 32]>::into(l2_header.inner.compute_digest::<<C as Spec>::Hasher>());
+        let expected_hash = l2_header.inner.compute_digest();
 
         if l2_block.hash() != expected_hash {
             return Err(StateTransitionError::L2BlockError(
@@ -515,10 +517,7 @@ where
                     - prev_hash_proof.prev_sequencer_commitment_start)
                     as usize;
                 let count = index + 1;
-                let last_header_hash = prev_hash_proof
-                    .last_header
-                    .compute_digest::<<C as Spec>::Hasher>()
-                    .into();
+                let last_header_hash = prev_hash_proof.last_header.compute_digest();
 
                 assert!(
                     merkle_proof.verify(
@@ -729,30 +728,5 @@ fn verify_signature(
 
     signature.verify(sequencer_public_key, &header.hash)?;
 
-    Ok(())
-}
-
-fn verify_tx_merkle_root<C: Context + Spec>(
-    l2_block: &L2Block,
-) -> Result<(), StateTransitionError> {
-    let tx_hashes: Vec<[u8; 32]> = l2_block
-        .txs
-        .iter()
-        .map(|tx| tx.compute_digest::<<C as Spec>::Hasher>().into())
-        .collect();
-
-    let tx_merkle_root = if tx_hashes.is_empty() {
-        EMPTY_TX_ROOT
-    } else {
-        MerkleTree::<Sha256>::from_leaves(&tx_hashes)
-            .root()
-            .expect("Couldn't compute merkle root")
-    };
-
-    if tx_merkle_root != l2_block.tx_merkle_root() {
-        return Err(StateTransitionError::L2BlockError(
-            L2BlockError::InvalidTxMerkleRoot,
-        ));
-    }
     Ok(())
 }

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -275,10 +275,11 @@ where
         &self,
         l2_block: &L2Block,
         sequencer_public_key: &K256PublicKey,
+        current_spec: SpecId,
     ) -> Result<(), StateTransitionError> {
         let l2_header = &l2_block.header;
 
-        if !verify_tx_merkle_root(&l2_block.txs, l2_block.tx_merkle_root()) {
+        if !verify_tx_merkle_root(&l2_block.txs, l2_block.tx_merkle_root(), current_spec) {
             return Err(StateTransitionError::L2BlockError(
                 L2BlockError::InvalidTxMerkleRoot,
             ));
@@ -440,7 +441,7 @@ where
 
         native_debug!("Applying l2 block in STF Blueprint");
 
-        self.verify_l2_block(l2_block, sequencer_public_key)?;
+        self.verify_l2_block(l2_block, sequencer_public_key, current_spec)?;
 
         self.begin_l2_block(&mut working_set, &l2_block_info)?;
 

--- a/crates/sovereign-sdk/rollup-interface/src/spec.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/spec.rs
@@ -38,6 +38,7 @@ pub enum SpecId {
     /// 1. Fixes for vulnerabilities that need forking on existing networks
     /// 2. Sov-tx signature serialization
     /// 3. Sov-tx serialization to generate signature
+    /// 4. L2 merkle tree separators
     Fork3 = 3,
     /// Fork4 spec
     #[cfg(feature = "testing")]

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/block.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/block.rs
@@ -2,7 +2,7 @@
 //! l2 block
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use digest::{Digest, Output};
+use digest::{Digest, FixedOutput};
 use serde::{Deserialize, Serialize};
 
 use super::transaction::Transaction;
@@ -67,15 +67,15 @@ impl L2Header {
     ///
     /// # Returns
     /// The computed hash digest of the header
-    pub fn compute_digest<D: Digest>(&self) -> Output<D> {
-        let mut hasher = D::new();
+    pub fn compute_digest(&self) -> [u8; 32] {
+        let mut hasher = sha2::Sha256::new();
         hasher.update(self.height.to_be_bytes());
         hasher.update(self.prev_hash);
         hasher.update(self.state_root);
         hasher.update(self.l1_fee_rate.to_be_bytes());
         hasher.update(self.tx_merkle_root);
         hasher.update(self.timestamp.to_be_bytes());
-        hasher.finalize()
+        <[u8; 32]>::from(hasher.finalize_fixed())
     }
 }
 

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/transaction.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/transaction.rs
@@ -1,8 +1,7 @@
 #![allow(missing_docs)]
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use digest::FixedOutput;
-use sha2::Digest;
+use sha2::digest::{Digest, FixedOutput};
 #[cfg(feature = "native")]
 use sov_keys::default_signature::k256_private_key::K256PrivateKey;
 use sov_keys::default_signature::{K256PublicKey, K256Signature};
@@ -65,12 +64,12 @@ impl TransactionV1 {
         Ok(())
     }
 
-    pub fn compute_digest<D: digest::Digest>(&self) -> digest::Output<D> {
-        let mut hasher = D::new();
+    pub fn compute_digest(&self) -> [u8; 32] {
+        let mut hasher = sha2::Sha256::new();
         hasher.update(&self.runtime_msg);
         hasher.update(self.chain_id.to_be_bytes());
         hasher.update(self.nonce.to_be_bytes());
-        hasher.finalize()
+        <[u8; 32]>::from(hasher.finalize_fixed())
     }
 }
 
@@ -117,13 +116,13 @@ impl TransactionV2 {
         Ok(())
     }
 
-    pub fn compute_digest<D: digest::Digest>(&self) -> digest::Output<D> {
-        let mut hasher = D::new();
+    pub fn compute_digest(&self) -> [u8; 32] {
+        let mut hasher = sha2::Sha256::new();
         hasher.update([TxVersion::V2 as u8]);
         hasher.update(&self.runtime_msg);
         hasher.update(self.chain_id.to_be_bytes());
         hasher.update(self.nonce.to_be_bytes());
-        hasher.finalize()
+        <[u8; 32]>::from(hasher.finalize_fixed())
     }
 }
 
@@ -218,10 +217,10 @@ impl Transaction {
         }
     }
 
-    pub fn compute_digest<D: digest::Digest>(&self) -> digest::Output<D> {
+    pub fn compute_digest(&self) -> [u8; 32] {
         match self {
-            Self::V1(tx) => tx.compute_digest::<D>(),
-            Self::V2(tx) => tx.compute_digest::<D>(),
+            Self::V1(tx) => tx.compute_digest(),
+            Self::V2(tx) => tx.compute_digest(),
         }
     }
 }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/transaction.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/transaction.rs
@@ -1,6 +1,8 @@
 #![allow(missing_docs)]
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use digest::FixedOutput;
+use sha2::Digest;
 #[cfg(feature = "native")]
 use sov_keys::default_signature::k256_private_key::K256PrivateKey;
 use sov_keys::default_signature::{K256PublicKey, K256Signature};

--- a/guests/risc0/batch-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.lock
@@ -1230,6 +1230,7 @@ version = "0.7.2"
 dependencies = [
  "alloy-eips",
  "brotli",
+ "rs_merkle",
  "sov-rollup-interface",
 ]
 

--- a/guests/risc0/batch-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "alloy-eips",
  "brotli",
  "rs_merkle",
+ "sha2",
  "sov-rollup-interface",
 ]
 

--- a/guests/risc0/batch-proof/mock/Cargo.lock
+++ b/guests/risc0/batch-proof/mock/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
  "alloy-eips",
  "brotli",
  "rs_merkle",
+ "sha2",
  "sov-rollup-interface",
 ]
 

--- a/guests/risc0/batch-proof/mock/Cargo.lock
+++ b/guests/risc0/batch-proof/mock/Cargo.lock
@@ -1169,6 +1169,7 @@ version = "0.7.2"
 dependencies = [
  "alloy-eips",
  "brotli",
+ "rs_merkle",
  "sov-rollup-interface",
 ]
 

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.lock
@@ -723,6 +723,7 @@ dependencies = [
  "alloy-eips",
  "brotli",
  "rs_merkle",
+ "sha2",
  "sov-rollup-interface",
 ]
 

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.lock
@@ -722,6 +722,7 @@ version = "0.7.2"
 dependencies = [
  "alloy-eips",
  "brotli",
+ "rs_merkle",
  "sov-rollup-interface",
 ]
 

--- a/guests/risc0/light-client-proof/mock/Cargo.lock
+++ b/guests/risc0/light-client-proof/mock/Cargo.lock
@@ -646,6 +646,7 @@ dependencies = [
  "alloy-eips",
  "brotli",
  "rs_merkle",
+ "sha2",
  "sov-rollup-interface",
 ]
 

--- a/guests/risc0/light-client-proof/mock/Cargo.lock
+++ b/guests/risc0/light-client-proof/mock/Cargo.lock
@@ -645,6 +645,7 @@ version = "0.7.2"
 dependencies = [
  "alloy-eips",
  "brotli",
+ "rs_merkle",
  "sov-rollup-interface",
 ]
 


### PR DESCRIPTION
# Description

- Get rid of Spec::Hasher (use sha256 everywhere)
- Use common code to build/verify merkle root
- Add separators to merkle tree leaves