### PR TITLE
Hide da_queue test behind testing feature

### DIFF
--- a/bin/citrea/tests/bitcoin/mod.rs
+++ b/bin/citrea/tests/bitcoin/mod.rs
@@ -9,6 +9,7 @@ pub mod backup;
 pub mod bitcoin_service;
 pub mod bitcoin_test;
 pub mod bitcoin_verifier;
+#[cfg(feature = "testing")]
 pub mod da_queue;
 pub mod fork;
 #[cfg(feature = "testing")]


### PR DESCRIPTION
# Description

Because without hiding it I got error in vscode:

```
use crate::bitcoin::full_node::create_serialized_fake_receipt_batch_proof_with_state_roots;

err: crate::bitcoin::full_node is enabled in the "testing" feature
```