### PR TITLE
Consolidate to single common L2Syncer

### DIFF
--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -347,7 +347,7 @@ where
             );
         }
         _ => {
-            let (mut l2_syncer, l1_block_handler, pruner_service, rpc_module) =
+            let (l2_syncer, l1_block_handler, pruner_service, rpc_module) =
                 CitreaRollupBlueprint::create_full_node(
                     &rollup_blueprint,
                     network,

--- a/bin/citrea/src/rollup/mod.rs
+++ b/bin/citrea/src/rollup/mod.rs
@@ -4,14 +4,14 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use citrea_batch_prover::l1_syncer::L1Syncer as BatchProverL1Syncer;
 use citrea_batch_prover::prover::Prover;
-use citrea_batch_prover::L2Syncer as BatchProverL2Syncer;
+use citrea_batch_prover::BatchProverL2Syncer;
 use citrea_common::backup::BackupManager;
 use citrea_common::{
     BatchProverConfig, FullNodeConfig, InitParams, LightClientProverConfig, NodeType,
     SequencerConfig,
 };
 use citrea_fullnode::da_block_handler::L1BlockHandler as FullNodeL1BlockHandler;
-use citrea_fullnode::L2Syncer as FullNodeL2Syncer;
+use citrea_fullnode::FullNodeL2Syncer;
 use citrea_light_client_prover::circuit::initial_values::InitialValueProvider;
 use citrea_light_client_prover::da_block_handler::L1BlockHandler as LightClientProverL1BlockHandler;
 use citrea_primitives::forks::get_forks;

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -362,7 +362,7 @@ pub async fn start_rollup(
     } else {
         let span = info_span!("FullNode");
 
-        let (mut l2_syncer, l1_block_handler, pruner, rpc_module) =
+        let (l2_syncer, l1_block_handler, pruner, rpc_module) =
             CitreaRollupBlueprint::create_full_node(
                 &mock_demo_rollup,
                 network.unwrap_or(Network::Nightly),

--- a/crates/batch-prover/src/l2_syncer.rs
+++ b/crates/batch-prover/src/l2_syncer.rs
@@ -11,18 +11,18 @@ use crate::metrics::BATCH_PROVER_METRICS;
 
 pub type BatchProverL2Syncer<DA, DB> = L2Syncer<DA, DB, BatchProverL2BlockProcessor>;
 
-// Batch prover L2 block processor
+/// Batch prover L2 block processor
 pub struct BatchProverL2BlockProcessor;
 
 impl<DB> L2BlockProcessor<DB> for BatchProverL2BlockProcessor
 where
     DB: BatchProverLedgerOps,
 {
-    fn process_result(&self, result: &ProcessL2BlockResult, db: &DB) -> anyhow::Result<()> {
+    fn process_result(result: &ProcessL2BlockResult, db: &DB) -> anyhow::Result<()> {
         db.set_l2_state_diff(L2BlockNumber(result.l2_height), result.state_diff.clone())
     }
 
-    fn record_metrics(&self, result: &ProcessL2BlockResult) {
+    fn record_metrics(result: &ProcessL2BlockResult) {
         BATCH_PROVER_METRICS
             .current_l2_block
             .set(result.l2_height as f64);

--- a/crates/batch-prover/src/l2_syncer.rs
+++ b/crates/batch-prover/src/l2_syncer.rs
@@ -3,234 +3,31 @@
 //! This module contains functionality for synchronizing L2 blocks from the sequencer
 //! and processing them to maintain the batch prover's state.
 
-use std::sync::Arc;
-
-use backoff::backoff::Backoff;
-use backoff::ExponentialBackoff;
-use borsh::BorshDeserialize;
-use citrea_common::backup::BackupManager;
-use citrea_common::cache::L1BlockCache;
-use citrea_common::l2::{process_l2_block, sync_l2, ProcessL2BlockResult};
-use citrea_primitives::types::L2BlockHash;
-use citrea_stf::runtime::CitreaRuntime;
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
-use reth_tasks::shutdown::GracefulShutdown;
+use citrea_common::l2::{L2BlockProcessor, L2Syncer, ProcessL2BlockResult};
 use sov_db::ledger_db::BatchProverLedgerOps;
 use sov_db::schema::types::L2BlockNumber;
-use sov_keys::default_signature::K256PublicKey;
-use sov_modules_api::default_context::DefaultContext;
-use sov_modules_stf_blueprint::StfBlueprint;
-use sov_prover_storage_manager::ProverStorageManager;
-use sov_rollup_interface::fork::ForkManager;
-use sov_rollup_interface::rpc::block::L2BlockResponse;
-use sov_rollup_interface::services::da::DaService;
-use sov_rollup_interface::zk::StorageRootHash;
-use tokio::select;
-use tokio::sync::{broadcast, mpsc, Mutex};
-use tracing::{error, info, instrument};
 
 use crate::metrics::BATCH_PROVER_METRICS;
-use crate::{InitParams, RollupPublicKeys, RunnerConfig};
 
-/// Component responsible for synchronizing and processing L2 blocks
-///
-/// The L2Syncer maintains the state of the L2 chain by:
-/// - Fetching new blocks from the sequencer
-/// - Validating block signatures and contents
-/// - Processing blocks to update the local state
-/// - Managing forks and state transitions
-pub struct L2Syncer<DA, DB>
+pub type BatchProverL2Syncer<DA, DB> = L2Syncer<DA, DB, BatchProverL2BlockProcessor>;
+
+// Batch prover L2 block processor
+pub struct BatchProverL2BlockProcessor;
+
+impl<DB> L2BlockProcessor<DB> for BatchProverL2BlockProcessor
 where
-    DA: DaService,
-    DB: BatchProverLedgerOps + Clone,
+    DB: BatchProverLedgerOps,
 {
-    /// Starting height for L2 block synchronization
-    start_l2_height: u64,
-    /// Data availability service instance
-    da_service: Arc<DA>,
-    /// State transition function blueprint
-    stf: StfBlueprint<DefaultContext, DA::Spec, CitreaRuntime<DefaultContext, DA::Spec>>,
-    /// Manager for prover storage
-    storage_manager: ProverStorageManager,
-    /// Database for ledger operations
-    ledger_db: DB,
-    /// Current state root hash
-    state_root: StorageRootHash,
-    /// Current L2 block hash
-    l2_block_hash: L2BlockHash,
-    /// HTTP client for connecting to the sequencer
-    sequencer_client: HttpClient,
-    /// Sequencer's public key for signature verification
-    sequencer_pub_key: K256PublicKey,
-    /// Whether to include transaction bodies in block storage
-    include_tx_body: bool,
-    /// Cache for L1 block data
-    _l1_block_cache: Arc<Mutex<L1BlockCache<DA>>>,
-    /// Number of blocks to sync at a time
-    sync_blocks_count: u64,
-    /// Manager for handling chain forks
-    fork_manager: ForkManager<'static>,
-    /// Channel for L2 block notifications
-    l2_block_tx: broadcast::Sender<u64>,
-    /// Manager for backup operations
-    backup_manager: Arc<BackupManager>,
-}
-
-impl<DA, DB> L2Syncer<DA, DB>
-where
-    DA: DaService<Error = anyhow::Error>,
-    DB: BatchProverLedgerOps + Clone + Send + Sync + 'static,
-{
-    /// Creates a new `L2Syncer` instance.
-    ///
-    /// # Arguments
-    /// * `runner_config` - Configuration for the runner.
-    /// * `init_params` - Initial parameters including previous state root and L2 block hash.
-    /// * `stf` - State transition function blueprint.
-    /// * `public_keys` - Public keys for the rollup, including the sequencer's public key.
-    /// * `da_service` - Data availability service instance.
-    /// * `ledger_db` - Database for ledger operations.
-    /// * `storage_manager` - Manager for prover storage.
-    /// * `fork_manager` - Manager for handling chain forks.
-    /// * `l2_block_tx` - Channel for L2 block notifications.
-    /// * `backup_manager` - Manager for backup operations.
-    /// * `include_tx_body` - Whether to include transaction bodies in block processing.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        runner_config: RunnerConfig,
-        init_params: InitParams,
-        stf: StfBlueprint<DefaultContext, DA::Spec, CitreaRuntime<DefaultContext, DA::Spec>>,
-        public_keys: RollupPublicKeys,
-        da_service: Arc<DA>,
-        ledger_db: DB,
-        storage_manager: ProverStorageManager,
-        fork_manager: ForkManager<'static>,
-        l2_block_tx: broadcast::Sender<u64>,
-        backup_manager: Arc<BackupManager>,
-        include_tx_body: bool,
-    ) -> Result<Self, anyhow::Error> {
-        let start_l2_height = ledger_db.get_head_l2_block_height()?.unwrap_or(0) + 1;
-
-        info!("Starting L2 height: {}", start_l2_height);
-
-        Ok(Self {
-            start_l2_height,
-            da_service,
-            stf,
-            storage_manager,
-            ledger_db,
-            state_root: init_params.prev_state_root,
-            l2_block_hash: init_params.prev_l2_block_hash,
-            sequencer_client: HttpClientBuilder::default()
-                .build(runner_config.sequencer_client_url)?,
-            sequencer_pub_key: K256PublicKey::try_from_slice(&public_keys.sequencer_public_key)?,
-            include_tx_body,
-            sync_blocks_count: runner_config.sync_blocks_count,
-            _l1_block_cache: Arc::new(Mutex::new(L1BlockCache::new())),
-            fork_manager,
-            l2_block_tx,
-            backup_manager,
-        })
+    fn process_result(&self, result: &ProcessL2BlockResult, db: &DB) -> anyhow::Result<()> {
+        db.set_l2_state_diff(L2BlockNumber(result.l2_height), result.state_diff.clone())
     }
 
-    /// Runs the L2Syncer until shutdown is signaled
-    ///
-    /// This method continuously:
-    /// 1. Fetches new L2 blocks from the sequencer
-    /// 2. Processes each block to update the local state
-    /// 3. Handles any errors with exponential backoff
-    /// 4. Maintains metrics about syncing progress
-    #[instrument(name = "L2Syncer", skip_all)]
-    pub async fn run(mut self, mut shutdown_signal: GracefulShutdown) {
-        let (l2_tx, mut l2_rx) = mpsc::channel(1);
-        let l2_sync_worker = sync_l2(
-            self.start_l2_height,
-            self.sequencer_client.clone(),
-            l2_tx,
-            self.sync_blocks_count,
-        );
-        tokio::pin!(l2_sync_worker);
-
-        let backup_manager = self.backup_manager.clone();
-        loop {
-            // poll l2 sync worker to continue syncing, and handle the incoming l2 blocks synchronously.
-            // hence, when processing the l2 blocks, l2 sync worker is blocked.
-            select! {
-                biased;
-                _ = &mut shutdown_signal => {
-                    info!("Shutting down L2 syncer");
-                    return;
-                },
-                Some(l2_blocks) = l2_rx.recv() => {
-                    // While syncing, we'd like to process L2 blocks as they come without any delays.
-                    for l2_block in l2_blocks {
-                        let mut backoff = ExponentialBackoff::default();
-                        loop {
-                            let _l2_lock = backup_manager.start_l2_processing().await;
-                            match self.process_l2_block(&l2_block).await {
-                                Ok(_) => break,
-                                Err(e) => {
-                                    error!("Failed to process L2 block {}: {}", l2_block.header.height, e);
-                                    let backoff_duration = backoff.next_backoff().expect("Failed to process L2 block multiple times. Killing L2Syncer...");
-                                    tokio::time::sleep(backoff_duration).await;
-                                }
-                            }
-                        }
-                    }
-                },
-                _ = &mut l2_sync_worker => {},
-            }
-        }
-    }
-
-    /// Processes a single L2 block
-    ///
-    /// # Arguments
-    /// * `l2_block_response` - Block data from the sequencer
-    ///
-    /// # Returns
-    /// Success if the block was processed and state was updated, error otherwise
-    async fn process_l2_block(
-        &mut self,
-        l2_block_response: &L2BlockResponse,
-    ) -> anyhow::Result<()> {
-        // call common l2 block processing logic
-        let l2_block_result = process_l2_block(
-            l2_block_response,
-            &self.storage_manager,
-            &mut self.fork_manager,
-            self.da_service.clone(),
-            &self.ledger_db,
-            &mut self.stf,
-            self.l2_block_hash,
-            self.state_root,
-            &self.sequencer_pub_key,
-            self.include_tx_body,
-        )
-        .await?;
-
-        let ProcessL2BlockResult {
-            l2_height,
-            l2_block_hash,
-            state_root,
-            state_diff,
-            process_duration,
-        } = l2_block_result;
-
-        self.state_root = state_root;
-        self.l2_block_hash = l2_block_hash;
-
-        self.ledger_db
-            .set_l2_state_diff(L2BlockNumber(l2_height), state_diff)?;
-
-        // Only errors when there are no receivers
-        let _ = self.l2_block_tx.send(l2_height);
-
-        BATCH_PROVER_METRICS.current_l2_block.set(l2_height as f64);
+    fn record_metrics(&self, result: &ProcessL2BlockResult) {
+        BATCH_PROVER_METRICS
+            .current_l2_block
+            .set(result.l2_height as f64);
         BATCH_PROVER_METRICS
             .process_l2_block
-            .record(process_duration);
-
-        Ok(())
+            .record(result.process_duration);
     }
 }

--- a/crates/batch-prover/src/lib.rs
+++ b/crates/batch-prover/src/lib.rs
@@ -47,7 +47,6 @@ use sov_rollup_interface::zk::ZkvmHost;
 use sov_rollup_interface::Network;
 use tokio::sync::{broadcast, mpsc, Mutex};
 
-use crate::l2_syncer::BatchProverL2BlockProcessor;
 pub use crate::l2_syncer::BatchProverL2Syncer;
 
 /// Module containing database migration definitions
@@ -155,7 +154,6 @@ where
         l2_block_tx.clone(),
         backup_manager.clone(),
         true,
-        BatchProverL2BlockProcessor,
     )?;
 
     let (l1_signal_tx, l1_signal_rx) = mpsc::channel(1);

--- a/crates/batch-prover/src/lib.rs
+++ b/crates/batch-prover/src/lib.rs
@@ -33,7 +33,6 @@ use citrea_common::{BatchProverConfig, InitParams, RollupPublicKeys, RunnerConfi
 use citrea_stf::runtime::CitreaRuntime;
 use jsonrpsee::RpcModule;
 pub use l1_syncer::L1Syncer;
-pub use l2_syncer::L2Syncer;
 pub use partition::PartitionMode;
 use prover::Prover;
 use prover_services::ParallelProverService;
@@ -47,6 +46,9 @@ use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::zk::ZkvmHost;
 use sov_rollup_interface::Network;
 use tokio::sync::{broadcast, mpsc, Mutex};
+
+use crate::l2_syncer::BatchProverL2BlockProcessor;
+pub use crate::l2_syncer::BatchProverL2Syncer;
 
 /// Module containing database migration definitions
 pub mod db_migrations;
@@ -119,7 +121,7 @@ pub async fn build_services<DA, DB, Vm>(
     rpc_module: RpcModule<()>,
     backup_manager: Arc<BackupManager>,
 ) -> Result<(
-    L2Syncer<DA, DB>,
+    BatchProverL2Syncer<DA, DB>,
     L1Syncer<DA, DB>,
     Prover<DA, DB, Vm>,
     RpcModule<()>,
@@ -141,7 +143,7 @@ where
     );
     let rpc_module = rpc::register_rpc_methods(rpc_context, rpc_module)?;
 
-    let l2_syncer = L2Syncer::new(
+    let l2_syncer = BatchProverL2Syncer::new(
         runner_config.clone(),
         init_params,
         native_stf,
@@ -153,6 +155,7 @@ where
         l2_block_tx.clone(),
         backup_manager.clone(),
         true,
+        BatchProverL2BlockProcessor,
     )?;
 
     let (l1_signal_tx, l1_signal_rx) = mpsc::channel(1);

--- a/crates/common/src/l2.rs
+++ b/crates/common/src/l2.rs
@@ -3,6 +3,7 @@
 //! This module contains functionality for synchronizing L2 blocks from the sequencer
 //! and processing them to maintain the node's state.
 
+use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -292,9 +293,9 @@ pub trait L2BlockProcessor<DB> {
     /// # Arguments
     /// * `result` - The processed l2 block result
     /// * `db` - Database handle for storage
-    fn process_result(&self, result: &ProcessL2BlockResult, db: &DB) -> anyhow::Result<()>;
+    fn process_result(result: &ProcessL2BlockResult, db: &DB) -> anyhow::Result<()>;
     /// Record metrics for the processed block
-    fn record_metrics(&self, result: &ProcessL2BlockResult);
+    fn record_metrics(result: &ProcessL2BlockResult);
 }
 
 /// Component responsible for synchronizing and processing L2 blocks
@@ -341,7 +342,7 @@ where
     /// Manager for backup operations
     backup_manager: Arc<BackupManager>,
     /// L2 Block processor
-    block_processor: P,
+    _phantom_processor: PhantomData<P>,
 }
 
 impl<DA, DB, P> L2Syncer<DA, DB, P>
@@ -377,7 +378,6 @@ where
         l2_block_tx: broadcast::Sender<u64>,
         backup_manager: Arc<BackupManager>,
         include_tx_body: bool,
-        block_processor: P,
     ) -> Result<Self, anyhow::Error> {
         let start_l2_height = ledger_db.get_head_l2_block_height()?.unwrap_or(0) + 1;
 
@@ -400,7 +400,7 @@ where
             fork_manager,
             l2_block_tx,
             backup_manager,
-            block_processor,
+            _phantom_processor: PhantomData,
         })
     }
 
@@ -481,9 +481,8 @@ where
         self.state_root = l2_block_result.state_root;
         self.l2_block_hash = l2_block_result.l2_block_hash;
 
-        self.block_processor
-            .process_result(&l2_block_result, &self.ledger_db)?;
-        self.block_processor.record_metrics(&l2_block_result);
+        P::process_result(&l2_block_result, &self.ledger_db)?;
+        P::record_metrics(&l2_block_result);
 
         // Only errors when there are no receivers
         let _ = self.l2_block_tx.send(l2_block_result.l2_height);

--- a/crates/common/src/l2.rs
+++ b/crates/common/src/l2.rs
@@ -1,15 +1,24 @@
+//! L2 block synchronization for Citrea nodes
+//!
+//! This module contains functionality for synchronizing L2 blocks from the sequencer
+//! and processing them to maintain the node's state.
+
 use std::sync::Arc;
 use std::time::Instant;
 
 use alloy_primitives::U64;
 use anyhow::{bail, Context as _};
+use backoff::backoff::Backoff;
 use backoff::exponential::ExponentialBackoffBuilder;
 use backoff::future::retry as retry_backoff;
+use backoff::ExponentialBackoff;
+use borsh::BorshDeserialize;
 use citrea_primitives::merkle::compute_tx_hashes;
 use citrea_primitives::types::L2BlockHash;
 use citrea_stf::runtime::CitreaRuntime;
 use jsonrpsee::core::client::Error as JsonrpseeError;
-use jsonrpsee::http_client::HttpClient;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use reth_tasks::shutdown::GracefulShutdown;
 use sov_db::ledger_db::SharedLedgerOps;
 use sov_keys::default_signature::K256PublicKey;
 use sov_ledger_rpc::LedgerRpcClient;
@@ -22,11 +31,15 @@ use sov_rollup_interface::rpc::block::L2BlockResponse;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::zk::StorageRootHash;
 use sov_state::storage::NativeStorage;
-use tokio::sync::mpsc;
+use tokio::select;
+use tokio::sync::{broadcast, mpsc, Mutex};
 use tokio::time::{sleep, Duration};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, instrument, warn};
 
+use crate::backup::BackupManager;
+use crate::cache::L1BlockCache;
 use crate::utils::decode_sov_tx_and_update_short_header_proofs;
+use crate::{InitParams, RollupPublicKeys, RunnerConfig};
 
 pub struct ProcessL2BlockResult {
     pub l2_height: u64,
@@ -271,4 +284,210 @@ async fn get_l2_blocks_range(
         }
     })
     .await
+}
+
+pub trait L2BlockProcessor<DB> {
+    ///// Process the result of an L2 block
+    ///
+    /// # Arguments
+    /// * `result` - The processed l2 block result
+    /// * `db` - Database handle for storage
+    fn process_result(&self, result: &ProcessL2BlockResult, db: &DB) -> anyhow::Result<()>;
+    /// Record metrics for the processed block
+    fn record_metrics(&self, result: &ProcessL2BlockResult);
+}
+
+/// Component responsible for synchronizing and processing L2 blocks
+///
+/// The L2Syncer maintains the state of the L2 chain by:
+/// - Fetching new blocks from the sequencer
+/// - Validating block signatures and contents
+/// - Processing blocks to update the local state
+/// - Managing forks and state transitions
+pub struct L2Syncer<DA, DB, P>
+where
+    DA: DaService,
+    DB: SharedLedgerOps + Clone + Send + Sync + 'static,
+    P: L2BlockProcessor<DB>,
+{
+    /// Starting height for L2 block synchronization
+    start_l2_height: u64,
+    /// Data availability service instance
+    da_service: Arc<DA>,
+    /// State transition function blueprint
+    stf: StfBlueprint<DefaultContext, DA::Spec, CitreaRuntime<DefaultContext, DA::Spec>>,
+    /// Manager for prover storage
+    storage_manager: ProverStorageManager,
+    /// Database for ledger operations
+    ledger_db: DB,
+    /// Current state root hash
+    state_root: StorageRootHash,
+    /// Current L2 block hash
+    l2_block_hash: L2BlockHash,
+    /// HTTP client for connecting to the sequencer
+    sequencer_client: HttpClient,
+    /// Sequencer's public key for signature verification
+    sequencer_pub_key: K256PublicKey,
+    /// Whether to include transaction bodies in block storage
+    include_tx_body: bool,
+    /// Cache for L1 block data
+    _l1_block_cache: Arc<Mutex<L1BlockCache<DA>>>,
+    /// Number of blocks to sync at a time
+    sync_blocks_count: u64,
+    /// Manager for handling chain forks
+    fork_manager: ForkManager<'static>,
+    /// Channel for L2 block notifications
+    l2_block_tx: broadcast::Sender<u64>,
+    /// Manager for backup operations
+    backup_manager: Arc<BackupManager>,
+    /// L2 Block processor
+    block_processor: P,
+}
+
+impl<DA, DB, P> L2Syncer<DA, DB, P>
+where
+    DA: DaService<Error = anyhow::Error>,
+    DB: SharedLedgerOps + Clone + Send + Sync + 'static,
+    P: L2BlockProcessor<DB>,
+{
+    /// Creates a new L2Syncer instance
+    ///
+    /// # Arguments
+    /// * `runner_config` - Configuration for the syncer
+    /// * `init_params` - Initial parameters including previous state root and block hash
+    /// * `stf` - State transition function blueprint
+    /// * `public_keys` - Public keys for cryptographic operations
+    /// * `da_service` - Data availability service
+    /// * `ledger_db` - Database for ledger operations
+    /// * `storage_manager` - Manager for prover storage
+    /// * `fork_manager` - Manager for handling chain forks
+    /// * `l2_block_tx` - Channel for L2 block notifications
+    /// * `backup_manager` - Manager for backup operations
+    /// * `include_tx_body` - Whether to include transaction bodies in block processing
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        runner_config: RunnerConfig,
+        init_params: InitParams,
+        stf: StfBlueprint<DefaultContext, DA::Spec, CitreaRuntime<DefaultContext, DA::Spec>>,
+        public_keys: RollupPublicKeys,
+        da_service: Arc<DA>,
+        ledger_db: DB,
+        storage_manager: ProverStorageManager,
+        fork_manager: ForkManager<'static>,
+        l2_block_tx: broadcast::Sender<u64>,
+        backup_manager: Arc<BackupManager>,
+        include_tx_body: bool,
+        block_processor: P,
+    ) -> Result<Self, anyhow::Error> {
+        let start_l2_height = ledger_db.get_head_l2_block_height()?.unwrap_or(0) + 1;
+
+        info!("Starting L2 height: {}", start_l2_height);
+
+        Ok(Self {
+            start_l2_height,
+            da_service,
+            stf,
+            storage_manager,
+            ledger_db,
+            state_root: init_params.prev_state_root,
+            l2_block_hash: init_params.prev_l2_block_hash,
+            sequencer_client: HttpClientBuilder::default()
+                .build(runner_config.sequencer_client_url)?,
+            sequencer_pub_key: K256PublicKey::try_from_slice(&public_keys.sequencer_public_key)?,
+            include_tx_body,
+            sync_blocks_count: runner_config.sync_blocks_count,
+            _l1_block_cache: Arc::new(Mutex::new(L1BlockCache::new())),
+            fork_manager,
+            l2_block_tx,
+            backup_manager,
+            block_processor,
+        })
+    }
+
+    /// Runs the L2Syncer until shutdown is signaled
+    ///
+    /// This method continuously:
+    /// 1. Fetches new L2 blocks from the sequencer
+    /// 2. Processes each block to update the local state
+    /// 3. Handles any errors with exponential backoff
+    /// 4. Maintains metrics about syncing progress
+    #[instrument(name = "L2Syncer", skip_all)]
+    pub async fn run(mut self, mut shutdown_signal: GracefulShutdown) {
+        let (l2_tx, mut l2_rx) = mpsc::channel(1);
+        let l2_sync_worker = sync_l2(
+            self.start_l2_height,
+            self.sequencer_client.clone(),
+            l2_tx,
+            self.sync_blocks_count,
+        );
+        tokio::pin!(l2_sync_worker);
+
+        let backup_manager = self.backup_manager.clone();
+        loop {
+            select! {
+                biased;
+                _ = &mut shutdown_signal => {
+                    info!("Shutting down L2 syncer");
+                    l2_rx.close();
+                    return;
+                },
+                Some(l2_blocks) = l2_rx.recv() => {
+                    // While syncing, we'd like to process L2 blocks as they come without any delays.
+                    for l2_block in l2_blocks {
+                        let mut backoff = ExponentialBackoff::default();
+                        loop {
+                            let _l2_lock = backup_manager.start_l2_processing().await;
+                            match self.process_l2_block(&l2_block).await {
+                                Ok(_) => break,
+                                Err(e) => {
+                                    error!("Failed to process L2 block {}: {}", l2_block.header.height, e);
+                                    let backoff_duration = backoff.next_backoff().expect("Failed to process L2 block multiple times. Killing L2Syncer...");
+                                    tokio::time::sleep(backoff_duration).await;
+                                }
+                            }
+                        }
+                    }
+                },
+                _ = &mut l2_sync_worker => {},
+            }
+        }
+    }
+
+    /// Processes a single L2 block
+    ///
+    /// # Arguments
+    /// * `l2_block_response` - Block data from the sequencer
+    ///
+    /// # Returns
+    /// Success if the block was processed and state was updated, error otherwise
+    async fn process_l2_block(
+        &mut self,
+        l2_block_response: &L2BlockResponse,
+    ) -> anyhow::Result<()> {
+        let l2_block_result = process_l2_block(
+            l2_block_response,
+            &self.storage_manager,
+            &mut self.fork_manager,
+            self.da_service.clone(),
+            &self.ledger_db,
+            &mut self.stf,
+            self.l2_block_hash,
+            self.state_root,
+            &self.sequencer_pub_key,
+            self.include_tx_body,
+        )
+        .await?;
+
+        self.state_root = l2_block_result.state_root;
+        self.l2_block_hash = l2_block_result.l2_block_hash;
+
+        self.block_processor
+            .process_result(&l2_block_result, &self.ledger_db)?;
+        self.block_processor.record_metrics(&l2_block_result);
+
+        // Only errors when there are no receivers
+        let _ = self.l2_block_tx.send(l2_block_result.l2_height);
+
+        Ok(())
+    }
 }

--- a/crates/fullnode/src/l2_syncer.rs
+++ b/crates/fullnode/src/l2_syncer.rs
@@ -3,225 +3,26 @@
 //! This module contains functionality for synchronizing L2 blocks from the sequencer
 //! and processing them to maintain the fullnode's state.
 
-use std::sync::Arc;
-
-use backoff::backoff::Backoff;
-use backoff::ExponentialBackoff;
-use borsh::BorshDeserialize;
-use citrea_common::backup::BackupManager;
-use citrea_common::cache::L1BlockCache;
-use citrea_common::l2::{process_l2_block, sync_l2, ProcessL2BlockResult};
-use citrea_primitives::types::L2BlockHash;
-use citrea_stf::runtime::CitreaRuntime;
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
-use reth_tasks::shutdown::GracefulShutdown;
-use sov_db::ledger_db::SharedLedgerOps;
-use sov_keys::default_signature::K256PublicKey;
-use sov_modules_api::default_context::DefaultContext;
-use sov_modules_stf_blueprint::StfBlueprint;
-use sov_prover_storage_manager::ProverStorageManager;
-use sov_rollup_interface::fork::ForkManager;
-use sov_rollup_interface::rpc::block::L2BlockResponse;
-use sov_rollup_interface::services::da::DaService;
-use sov_rollup_interface::zk::StorageRootHash;
-use tokio::select;
-use tokio::sync::{broadcast, mpsc, Mutex};
-use tracing::{error, info, instrument};
+use citrea_common::l2::{L2BlockProcessor, L2Syncer, ProcessL2BlockResult};
 
 use crate::metrics::FULLNODE_METRICS;
-use crate::{InitParams, RollupPublicKeys, RunnerConfig};
 
-/// Component responsible for synchronizing and processing L2 blocks
-///
-/// The L2Syncer maintains the state of the L2 chain by:
-/// - Fetching new blocks from the sequencer
-/// - Validating block signatures and contents
-/// - Processing blocks to update the local state
-/// - Managing forks and state transitions
-pub struct L2Syncer<DA, DB>
-where
-    DA: DaService,
-    DB: SharedLedgerOps + Clone,
-{
-    /// Starting height for L2 block synchronization
-    start_l2_height: u64,
-    /// Data availability service instance
-    da_service: Arc<DA>,
-    /// State transition function blueprint
-    stf: StfBlueprint<DefaultContext, DA::Spec, CitreaRuntime<DefaultContext, DA::Spec>>,
-    /// Manager for prover storage
-    storage_manager: ProverStorageManager,
-    /// Database for ledger operations
-    ledger_db: DB,
-    /// Current state root hash
-    state_root: StorageRootHash,
-    /// Current L2 block hash
-    l2_block_hash: L2BlockHash,
-    /// HTTP client for connecting to the sequencer
-    sequencer_client: HttpClient,
-    /// Sequencer's public key for signature verification
-    sequencer_pub_key: K256PublicKey,
-    /// Whether to include transaction bodies in block storage
-    include_tx_body: bool,
-    /// Cache for L1 block data
-    _l1_block_cache: Arc<Mutex<L1BlockCache<DA>>>,
-    /// Number of blocks to sync at a time
-    sync_blocks_count: u64,
-    /// Manager for handling chain forks
-    fork_manager: ForkManager<'static>,
-    /// Channel for L2 block notifications
-    l2_block_tx: broadcast::Sender<u64>,
-    /// Manager for backup operations
-    backup_manager: Arc<BackupManager>,
-}
+pub type FullNodeL2Syncer<DA, DB> = L2Syncer<DA, DB, FullNodeL2BlockProcessor>;
 
-impl<DA, DB> L2Syncer<DA, DB>
-where
-    DA: DaService<Error = anyhow::Error>,
-    DB: SharedLedgerOps + Clone + Send + Sync + 'static,
-{
-    /// Creates a new L2Syncer instance
-    ///
-    /// # Arguments
-    /// * `runner_config` - Configuration for the syncer
-    /// * `init_params` - Initial parameters including previous state root and block hash
-    /// * `stf` - State transition function blueprint
-    /// * `public_keys` - Public keys for cryptographic operations
-    /// * `da_service` - Data availability service
-    /// * `ledger_db` - Database for ledger operations
-    /// * `storage_manager` - Manager for prover storage
-    /// * `fork_manager` - Manager for handling chain forks
-    /// * `l2_block_tx` - Channel for L2 block notifications
-    /// * `backup_manager` - Manager for backup operations
-    /// * `include_tx_body` - Whether to include transaction bodies in block processing
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        runner_config: RunnerConfig,
-        init_params: InitParams,
-        stf: StfBlueprint<DefaultContext, DA::Spec, CitreaRuntime<DefaultContext, DA::Spec>>,
-        public_keys: RollupPublicKeys,
-        da_service: Arc<DA>,
-        ledger_db: DB,
-        storage_manager: ProverStorageManager,
-        fork_manager: ForkManager<'static>,
-        l2_block_tx: broadcast::Sender<u64>,
-        backup_manager: Arc<BackupManager>,
-        include_tx_body: bool,
-    ) -> Result<Self, anyhow::Error> {
-        let start_l2_height = ledger_db.get_head_l2_block_height()?.unwrap_or(0) + 1;
+/// Full node L2 block processor
+pub struct FullNodeL2BlockProcessor;
 
-        info!("Starting L2 height: {}", start_l2_height);
-
-        Ok(Self {
-            start_l2_height,
-            da_service,
-            stf,
-            storage_manager,
-            ledger_db,
-            state_root: init_params.prev_state_root,
-            l2_block_hash: init_params.prev_l2_block_hash,
-            sequencer_client: HttpClientBuilder::default()
-                .build(runner_config.sequencer_client_url)?,
-            sequencer_pub_key: K256PublicKey::try_from_slice(&public_keys.sequencer_public_key)?,
-            include_tx_body,
-            sync_blocks_count: runner_config.sync_blocks_count,
-            _l1_block_cache: Arc::new(Mutex::new(L1BlockCache::new())),
-            fork_manager,
-            l2_block_tx,
-            backup_manager,
-        })
-    }
-
-    /// Runs the L2Syncer until shutdown is signaled
-    ///
-    /// This method continuously:
-    /// 1. Fetches new L2 blocks from the sequencer
-    /// 2. Processes each block to update the local state
-    /// 3. Handles any errors with exponential backoff
-    /// 4. Maintains metrics about syncing progress
-    #[instrument(name = "L2Syncer", skip_all)]
-    pub async fn run(&mut self, mut shutdown_signal: GracefulShutdown) {
-        let (l2_tx, mut l2_rx) = mpsc::channel(1);
-        let l2_sync_worker = sync_l2(
-            self.start_l2_height,
-            self.sequencer_client.clone(),
-            l2_tx,
-            self.sync_blocks_count,
-        );
-        tokio::pin!(l2_sync_worker);
-
-        let backup_manager = self.backup_manager.clone();
-        loop {
-            select! {
-                _ = &mut l2_sync_worker => {},
-                Some(l2_blocks) = l2_rx.recv() => {
-                    // While syncing, we'd like to process L2 blocks as they come without any delays.
-                    for l2_block in l2_blocks {
-                        let mut backoff = ExponentialBackoff::default();
-                        loop {
-                            let _l2_lock = backup_manager.start_l2_processing().await;
-                            match self.process_l2_block(&l2_block).await {
-                                Ok(_) => break,
-                                Err(e) => {
-                                    error!("Failed to process L2 block {}: {}", l2_block.header.height, e);
-                                    let backoff_duration = backoff.next_backoff().expect("Failed to process L2 block multiple times. Killing L2Syncer...");
-                                    tokio::time::sleep(backoff_duration).await;
-                                }
-                            }
-                        }
-                    }
-                },
-                _ = &mut shutdown_signal => {
-                    info!("Shutting down L2 sync worker");
-                    l2_rx.close();
-                    return;
-                },
-            }
-        }
-    }
-
-    /// Processes a single L2 block
-    ///
-    /// # Arguments
-    /// * `l2_block_response` - Block data from the sequencer
-    ///
-    /// # Returns
-    /// Success if the block was processed and state was updated, error otherwise
-    async fn process_l2_block(
-        &mut self,
-        l2_block_response: &L2BlockResponse,
-    ) -> anyhow::Result<()> {
-        let l2_block_result = process_l2_block(
-            l2_block_response,
-            &self.storage_manager,
-            &mut self.fork_manager,
-            self.da_service.clone(),
-            &self.ledger_db,
-            &mut self.stf,
-            self.l2_block_hash,
-            self.state_root,
-            &self.sequencer_pub_key,
-            self.include_tx_body,
-        )
-        .await?;
-
-        let ProcessL2BlockResult {
-            l2_height,
-            l2_block_hash,
-            state_root,
-            process_duration,
-            ..
-        } = l2_block_result;
-
-        self.state_root = state_root;
-        self.l2_block_hash = l2_block_hash;
-
-        // Only errors when there are no receivers
-        let _ = self.l2_block_tx.send(l2_height);
-
-        FULLNODE_METRICS.current_l2_block.set(l2_height as f64);
-        FULLNODE_METRICS.process_l2_block.record(process_duration);
-
+impl<DB> L2BlockProcessor<DB> for FullNodeL2BlockProcessor {
+    fn process_result(&self, _result: &ProcessL2BlockResult, _db: &DB) -> anyhow::Result<()> {
         Ok(())
+    }
+
+    fn record_metrics(&self, result: &ProcessL2BlockResult) {
+        FULLNODE_METRICS
+            .current_l2_block
+            .set(result.l2_height as f64);
+        FULLNODE_METRICS
+            .process_l2_block
+            .record(result.process_duration);
     }
 }

--- a/crates/fullnode/src/l2_syncer.rs
+++ b/crates/fullnode/src/l2_syncer.rs
@@ -13,11 +13,11 @@ pub type FullNodeL2Syncer<DA, DB> = L2Syncer<DA, DB, FullNodeL2BlockProcessor>;
 pub struct FullNodeL2BlockProcessor;
 
 impl<DB> L2BlockProcessor<DB> for FullNodeL2BlockProcessor {
-    fn process_result(&self, _result: &ProcessL2BlockResult, _db: &DB) -> anyhow::Result<()> {
+    fn process_result(_result: &ProcessL2BlockResult, _db: &DB) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn record_metrics(&self, result: &ProcessL2BlockResult) {
+    fn record_metrics(result: &ProcessL2BlockResult) {
         FULLNODE_METRICS
             .current_l2_block
             .set(result.l2_height as f64);

--- a/crates/fullnode/src/lib.rs
+++ b/crates/fullnode/src/lib.rs
@@ -139,7 +139,6 @@ use sov_rollup_interface::zk::ZkvmHost;
 use sov_rollup_interface::Network;
 use tokio::sync::{broadcast, Mutex};
 
-use crate::l2_syncer::FullNodeL2BlockProcessor;
 pub use crate::l2_syncer::FullNodeL2Syncer;
 
 /// Module for handling L1 data availability blocks
@@ -241,7 +240,6 @@ where
         l2_block_tx,
         backup_manager.clone(),
         include_tx_bodies,
-        FullNodeL2BlockProcessor,
     )?;
 
     let l1_block_handler = L1BlockHandler::new(

--- a/crates/fullnode/src/lib.rs
+++ b/crates/fullnode/src/lib.rs
@@ -128,7 +128,6 @@ use citrea_stf::runtime::CitreaRuntime;
 use citrea_storage_ops::pruning::{Pruner, PrunerService};
 use da_block_handler::L1BlockHandler;
 use jsonrpsee::RpcModule;
-pub use l2_syncer::L2Syncer;
 use sov_db::ledger_db::NodeLedgerOps;
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::fork::ForkManager;
@@ -139,6 +138,9 @@ use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::zk::ZkvmHost;
 use sov_rollup_interface::Network;
 use tokio::sync::{broadcast, Mutex};
+
+use crate::l2_syncer::FullNodeL2BlockProcessor;
+pub use crate::l2_syncer::FullNodeL2Syncer;
 
 /// Module for handling L1 data availability blocks
 pub mod da_block_handler;
@@ -201,7 +203,7 @@ pub fn build_services<DA, DB, Vm>(
     rpc_module: RpcModule<()>,
     backup_manager: Arc<BackupManager>,
 ) -> Result<(
-    L2Syncer<DA, DB>,
+    FullNodeL2Syncer<DA, DB>,
     L1BlockHandler<Vm, DA, DB>,
     Option<PrunerService>,
     RpcModule<()>,
@@ -227,7 +229,7 @@ where
     });
 
     let include_tx_bodies = runner_config.include_tx_body;
-    let l2_syncer = L2Syncer::new(
+    let l2_syncer = FullNodeL2Syncer::new(
         runner_config,
         init_params,
         native_stf,
@@ -239,6 +241,7 @@ where
         l2_block_tx,
         backup_manager.clone(),
         include_tx_bodies,
+        FullNodeL2BlockProcessor,
     )?;
 
     let l1_block_handler = L1BlockHandler::new(


### PR DESCRIPTION
# Description

- Replace fullnode and batch prover L2 syncer by common L2Syncer. Can then be used for listen mode sequencer as well

## Linked Issues
- Related to #2604 