### PR TITLE
Make getL2StatusHeightsByL1Height and getLightClientProofByL1Height accept l1 height in hex

### DIFF
--- a/bin/citrea/tests/bitcoin/backup.rs
+++ b/bin/citrea/tests/bitcoin/backup.rs
@@ -988,7 +988,7 @@ impl TestCase for BackupLightClientProverTest {
         let first_proof = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await?;
 
         assert!(first_proof.is_some());
@@ -1053,7 +1053,7 @@ impl TestCase for BackupLightClientProverTest {
         let second_proof = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(second_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(second_proof_l1_height))
             .await?
             .unwrap();
 
@@ -1097,7 +1097,7 @@ impl TestCase for BackupLightClientProverTest {
         let restored_proof = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(second_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(second_proof_l1_height))
             .await?
             .unwrap();
 
@@ -1158,7 +1158,7 @@ impl TestCase for BackupLightClientProverTest {
         let rollback_proof = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(second_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(second_proof_l1_height))
             .await?
             .unwrap();
 
@@ -1200,7 +1200,7 @@ impl TestCase for BackupLightClientProverTest {
         let third_proof = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(third_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(third_proof_l1_height))
             .await?
             .unwrap();
 
@@ -1237,7 +1237,7 @@ impl TestCase for BackupLightClientProverTest {
         let final_proof = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(third_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(third_proof_l1_height))
             .await?
             .unwrap();
 
@@ -1253,7 +1253,7 @@ impl TestCase for BackupLightClientProverTest {
         assert!(light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(third_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(third_proof_l1_height))
             .await?
             .is_some());
 

--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -1060,7 +1060,7 @@ impl TestCase for SubmitFakeProofRpcTest {
         let lcp_output = light_client
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?
             .unwrap()
             .light_client_proof_output;
@@ -1110,7 +1110,7 @@ impl TestCase for SubmitFakeProofRpcTest {
         let lcp_output = light_client
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?
             .unwrap()
             .light_client_proof_output;
@@ -1141,7 +1141,7 @@ impl TestCase for SubmitFakeProofRpcTest {
         let lcp_output = light_client
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?
             .unwrap()
             .light_client_proof_output;

--- a/bin/citrea/tests/bitcoin/da_queue.rs
+++ b/bin/citrea/tests/bitcoin/da_queue.rs
@@ -272,7 +272,7 @@ impl TestCase for DaTransactionQueueingTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
 

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -727,7 +727,7 @@ impl TestCase for L2StatusTest {
         assert_eq!(initial_proven_height, None);
 
         let initial_heights_by_l1 = full_node_http_client
-            .get_l2_status_heights_by_l1_height(0)
+            .get_l2_status_heights_by_l1_height(U64::from(0))
             .await?;
         assert_eq!(initial_heights_by_l1.committed.height, 0);
         assert_eq!(initial_heights_by_l1.proven.height, 0);
@@ -758,7 +758,7 @@ impl TestCase for L2StatusTest {
         assert!(proven_height.is_none());
 
         let status_at_commitment_l1_height = full_node_http_client
-            .get_l2_status_heights_by_l1_height(commitment_l1_height)
+            .get_l2_status_heights_by_l1_height(U64::from(commitment_l1_height))
             .await?;
         assert_eq!(
             status_at_commitment_l1_height.committed.height,
@@ -795,7 +795,7 @@ impl TestCase for L2StatusTest {
         let status_at_proof_l1_height = full_node
             .client
             .http_client()
-            .get_l2_status_heights_by_l1_height(batch_proof_l1_height)
+            .get_l2_status_heights_by_l1_height(U64::from(batch_proof_l1_height))
             .await?;
         assert_eq!(
             status_at_proof_l1_height.committed.height,
@@ -841,13 +841,13 @@ impl TestCase for L2StatusTest {
         let status = full_node
             .client
             .http_client()
-            .get_l2_status_heights_by_l1_height(future_l1_height)
+            .get_l2_status_heights_by_l1_height(U64::from(future_l1_height))
             .await?;
         assert_eq!(status.committed.height, max_l2_blocks_per_commitment * 2);
         assert_eq!(status.proven.height, max_l2_blocks_per_commitment);
 
         let status_at_commitment_l1_height = full_node_http_client
-            .get_l2_status_heights_by_l1_height(commitment_l1_height)
+            .get_l2_status_heights_by_l1_height(U64::from(commitment_l1_height))
             .await?;
         assert_eq!(
             status_at_commitment_l1_height.committed.height,
@@ -889,7 +889,7 @@ impl TestCase for L2StatusTest {
         let status_after_rollback = full_node
             .client
             .http_client()
-            .get_l2_status_heights_by_l1_height(0)
+            .get_l2_status_heights_by_l1_height(U64::from(0))
             .await?;
         assert_eq!(status_after_rollback.committed.height, 0);
         assert_eq!(status_after_rollback.proven.height, 0);
@@ -1398,7 +1398,7 @@ impl TestCase for OutOfRangeProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
 
@@ -1861,7 +1861,7 @@ impl TestCase for OutOfRangeProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(proof_l1_height))
             .await?
             .unwrap();
         assert_eq!(
@@ -1918,7 +1918,7 @@ impl TestCase for OutOfRangeProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(proof_l1_height))
             .await?
             .unwrap();
         assert_eq!(
@@ -2015,7 +2015,7 @@ impl TestCase for OverlappingProofRangesTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
 
@@ -2398,7 +2398,7 @@ impl TestCase for OverlappingProofRangesTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(proof_a_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(proof_a_l1_height))
             .await?
             .unwrap();
         assert_eq!(
@@ -2483,7 +2483,7 @@ impl TestCase for OverlappingProofRangesTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(proof_b_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(proof_b_l1_height))
             .await?
             .unwrap();
         assert_eq!(
@@ -2894,7 +2894,7 @@ impl TestCase for UnsyncedCommitmentL2RangeTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?
             .unwrap();
         assert_eq!(
@@ -3042,7 +3042,7 @@ impl TestCase for FullNodeLcpChunkProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
 
@@ -3279,7 +3279,7 @@ impl TestCase for FullNodeLcpChunkProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
         assert_eq!(
@@ -3397,7 +3397,7 @@ impl TestCase for FullNodeLcpChunkProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
         assert_eq!(
@@ -3520,7 +3520,7 @@ impl TestCase for FullNodeLcpChunkProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
         assert_eq!(
@@ -3639,7 +3639,7 @@ impl TestCase for FullNodeLcpChunkProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
         assert_eq!(

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -143,7 +143,7 @@ impl TestCase for LightClientProvingTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await?;
         assert!(lcp.is_some());
 
@@ -299,7 +299,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await
             .unwrap();
         assert!(lcp.is_some());
@@ -350,7 +350,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         let lcp2 = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(last_finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(last_finalized_height))
             .await
             .unwrap();
         assert!(lcp2.is_some());
@@ -454,7 +454,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
         let lcp3 = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await
             .unwrap();
         assert!(lcp3.is_some());
@@ -633,7 +633,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
         let _lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await?;
 
         let batch_proof_method_ids_before = light_client_prover
@@ -681,7 +681,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
         let _lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(method_id_l1_height - 1)
+            .get_light_client_proof_by_l1_height(U64::from(method_id_l1_height - 1))
             .await?;
 
         // Assert that method ids are updated
@@ -806,7 +806,7 @@ impl TestCase for LightClientUnverifiableBatchProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
 
@@ -980,7 +980,7 @@ impl TestCase for LightClientUnverifiableBatchProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await?;
 
         let lcp_output = lcp.unwrap().light_client_proof_output;
@@ -1117,7 +1117,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
 
@@ -1176,7 +1176,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await?;
 
         let lcp_output = lcp.unwrap().light_client_proof_output;
@@ -1269,7 +1269,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
         let lcp_first_chunks = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height - 2)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height - 2))
             .await?;
 
         let lcp_output = lcp_first_chunks.unwrap().light_client_proof_output;
@@ -1282,7 +1282,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
         let lcp_last_chunks = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height - 1)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height - 1))
             .await?;
 
         let lcp_output = lcp_last_chunks.unwrap().light_client_proof_output;
@@ -1296,7 +1296,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
         let lcp_aggregate = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await?;
 
         let lcp_output = lcp_aggregate.unwrap().light_client_proof_output;
@@ -1347,7 +1347,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await?;
 
         let lcp_output = lcp.unwrap().light_client_proof_output;
@@ -1498,7 +1498,7 @@ impl TestCase for UnchainedBatchProofsTest {
         let initial_lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(170)
+            .get_light_client_proof_by_l1_height(U64::from(170))
             .await?
             .unwrap();
 
@@ -1602,7 +1602,9 @@ impl TestCase for UnchainedBatchProofsTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(start_l1_height + DEFAULT_FINALITY_DEPTH)
+            .get_light_client_proof_by_l1_height(U64::from(
+                start_l1_height + DEFAULT_FINALITY_DEPTH,
+            ))
             .await?
             .unwrap();
 
@@ -1628,7 +1630,9 @@ impl TestCase for UnchainedBatchProofsTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(start_l1_height + 2 * DEFAULT_FINALITY_DEPTH)
+            .get_light_client_proof_by_l1_height(U64::from(
+                start_l1_height + 2 * DEFAULT_FINALITY_DEPTH,
+            ))
             .await?
             .unwrap();
 
@@ -1726,7 +1730,7 @@ impl TestCase for UnknownL1HashBatchProofTest {
         let initial_lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(170)
+            .get_light_client_proof_by_l1_height(U64::from(170))
             .await?
             .unwrap();
 
@@ -1770,7 +1774,9 @@ impl TestCase for UnknownL1HashBatchProofTest {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(start_l1_height + DEFAULT_FINALITY_DEPTH)
+            .get_light_client_proof_by_l1_height(U64::from(
+                start_l1_height + DEFAULT_FINALITY_DEPTH,
+            ))
             .await?
             .unwrap();
 
@@ -1907,7 +1913,7 @@ impl TestCase for ChainProofByCommitmentIndex {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
 
@@ -1983,7 +1989,7 @@ impl TestCase for ChainProofByCommitmentIndex {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await?;
 
         let lcp_output = lcp.unwrap().light_client_proof_output;
@@ -2074,7 +2080,7 @@ impl TestCase for ProofWithMissingCommitment {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
 
@@ -2128,7 +2134,7 @@ impl TestCase for ProofWithMissingCommitment {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(batch_proof_l1_height)
+            .get_light_client_proof_by_l1_height(U64::from(batch_proof_l1_height))
             .await?;
 
         let lcp_output = lcp.unwrap().light_client_proof_output;
@@ -2240,7 +2246,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
         let initial_lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(170)
+            .get_light_client_proof_by_l1_height(U64::from(170))
             .await?
             .unwrap();
 
@@ -2293,7 +2299,9 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(start_l1_height + DEFAULT_FINALITY_DEPTH)
+            .get_light_client_proof_by_l1_height(U64::from(
+                start_l1_height + DEFAULT_FINALITY_DEPTH,
+            ))
             .await?
             .unwrap();
 
@@ -2362,7 +2370,9 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height + DEFAULT_FINALITY_DEPTH)
+            .get_light_client_proof_by_l1_height(U64::from(
+                finalized_height + DEFAULT_FINALITY_DEPTH,
+            ))
             .await?
             .unwrap();
 
@@ -2438,7 +2448,9 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height + DEFAULT_FINALITY_DEPTH)
+            .get_light_client_proof_by_l1_height(U64::from(
+                finalized_height + DEFAULT_FINALITY_DEPTH,
+            ))
             .await?
             .unwrap();
 
@@ -2478,7 +2490,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?
             .unwrap();
 
@@ -2568,7 +2580,7 @@ impl TestCase for ProofWithWrongPreviousCommitmentHash {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
 
@@ -2643,7 +2655,7 @@ impl TestCase for ProofWithWrongPreviousCommitmentHash {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
 
         let lcp_output = lcp.unwrap().light_client_proof_output;
@@ -2682,7 +2694,7 @@ impl TestCase for ProofWithWrongPreviousCommitmentHash {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
         // The batch proof should not have updated the state root and the last l2 height
@@ -2716,7 +2728,7 @@ impl TestCase for ProofWithWrongPreviousCommitmentHash {
         let lcp = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
         // The batch proof should have updated the state root and the last l2 height
@@ -3124,7 +3136,7 @@ impl TestCase for UndecompressableBlobTest {
         let lcp_output = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?
             .unwrap()
             .light_client_proof_output;
@@ -3189,7 +3201,7 @@ impl TestCase for UndecompressableBlobTest {
         let lcp_output = light_client_prover
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(finalized_height)
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?
             .unwrap()
             .light_client_proof_output;

--- a/crates/fullnode/src/rpc.rs
+++ b/crates/fullnode/src/rpc.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::U64;
 use citrea_common::rpc::utils::internal_rpc_error;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -102,7 +103,7 @@ pub trait FullNodeRpc {
     #[method(name = "getL2StatusHeightsByL1Height")]
     async fn get_l2_status_heights_by_l1_height(
         &self,
-        l1_height: u64,
+        l1_height: U64,
     ) -> RpcResult<L2StatusHeightsByL1Height>;
 }
 
@@ -151,12 +152,12 @@ where
 
     async fn get_l2_status_heights_by_l1_height(
         &self,
-        l1_height: u64,
+        l1_height: U64,
     ) -> RpcResult<L2StatusHeightsByL1Height> {
         let (committed, proven) = self
             .context
             .ledger
-            .get_l2_status_heights_by_l1_height(l1_height)
+            .get_l2_status_heights_by_l1_height(l1_height.to())
             .map_err(|e| {
                 internal_rpc_error(format!("Failed to get L2 status heights by L1 height: {e}"))
             })?;

--- a/crates/light-client-prover/src/rpc.rs
+++ b/crates/light-client-prover/src/rpc.rs
@@ -4,6 +4,7 @@
 //! specifically getting light client proofs by L1 height, and getting batch proof method IDs.
 use std::sync::Arc;
 
+use alloy_primitives::U64;
 use citrea_common::rpc::utils::internal_rpc_error;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -78,7 +79,7 @@ pub trait LightClientProverRpc {
     #[method(name = "getLightClientProofByL1Height")]
     async fn get_light_client_proof_by_l1_height(
         &self,
-        l1_height: u64,
+        l1_height: U64,
     ) -> RpcResult<Option<LightClientProofResponse>>;
 
     /// Gets the current method ids saved light client provers jmt state
@@ -117,12 +118,12 @@ where
 {
     async fn get_light_client_proof_by_l1_height(
         &self,
-        l1_height: u64,
+        l1_height: U64,
     ) -> RpcResult<Option<LightClientProofResponse>> {
         let proof = self
             .context
             .ledger
-            .get_light_client_proof_data_by_l1_height(l1_height)
+            .get_light_client_proof_data_by_l1_height(l1_height.to())
             .map_err(internal_rpc_error)?;
         let res = proof.map(LightClientProofResponse::from);
         Ok(res)


### PR DESCRIPTION
# Description

## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/2535, https://github.com/chainwayxyz/citrea/issues/2509