### PR TITLE
chore: Remove CommitmentMerkleRoots table from Ledger DB

### DIFF
--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -475,11 +475,6 @@ where
             sequencer_commitment.clone(),
         )?;
 
-        self.ledger_db.set_l2_range_by_commitment_merkle_root(
-            sequencer_commitment.merkle_root,
-            (L2BlockNumber(start_l2_height), L2BlockNumber(end_l2_height)),
-        )?;
-
         self.ledger_db
             .put_commitment_by_index(sequencer_commitment)?;
 

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -16,9 +16,9 @@ use crate::rocks_db_config::RocksdbConfig;
 #[cfg(test)]
 use crate::schema::tables::TestTableNew;
 use crate::schema::tables::{
-    CommitmentIndicesByJobId, CommitmentIndicesByL1, CommitmentMerkleRoots, CommitmentsByNumber,
-    ExecutedMigrations, JobIdOfCommitment, L2BlockByHash, L2BlockByNumber, L2GenesisStateRoot,
-    L2RangeByL1Height, L2StatusHeights, LastPrunedBlock, LightClientProofBySlotNumber, MempoolTxs,
+    CommitmentIndicesByJobId, CommitmentIndicesByL1, CommitmentsByNumber, ExecutedMigrations,
+    JobIdOfCommitment, L2BlockByHash, L2BlockByNumber, L2GenesisStateRoot, L2RangeByL1Height,
+    L2StatusHeights, LastPrunedBlock, LightClientProofBySlotNumber, MempoolTxs,
     PendingBonsaiSessionByJobId, PendingL1SubmissionJobs, PendingProofs,
     PendingSequencerCommitment, PendingSequencerCommitments, ProofByJobId, ProofsBySlotNumberV2,
     ProverLastScannedSlot, ProverPendingCommitments, ProverStateDiffs, SequencerCommitmentByIndex,
@@ -34,7 +34,7 @@ use crate::schema::types::light_client_proof::{
     StoredLightClientProof, StoredLightClientProofOutput,
 };
 use crate::schema::types::{
-    BonsaiSession, L2BlockNumber, L2HeightAndIndex, L2HeightRange, L2HeightStatus, SlotNumber,
+    BonsaiSession, L2BlockNumber, L2HeightAndIndex, L2HeightStatus, SlotNumber,
 };
 
 /// Implementation of database migrator
@@ -425,21 +425,6 @@ impl SharedLedgerOps for LedgerDB {
     #[instrument(level = "trace", skip(self), err)]
     fn put_executed_migration(&self, migration: (String, u64)) -> anyhow::Result<()> {
         self.db.put::<ExecutedMigrations>(&migration, &())
-    }
-
-    fn set_l2_range_by_commitment_merkle_root(
-        &self,
-        root: [u8; 32],
-        range: L2HeightRange,
-    ) -> anyhow::Result<()> {
-        self.db.put::<CommitmentMerkleRoots>(&root, &range)
-    }
-
-    fn get_l2_range_by_commitment_merkle_root(
-        &self,
-        root: [u8; 32],
-    ) -> anyhow::Result<Option<L2HeightRange>> {
-        self.db.get::<CommitmentMerkleRoots>(&root)
     }
 
     fn put_commitment_by_index(&self, commitment: &SequencerCommitment) -> anyhow::Result<()> {

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
@@ -16,8 +16,7 @@ use crate::schema::types::light_client_proof::{
     StoredLightClientProof, StoredLightClientProofOutput,
 };
 use crate::schema::types::{
-    BonsaiSession, L2BlockNumber, L2HeightAndIndex, L2HeightRange, L2HeightStatus,
-    PendingProofsOutput, SlotNumber,
+    BonsaiSession, L2BlockNumber, L2HeightAndIndex, L2HeightStatus, PendingProofsOutput, SlotNumber,
 };
 
 /// Shared ledger operations
@@ -113,18 +112,6 @@ pub trait SharedLedgerOps {
     /// Returns stored short header proof by l1 hash
     fn get_short_header_proof_by_l1_hash(&self, hash: &[u8; 32])
         -> anyhow::Result<Option<Vec<u8>>>;
-    /// Set L2 range by l2 block hash merkle root
-    fn set_l2_range_by_commitment_merkle_root(
-        &self,
-        root: [u8; 32],
-        range: L2HeightRange,
-    ) -> anyhow::Result<()>;
-
-    /// Get L2 range by l2 block hash merkle root
-    fn get_l2_range_by_commitment_merkle_root(
-        &self,
-        root: [u8; 32],
-    ) -> anyhow::Result<Option<L2HeightRange>>;
 
     /// Store commitment by index
     fn put_commitment_by_index(&self, commitment: &SequencerCommitment) -> anyhow::Result<()>;

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
@@ -68,7 +68,6 @@ pub const SEQUENCER_LEDGER_TABLES: &[&str] = &[
     ProverLastScannedSlot::table_name(),
     SlotByHash::table_name(),
     ShortHeaderProofBySlotHash::table_name(),
-    CommitmentMerkleRoots::table_name(),
     SequencerCommitmentByIndex::table_name(),
     L2StatusHeights::table_name(),
     PendingSequencerCommitments::table_name(),
@@ -94,7 +93,6 @@ pub const FULL_NODE_LEDGER_TABLES: &[&str] = &[
     CommitmentsByNumber::table_name(),
     LastPrunedBlock::table_name(),
     VerifiedBatchProofsBySlotNumber::table_name(),
-    CommitmentMerkleRoots::table_name(),
     SequencerCommitmentByIndex::table_name(),
     L2StatusHeights::table_name(),
     PendingSequencerCommitments::table_name(),
@@ -135,8 +133,6 @@ pub const LIGHT_CLIENT_PROVER_LEDGER_TABLES: &[&str] = &[
     SlotByHash::table_name(),
     LightClientProofBySlotNumber::table_name(),
     ProverLastScannedSlot::table_name(),
-    // Don't know if this will be needed
-    CommitmentMerkleRoots::table_name(),
     #[cfg(test)]
     TestTableOld::table_name(),
     #[cfg(test)]
@@ -166,7 +162,6 @@ pub const LEDGER_TABLES: &[&str] = &[
     PendingProvingSessions::table_name(),
     ProverStateDiffs::table_name(),
     LastPrunedBlock::table_name(),
-    CommitmentMerkleRoots::table_name(),
     SequencerCommitmentByIndex::table_name(),
     CommitmentIndicesByL1::table_name(),
     ProofByJobId::table_name(),
@@ -501,11 +496,6 @@ define_table_with_seek_key_codec!(
 define_table_with_seek_key_codec!(
     /// Stores the MMR tree size
     (MMRTreeSize) () => u32
-);
-
-define_table_with_default_codec!(
-    /// Stores merkle hash of seuencer commitment => l2 range
-    (CommitmentMerkleRoots) [u8; 32] => L2HeightRange
 );
 
 define_table_with_seek_key_codec!(


### PR DESCRIPTION
# Description
Removes:
- `set_l2_range_by_commitment_merkle_root`
- `get_l2_range_by_commitment_merkle_root`
- `CommitmentMerkleRoots`

## Linked Issues
- Fixes #2556 
