### PR TITLE
Boundless: Adjust offer params on expiry

### DIFF
--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -160,14 +160,7 @@ impl BoundlessProver {
 
         // Start boundless proving session
         let (req_id, request_expiry) = self
-            .send_request(
-                request,
-                job_id,
-                image_id,
-                receipt_type,
-                mcycles_count,
-                max_possible_price,
-            )
+            .send_request(request, job_id, image_id, receipt_type, mcycles_count, max_possible_price)
             .await?;
 
         let rx = self.spawn_handler(
@@ -410,12 +403,7 @@ impl BoundlessProver {
         // TODO: https://github.com/chainwayxyz/citrea/issues/2417
         // Define new request with updated parameters
         let (new_min_price_per_mcycle, new_max_price_per_mcycle, new_lock_timeout) = {
-            let is_locked = match self
-                .client
-                .boundless_market
-                .is_locked(U256::from_str(request_id).unwrap())
-                .await
-            {
+            let is_locked = match self.client.boundless_market.is_locked(U256::from_str(request_id).unwrap()).await{
                 Ok(locked) => locked,
                 Err(e) => {
                     tracing::error!(
@@ -434,10 +422,10 @@ impl BoundlessProver {
                 .minPrice
                 .div_ceil(U256::from(mcycles_count));
             let max_price_per_mcycle = failed_order
-                .request
-                .offer
-                .maxPrice
-                .div_ceil(U256::from(mcycles_count));
+                    .request
+                    .offer
+                    .maxPrice
+                    .div_ceil(U256::from(mcycles_count));
             let lock_timeout = failed_order.request.offer.lockTimeout;
 
             if is_locked {
@@ -445,6 +433,7 @@ impl BoundlessProver {
                 // Increase the lock timeout.
                 let lock_timeout = lock_timeout.saturating_mul(2);
                 (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
+
             } else {
                 // If not locked, that means the request was never taken by a prover.
                 // Increase the min and max price per mcycle.
@@ -458,6 +447,7 @@ impl BoundlessProver {
                 (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
             }
         };
+       
 
         let new_request = self.build_proof_request(
             image_id,
@@ -482,14 +472,7 @@ impl BoundlessProver {
 
         // Resubmit the request with updated parameters
         let Ok((new_req_id, new_exp_time)) = self
-            .send_request(
-                new_request,
-                job_id,
-                image_id,
-                receipt_type,
-                mcycles_count,
-                max_possible_price,
-            )
+            .send_request(new_request, job_id, image_id, receipt_type, mcycles_count, max_possible_price)
             .await
         else {
             tracing::error!(

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -5,6 +5,7 @@ use alloy_primitives::utils::parse_ether;
 use anyhow::Context;
 use boundless_market::alloy::primitives::U256;
 use boundless_market::client::{Client, ClientBuilder, ClientError};
+use boundless_market::contracts::boundless_market::MarketError;
 use boundless_market::contracts::{Offer, Predicate, Requirements};
 use boundless_market::request_builder::RequestParams;
 use boundless_market::GuestEnv;
@@ -297,9 +298,15 @@ impl BoundlessProver {
                     }
                     Err(e) => {
                         tracing::error!(
-                    "Failed to handle Boundless proving session job: {} | Boundless request id: {} | err={}",
-                    job_id, request_id, e
-                );
+                            "Failed to handle Boundless proving session job: {} | Boundless request id: {} | err={}",
+                            job_id, request_id, e
+                        );
+                        if !matches!(e, ClientError::MarketError(MarketError::RequestHasExpired(_))) {
+                            // Only resubmit if the request has expired.
+                            // Other possible errors include network errors, or
+                            // MarketError::ProofNotFound, which we should not get?
+                            continue;
+                        }
                         match this.handle_resubmit_on_failed_request(
                             job_id,
                             &mut request_id,
@@ -380,22 +387,50 @@ impl BoundlessProver {
 
         // TODO: https://github.com/chainwayxyz/citrea/issues/2417
         // Define new request with updated parameters
-        let new_min_price_per_mcycle = failed_order
-            .request
-            .offer
-            .minPrice
-            .div_ceil(U256::from(mcycles_count))
-            .wrapping_mul(U256::from(15))
-            .div_ceil(U256::from(10));
+        let (new_min_price_per_mcycle, new_max_price_per_mcycle, new_lock_timeout) = {
+            let is_locked = match self.client.boundless_market.is_locked(U256::from_str(request_id).unwrap()).await{
+                Ok(locked) => locked,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to check if request is locked for job: {} request_id: {} | err={}",
+                        job_id,
+                        request_id,
+                        e
+                    );
+                    return Ok(());
+                }
+            };
+            // Get old parameters from the failed order
+            let min_price_per_mcycle = failed_order
+                .request
+                .offer
+                .minPrice
+                .div_ceil(U256::from(mcycles_count));
+            let max_price_per_mcycle = failed_order
+                    .request
+                    .offer
+                    .maxPrice
+                    .div_ceil(U256::from(mcycles_count));
+            let lock_timeout = failed_order.request.offer.lockTimeout;
 
-        let new_max_price_per_mcycle = failed_order
-            .request
-            .offer
-            .maxPrice
-            .div_ceil(U256::from(mcycles_count))
-            .wrapping_mul(U256::from(2));
+            if is_locked {
+                // If locked, that means a prover worked on the request but failed to deliver it on time.
+                // Increase the lock timeout.
+                let lock_timeout = lock_timeout.saturating_mul(2);
+                (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
 
-        let new_lock_timeout = failed_order.request.offer.lockTimeout.wrapping_mul(2);
+            } else {
+                // If not locked, that means the request was never taken by a prover.
+                // Increase the min and max price per mcycle.
+                let min_price_per_mcycle = min_price_per_mcycle
+                    .saturating_mul(U256::from(15))
+                    .div_ceil(U256::from(10));
+                let max_price_per_mcycle = max_price_per_mcycle
+                    .saturating_mul(U256::from(2));
+                (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
+            }
+        };
+       
 
         let new_request = self.build_proof_request(
             image_id,
@@ -417,7 +452,6 @@ impl BoundlessProver {
             mcycles_count,
             new_lock_timeout as u64,
         );
-        // Update request_id and request_expiry for the next iteration
 
         // Resubmit the request with updated parameters
         let Ok((new_req_id, new_exp_time)) = self
@@ -432,6 +466,7 @@ impl BoundlessProver {
             return Ok(());
         };
 
+        // Update request_id and request_expiry for the next iteration
         *request_id = new_req_id;
         *request_expiry = new_exp_time;
 

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -160,7 +160,14 @@ impl BoundlessProver {
 
         // Start boundless proving session
         let (req_id, request_expiry) = self
-            .send_request(request, job_id, image_id, receipt_type, mcycles_count, max_possible_price)
+            .send_request(
+                request,
+                job_id,
+                image_id,
+                receipt_type,
+                mcycles_count,
+                max_possible_price,
+            )
             .await?;
 
         let rx = self.spawn_handler(
@@ -403,7 +410,12 @@ impl BoundlessProver {
         // TODO: https://github.com/chainwayxyz/citrea/issues/2417
         // Define new request with updated parameters
         let (new_min_price_per_mcycle, new_max_price_per_mcycle, new_lock_timeout) = {
-            let is_locked = match self.client.boundless_market.is_locked(U256::from_str(request_id).unwrap()).await{
+            let is_locked = match self
+                .client
+                .boundless_market
+                .is_locked(U256::from_str(request_id).unwrap())
+                .await
+            {
                 Ok(locked) => locked,
                 Err(e) => {
                     tracing::error!(
@@ -422,10 +434,10 @@ impl BoundlessProver {
                 .minPrice
                 .div_ceil(U256::from(mcycles_count));
             let max_price_per_mcycle = failed_order
-                    .request
-                    .offer
-                    .maxPrice
-                    .div_ceil(U256::from(mcycles_count));
+                .request
+                .offer
+                .maxPrice
+                .div_ceil(U256::from(mcycles_count));
             let lock_timeout = failed_order.request.offer.lockTimeout;
 
             if is_locked {
@@ -433,7 +445,6 @@ impl BoundlessProver {
                 // Increase the lock timeout.
                 let lock_timeout = lock_timeout.saturating_mul(2);
                 (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
-
             } else {
                 // If not locked, that means the request was never taken by a prover.
                 // Increase the min and max price per mcycle.
@@ -447,7 +458,6 @@ impl BoundlessProver {
                 (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
             }
         };
-       
 
         let new_request = self.build_proof_request(
             image_id,
@@ -472,7 +482,14 @@ impl BoundlessProver {
 
         // Resubmit the request with updated parameters
         let Ok((new_req_id, new_exp_time)) = self
-            .send_request(new_request, job_id, image_id, receipt_type, mcycles_count, max_possible_price)
+            .send_request(
+                new_request,
+                job_id,
+                image_id,
+                receipt_type,
+                mcycles_count,
+                max_possible_price,
+            )
             .await
         else {
             tracing::error!(

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -269,6 +269,7 @@ impl BoundlessProver {
         Ok((req_id.to_string(), request_expiry))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn spawn_handler(
         &self,
         job_id: Uuid,
@@ -372,6 +373,7 @@ impl BoundlessProver {
         rx
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn handle_resubmit_on_failed_request(
         &self,
         job_id: Uuid,

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -269,7 +269,6 @@ impl BoundlessProver {
         Ok((req_id.to_string(), request_expiry))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn spawn_handler(
         &self,
         job_id: Uuid,
@@ -373,7 +372,6 @@ impl BoundlessProver {
         rx
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn handle_resubmit_on_failed_request(
         &self,
         job_id: Uuid,

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -394,6 +394,22 @@ impl BoundlessProver {
             return Ok(());
         };
 
+        // Retrieve the maximum possible price again from the pricing service as the price of ether may have changed.
+        let max_possible_price = match self.pricing_service
+            .get_price(mcycles_count)
+            .await
+        {
+            Ok(price) => price.max_possible_price,
+            Err(_) => {
+                tracing::error!(
+                    "Failed to get max possible price for job: {} request_id: {}",
+                    job_id,
+                    request_id,
+                );
+                return Ok(());
+            }
+        };
+
         // TODO: https://github.com/chainwayxyz/citrea/issues/2417
         // Define new request with updated parameters
         let (new_min_price_per_mcycle, new_max_price_per_mcycle, new_lock_timeout) = {
@@ -433,9 +449,11 @@ impl BoundlessProver {
                 // Increase the min and max price per mcycle.
                 let min_price_per_mcycle = min_price_per_mcycle
                     .saturating_mul(U256::from(15))
-                    .div_ceil(U256::from(10));
+                    .div_ceil(U256::from(10))
+                    .min(U256::from(max_possible_price));
                 let max_price_per_mcycle = max_price_per_mcycle
-                    .saturating_mul(U256::from(2));
+                    .saturating_mul(U256::from(2))
+                    .min(U256::from(max_possible_price));
                 (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
             }
         };

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -160,7 +160,7 @@ impl BoundlessProver {
 
         // Start boundless proving session
         let (req_id, request_expiry) = self
-            .send_request(request, job_id, image_id, receipt_type, mcycles_count)
+            .send_request(request, job_id, image_id, receipt_type, mcycles_count, max_possible_price)
             .await?;
 
         let rx = self.spawn_handler(
@@ -170,6 +170,7 @@ impl BoundlessProver {
             image_id,
             request_expiry,
             mcycles_count,
+            max_possible_price,
         );
 
         Ok(rx)
@@ -218,6 +219,7 @@ impl BoundlessProver {
         image_id: Digest,
         receipt_type: ReceiptType,
         mcycles_count: u64,
+        max_possible_price: u64,
     ) -> anyhow::Result<(String, u64)> {
         // Start boundless proving session
         tracing::info!(
@@ -251,6 +253,7 @@ impl BoundlessProver {
             image_id: image_id.into(),
             receipt_type,
             mcycles_count,
+            max_possible_price,
         };
         self.ledger_db
             .upsert_pending_boundless_session(job_id, db_session)
@@ -267,6 +270,7 @@ impl BoundlessProver {
         image_id: Digest,
         request_expiry: u64,
         mcycles_count: u64,
+        max_possible_price: u64,
     ) -> oneshot::Receiver<ProofWithJob> {
         let this = self.clone();
         let (tx, rx) = oneshot::channel();
@@ -323,6 +327,7 @@ impl BoundlessProver {
                             mcycles_count,
                             image_id,
                             receipt_type,
+                            max_possible_price,
                         )
                         .await
                         {
@@ -368,6 +373,7 @@ impl BoundlessProver {
         mcycles_count: u64,
         image_id: Digest,
         receipt_type: ReceiptType,
+        max_possible_price: u64,
     ) -> anyhow::Result<()> {
         // Remove failed job from pending boundless sessions
         self.ledger_db
@@ -433,9 +439,11 @@ impl BoundlessProver {
                 // Increase the min and max price per mcycle.
                 let min_price_per_mcycle = min_price_per_mcycle
                     .saturating_mul(U256::from(15))
-                    .div_ceil(U256::from(10));
+                    .div_ceil(U256::from(10))
+                    .min(U256::from(max_possible_price));
                 let max_price_per_mcycle = max_price_per_mcycle
-                    .saturating_mul(U256::from(2));
+                    .saturating_mul(U256::from(2))
+                    .min(U256::from(max_possible_price));
                 (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
             }
         };
@@ -464,7 +472,7 @@ impl BoundlessProver {
 
         // Resubmit the request with updated parameters
         let Ok((new_req_id, new_exp_time)) = self
-            .send_request(new_request, job_id, image_id, receipt_type, mcycles_count)
+            .send_request(new_request, job_id, image_id, receipt_type, mcycles_count, max_possible_price)
             .await
         else {
             tracing::error!(
@@ -543,6 +551,7 @@ impl BoundlessProver {
                 session.image_id.into(),
                 session.request_expiry,
                 session.mcycles_count,
+                session.max_possible_price,
             );
             rxs.push(rx);
         }

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -160,7 +160,7 @@ impl BoundlessProver {
 
         // Start boundless proving session
         let (req_id, request_expiry) = self
-            .send_request(request, job_id, image_id, receipt_type, mcycles_count, max_possible_price)
+            .send_request(request, job_id, image_id, receipt_type, mcycles_count)
             .await?;
 
         let rx = self.spawn_handler(
@@ -170,7 +170,6 @@ impl BoundlessProver {
             image_id,
             request_expiry,
             mcycles_count,
-            max_possible_price,
         );
 
         Ok(rx)
@@ -219,7 +218,6 @@ impl BoundlessProver {
         image_id: Digest,
         receipt_type: ReceiptType,
         mcycles_count: u64,
-        max_possible_price: u64,
     ) -> anyhow::Result<(String, u64)> {
         // Start boundless proving session
         tracing::info!(
@@ -253,7 +251,6 @@ impl BoundlessProver {
             image_id: image_id.into(),
             receipt_type,
             mcycles_count,
-            max_possible_price,
         };
         self.ledger_db
             .upsert_pending_boundless_session(job_id, db_session)
@@ -270,7 +267,6 @@ impl BoundlessProver {
         image_id: Digest,
         request_expiry: u64,
         mcycles_count: u64,
-        max_possible_price: u64,
     ) -> oneshot::Receiver<ProofWithJob> {
         let this = self.clone();
         let (tx, rx) = oneshot::channel();
@@ -327,7 +323,6 @@ impl BoundlessProver {
                             mcycles_count,
                             image_id,
                             receipt_type,
-                            max_possible_price,
                         )
                         .await
                         {
@@ -373,7 +368,6 @@ impl BoundlessProver {
         mcycles_count: u64,
         image_id: Digest,
         receipt_type: ReceiptType,
-        max_possible_price: u64,
     ) -> anyhow::Result<()> {
         // Remove failed job from pending boundless sessions
         self.ledger_db
@@ -439,11 +433,9 @@ impl BoundlessProver {
                 // Increase the min and max price per mcycle.
                 let min_price_per_mcycle = min_price_per_mcycle
                     .saturating_mul(U256::from(15))
-                    .div_ceil(U256::from(10))
-                    .min(U256::from(max_possible_price));
+                    .div_ceil(U256::from(10));
                 let max_price_per_mcycle = max_price_per_mcycle
-                    .saturating_mul(U256::from(2))
-                    .min(U256::from(max_possible_price));
+                    .saturating_mul(U256::from(2));
                 (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
             }
         };
@@ -472,7 +464,7 @@ impl BoundlessProver {
 
         // Resubmit the request with updated parameters
         let Ok((new_req_id, new_exp_time)) = self
-            .send_request(new_request, job_id, image_id, receipt_type, mcycles_count, max_possible_price)
+            .send_request(new_request, job_id, image_id, receipt_type, mcycles_count)
             .await
         else {
             tracing::error!(
@@ -551,7 +543,6 @@ impl BoundlessProver {
                 session.image_id.into(),
                 session.request_expiry,
                 session.mcycles_count,
-                session.max_possible_price,
             );
             rxs.push(rx);
         }

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -395,10 +395,7 @@ impl BoundlessProver {
         };
 
         // Retrieve the maximum possible price again from the pricing service as the price of ether may have changed.
-        let max_possible_price = match self.pricing_service
-            .get_price(mcycles_count)
-            .await
-        {
+        let max_possible_price = match self.pricing_service.get_price(mcycles_count).await {
             Ok(price) => price.max_possible_price,
             Err(_) => {
                 tracing::error!(
@@ -413,7 +410,12 @@ impl BoundlessProver {
         // TODO: https://github.com/chainwayxyz/citrea/issues/2417
         // Define new request with updated parameters
         let (new_min_price_per_mcycle, new_max_price_per_mcycle, new_lock_timeout) = {
-            let is_locked = match self.client.boundless_market.is_locked(U256::from_str(request_id).unwrap()).await{
+            let is_locked = match self
+                .client
+                .boundless_market
+                .is_locked(U256::from_str(request_id).unwrap())
+                .await
+            {
                 Ok(locked) => locked,
                 Err(e) => {
                     tracing::error!(
@@ -432,10 +434,10 @@ impl BoundlessProver {
                 .minPrice
                 .div_ceil(U256::from(mcycles_count));
             let max_price_per_mcycle = failed_order
-                    .request
-                    .offer
-                    .maxPrice
-                    .div_ceil(U256::from(mcycles_count));
+                .request
+                .offer
+                .maxPrice
+                .div_ceil(U256::from(mcycles_count));
             let lock_timeout = failed_order.request.offer.lockTimeout;
 
             if is_locked {
@@ -443,7 +445,6 @@ impl BoundlessProver {
                 // Increase the lock timeout.
                 let lock_timeout = lock_timeout.saturating_mul(2);
                 (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
-
             } else {
                 // If not locked, that means the request was never taken by a prover.
                 // Increase the min and max price per mcycle.
@@ -457,7 +458,6 @@ impl BoundlessProver {
                 (min_price_per_mcycle, max_price_per_mcycle, lock_timeout)
             }
         };
-       
 
         let new_request = self.build_proof_request(
             image_id,

--- a/crates/risc0/src/host/pricing_service.rs
+++ b/crates/risc0/src/host/pricing_service.rs
@@ -22,6 +22,12 @@ pub struct PricingService {
     base_url: String,
 }
 
+impl Default for PricingService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PricingService {
     /// Create a new instance of `PricingService`
     /// Reads the base URL from the `PRICING_SERVICE_URL` environment variable

--- a/crates/risc0/src/host/pricing_service.rs
+++ b/crates/risc0/src/host/pricing_service.rs
@@ -22,12 +22,6 @@ pub struct PricingService {
     base_url: String,
 }
 
-impl Default for PricingService {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl PricingService {
     /// Create a new instance of `PricingService`
     /// Reads the base URL from the `PRICING_SERVICE_URL` environment variable

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/mod.rs
@@ -147,6 +147,4 @@ pub struct BoundlessSession {
     pub receipt_type: ReceiptType,
     /// Number of mcycles used for the proof generation
     pub mcycles_count: u64,
-    /// Maximum possible price per mcycle for the request
-    pub max_possible_price: u64,
 }

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/mod.rs
@@ -147,4 +147,6 @@ pub struct BoundlessSession {
     pub receipt_type: ReceiptType,
     /// Number of mcycles used for the proof generation
     pub mcycles_count: u64,
+    /// Maximum possible price per mcycle for the request
+    pub max_possible_price: u64,
 }


### PR DESCRIPTION
# Description
- Check the error from `handle_session`, do not resubmit on network errors
- If the request is expired, check if it is locked to see if it was taken by a prover
- If taken, only bump lock timeout, else, bump price. 

## Linked Issues
- Fixes #2428 
