### PR TITLE
Da monitoring: Pass transaction alongside id when monitoring

### DIFF
--- a/bin/citrea/tests/bitcoin/bitcoin_test.rs
+++ b/bin/citrea/tests/bitcoin/bitcoin_test.rs
@@ -99,7 +99,7 @@ impl TestCase for BitcoinReorgTest {
             .http_client()
             .da_get_tx_status(mempool0[0])
             .await?;
-        assert!(matches!(tx_status, Some(TxStatus::Pending { .. })));
+        assert!(matches!(tx_status, Some(TxStatus::InMempool { .. })));
 
         // Wait for re-org monitoring
         tokio::time::sleep(Duration::from_secs(20)).await;
@@ -181,7 +181,7 @@ impl TestCase for DaMonitoringTest {
             .http_client()
             .da_get_tx_status(mempool0[0])
             .await?;
-        assert!(matches!(tx_status, Some(TxStatus::Pending { .. })));
+        assert!(matches!(tx_status, Some(TxStatus::InMempool { .. })));
 
         let monitored_tx = sequencer
             .client

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -1557,19 +1557,19 @@ impl TestCase for UnchainedBatchProofsTest {
             Some(fake_sequencer_commitment.serialize_and_calculate_sha_256()),
         );
 
-        let mut txids = bitcoin_da_service
+        let mut txs = bitcoin_da_service
             .send_transaction_with_fee_rate(DaTxRequest::ZKProof(bp1), 1)
             .await
             .unwrap();
 
-        txids.extend(
+        txs.extend(
             bitcoin_da_service
                 .send_transaction_with_fee_rate(DaTxRequest::ZKProof(bp2), 1)
                 .await
                 .unwrap(),
         );
 
-        txids.extend(
+        txs.extend(
             bitcoin_da_service
                 .send_transaction_with_fee_rate(DaTxRequest::ZKProof(bp3), 1)
                 .await
@@ -1582,7 +1582,7 @@ impl TestCase for UnchainedBatchProofsTest {
                 .await?
                 .assume_checked()
                 .to_string(),
-            txids.into_iter().map(|txid| txid.to_string()).collect(),
+            txs.into_iter().map(|tx| tx.id.to_string()).collect(),
         )
         .await?;
 
@@ -2259,7 +2259,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
             None,
         );
 
-        let txids = batch_prover_bitcoin_da_service
+        let txs = batch_prover_bitcoin_da_service
             .send_transaction_with_fee_rate(DaTxRequest::ZKProof(bp1), 1)
             .await
             .unwrap();
@@ -2271,7 +2271,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
                 .await?
                 .assume_checked()
                 .to_string(),
-            txids.into_iter().map(|txid| txid.to_string()).collect(),
+            txs.into_iter().map(|tx| tx.id.to_string()).collect(),
         )
         .await?;
 
@@ -2326,7 +2326,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
             None,
         );
 
-        let txids = batch_prover_bitcoin_da_service
+        let txs = batch_prover_bitcoin_da_service
             .send_transaction_with_fee_rate(DaTxRequest::ZKProof(bp1), 1)
             .await
             .unwrap();
@@ -2338,7 +2338,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
                 .await?
                 .assume_checked()
                 .to_string(),
-            txids.into_iter().map(|txid| txid.to_string()).collect(),
+            txs.into_iter().map(|tx| tx.id.to_string()).collect(),
         )
         .await?;
 
@@ -2400,7 +2400,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
             Some(fake_sequencer_commitment.serialize_and_calculate_sha_256()),
         );
 
-        let txids = malicious_bitcoin_da_service
+        let txs = malicious_bitcoin_da_service
             .send_transaction_with_fee_rate(DaTxRequest::ZKProof(bp2.clone()), 1)
             .await
             .unwrap();
@@ -2412,7 +2412,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
                 .await?
                 .assume_checked()
                 .to_string(),
-            txids.into_iter().map(|txid| txid.to_string()).collect(),
+            txs.into_iter().map(|tx| tx.id.to_string()).collect(),
         )
         .await?;
 
@@ -2437,7 +2437,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
         assert_eq!(lcp_output.last_sequencer_commitment_index, U32::from(1));
 
         // Now send batch proof with the correct da pub key and expect it to transition
-        let txids = batch_prover_bitcoin_da_service
+        let txs = batch_prover_bitcoin_da_service
             .send_transaction_with_fee_rate(DaTxRequest::ZKProof(bp2.clone()), 1)
             .await
             .unwrap();
@@ -2449,7 +2449,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
                 .await?
                 .assume_checked()
                 .to_string(),
-            txids.into_iter().map(|txid| txid.to_string()).collect(),
+            txs.into_iter().map(|tx| tx.id.to_string()).collect(),
         )
         .await?;
 

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -26,7 +26,7 @@ pub struct MonitoredTxResponse {
 
 impl From<(Txid, MonitoredTx, bool)> for MonitoredTxResponse {
     fn from((txid, tx, with_hex): (Txid, MonitoredTx, bool)) -> Self {
-        let base_fee = if let TxStatus::Pending { base_fee, .. } = tx.status {
+        let base_fee = if let TxStatus::InMempool { base_fee, .. } = tx.status {
             Some(base_fee)
         } else {
             None
@@ -105,7 +105,7 @@ impl DaRpcServer for DaRpcServerImpl {
             .get_monitored_txs()
             .await
             .into_iter()
-            .filter(|(_, tx)| matches!(tx.status, TxStatus::Pending { .. }))
+            .filter(|(_, tx)| matches!(tx.status, TxStatus::InMempool { .. }))
             .map(Into::into)
             .collect::<Vec<_>>();
 

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -235,13 +235,13 @@ impl BitcoinService {
                                 )
                                 .await
                             {
-                            Ok(txids) => {
-                                let txid = txids.last().unwrap();
-                                let tx_id = TxidWrapper(*txid);
+                            Ok(txs) => {
+                                let txid = txs.last().unwrap().id;
+                                let tx_id = TxidWrapper(txid);
                                 info!(%txid, "Sent tx to BitcoinDA");
                                 let _ = request.notify.send(Ok(tx_id));
 
-                                if let Err(e) = self.monitoring.monitor_transaction_chain(txids).await {
+                                if let Err(e) = self.monitoring.monitor_transaction_chain(txs).await {
                                     error!(?e, "Failed to monitor tx chain");
                                 }
 
@@ -312,7 +312,7 @@ impl BitcoinService {
             .get_monitored_txs()
             .await
             .into_iter()
-            .filter(|(_, tx)| matches!(tx.status, TxStatus::Pending { .. }))
+            .filter(|(_, tx)| matches!(tx.status, TxStatus::InMempool { .. }))
             .map(|(_, monitored_tx)| monitored_tx.tx)
             .collect()
     }
@@ -322,7 +322,7 @@ impl BitcoinService {
         &self,
         tx_request: DaTxRequest,
         fee_sat_per_vbyte: u64,
-    ) -> Result<Vec<Txid>> {
+    ) -> Result<Vec<TxWithId>> {
         let network = self.network;
 
         let da_private_key = self.da_private_key.expect("No private key set");
@@ -472,7 +472,7 @@ impl BitcoinService {
         commit: Transaction,
         reveal: TxWithId,
         back_up_path: PathBuf,
-    ) -> Result<Vec<Txid>> {
+    ) -> Result<Vec<TxWithId>> {
         assert!(!commit_chunks.is_empty(), "Received empty chunks");
         assert_eq!(
             commit_chunks.len(),
@@ -482,11 +482,19 @@ impl BitcoinService {
 
         debug!("Sending chunked transaction");
 
-        let all_tx_map = commit_chunks
+        let all_txs: Vec<TxWithId> = commit_chunks
             .iter()
             .chain(reveal_chunks.iter())
             .chain([&commit, &reveal.tx].into_iter())
-            .map(|tx| (tx.compute_txid(), tx.clone()))
+            .map(|tx| TxWithId {
+                id: tx.compute_txid(),
+                tx: tx.clone(),
+            })
+            .collect();
+
+        let all_tx_map = all_txs
+            .iter()
+            .map(|tx| (tx.id, tx.tx.clone()))
             .collect::<HashMap<_, _>>();
 
         let mut raw_txs = Vec::with_capacity(all_tx_map.len());
@@ -577,7 +585,7 @@ impl BitcoinService {
             info!("Blob chunk aggregate tx sent. Hash: {last_txid}");
         }
 
-        Ok(txids)
+        Ok(all_txs)
     }
 
     pub(crate) async fn send_complete_transaction(
@@ -586,7 +594,7 @@ impl BitcoinService {
         reveal: TxWithId,
         back_up_path: PathBuf,
         back_up_name: &str,
-    ) -> Result<Vec<Txid>> {
+    ) -> Result<Vec<TxWithId>> {
         let signed_raw_commit_tx = self
             .client
             .sign_raw_transaction_with_wallet(&commit, None, None)
@@ -613,7 +621,14 @@ impl BitcoinService {
 
         let txids = self.send_raw_transactions(&raw_txs).await?;
         info!("Blob inscribe tx sent. Hash: {}", txids[1]);
-        Ok(txids)
+
+        Ok(vec![
+            TxWithId {
+                id: commit.compute_txid(),
+                tx: commit,
+            },
+            reveal,
+        ])
     }
 
     #[instrument(level = "trace", skip_all, ret)]
@@ -685,7 +700,7 @@ impl BitcoinService {
             }
         };
 
-        let TxStatus::Pending { .. } = tx.status else {
+        let TxStatus::InMempool { .. } = tx.status else {
             return Err(BitcoinServiceError::WrongStatusForBumping(tx.status));
         };
 
@@ -709,6 +724,9 @@ impl BitcoinService {
 
         let processed = self.client.finalize_psbt(&wallet_psbt.psbt, None).await?;
 
+        let Some(Ok(new_tx)) = processed.transaction() else {
+            return Err(BitcoinServiceError::PsbtFinalizationFailure);
+        };
         let Some(raw_hex) = processed.hex else {
             return Err(BitcoinServiceError::PsbtFinalizationFailure);
         };
@@ -721,7 +739,15 @@ impl BitcoinService {
         match method {
             BumpFeeMethod::Cpfp => {
                 self.monitoring
-                    .monitor_transaction(new_txid, Some(txid), None, MonitoredTxKind::Cpfp)
+                    .monitor_transaction(
+                        TxWithId {
+                            id: new_txid,
+                            tx: new_tx,
+                        },
+                        Some(txid),
+                        None,
+                        MonitoredTxKind::Cpfp,
+                    )
                     .await?;
                 self.monitoring.set_next_tx(&txid, new_txid).await;
             }


### PR DESCRIPTION
# Description

- Pass a vector of `TxWithId` to `monitor_transaction_chain`. This lets us monitor a tx not found via bitcoin rpc (nor in mempool nor in txindex)

## Linked Issues
- Related to #2504, as we need to be able to monitor a transaction that hasn't been broadcasted yet