### PR TITLE
upgrade risc0 to 2.3.0

### DIFF
--- a/.github/actions/install-risc0/action.yml
+++ b/.github/actions/install-risc0/action.yml
@@ -16,7 +16,7 @@ runs:
       run: | 
         curl -L https://risczero.com/install | bash
         export PATH="$PATH:$HOME/.risc0/bin"
-        rzup install cargo-risczero 2.1.0
+        rzup install cargo-risczero 2.3.0
         rzup install cpp
-        rzup install r0vm 2.1.0
+        rzup install r0vm 2.3.0
         rzup install rust 1.85.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8849,9 +8849,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fe7599ac55ad77515608ec42a9727001559fe4f579c533cb7c973b54800c05"
+checksum = "62eb7025356a233c1bc267c458a2ce56fcfc89b136d813c8a77be14ef1eaf2b1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8868,9 +8868,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.1.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17d6657b1fb615c0482bd4b57aae7850911ed7dbdc8e783df20e93f33209a8f"
+checksum = "c951d23a3255fe9e43526418ad8fc3471cac1c48b338f9cfeb4063d250c1f698"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -8892,9 +8892,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d339c65b0e011677404bd6bdfe1b0f29748187a568fb2f74df7fb650590181a"
+checksum = "0094af5a57b020388a03bdd3834959c7d62723f1687be81414ade25104d93263"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -8908,9 +8908,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6501fd3936aea2dd3e55915f34328fe96e6ca25ef00320242f837ae668785b"
+checksum = "76ebded45c902c2b6939924a1cddd1d06b5d1d4ad1531e8798ebfee78f9c038d"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -8923,9 +8923,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e0a8f0f56106295bb682dbc27093438e163a5f6384a79e877ab895a11d9ae"
+checksum = "15030849f8356f01f23c74b37dbfa4283100b594eb634109993e9e005ef45f64"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -8952,9 +8952,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b31cb7b2a46f0cdaf71803ea7e0389af9f5bc1aea2531106f2972b241f26e98"
+checksum = "7cf5d0b673d5fc67a89147c2e9c53134707dcc8137a43d1ef06b4ff68e99b74f"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -8983,9 +8983,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa210a232361fd671b30918469856b64d715f2564956d0a5df97ab6cb116d28b"
+checksum = "a287e9cd6d7b3b38eeb49c62090c46a1935922309fbd997a9143ed8c43c8f3cb"
 dependencies = [
  "anyhow",
  "blake2",
@@ -9008,9 +9008,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1014d2efcb3b359aff878c9aeb6aa949a6d91f091a2ffb5ffd8d928a1ab7f3"
+checksum = "910c2023c39ac1e23dd4f7acdff086333f31ca608035f96c74366a79c098de3b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9045,9 +9045,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4de2938eaf24892ef927d9cef6e4acb6a19ce01c017cd498533896f633f332"
+checksum = "cae9cb2c2f6cab2dfa395ea6e2576713929040c7fb0c5f4150d13e1119d18686"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,12 +119,12 @@ tower = { version = "0.4.13", features = ["full"] }
 
 # Risc0 dependencies
 bonsai-sdk = { version = "1.4" }
-risc0-binfmt = "2.0.1"
-risc0-zkvm = { version = "2.1.0", default-features = false }
-risc0-zkvm-platform = "2.0.2"
-risc0-zkp = "2.0.1"
-risc0-circuit-rv32im = "2.0.4"
-risc0-build = "2.1.2"
+risc0-binfmt = "2.0.2"
+risc0-zkvm = { version = "2.3.0", default-features = false }
+risc0-zkvm-platform = "2.0.3"
+risc0-zkp = "2.0.2"
+risc0-circuit-rv32im = "3.0.0"
+risc0-build = "2.3.0"
 rzup = "0.4.1"
 
 # EVM dependencies

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -348,6 +348,7 @@ where
         _ => {
             let (mut l2_syncer, l1_block_handler, pruner_service, rpc_module) =
                 CitreaRollupBlueprint::create_full_node(
+                    network,
                     &rollup_blueprint,
                     genesis_config,
                     rollup_config.clone(),

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -286,6 +286,7 @@ where
         NodeWithConfig::BatchProver(batch_prover_config) => {
             let (l2_syncer, l1_syncer, prover, rpc_module) =
                 CitreaRollupBlueprint::create_batch_prover(
+                    network,
                     &rollup_blueprint,
                     batch_prover_config,
                     genesis_config,

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -286,8 +286,8 @@ where
         NodeWithConfig::BatchProver(batch_prover_config) => {
             let (l2_syncer, l1_syncer, prover, rpc_module) =
                 CitreaRollupBlueprint::create_batch_prover(
-                    network,
                     &rollup_blueprint,
+                    network,
                     batch_prover_config,
                     genesis_config,
                     rollup_config.clone(),
@@ -349,8 +349,8 @@ where
         _ => {
             let (mut l2_syncer, l1_block_handler, pruner_service, rpc_module) =
                 CitreaRollupBlueprint::create_full_node(
-                    network,
                     &rollup_blueprint,
+                    network,
                     genesis_config,
                     rollup_config.clone(),
                     da_service,

--- a/bin/citrea/src/rollup/mod.rs
+++ b/bin/citrea/src/rollup/mod.rs
@@ -242,6 +242,7 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
     #[allow(clippy::too_many_arguments)]
     async fn create_full_node(
         &self,
+        network: Network,
         genesis_config: GenesisParams<Self>,
         rollup_config: FullNodeConfig<Self::DaConfig>,
         da_service: Arc<<Self as RollupBlueprint>::DaService>,
@@ -276,6 +277,7 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
         let code_commitments = self.get_batch_proof_code_commitments();
 
         citrea_fullnode::build_services(
+            network,
             runner_config,
             init_params,
             native_stf,

--- a/bin/citrea/src/rollup/mod.rs
+++ b/bin/citrea/src/rollup/mod.rs
@@ -298,6 +298,7 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
     #[allow(clippy::type_complexity, clippy::too_many_arguments)]
     async fn create_batch_prover(
         &self,
+        network: Network,
         prover_config: BatchProverConfig,
         genesis_config: GenesisParams<Self>,
         rollup_config: FullNodeConfig<Self::DaConfig>,
@@ -344,6 +345,7 @@ pub trait CitreaRollupBlueprint: RollupBlueprint {
         let elfs = self.get_batch_proof_elfs();
 
         citrea_batch_prover::build_services(
+            network,
             prover_config,
             runner_config,
             init_params,

--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -1291,7 +1291,7 @@ impl TestCase for BatchProverCreateInputTest {
             let output: BatchProofCircuitOutput = Risc0Host::extract_output(&proof).unwrap();
 
             // Verify the proof
-            Risc0Host::verify(proof.as_slice(), &code_commitment)
+            Risc0Host::verify(proof.as_slice(), &code_commitment, true)
                 .expect("Proof verification failed");
 
             assert_eq!(output.last_l2_height(), max_l2_blocks_per_commitment);

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -273,6 +273,7 @@ pub async fn start_rollup(
         let (l2_syncer, l1_syncer, prover, rpc_module) =
             CitreaRollupBlueprint::create_batch_prover(
                 &mock_demo_rollup,
+                network.unwrap_or(Network::Nightly),
                 rollup_prover_config,
                 genesis_config,
                 rollup_config.clone(),
@@ -363,8 +364,8 @@ pub async fn start_rollup(
 
         let (mut l2_syncer, l1_block_handler, pruner, rpc_module) =
             CitreaRollupBlueprint::create_full_node(
-                network.unwrap_or(Network::Nightly),
                 &mock_demo_rollup,
+                network.unwrap_or(Network::Nightly),
                 genesis_config,
                 rollup_config.clone(),
                 da_service,

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -363,6 +363,7 @@ pub async fn start_rollup(
 
         let (mut l2_syncer, l1_block_handler, pruner, rpc_module) =
             CitreaRollupBlueprint::create_full_node(
+                network.unwrap_or(Network::Nightly),
                 &mock_demo_rollup,
                 genesis_config,
                 rollup_config.clone(),

--- a/crates/batch-prover/src/lib.rs
+++ b/crates/batch-prover/src/lib.rs
@@ -45,6 +45,7 @@ use sov_modules_stf_blueprint::StfBlueprint;
 use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::zk::ZkvmHost;
+use sov_rollup_interface::Network;
 use tokio::sync::{broadcast, mpsc, Mutex};
 
 /// Module containing database migration definitions
@@ -96,6 +97,7 @@ pub mod rpc;
 /// - `RpcModule` configured with the necessary RPC methods.
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub async fn build_services<DA, DB, Vm>(
+    network: Network,
     prover_config: BatchProverConfig,
     runner_config: RunnerConfig,
     init_params: InitParams,
@@ -167,6 +169,7 @@ where
     let l2_block_rx = l2_block_tx.subscribe();
 
     let prover = Prover::new(
+        network,
         prover_config,
         ledger_db,
         storage_manager,

--- a/crates/batch-prover/src/lib.rs
+++ b/crates/batch-prover/src/lib.rs
@@ -68,6 +68,7 @@ pub mod rpc;
 /// Builds and initializes all batch prover services.
 ///
 /// # Arguments
+/// * `network` - The Citrea network this batch prover is running on.
 /// * `prover_config` - Configuration for the batch prover.
 /// * `runner_config` - Runner configuration for the batch prover.
 /// * `init_params` - Initialization parameters for the batch prover start up.

--- a/crates/fullnode/src/lib.rs
+++ b/crates/fullnode/src/lib.rs
@@ -137,6 +137,7 @@ use sov_modules_stf_blueprint::StfBlueprint;
 use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::zk::ZkvmHost;
+use sov_rollup_interface::Network;
 use tokio::sync::{broadcast, Mutex};
 
 /// Module for handling L1 data availability blocks
@@ -181,6 +182,7 @@ pub mod rpc;
 /// - Configured RPC module
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn build_services<DA, DB, Vm>(
+    network: Network,
     runner_config: RunnerConfig,
     init_params: InitParams,
     native_stf: StfBlueprint<
@@ -239,6 +241,7 @@ where
     )?;
 
     let l1_block_handler = L1BlockHandler::new(
+        network,
         ledger_db,
         da_service,
         public_keys.sequencer_da_pub_key,

--- a/crates/fullnode/src/lib.rs
+++ b/crates/fullnode/src/lib.rs
@@ -156,6 +156,7 @@ pub mod rpc;
 /// Builds and initializes all fullnode services
 ///
 /// # Arguments
+/// * `network` - The Citrea network this fullnode is running on
 /// * `runner_config` - Configuration for the fullnode
 /// * `init_params` - Initial parameters for node setup
 /// * `native_stf` - State transition function blueprint

--- a/crates/light-client-prover/Cargo.toml
+++ b/crates/light-client-prover/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 # Citrea Deps
 bitcoin-da = { path = "../bitcoin-da", optional = true }
 citrea-common = { path = "../common", optional = true }
-citrea-primitives = { path = "../primitives", optional = true }
+citrea-primitives = { path = "../primitives" }
 citrea-risc0-batch-proof = { path = "../../guests/risc0/batch-proof" }
 prover-services = { path = "../prover-services", optional = true }
 
@@ -56,7 +56,6 @@ native = [
   "dep:sov-mock-da",
   "dep:bitcoin-da",
   "dep:prover-services",
-  "dep:citrea-primitives",
   "dep:citrea-common",
   "dep:sov-prover-storage-manager",
   "dep:sov-db",

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -8,6 +8,7 @@ use accessors::{
     VerifiedStateTransitionForSequencerCommitmentIndexAccessor,
 };
 use borsh::BorshDeserialize;
+use citrea_primitives::network_to_dev_mode;
 use initial_values::LCP_JMT_GENESIS_ROOT;
 use sov_modules_api::da::BlockHeaderTrait;
 use sov_modules_api::{BlobReaderTrait, DaSpec, WorkingSet, Zkvm};
@@ -243,6 +244,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
         proof: &[u8],
         last_l2_height: u64,
         last_sequencer_commitment_index: u32,
+        network: Network,
         working_set: &mut WorkingSet<S>,
     ) -> Result<(), CircuitError> {
         let Ok(journal) = Z::extract_raw_output(proof) else {
@@ -290,7 +292,12 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
 
         log!("Using batch proof method id {:?}", batch_proof_method_id);
 
-        Z::verify(proof, &batch_proof_method_id.into()).map_err(|_| "Failed to verify proof")?;
+        Z::verify(
+            proof,
+            &batch_proof_method_id.into(),
+            network_to_dev_mode(network),
+        )
+        .map_err(|_| "Failed to verify proof")?;
 
         if !self.verify_batch_proof_seq_comm_relation(&batch_proof_output, working_set) {
             return Err("Failed to verify sequencer commitment relation");
@@ -363,6 +370,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
     /// * `RunL1BlockResult` - The result of running the L1 block, contains updates to the L2 state and the light client's JMT state.
     pub fn run_l1_block(
         &self,
+        network: Network,
         storage: S,
         witness: Witness,
         da_txs: Vec<DS::BlobTransaction>,
@@ -435,6 +443,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
                         &proof,
                         last_l2_height,
                         last_sequencer_commitment_index,
+                        network,
                         &mut working_set,
                     ) {
                         Ok(()) => {}
@@ -478,6 +487,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
                         &complete_proof,
                         last_l2_height,
                         last_sequencer_commitment_index,
+                        network,
                         &mut working_set,
                     ) {
                         Ok(()) => {}
@@ -645,6 +655,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
                 let prev_output = Z::verify_and_deserialize_output::<LightClientCircuitOutput>(
                     &proof,
                     &input.light_client_proof_method_id.into(),
+                    network_to_dev_mode(network),
                 )
                 .expect("Previous light client proof is invalid");
 
@@ -679,6 +690,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
 
         // then we can call run_l1_block to run the logic of the circuit
         let result = self.run_l1_block(
+            network,
             storage,
             input.witness,
             da_txs,

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -8,7 +8,6 @@ use accessors::{
     VerifiedStateTransitionForSequencerCommitmentIndexAccessor,
 };
 use borsh::BorshDeserialize;
-use citrea_primitives::network_to_dev_mode;
 use initial_values::LCP_JMT_GENESIS_ROOT;
 use sov_modules_api::da::BlockHeaderTrait;
 use sov_modules_api::{BlobReaderTrait, DaSpec, WorkingSet, Zkvm};
@@ -718,4 +717,10 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> Default for LightClientProofCircuit<S, DS,
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Allow dev mode usage for proof verification, only in testing or dev networks.
+/// So we return false for mainnet and true for all other networks.
+pub fn network_to_dev_mode(network: Network) -> bool {
+    !matches!(network, Network::Mainnet)
 }

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -222,6 +222,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
     /// * `proof` - The serialized complete proof to process.
     /// * `last_l2_height` - The last L2 height known before processing this proof.
     /// * `last_sequencer_commitment_index` - The last sequencer commitment index known before processing this proof.
+    /// * `network` - The Citrea network this light client proof is running on.
     /// * `working_set` - The working set to use accessor that reads the JMT state.
     ///
     /// # Logic
@@ -344,6 +345,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
     /// This function processes the relevant transactions, moves the L2 state forward, and validates the changes to the LCP’s JMT state.
     ///
     /// # Arguments
+    /// * `network` - The Citrea network this light client proof is running on.
     /// * `storage` - The storage used for accessing the JMT state, performing updates, and validating read and write operations.
     /// * `witness` - The witness that contains the hints for the JMT state.
     /// * `da_txs` - Vector of the relevant transactions. Transactions are considered relevant if their wtxid begins with a predefined constant reveal transaction prefix.

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -8,6 +8,7 @@ use accessors::{
     VerifiedStateTransitionForSequencerCommitmentIndexAccessor,
 };
 use borsh::BorshDeserialize;
+use citrea_primitives::network_to_dev_mode;
 use initial_values::LCP_JMT_GENESIS_ROOT;
 use sov_modules_api::da::BlockHeaderTrait;
 use sov_modules_api::{BlobReaderTrait, DaSpec, WorkingSet, Zkvm};
@@ -717,10 +718,4 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> Default for LightClientProofCircuit<S, DS,
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Allow dev mode usage for proof verification, only in testing or dev networks.
-/// So we return false for mainnet and true for all other networks.
-pub fn network_to_dev_mode(network: Network) -> bool {
-    !matches!(network, Network::Mainnet)
 }

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -238,8 +238,8 @@ where
 
         let storage = self.storage_manager.create_storage_for_next_l2_height();
 
-        // TODO: might need to iterate over da_data and call .full_data() on each
         let result = self.circuit.run_l1_block(
+            self.network,
             storage,
             Default::default(),
             da_data,

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -300,6 +300,7 @@ impl NativeCircuitRunner {
             .unwrap();
 
         let res = self.circuit.run_l1_block(
+            sov_rollup_interface::Network::Nightly,
             prover_storage,
             Default::default(),
             da_txs,

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -4,5 +4,7 @@ mod constants;
 pub mod forks;
 pub mod merkle;
 pub mod types;
+pub mod zk_dev_mode;
 
 pub use constants::*;
+pub use zk_dev_mode::*;

--- a/crates/primitives/src/zk_dev_mode.rs
+++ b/crates/primitives/src/zk_dev_mode.rs
@@ -1,0 +1,7 @@
+use sov_rollup_interface::Network;
+
+/// Allow dev mode usage for proof verification, only in testing or dev networks.
+/// So we return false for mainnet and true for all other networks.
+pub fn network_to_dev_mode(network: Network) -> bool {
+    !matches!(network, Network::Mainnet)
+}

--- a/crates/primitives/src/zk_dev_mode.rs
+++ b/crates/primitives/src/zk_dev_mode.rs
@@ -5,3 +5,13 @@ use sov_rollup_interface::Network;
 pub fn network_to_dev_mode(network: Network) -> bool {
     !matches!(network, Network::Mainnet)
 }
+
+#[test]
+fn test_network_to_dev_mode() {
+    assert!(network_to_dev_mode(Network::Testnet));
+    assert!(network_to_dev_mode(Network::Devnet));
+    assert!(network_to_dev_mode(Network::Nightly));
+    assert!(network_to_dev_mode(Network::TestNetworkWithForks));
+
+    assert!(!network_to_dev_mode(Network::Mainnet));
+}

--- a/crates/risc0/src/guest.rs
+++ b/crates/risc0/src/guest.rs
@@ -1,8 +1,8 @@
 //! This module implements the `ZkvmGuest` trait for the RISC0 VM.
 use borsh::{BorshDeserialize, BorshSerialize};
-use risc0_zkvm::guest::env;
 use risc0_zkvm::guest::env::Write;
 use risc0_zkvm::Digest;
+use risc0_zkvm::{guest::env, VerifierContext};
 use sov_rollup_interface::zk::{Zkvm, ZkvmGuest};
 
 use crate::receipt_from_proof;
@@ -53,12 +53,16 @@ impl Zkvm for Risc0Guest {
     fn verify(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
+        allow_dev_mode: bool,
     ) -> Result<(), Self::Error> {
         let receipt = receipt_from_proof(serialized_proof)
             .map_err(|_| Risc0GuestError::FailedToDeserialize)?;
 
         receipt
-            .verify(*code_commitment)
+            .verify_with_context(
+                &VerifierContext::default().with_dev_mode(allow_dev_mode),
+                *code_commitment,
+            )
             .map_err(|_| Risc0GuestError::ProofVerificationFailed)
     }
 
@@ -75,12 +79,16 @@ impl Zkvm for Risc0Guest {
     fn verify_and_deserialize_output<T: BorshDeserialize>(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
+        allow_dev_mode: bool,
     ) -> Result<T, Self::Error> {
         let receipt = receipt_from_proof(serialized_proof)
             .map_err(|_| Risc0GuestError::FailedToDeserialize)?;
 
         receipt
-            .verify(*code_commitment)
+            .verify_with_context(
+                &VerifierContext::default().with_dev_mode(allow_dev_mode),
+                *code_commitment,
+            )
             .map_err(|_| Risc0GuestError::ProofVerificationFailed)?;
 
         T::try_from_slice(&receipt.journal.bytes).map_err(|_| Risc0GuestError::FailedToDeserialize)

--- a/crates/risc0/src/guest.rs
+++ b/crates/risc0/src/guest.rs
@@ -1,8 +1,8 @@
 //! This module implements the `ZkvmGuest` trait for the RISC0 VM.
 use borsh::{BorshDeserialize, BorshSerialize};
+use risc0_zkvm::guest::env;
 use risc0_zkvm::guest::env::Write;
-use risc0_zkvm::Digest;
-use risc0_zkvm::{guest::env, VerifierContext};
+use risc0_zkvm::{Digest, VerifierContext};
 use sov_rollup_interface::zk::{Zkvm, ZkvmGuest};
 
 use crate::receipt_from_proof;

--- a/crates/risc0/src/host/local.rs
+++ b/crates/risc0/src/host/local.rs
@@ -108,9 +108,6 @@ impl LocalProver {
 
         #[cfg(feature = "testing")]
         {
-            // If we are testing, set guest env var to enable dev mode so that it verifies fake receipts
-            env.env_var("RISC0_DEV_MODE", "1");
-
             match self.network {
                 Network::Nightly => {}
                 Network::TestNetworkWithForks => {
@@ -118,11 +115,6 @@ impl LocalProver {
                 }
                 _ => panic!("Invalid network in testing feature!"),
             }
-        }
-
-        if self.dev_mode {
-            // on dev mode always propagate dev mode to the guest
-            env.env_var("RISC0_DEV_MODE", "1");
         }
 
         // Add input

--- a/crates/risc0/src/host/mod.rs
+++ b/crates/risc0/src/host/mod.rs
@@ -11,7 +11,7 @@ use bonsai::BonsaiProver;
 use borsh::BorshDeserialize;
 use local::LocalProver;
 use risc0_zkvm::sha::Digest;
-use risc0_zkvm::AssumptionReceipt;
+use risc0_zkvm::{AssumptionReceipt, VerifierContext};
 use sov_db::ledger_db::LedgerDB;
 use sov_rollup_interface::zk::{Proof, ProofWithJob, ReceiptType, Zkvm, ZkvmHost};
 use sov_rollup_interface::Network;
@@ -133,10 +133,14 @@ impl Zkvm for Risc0Host {
     fn verify(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
+        allow_dev_mode: bool,
     ) -> Result<(), Self::Error> {
         let receipt = receipt_from_proof(serialized_proof)?;
 
-        Ok(receipt.verify(*code_commitment)?)
+        Ok(receipt.verify_with_context(
+            &VerifierContext::default().with_dev_mode(allow_dev_mode),
+            *code_commitment,
+        )?)
     }
 
     fn extract_raw_output(serialized_proof: &[u8]) -> Result<Vec<u8>, Self::Error> {
@@ -151,11 +155,15 @@ impl Zkvm for Risc0Host {
     fn verify_and_deserialize_output<T: BorshDeserialize>(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
+        allow_dev_mode: bool,
     ) -> Result<T, Self::Error> {
         let receipt = receipt_from_proof(serialized_proof)?;
 
         #[allow(clippy::clone_on_copy)]
-        receipt.verify(code_commitment.clone())?;
+        receipt.verify_with_context(
+            &VerifierContext::default().with_dev_mode(allow_dev_mode),
+            code_commitment.clone(),
+        )?;
 
         Ok(T::deserialize(&mut receipt.journal.as_ref())?)
     }

--- a/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
+++ b/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
@@ -135,6 +135,7 @@ impl sov_rollup_interface::zk::Zkvm for MockZkvm {
     fn verify(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
+        _allow_dev_mode: bool,
     ) -> Result<(), Self::Error> {
         let proof = MockProof::decode(serialized_proof)?;
         anyhow::ensure!(
@@ -161,8 +162,9 @@ impl sov_rollup_interface::zk::Zkvm for MockZkvm {
     fn verify_and_deserialize_output<T: BorshDeserialize>(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
+        _allow_dev_mode: bool,
     ) -> Result<T, Self::Error> {
-        Self::verify(serialized_proof, code_commitment)?;
+        Self::verify(serialized_proof, code_commitment, true)?;
         Self::deserialize_output(&serialized_proof[37..])
     }
 }
@@ -249,6 +251,7 @@ impl sov_rollup_interface::zk::Zkvm for MockZkGuest {
     fn verify(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
+        _allow_dev_mode: bool,
     ) -> Result<(), Self::Error> {
         let proof = MockProof::decode(serialized_proof)?;
         anyhow::ensure!(
@@ -275,8 +278,9 @@ impl sov_rollup_interface::zk::Zkvm for MockZkGuest {
     fn verify_and_deserialize_output<T: BorshDeserialize>(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
+        _allow_dev_mode: bool,
     ) -> Result<T, Self::Error> {
-        Self::verify(serialized_proof, code_commitment)?;
+        Self::verify(serialized_proof, code_commitment, true)?;
         Self::deserialize_output(&serialized_proof[37..])
     }
 }

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
@@ -104,6 +104,7 @@ pub trait Zkvm: Send + Sync {
     fn verify(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
+        allow_dev_mode: bool,
     ) -> Result<(), Self::Error>;
 
     /// Extracts the raw output without doing any verification.
@@ -120,6 +121,7 @@ pub trait Zkvm: Send + Sync {
     fn verify_and_deserialize_output<T: BorshDeserialize>(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
+        allow_dev_mode: bool,
     ) -> Result<T, Self::Error>;
 }
 

--- a/guests/risc0/batch-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.lock
@@ -3097,9 +3097,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a065c83232c9945f9c1690f9766bec75f8919272b3a724b44dcc68b05f4625"
+checksum = "b5174056ad92cd5adc1bfcbdf64ef964114796c09cc71c178668a9e82939e61d"
 dependencies = [
  "include_bytes_aligned",
  "stability",
@@ -3107,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fe7599ac55ad77515608ec42a9727001559fe4f579c533cb7c973b54800c05"
+checksum = "62eb7025356a233c1bc267c458a2ce56fcfc89b136d813c8a77be14ef1eaf2b1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3126,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d339c65b0e011677404bd6bdfe1b0f29748187a568fb2f74df7fb650590181a"
+checksum = "0094af5a57b020388a03bdd3834959c7d62723f1687be81414ade25104d93263"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3142,9 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6501fd3936aea2dd3e55915f34328fe96e6ca25ef00320242f837ae668785b"
+checksum = "76ebded45c902c2b6939924a1cddd1d06b5d1d4ad1531e8798ebfee78f9c038d"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3157,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e0a8f0f56106295bb682dbc27093438e163a5f6384a79e877ab895a11d9ae"
+checksum = "15030849f8356f01f23c74b37dbfa4283100b594eb634109993e9e005ef45f64"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -3186,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b31cb7b2a46f0cdaf71803ea7e0389af9f5bc1aea2531106f2972b241f26e98"
+checksum = "7cf5d0b673d5fc67a89147c2e9c53134707dcc8137a43d1ef06b4ff68e99b74f"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3217,9 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa210a232361fd671b30918469856b64d715f2564956d0a5df97ab6cb116d28b"
+checksum = "a287e9cd6d7b3b38eeb49c62090c46a1935922309fbd997a9143ed8c43c8f3cb"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3242,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1014d2efcb3b359aff878c9aeb6aa949a6d91f091a2ffb5ffd8d928a1ab7f3"
+checksum = "910c2023c39ac1e23dd4f7acdff086333f31ca608035f96c74366a79c098de3b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3271,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4de2938eaf24892ef927d9cef6e4acb6a19ce01c017cd498533896f633f332"
+checksum = "cae9cb2c2f6cab2dfa395ea6e2576713929040c7fb0c5f4150d13e1119d18686"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/guests/risc0/batch-proof/bitcoin/Cargo.toml
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.toml
@@ -26,6 +26,7 @@ sov-rollup-interface = { path = "../../../../crates/sovereign-sdk/rollup-interfa
 sov-state = { path = "../../../../crates/sovereign-sdk/module-system/sov-state" }
 
 [features]
+# sys-getenv enabled for network selection here, only used in tests
 testing = ["citrea-primitives/testing", "risc0-zkvm-platform/sys-getenv"]
 
 [patch.crates-io]

--- a/guests/risc0/batch-proof/bitcoin/Cargo.toml
+++ b/guests/risc0/batch-proof/bitcoin/Cargo.toml
@@ -10,9 +10,9 @@ resolver = "2"
 # automatically added by the unstable feature
 # but we tend to forget to update this while updating risc0
 # so putting here explicitly
-risc0-bigint2 = "1.4.3"
-risc0-zkvm = { version = "2.1.0", default-features = false, features = ["unstable"] }
-risc0-zkvm-platform = { version = "2.0.2", features = ["heap-embedded-alloc"] }
+risc0-bigint2 = "1.4.5"
+risc0-zkvm = { version = "2.3.0", default-features = false, features = ["unstable"] }
+risc0-zkvm-platform = { version = "2.0.3", features = ["heap-embedded-alloc"] }
 
 anyhow = "1.0.95"
 bitcoin-da = { path = "../../../../crates/bitcoin-da", default-features = false }

--- a/guests/risc0/batch-proof/mock/Cargo.lock
+++ b/guests/risc0/batch-proof/mock/Cargo.lock
@@ -3030,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a065c83232c9945f9c1690f9766bec75f8919272b3a724b44dcc68b05f4625"
+checksum = "b5174056ad92cd5adc1bfcbdf64ef964114796c09cc71c178668a9e82939e61d"
 dependencies = [
  "include_bytes_aligned",
  "stability",
@@ -3040,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fe7599ac55ad77515608ec42a9727001559fe4f579c533cb7c973b54800c05"
+checksum = "62eb7025356a233c1bc267c458a2ce56fcfc89b136d813c8a77be14ef1eaf2b1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3059,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d339c65b0e011677404bd6bdfe1b0f29748187a568fb2f74df7fb650590181a"
+checksum = "0094af5a57b020388a03bdd3834959c7d62723f1687be81414ade25104d93263"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3075,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6501fd3936aea2dd3e55915f34328fe96e6ca25ef00320242f837ae668785b"
+checksum = "76ebded45c902c2b6939924a1cddd1d06b5d1d4ad1531e8798ebfee78f9c038d"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3090,9 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e0a8f0f56106295bb682dbc27093438e163a5f6384a79e877ab895a11d9ae"
+checksum = "15030849f8356f01f23c74b37dbfa4283100b594eb634109993e9e005ef45f64"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -3119,9 +3119,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b31cb7b2a46f0cdaf71803ea7e0389af9f5bc1aea2531106f2972b241f26e98"
+checksum = "7cf5d0b673d5fc67a89147c2e9c53134707dcc8137a43d1ef06b4ff68e99b74f"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3150,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa210a232361fd671b30918469856b64d715f2564956d0a5df97ab6cb116d28b"
+checksum = "a287e9cd6d7b3b38eeb49c62090c46a1935922309fbd997a9143ed8c43c8f3cb"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3175,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1014d2efcb3b359aff878c9aeb6aa949a6d91f091a2ffb5ffd8d928a1ab7f3"
+checksum = "910c2023c39ac1e23dd4f7acdff086333f31ca608035f96c74366a79c098de3b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3204,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4de2938eaf24892ef927d9cef6e4acb6a19ce01c017cd498533896f633f332"
+checksum = "cae9cb2c2f6cab2dfa395ea6e2576713929040c7fb0c5f4150d13e1119d18686"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/guests/risc0/batch-proof/mock/Cargo.toml
+++ b/guests/risc0/batch-proof/mock/Cargo.toml
@@ -26,6 +26,7 @@ sov-rollup-interface = { path = "../../../../crates/sovereign-sdk/rollup-interfa
 sov-state = { path = "../../../../crates/sovereign-sdk/module-system/sov-state" }
 
 [features]
+# sys-getenv enabled for network selection here, only used in tests
 testing = ["citrea-primitives/testing", "risc0-zkvm-platform/sys-getenv"]
 
 [patch.crates-io]

--- a/guests/risc0/batch-proof/mock/Cargo.toml
+++ b/guests/risc0/batch-proof/mock/Cargo.toml
@@ -10,9 +10,9 @@ resolver = "2"
 # automatically added by the unstable feature
 # but we tend to forget to update this while updating risc0
 # so putting here explicitly
-risc0-bigint2 = "1.4.3"
-risc0-zkvm = { version = "2.1.0", default-features = false, features = ["unstable"] }
-risc0-zkvm-platform = { version = "2.0.2", features = ["heap-embedded-alloc"] }
+risc0-bigint2 = "1.4.5"
+risc0-zkvm = { version = "2.3.0", default-features = false, features = ["unstable"] }
+risc0-zkvm-platform = { version = "2.0.3", features = ["heap-embedded-alloc"] }
 
 anyhow = "1.0.95"
 citrea-primitives = { path = "../../../../crates/primitives" }

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.lock
@@ -1867,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a065c83232c9945f9c1690f9766bec75f8919272b3a724b44dcc68b05f4625"
+checksum = "b5174056ad92cd5adc1bfcbdf64ef964114796c09cc71c178668a9e82939e61d"
 dependencies = [
  "include_bytes_aligned",
  "stability",
@@ -1877,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fe7599ac55ad77515608ec42a9727001559fe4f579c533cb7c973b54800c05"
+checksum = "62eb7025356a233c1bc267c458a2ce56fcfc89b136d813c8a77be14ef1eaf2b1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1896,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.1.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17d6657b1fb615c0482bd4b57aae7850911ed7dbdc8e783df20e93f33209a8f"
+checksum = "c951d23a3255fe9e43526418ad8fc3471cac1c48b338f9cfeb4063d250c1f698"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1920,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d339c65b0e011677404bd6bdfe1b0f29748187a568fb2f74df7fb650590181a"
+checksum = "0094af5a57b020388a03bdd3834959c7d62723f1687be81414ade25104d93263"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1936,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6501fd3936aea2dd3e55915f34328fe96e6ca25ef00320242f837ae668785b"
+checksum = "76ebded45c902c2b6939924a1cddd1d06b5d1d4ad1531e8798ebfee78f9c038d"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1951,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e0a8f0f56106295bb682dbc27093438e163a5f6384a79e877ab895a11d9ae"
+checksum = "15030849f8356f01f23c74b37dbfa4283100b594eb634109993e9e005ef45f64"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1980,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b31cb7b2a46f0cdaf71803ea7e0389af9f5bc1aea2531106f2972b241f26e98"
+checksum = "7cf5d0b673d5fc67a89147c2e9c53134707dcc8137a43d1ef06b4ff68e99b74f"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2011,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa210a232361fd671b30918469856b64d715f2564956d0a5df97ab6cb116d28b"
+checksum = "a287e9cd6d7b3b38eeb49c62090c46a1935922309fbd997a9143ed8c43c8f3cb"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1014d2efcb3b359aff878c9aeb6aa949a6d91f091a2ffb5ffd8d928a1ab7f3"
+checksum = "910c2023c39ac1e23dd4f7acdff086333f31ca608035f96c74366a79c098de3b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2065,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4de2938eaf24892ef927d9cef6e4acb6a19ce01c017cd498533896f633f332"
+checksum = "cae9cb2c2f6cab2dfa395ea6e2576713929040c7fb0c5f4150d13e1119d18686"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.lock
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.lock
@@ -708,6 +708,7 @@ name = "citrea-light-client-prover"
 version = "0.7.2"
 dependencies = [
  "borsh",
+ "citrea-primitives",
  "citrea-risc0-batch-proof",
  "const-hex",
  "constmuck",

--- a/guests/risc0/light-client-proof/bitcoin/Cargo.toml
+++ b/guests/risc0/light-client-proof/bitcoin/Cargo.toml
@@ -10,9 +10,9 @@ resolver = "2"
 # automatically added by the unstable feature
 # but we tend to forget to update this while updating risc0
 # so putting here explicitly
-risc0-bigint2 = "1.4.3"
-risc0-zkvm = { version = "2.1.0", default-features = false, features = ["unstable", "std"] }
-risc0-zkvm-platform = { version = "2.0.2", features = ["sys-getenv"] }
+risc0-bigint2 = "1.4.5"
+risc0-zkvm = { version = "2.3.0", default-features = false, features = ["unstable", "std"] }
+risc0-zkvm-platform = { version = "2.0.3", features = ["sys-getenv"] }
 
 anyhow = "1.0.95"
 bitcoin-da = { path = "../../../../crates/bitcoin-da", default-features = false }

--- a/guests/risc0/light-client-proof/mock/Cargo.lock
+++ b/guests/risc0/light-client-proof/mock/Cargo.lock
@@ -1775,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a065c83232c9945f9c1690f9766bec75f8919272b3a724b44dcc68b05f4625"
+checksum = "b5174056ad92cd5adc1bfcbdf64ef964114796c09cc71c178668a9e82939e61d"
 dependencies = [
  "include_bytes_aligned",
  "stability",
@@ -1785,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fe7599ac55ad77515608ec42a9727001559fe4f579c533cb7c973b54800c05"
+checksum = "62eb7025356a233c1bc267c458a2ce56fcfc89b136d813c8a77be14ef1eaf2b1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1804,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.1.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17d6657b1fb615c0482bd4b57aae7850911ed7dbdc8e783df20e93f33209a8f"
+checksum = "c951d23a3255fe9e43526418ad8fc3471cac1c48b338f9cfeb4063d250c1f698"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1828,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d339c65b0e011677404bd6bdfe1b0f29748187a568fb2f74df7fb650590181a"
+checksum = "0094af5a57b020388a03bdd3834959c7d62723f1687be81414ade25104d93263"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1844,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6501fd3936aea2dd3e55915f34328fe96e6ca25ef00320242f837ae668785b"
+checksum = "76ebded45c902c2b6939924a1cddd1d06b5d1d4ad1531e8798ebfee78f9c038d"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1859,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e0a8f0f56106295bb682dbc27093438e163a5f6384a79e877ab895a11d9ae"
+checksum = "15030849f8356f01f23c74b37dbfa4283100b594eb634109993e9e005ef45f64"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1888,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b31cb7b2a46f0cdaf71803ea7e0389af9f5bc1aea2531106f2972b241f26e98"
+checksum = "7cf5d0b673d5fc67a89147c2e9c53134707dcc8137a43d1ef06b4ff68e99b74f"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1919,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa210a232361fd671b30918469856b64d715f2564956d0a5df97ab6cb116d28b"
+checksum = "a287e9cd6d7b3b38eeb49c62090c46a1935922309fbd997a9143ed8c43c8f3cb"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1014d2efcb3b359aff878c9aeb6aa949a6d91f091a2ffb5ffd8d928a1ab7f3"
+checksum = "910c2023c39ac1e23dd4f7acdff086333f31ca608035f96c74366a79c098de3b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1973,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4de2938eaf24892ef927d9cef6e4acb6a19ce01c017cd498533896f633f332"
+checksum = "cae9cb2c2f6cab2dfa395ea6e2576713929040c7fb0c5f4150d13e1119d18686"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/guests/risc0/light-client-proof/mock/Cargo.lock
+++ b/guests/risc0/light-client-proof/mock/Cargo.lock
@@ -631,6 +631,7 @@ name = "citrea-light-client-prover"
 version = "0.7.2"
 dependencies = [
  "borsh",
+ "citrea-primitives",
  "citrea-risc0-batch-proof",
  "const-hex",
  "constmuck",

--- a/guests/risc0/light-client-proof/mock/Cargo.toml
+++ b/guests/risc0/light-client-proof/mock/Cargo.toml
@@ -10,9 +10,9 @@ resolver = "2"
 # automatically added by the unstable feature
 # but we tend to forget to update this while updating risc0
 # so putting here explicitly
-risc0-bigint2 = "1.4.3"
-risc0-zkvm = { version = "2.1.0", default-features = false, features = ["unstable", "std"] }
-risc0-zkvm-platform = { version = "2.0.2", features = ["sys-getenv"] }
+risc0-bigint2 = "1.4.5"
+risc0-zkvm = { version = "2.3.0", default-features = false, features = ["unstable", "std"] }
+risc0-zkvm-platform = { version = "2.0.3", features = ["sys-getenv"] }
 
 anyhow = "1.0.95"
 sov-mock-da = { path = "../../../../crates/sovereign-sdk/adapters/mock-da", default-features = false }


### PR DESCRIPTION
# Description
Upgrades to risc0 v2.3.0

In this upgrade "dev mode" (fake receipt verification) is enabled programatically in the runtime by setting a field in the Receipt::verify_with_context functions. 

We must make sure we are not calling the regular `Receipt::verify` function as it will default to old the environment variable method.

