### PR TITLE
chore: remove sequencer_pub_key from HookL2BlockInfo

### DIFF
--- a/crates/citrea-stf/tests/blueprint.rs
+++ b/crates/citrea-stf/tests/blueprint.rs
@@ -96,13 +96,12 @@ fn create_l2_block(
         l2_height: height,
         pre_state_root: prev_state_root,
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: sequencer_public_key.clone(),
         l1_fee_rate: 128u128,
         timestamp: 10 * (height - 1),
     };
 
     stf_blueprint
-        .begin_l2_block(&mut working_set, &l2_block_info)
+        .begin_l2_block(&mut working_set, &l2_block_info, &sequencer_public_key)
         .unwrap();
     stf_blueprint
         .end_l2_block(l2_block_info, &mut working_set)
@@ -1197,13 +1196,12 @@ fn test_panic_state_root_assertion_failure() {
         l2_height: 1,
         pre_state_root: state_root,
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: sequencer_public_key.clone(),
         l1_fee_rate: 128u128,
         timestamp: 0,
     };
 
     stf_blueprint
-        .begin_l2_block(&mut working_set, &l2_block_info)
+        .begin_l2_block(&mut working_set, &l2_block_info, &sequencer_public_key)
         .unwrap();
     stf_blueprint
         .end_l2_block(l2_block_info, &mut working_set)
@@ -1451,13 +1449,12 @@ fn test_panic_state_root_mismatch_assertion() {
         l2_height: 1,
         pre_state_root: state_root,
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: sequencer_public_key.clone(),
         l1_fee_rate: u128::MAX, // This should match the block's gas fee rate
         timestamp: 0,
     };
 
     stf_blueprint
-        .begin_l2_block(&mut working_set, &l2_block_info)
+        .begin_l2_block(&mut working_set, &l2_block_info, &sequencer_public_key)
         .unwrap();
     stf_blueprint
         .end_l2_block(l2_block_info, &mut working_set)

--- a/crates/evm/src/tests/call_tests.rs
+++ b/crates/evm/src/tests/call_tests.rs
@@ -35,7 +35,7 @@ use crate::tests::utils::{
     get_evm_config, get_evm_config_starting_base_fee, get_evm_with_spec, get_fork_fn_latest,
     publish_event_message, set_arg_message,
 };
-use crate::tests::{get_test_seq_pub_key, DEFAULT_CHAIN_ID};
+use crate::tests::DEFAULT_CHAIN_ID;
 use crate::{
     AccountData, EvmConfig, RlpEvmTransaction, BASE_FEE_VAULT, L1_FEE_VAULT, PRIORITY_FEE_VAULT,
 };
@@ -67,7 +67,6 @@ fn call_multiple_test() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -201,7 +200,6 @@ fn call_test() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -279,7 +277,6 @@ fn failed_transaction_test() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -347,7 +344,6 @@ fn self_destruct_test() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -414,7 +410,6 @@ fn self_destruct_test() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -502,7 +497,6 @@ fn test_block_hash_in_evm() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -535,7 +529,6 @@ fn test_block_hash_in_evm() {
             l2_height,
             pre_state_root: [99u8; 32],
             current_spec: SovSpecId::Tangerine,
-            sequencer_pub_key: get_test_seq_pub_key(),
             l1_fee_rate,
             timestamp: 0,
         };
@@ -655,7 +648,6 @@ fn test_block_gas_limit() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -716,7 +708,6 @@ fn test_block_gas_limit() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -876,7 +867,6 @@ fn test_l1_fee_success() {
             l2_height: 2,
             pre_state_root: [10u8; 32],
             current_spec: SovSpecId::Tangerine,
-            sequencer_pub_key: get_test_seq_pub_key(),
             l1_fee_rate,
             timestamp: 0,
         };
@@ -981,7 +971,6 @@ fn test_l1_fee_not_enough_funds() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1054,7 +1043,6 @@ fn test_l1_fee_halt() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1168,7 +1156,6 @@ fn test_l1_fee_compression_discount() {
         l2_height: 2,
         pre_state_root: [99u8; 32],
         current_spec: SovSpecId::Tangerine, // Compression discount is enabled
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1257,7 +1244,6 @@ fn test_blob_tx() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine, // won't be Tangerine at height 2 currently but we can trick the spec id
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1333,7 +1319,6 @@ fn test_eip7702_tx() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1379,7 +1364,6 @@ fn test_eip7702_tx() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1503,7 +1487,6 @@ fn test_eip7702_tx() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1609,7 +1592,6 @@ fn test_eip7702_tx() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -20,7 +20,6 @@ use sov_state::ProverStorage;
 use crate::primitive_types::Block;
 use crate::tests::ef_tests::models::{BlockchainTest, ForkSpec};
 use crate::tests::ef_tests::{Case, Error, Suite};
-use crate::tests::get_test_seq_pub_key;
 use crate::tests::utils::{commit, config_push_contracts, get_evm_with_storage};
 use crate::{AccountData, Evm, EvmChainConfig, EvmConfig, RlpEvmTransaction, U256};
 
@@ -71,8 +70,7 @@ impl BlockchainTestCase {
                 l2_height,
                 pre_state_root: *root,
                 current_spec,
-                sequencer_pub_key: get_test_seq_pub_key(),
-                l1_fee_rate,
+                        l1_fee_rate,
                 timestamp: 0,
             };
 

--- a/crates/evm/src/tests/fork_tests.rs
+++ b/crates/evm/src/tests/fork_tests.rs
@@ -18,7 +18,6 @@ use crate::smart_contracts::{
     SchnorrVerifyCallerContract, SelfDestructorContract, SelfdestructingConstructorContract,
     SimpleStorageContract, TransientStorageContract,
 };
-use crate::tests::get_test_seq_pub_key;
 use crate::tests::test_signer::TestSigner;
 use crate::tests::utils::{
     create_contract_message, get_evm, get_evm_config, get_evm_with_spec, set_arg_message,
@@ -130,7 +129,6 @@ fn test_cancun_transient_storage_activation() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -243,7 +241,6 @@ fn test_cancun_mcopy_activation() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -319,7 +316,6 @@ fn test_self_destructing_constructor() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -399,7 +395,6 @@ fn test_blob_base_fee_should_return_1() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -476,7 +471,6 @@ fn test_kzg_point_eval_should_revert() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -585,7 +579,6 @@ fn test_p256_verify() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -641,7 +634,6 @@ fn test_schnorr_verify() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -676,8 +668,7 @@ fn test_schnorr_verify() {
                 l2_height,
                 pre_state_root: [10u8; 32],
                 current_spec: SovSpecId::Tangerine,
-                sequencer_pub_key: get_test_seq_pub_key(),
-                l1_fee_rate,
+                        l1_fee_rate,
                 timestamp: 0,
             };
             let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
@@ -774,7 +765,6 @@ fn test_offchain_contract_storage_evm() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -874,7 +864,6 @@ fn test_offchain_contract_storage_evm() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -18,7 +18,7 @@ use crate::evm::primitive_types::{
 use crate::system_events::SYSTEM_SIGNATURE;
 use crate::tests::genesis_tests::BENEFICIARY;
 use crate::tests::utils::{get_evm, get_evm_test_config, GENESIS_STATE_ROOT};
-use crate::tests::{get_test_seq_pub_key, DEFAULT_CHAIN_ID};
+use crate::tests::DEFAULT_CHAIN_ID;
 use crate::PendingTransaction;
 
 lazy_static! {
@@ -35,7 +35,7 @@ fn begin_l2_block_hook_creates_pending_block() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+
         l1_fee_rate,
         timestamp: 54,
     };
@@ -71,7 +71,7 @@ fn end_l2_block_hook_sets_head() {
         l2_height,
         pre_state_root,
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+
         l1_fee_rate,
         timestamp: 54,
     };
@@ -141,7 +141,6 @@ fn end_l2_block_hook_moves_transactions_and_receipts() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -256,7 +255,7 @@ fn finalize_hook_creates_final_block() {
         l2_height,
         pre_state_root: root,
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+
         l1_fee_rate,
         timestamp: 54,
     };
@@ -281,7 +280,7 @@ fn finalize_hook_creates_final_block() {
             l2_height,
             pre_state_root: root_hash,
             current_spec: SpecId::Tangerine,
-            sequencer_pub_key: get_test_seq_pub_key(),
+
             l1_fee_rate,
             timestamp: 54,
         },
@@ -365,7 +364,7 @@ fn begin_l2_block_hook_appends_last_block_hashes() {
         l2_height,
         pre_state_root: root,
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+
         l1_fee_rate,
         timestamp: 0,
     };
@@ -399,7 +398,7 @@ fn begin_l2_block_hook_appends_last_block_hashes() {
             l2_height,
             pre_state_root: random_32_bytes,
             current_spec: SpecId::Tangerine,
-            sequencer_pub_key: get_test_seq_pub_key(),
+
             l1_fee_rate,
             timestamp: 0,
         };
@@ -419,7 +418,7 @@ fn begin_l2_block_hook_appends_last_block_hashes() {
         l2_height,
         pre_state_root: random_32_bytes,
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+
         l1_fee_rate,
         timestamp: 0,
     };

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -35,7 +35,6 @@ fn begin_l2_block_hook_creates_pending_block() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-
         l1_fee_rate,
         timestamp: 54,
     };
@@ -71,7 +70,6 @@ fn end_l2_block_hook_sets_head() {
         l2_height,
         pre_state_root,
         current_spec: SpecId::Tangerine,
-
         l1_fee_rate,
         timestamp: 54,
     };
@@ -255,7 +253,6 @@ fn finalize_hook_creates_final_block() {
         l2_height,
         pre_state_root: root,
         current_spec: SpecId::Tangerine,
-
         l1_fee_rate,
         timestamp: 54,
     };
@@ -280,7 +277,6 @@ fn finalize_hook_creates_final_block() {
             l2_height,
             pre_state_root: root_hash,
             current_spec: SpecId::Tangerine,
-
             l1_fee_rate,
             timestamp: 54,
         },
@@ -364,7 +360,6 @@ fn begin_l2_block_hook_appends_last_block_hashes() {
         l2_height,
         pre_state_root: root,
         current_spec: SpecId::Tangerine,
-
         l1_fee_rate,
         timestamp: 0,
     };
@@ -398,7 +393,6 @@ fn begin_l2_block_hook_appends_last_block_hashes() {
             l2_height,
             pre_state_root: random_32_bytes,
             current_spec: SpecId::Tangerine,
-
             l1_fee_rate,
             timestamp: 0,
         };
@@ -418,7 +412,6 @@ fn begin_l2_block_hook_appends_last_block_hashes() {
         l2_height,
         pre_state_root: random_32_bytes,
         current_spec: SpecId::Tangerine,
-
         l1_fee_rate,
         timestamp: 0,
     };

--- a/crates/evm/src/tests/mod.rs
+++ b/crates/evm/src/tests/mod.rs
@@ -17,6 +17,7 @@ mod utils;
 #[cfg(test)]
 pub const DEFAULT_CHAIN_ID: u64 = 1;
 
+#[allow(dead_code)]
 fn get_test_seq_pub_key() -> K256PublicKey {
     K256PublicKey::try_from_slice(
         &hex::decode("036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f7").unwrap(),

--- a/crates/evm/src/tests/mod.rs
+++ b/crates/evm/src/tests/mod.rs
@@ -16,11 +16,3 @@ mod utils;
 /// Different chain ids can be given in the genesis config.
 #[cfg(test)]
 pub const DEFAULT_CHAIN_ID: u64 = 1;
-
-#[allow(dead_code)]
-fn get_test_seq_pub_key() -> K256PublicKey {
-    K256PublicKey::try_from_slice(
-        &hex::decode("036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f7").unwrap(),
-    )
-    .unwrap()
-}

--- a/crates/evm/src/tests/queries/eth_call_tests.rs
+++ b/crates/evm/src/tests/queries/eth_call_tests.rs
@@ -17,7 +17,6 @@ use sov_modules_api::{Context, Module, Spec, WorkingSet};
 use sov_rollup_interface::spec::SpecId;
 
 use crate::smart_contracts::{BlockHashContract, SimpleStorageContract};
-use crate::tests::get_test_seq_pub_key;
 use crate::tests::queries::{init_evm, init_evm_single_block};
 use crate::tests::test_signer::TestSigner;
 use crate::tests::utils::{create_contract_message, get_evm, get_evm_config, get_fork_fn_latest};
@@ -89,7 +88,6 @@ fn test_state_change() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate: 1,
         timestamp: 0,
     };
@@ -757,7 +755,6 @@ fn test_call_with_block_overrides() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -791,8 +788,7 @@ fn test_call_with_block_overrides() {
             l2_height,
             pre_state_root: [99u8; 32],
             current_spec: SpecId::Tangerine,
-            sequencer_pub_key: get_test_seq_pub_key(),
-            l1_fee_rate,
+                l1_fee_rate,
             timestamp: 0,
         };
 

--- a/crates/evm/src/tests/queries/log_tests.rs
+++ b/crates/evm/src/tests/queries/log_tests.rs
@@ -14,7 +14,6 @@ use sov_rollup_interface::spec::SpecId;
 
 use crate::call::CallMessage;
 use crate::smart_contracts::LogsContract;
-use crate::tests::get_test_seq_pub_key;
 use crate::tests::queries::init_evm;
 use crate::tests::utils::{
     create_contract_message, get_evm, get_evm_config, publish_event_message,
@@ -92,7 +91,6 @@ fn log_filter_test_at_block_hash() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -303,7 +301,6 @@ fn log_filter_test_with_range() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -361,7 +358,6 @@ fn log_filter_test_with_range() {
         l2_height,
         pre_state_root: [99u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -421,7 +417,6 @@ fn test_log_limits() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -518,8 +513,7 @@ fn test_log_limits() {
             l2_height,
             pre_state_root: [99u8; 32],
             current_spec: SpecId::Tangerine,
-            sequencer_pub_key: get_test_seq_pub_key(),
-            l1_fee_rate,
+                l1_fee_rate,
             timestamp: 0,
         };
         // generate 100_000 blocks to test the max block range limit

--- a/crates/evm/src/tests/queries/mod.rs
+++ b/crates/evm/src/tests/queries/mod.rs
@@ -15,7 +15,6 @@ use sov_modules_api::{Context, Module, Spec, WorkingSet};
 use sov_rollup_interface::spec::SpecId as SovSpecId;
 use sov_state::ProverStorage;
 
-use super::get_test_seq_pub_key;
 use crate::call::CallMessage;
 use crate::smart_contracts::{
     CallerContract, LogsContract, SimplePayableContract, SimpleStorageContract,
@@ -79,7 +78,6 @@ fn init_evm(
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: spec_id,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 24,
     };
@@ -117,7 +115,6 @@ fn init_evm(
         l2_height,
         pre_state_root: [99u8; 32],
         current_spec: spec_id,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 24,
     };
@@ -156,7 +153,6 @@ fn init_evm(
         l2_height,
         pre_state_root: [100u8; 32],
         current_spec: spec_id,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 24,
     };
@@ -244,7 +240,6 @@ pub fn init_evm_single_block(
         l2_height: 1,
         pre_state_root: [0u8; 32],
         current_spec: spec_id,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -319,7 +314,6 @@ pub fn init_evm_with_caller_contract() -> (
         l2_height,
         pre_state_root: [0u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -355,7 +349,6 @@ pub fn init_evm_with_caller_contract() -> (
         l2_height,
         pre_state_root: [2u8; 32],
         current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };

--- a/crates/evm/src/tests/sys_tx_tests.rs
+++ b/crates/evm/src/tests/sys_tx_tests.rs
@@ -971,7 +971,6 @@ fn test_change_upgrade_owner() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1006,7 +1005,6 @@ fn test_change_upgrade_owner() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1092,7 +1090,6 @@ fn test_wcbtc() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1163,7 +1160,6 @@ fn test_wcbtc() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1254,7 +1250,6 @@ fn test_system_tx_after_user_tx_should_error_out() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        
         l1_fee_rate: 1,
         timestamp: 0,
     };
@@ -1281,7 +1276,6 @@ fn test_system_tx_after_user_tx_should_error_out() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1367,7 +1361,6 @@ fn test_set_block_info_shp_not_found() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        
         l1_fee_rate,
         timestamp: 42,
     };
@@ -1479,7 +1472,6 @@ fn test_set_block_info_shp_verification_failed() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        
         l1_fee_rate,
         timestamp: 42,
     };

--- a/crates/evm/src/tests/sys_tx_tests.rs
+++ b/crates/evm/src/tests/sys_tx_tests.rs
@@ -28,7 +28,6 @@ use crate::handler::L1_FEE_OVERHEAD;
 use crate::smart_contracts::{BlockHashContract, LogsContract, SimpleStorageContract};
 use crate::system_contracts::{BridgeWrapper, ProxyAdmin, WCBTC};
 use crate::system_events::{create_system_transactions, SystemEvent};
-use crate::tests::get_test_seq_pub_key;
 use crate::tests::test_signer::TestSigner;
 use crate::tests::utils::{
     config_push_contracts, create_contract_message, create_contract_message_with_fee,
@@ -176,7 +175,6 @@ fn test_sys_bitcoin_light_client() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 42,
     };
@@ -313,7 +311,6 @@ fn test_sys_bitcoin_light_client() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 42,
     };
@@ -446,7 +443,6 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate: 1,
         timestamp: 0,
     };
@@ -473,7 +469,6 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -552,7 +547,6 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -661,7 +655,6 @@ fn test_bridge() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate: 1,
         timestamp: 0,
     };
@@ -869,7 +862,6 @@ fn test_upgrade_light_client() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
@@ -979,7 +971,7 @@ fn test_change_upgrade_owner() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+        
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1014,7 +1006,7 @@ fn test_change_upgrade_owner() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+        
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1100,7 +1092,7 @@ fn test_wcbtc() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+        
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1171,7 +1163,7 @@ fn test_wcbtc() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+        
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1262,7 +1254,7 @@ fn test_system_tx_after_user_tx_should_error_out() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+        
         l1_fee_rate: 1,
         timestamp: 0,
     };
@@ -1289,7 +1281,7 @@ fn test_system_tx_after_user_tx_should_error_out() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+        
         l1_fee_rate,
         timestamp: 0,
     };
@@ -1375,7 +1367,7 @@ fn test_set_block_info_shp_not_found() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+        
         l1_fee_rate,
         timestamp: 42,
     };
@@ -1487,7 +1479,7 @@ fn test_set_block_info_shp_verification_failed() {
         l2_height,
         pre_state_root: [10u8; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
+        
         l1_fee_rate,
         timestamp: 42,
     };

--- a/crates/evm/src/tests/utils.rs
+++ b/crates/evm/src/tests/utils.rs
@@ -17,7 +17,6 @@ use sov_prover_storage_manager::new_orphan_storage;
 use sov_rollup_interface::spec::SpecId as SovSpecId;
 use sov_state::{ProverStorage, Storage};
 
-use super::get_test_seq_pub_key;
 use crate::smart_contracts::{LogsContract, SimpleStorageContract, TestContract};
 use crate::tests::test_signer::TestSigner;
 use crate::{AccountData, Evm, EvmConfig, RlpEvmTransaction, PRIORITY_FEE_VAULT};
@@ -87,7 +86,6 @@ pub(crate) fn get_evm_with_spec(
         l2_height: 1,
         pre_state_root: root,
         current_spec: spec_id,
-        sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate: 0,
         timestamp: 0,
     };

--- a/crates/l2-block-rule-enforcer/src/tests/mod.rs
+++ b/crates/l2-block-rule-enforcer/src/tests/mod.rs
@@ -7,9 +7,7 @@ mod hooks_tests;
 #[cfg(test)]
 mod query_tests;
 
-use borsh::BorshDeserialize;
 use citrea_evm::{keccak256, Evm, BITCOIN_LIGHT_CLIENT_CONTRACT_ADDRESS, U256};
-use sov_keys::default_signature::K256PublicKey;
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::hooks::HookL2BlockInfo;
 use sov_modules_api::{SpecId, WorkingSet};
@@ -20,11 +18,6 @@ fn sc_info_helper() -> HookL2BlockInfo {
         l2_height: 1,
         pre_state_root: [0; 32],
         current_spec: SpecId::Tangerine,
-        sequencer_pub_key: K256PublicKey::try_from_slice(
-            &hex::decode("036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f7")
-                .unwrap(),
-        )
-        .unwrap(),
         l1_fee_rate: 1,
         timestamp: 10,
     }

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -35,6 +35,7 @@ use sov_accounts::Response::{AccountEmpty, AccountExists};
 use sov_db::ledger_db::{LedgerDB, SequencerLedgerOps, SharedLedgerOps};
 use sov_db::schema::types::L2BlockNumber;
 use sov_keys::default_signature::k256_private_key::K256PrivateKey;
+use sov_keys::default_signature::K256PublicKey;
 use sov_modules_api::hooks::HookL2BlockInfo;
 use sov_modules_api::{
     EncodeCall, L2Block, L2BlockModuleCallError, PrivateKey, SlotData, Spec, SpecId, StateDiff,
@@ -195,6 +196,7 @@ where
         >,
         prestate: ProverStorage,
         l2_block_info: HookL2BlockInfo,
+        sequencer_public_key: &K256PublicKey,
         deposit_data: &[Vec<u8>],
         da_blocks: Vec<Da::FilteredBlock>,
     ) -> anyhow::Result<(Vec<RlpEvmTransaction>, Vec<TxHash>)> {
@@ -209,10 +211,11 @@ where
             let mut nonce = self.get_nonce(&mut working_set_to_discard)?;
 
             // Apply L2 block hook before processing transactions
-            if let Err(err) = self
-                .stf
-                .begin_l2_block(&mut working_set_to_discard, &l2_block_info)
-            {
+            if let Err(err) = self.stf.begin_l2_block(
+                &mut working_set_to_discard,
+                &l2_block_info,
+                sequencer_public_key,
+            ) {
                 warn!(
                     "DryRun: Failed to apply l2 block hook: {:?} \n reverting batch workspace",
                     err
@@ -460,7 +463,6 @@ where
             l2_height,
             pre_state_root: self.state_root,
             current_spec: active_fork_spec,
-            sequencer_pub_key: pub_key.clone(),
             l1_fee_rate,
             timestamp,
         };
@@ -481,6 +483,7 @@ where
                 evm_txs,
                 prestate.clone(),
                 l2_block_info.clone(),
+                &pub_key,
                 &deposit_data,
                 da_blocks,
             )
@@ -495,7 +498,10 @@ where
 
         let mut working_set = WorkingSet::new(prestate.clone());
 
-        if let Err(err) = self.stf.begin_l2_block(&mut working_set, &l2_block_info) {
+        if let Err(err) = self
+            .stf
+            .begin_l2_block(&mut working_set, &l2_block_info, &pub_key)
+        {
             warn!(
                 "Failed to apply l2 block hook: {:?} \n reverting batch workspace",
                 err

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/hooks.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/hooks.rs
@@ -1,6 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use sov_keys::default_signature::K256PublicKey;
 use sov_modules_core::{AccessoryWorkingSet, Context, Spec, WorkingSet};
 use sov_rollup_interface::block::L2Block;
 use sov_rollup_interface::da::DaSpec;
@@ -71,8 +70,6 @@ pub struct HookL2BlockInfo {
     pub pre_state_root: StorageRootHash,
     /// The current spec
     pub current_spec: SpecId,
-    /// Public key of the sequencer
-    pub sequencer_pub_key: K256PublicKey,
     /// L1 fee rate
     pub l1_fee_rate: u128,
     /// Timestamp
@@ -90,10 +87,6 @@ impl HookL2BlockInfo {
 
     pub fn current_spec(&self) -> SpecId {
         self.current_spec
-    }
-
-    pub fn sequencer_pub_key(&self) -> &K256PublicKey {
-        &self.sequencer_pub_key
     }
 
     pub fn l1_fee_rate(&self) -> u128 {
@@ -115,13 +108,11 @@ impl HookL2BlockInfo {
         l2_block: &L2Block,
         pre_state_root: StorageRootHash,
         current_spec: SpecId,
-        sequencer_pub_key: K256PublicKey,
     ) -> Self {
         Self {
             l2_height: l2_block.height(),
             pre_state_root,
             current_spec,
-            sequencer_pub_key,
             l1_fee_rate: l2_block.l1_fee_rate(),
             timestamp: l2_block.timestamp(),
         }

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -254,8 +254,9 @@ where
         &mut self,
         working_set: &mut WorkingSet<C::Storage>,
         l2_block_info: &HookL2BlockInfo,
+        sequencer_pub_key: &K256PublicKey,
     ) -> Result<(), StateTransitionError> {
-        self.begin_l2_block_inner(working_set, l2_block_info)
+        self.begin_l2_block_inner(working_set, l2_block_info, sequencer_pub_key)
             .map_err(StateTransitionError::HookError)
     }
 
@@ -424,7 +425,6 @@ where
             l2_block,
             *pre_state_root,
             current_spec,
-            sequencer_public_key.clone(),
         );
 
         let mut working_set = if let Some(state_log) = cumulative_state_log {
@@ -443,7 +443,7 @@ where
 
         self.verify_l2_block(l2_block, sequencer_public_key, current_spec)?;
 
-        self.begin_l2_block(&mut working_set, &l2_block_info)?;
+        self.begin_l2_block(&mut working_set, &l2_block_info, sequencer_public_key)?;
 
         self.apply_l2_block_txs(&l2_block_info, &l2_block.txs, &mut working_set)?;
 

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use sov_keys::default_signature::K256PublicKey;
 use sov_modules_api::hooks::HookL2BlockInfo;
 use sov_modules_api::{native_debug, native_error, Context, DaSpec, WorkingSet};
 use sov_rollup_interface::stf::{L2BlockError, L2BlockHookError, StateTransitionError};
@@ -109,11 +110,12 @@ where
         &mut self,
         working_set: &mut WorkingSet<C::Storage>,
         l2_block_info: &HookL2BlockInfo,
+        sequencer_pub_key: &K256PublicKey,
     ) -> Result<(), L2BlockHookError> {
         native_debug!(
             "Beginning l2 block #{} from sequencer: 0x{}",
             l2_block_info.l2_height(),
-            l2_block_info.sequencer_pub_key()
+            sequencer_pub_key
         );
 
         // ApplyL2BlockHook: begin


### PR DESCRIPTION
# Description
- Removes `sequencer_pub_key` from `HookL2BlockInfo`
- Modifies signature of `begin_l2_block` to include a parameter of type `&K256PublicKey` and executes the log inside this function itself.
- Modifies signature of `dry_run_transactions` to include a parameter of type `&K256PublicKey` since it calls `begin_l2_block`

## Linked Issues
- Fixes #2472 
