### PR TITLE
Fix lagged blocks recovery

### DIFF
--- a/crates/sequencer/src/rpc.rs
+++ b/crates/sequencer/src/rpc.rs
@@ -402,9 +402,9 @@ async fn handle_l2_block_subscription(
     ledger: LedgerDB,
 ) {
     let head_block_num = ledger.get_head_l2_block_height().unwrap_or(0);
-    let last_sent_block = Arc::new(AtomicU64::new(head_block_num));
+    let last_sent_block = AtomicU64::new(head_block_num);
     loop {
-        match receive_next_blocks(rx, last_sent_block.clone()).await {
+        match receive_next_blocks(rx, &last_sent_block).await {
             BlockReceiveResult::HighestBlock(highest_block_height) => {
                 let last_sent_block_num = last_sent_block.load(Ordering::SeqCst);
                 for block_height in last_sent_block_num + 1..=highest_block_height {
@@ -425,7 +425,7 @@ async fn handle_l2_block_subscription(
 /// Receive the next block(s) from the channel, handling lag recovery
 async fn receive_next_blocks(
     rx: &mut broadcast::Receiver<u64>,
-    last_sent_block: Arc<AtomicU64>,
+    last_sent_block: &AtomicU64,
 ) -> BlockReceiveResult {
     match rx.recv().await {
         Ok(block_height) => BlockReceiveResult::HighestBlock(block_height),

--- a/crates/sequencer/src/rpc.rs
+++ b/crates/sequencer/src/rpc.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use alloy_eips::eip2718::Encodable2718;
@@ -400,13 +401,15 @@ async fn handle_l2_block_subscription(
     rx: &mut tokio::sync::broadcast::Receiver<u64>,
     ledger: LedgerDB,
 ) {
+    let last_sent_block = Arc::new(AtomicU64::new(0));
     loop {
-        match receive_next_blocks(rx).await {
+        match receive_next_blocks(rx, last_sent_block.clone()).await {
             BlockReceiveResult::Blocks(blocks) => {
                 for block_height in blocks {
                     if !send_block_notification(&subscription, block_height, &ledger).await {
                         return;
                     }
+                    last_sent_block.store(block_height, Ordering::SeqCst);
                 }
             }
             BlockReceiveResult::ChannelClosed => {
@@ -418,7 +421,10 @@ async fn handle_l2_block_subscription(
 }
 
 /// Receive the next block(s) from the channel, handling lag recovery
-async fn receive_next_blocks(rx: &mut broadcast::Receiver<u64>) -> BlockReceiveResult {
+async fn receive_next_blocks(
+    rx: &mut broadcast::Receiver<u64>,
+    last_sent_block: Arc<AtomicU64>,
+) -> BlockReceiveResult {
     match rx.recv().await {
         Ok(block_height) => BlockReceiveResult::Blocks(vec![block_height]),
         Err(broadcast::error::RecvError::Lagged(num_lagged)) => {
@@ -427,31 +433,22 @@ async fn receive_next_blocks(rx: &mut broadcast::Receiver<u64>) -> BlockReceiveR
                 num_lagged
             );
 
-            // Try to get the next available block and calculate missed blocks
-            match rx.recv().await {
-                Ok(current_block_height) => {
-                    let start_height = current_block_height.saturating_sub(num_lagged);
-                    let mut blocks = Vec::with_capacity(num_lagged as usize + 1);
+            // Explanation of lag recovery:
+            // If the channel size is for example 10 and we somehow sent 30 blocks at the same time to the channel,
+            // The first 20 blocks will be dropped and we will only receive the last 10 blocks.
+            // Since we send blocks sequentially, we can recover the lagged blocks by
+            // calculating the range of blocks that were missed based on the last sent block number.
+            // Assume our last sent block number is 0, initial state, we receive a lagged error with num_lagged = 20.
+            // We return blocks from 1 to 20 to recover from the lag. After that when we call receive again,
+            // we will receive the next block, which is 21, and continue from there as normal.
 
-                    // Add all missed blocks
-                    for height in start_height..current_block_height {
-                        blocks.push(height);
-                    }
-                    // Add the current block
-                    blocks.push(current_block_height);
-
-                    BlockReceiveResult::Blocks(blocks)
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    tracing::info!("L2 block channel closed during lag recovery");
-                    BlockReceiveResult::ChannelClosed
-                }
-                Err(broadcast::error::RecvError::Lagged(_)) => {
-                    // Still lagging, return empty to try again
-                    tracing::warn!("Still lagging after recovery attempt");
-                    BlockReceiveResult::Blocks(vec![])
-                }
+            // Recover blocks from the `last_sent_block + 1`, to `last_sent_block + num_lagged`
+            let mut blocks = Vec::with_capacity(num_lagged as usize + 1);
+            let last_sent_block_num = last_sent_block.load(Ordering::SeqCst);
+            for height in (last_sent_block_num + 1)..=(last_sent_block_num + num_lagged) {
+                blocks.push(height);
             }
+            BlockReceiveResult::Blocks(blocks)
         }
         Err(broadcast::error::RecvError::Closed) => BlockReceiveResult::ChannelClosed,
     }

--- a/crates/sequencer/src/rpc.rs
+++ b/crates/sequencer/src/rpc.rs
@@ -34,7 +34,7 @@ use crate::utils::recover_raw_transaction;
 /// Result of receiving blocks from the `l2_block_rx` channel
 enum BlockReceiveResult {
     /// Successfully received blocks (may include recovered lagged blocks)
-    Blocks(Vec<u64>),
+    HighestBlock(u64),
     /// Channel was closed
     ChannelClosed,
 }
@@ -405,8 +405,9 @@ async fn handle_l2_block_subscription(
     let last_sent_block = Arc::new(AtomicU64::new(head_block_num));
     loop {
         match receive_next_blocks(rx, last_sent_block.clone()).await {
-            BlockReceiveResult::Blocks(blocks) => {
-                for block_height in blocks {
+            BlockReceiveResult::HighestBlock(highest_block_height) => {
+                let last_sent_block_num = last_sent_block.load(Ordering::SeqCst);
+                for block_height in last_sent_block_num + 1..=highest_block_height {
                     if !send_block_notification(&subscription, block_height, &ledger).await {
                         return;
                     }
@@ -427,7 +428,7 @@ async fn receive_next_blocks(
     last_sent_block: Arc<AtomicU64>,
 ) -> BlockReceiveResult {
     match rx.recv().await {
-        Ok(block_height) => BlockReceiveResult::Blocks(vec![block_height]),
+        Ok(block_height) => BlockReceiveResult::HighestBlock(block_height),
         Err(broadcast::error::RecvError::Lagged(num_lagged)) => {
             tracing::warn!(
                 "Subscription lagged by {} blocks, attempting to recover",
@@ -444,12 +445,8 @@ async fn receive_next_blocks(
             // we will receive the next block, which is 21, and continue from there as normal.
 
             // Recover blocks from the `last_sent_block + 1`, to `last_sent_block + num_lagged`
-            let mut blocks = Vec::with_capacity(num_lagged as usize + 1);
             let last_sent_block_num = last_sent_block.load(Ordering::SeqCst);
-            for height in (last_sent_block_num + 1)..=(last_sent_block_num + num_lagged) {
-                blocks.push(height);
-            }
-            BlockReceiveResult::Blocks(blocks)
+            BlockReceiveResult::HighestBlock(last_sent_block_num + num_lagged)
         }
         Err(broadcast::error::RecvError::Closed) => BlockReceiveResult::ChannelClosed,
     }

--- a/crates/sequencer/src/rpc.rs
+++ b/crates/sequencer/src/rpc.rs
@@ -401,7 +401,8 @@ async fn handle_l2_block_subscription(
     rx: &mut tokio::sync::broadcast::Receiver<u64>,
     ledger: LedgerDB,
 ) {
-    let last_sent_block = Arc::new(AtomicU64::new(0));
+    let head_block_num = ledger.get_head_l2_block_height().unwrap_or(0);
+    let last_sent_block = Arc::new(AtomicU64::new(head_block_num));
     loop {
         match receive_next_blocks(rx, last_sent_block.clone()).await {
             BlockReceiveResult::Blocks(blocks) => {

--- a/crates/sequencer/src/rpc.rs
+++ b/crates/sequencer/src/rpc.rs
@@ -411,8 +411,8 @@ async fn handle_l2_block_subscription(
                     if !send_block_notification(&subscription, block_height, &ledger).await {
                         return;
                     }
-                    last_sent_block.store(block_height, Ordering::SeqCst);
                 }
+                last_sent_block.store(highest_block_height, Ordering::SeqCst);
             }
             BlockReceiveResult::ChannelClosed => {
                 tracing::info!("L2 block channel closed, ending subscription");


### PR DESCRIPTION
# Description
I believe that in the first implementation If we had lagged responses twice in a row we would skip those lagged blocks because we return an empty vector, with this implementation there is an atomic variable for each subscriber that tracks the last successfully sent block and acts accordingly in lagged responses

## Linked Issues
- Fixes #2612 
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
