### PR TITLE
Use enum for node kind instead of string

### DIFF
--- a/bin/citrea/src/cli.rs
+++ b/bin/citrea/src/cli.rs
@@ -3,6 +3,7 @@ use citrea::NetworkArg;
 use citrea_common::{
     from_toml_path, BatchProverConfig, FromEnv, LightClientProverConfig, SequencerConfig,
 };
+use citrea_storage_ops::types::NodeKind;
 use clap::{command, Parser};
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -83,6 +84,17 @@ impl std::fmt::Display for NodeType {
             NodeType::LightClientProver(_) => {
                 write!(f, "light-client-prover")
             }
+        }
+    }
+}
+
+impl From<&NodeType> for NodeKind {
+    fn from(value: &NodeType) -> Self {
+        match value {
+            NodeType::Sequencer(_) => NodeKind::Sequencer,
+            NodeType::FullNode => NodeKind::FullNode,
+            NodeType::BatchProver(_) => NodeKind::BatchProver,
+            NodeType::LightClientProver(_) => NodeKind::LightClientProver,
         }
     }
 }

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -141,7 +141,7 @@ where
     let rollup_blueprint = S::new(network);
 
     let backup_manager = Arc::new(BackupManager::new(
-        node_type.to_string(),
+        (&node_type).into(),
         rollup_config.storage.backup_path.clone(),
         Default::default(),
     ));

--- a/bin/cli/src/commands/backup.rs
+++ b/bin/cli/src/commands/backup.rs
@@ -1,10 +1,11 @@
 use std::path::PathBuf;
 
 use citrea_common::backup::BackupManager;
+use citrea_storage_ops::types::NodeKind;
 use tracing::info;
 
 pub(crate) async fn restore_backup(
-    node_kind: String,
+    node_kind: NodeKind,
     db_path: PathBuf,
     backup_path: PathBuf,
     backup_id: u32,

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use citrea_storage_ops::types::NodeKind;
 use clap::{Parser, Subcommand, ValueEnum};
 use commands::StorageNodeTypeArg;
 use tracing_subscriber::fmt;
@@ -10,20 +11,31 @@ mod commands;
 
 #[derive(Clone, Debug, ValueEnum)]
 #[value(rename_all = "kebab-case")]
-enum NodeKind {
+enum NodeKindArg {
     BatchProver,
     Sequencer,
     FullNode,
     LightClientProver,
 }
 
-impl std::fmt::Display for NodeKind {
+impl std::fmt::Display for NodeKindArg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            NodeKind::BatchProver => write!(f, "batch-prover"),
-            NodeKind::Sequencer => write!(f, "sequencer"),
-            NodeKind::FullNode => write!(f, "full-node"),
-            NodeKind::LightClientProver => write!(f, "light-client-prover"),
+            NodeKindArg::BatchProver => write!(f, "batch-prover"),
+            NodeKindArg::Sequencer => write!(f, "sequencer"),
+            NodeKindArg::FullNode => write!(f, "full-node"),
+            NodeKindArg::LightClientProver => write!(f, "light-client-prover"),
+        }
+    }
+}
+
+impl From<NodeKindArg> for NodeKind {
+    fn from(value: NodeKindArg) -> Self {
+        match value {
+            NodeKindArg::Sequencer => NodeKind::Sequencer,
+            NodeKindArg::FullNode => NodeKind::FullNode,
+            NodeKindArg::BatchProver => NodeKind::BatchProver,
+            NodeKindArg::LightClientProver => NodeKind::LightClientProver,
         }
     }
 }
@@ -70,7 +82,7 @@ enum Commands {
     RestoreBackup {
         /// The node kind
         #[arg(long)]
-        node_kind: NodeKind,
+        node_kind: NodeKindArg,
         /// The path of the databases to restore to
         #[arg(long)]
         db_path: PathBuf,
@@ -125,8 +137,7 @@ async fn main() -> anyhow::Result<()> {
             node_kind,
             backup_id,
         } => {
-            commands::restore_backup(node_kind.to_string(), db_path, backup_path, backup_id)
-                .await?;
+            commands::restore_backup(node_kind.into(), db_path, backup_path, backup_id).await?;
         }
     }
 

--- a/crates/storage-ops/src/types.rs
+++ b/crates/storage-ops/src/types.rs
@@ -7,3 +7,22 @@ pub enum StorageNodeType {
     BatchProver,
     LightClient,
 }
+
+#[derive(Copy, Clone, Debug)]
+pub enum NodeKind {
+    Sequencer,
+    FullNode,
+    BatchProver,
+    LightClientProver,
+}
+
+impl std::fmt::Display for NodeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NodeKind::BatchProver => write!(f, "batch-prover"),
+            NodeKind::Sequencer => write!(f, "sequencer"),
+            NodeKind::FullNode => write!(f, "full-node"),
+            NodeKind::LightClientProver => write!(f, "light-client-prover"),
+        }
+    }
+}


### PR DESCRIPTION
# Description
`node_kind` in backup manager used to be String, now it is enum.

Fixes TODO:
https://github.com/chainwayxyz/citrea/blob/f91916d9bc0a96e200698af168410899f85cd7f6/crates/common/src/backup/manager.rs#L87

