### PR TITLE
Use error level on l2 sync errors

### DIFF
--- a/crates/common/src/l2.rs
+++ b/crates/common/src/l2.rs
@@ -246,7 +246,7 @@ async fn get_l2_blocks_range(
                         return Err(backoff::Error::Permanent(SyncError::ResponseOverLimit));
                     }
                     let error_msg = format!("L2 block: call error during RPC call: {:?}", e);
-                    debug!(error_msg);
+                    error!(error_msg);
                     Err(backoff::Error::Transient {
                         err: SyncError::Call(error_msg),
                         retry_after: None,
@@ -254,7 +254,7 @@ async fn get_l2_blocks_range(
                 }
                 JsonrpseeError::Transport(e) => {
                     let error_msg = format!("L2 block: connection error during RPC call: {:?}", e);
-                    debug!(error_msg);
+                    error!(error_msg);
                     Err(backoff::Error::Transient {
                         err: SyncError::Connection(error_msg),
                         retry_after: None,


### PR DESCRIPTION
# Description
Had issues with l2 sync did not realize because RUST_LOG was not debug, making this error level makes more sense

