### PR TITLE
Read log related max values from env

### DIFF
--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1521,7 +1521,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         from_block_number: u64,
         to_block_number: u64,
     ) -> Result<Vec<Log>, EthFilterError> {
-        let max_blocks_per_filter: u64 = DEFAULT_MAX_BLOCKS_PER_FILTER;
+        let max_blocks_per_filter: u64 = get_max_blocks_per_filter();
         if to_block_number - from_block_number >= max_blocks_per_filter {
             return Err(EthFilterError::QueryExceedsMaxBlocks(max_blocks_per_filter));
         }
@@ -1532,7 +1532,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let topics_filter: Vec<BloomFilter> =
             filter.topics.iter().map(|t| t.to_bloom_filter()).collect();
 
-        let max_headers_range = MAX_HEADERS_RANGE;
+        let max_headers_range = get_max_headers_range();
 
         // loop over the range of new blocks and check logs if the filter matches the log's bloom
         // filter
@@ -1564,7 +1564,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                         filter.clone(),
                         block,
                     );
-                    let max_logs_per_response = DEFAULT_MAX_LOGS_PER_RESPONSE;
+                    let max_logs_per_response = get_max_logs_per_response();
                     // size check but only if range is multiple blocks, so we always return all
                     // logs of a single block
                     let is_multi_block_range = from_block_number != to_block_number;

--- a/crates/evm/src/rpc_helpers/filter.rs
+++ b/crates/evm/src/rpc_helpers/filter.rs
@@ -18,30 +18,30 @@ pub const DEFAULT_MAX_HEADERS_RANGE: u64 = 1_000; // with ~530bytes? per header 
 /// This value can be configured via the `ETH_RPC_MAX_BLOCKS_PER_FILTER` environment variable.
 /// If the variable is not set, it defaults to `DEFAULT_MAX_BLOCKS_PER_FILTER`.
 pub fn get_max_blocks_per_filter() -> u64 {
-    env::var("ETH_RPC_MAX_BLOCKS_PER_FILTER")
-        .map_or(DEFAULT_MAX_BLOCKS_PER_FILTER, |v| {
-            v.parse().expect("ETH_RPC_MAX_BLOCKS_PER_FILTER must be a valid u64")
-        })
+    env::var("ETH_RPC_MAX_BLOCKS_PER_FILTER").map_or(DEFAULT_MAX_BLOCKS_PER_FILTER, |v| {
+        v.parse()
+            .expect("ETH_RPC_MAX_BLOCKS_PER_FILTER must be a valid u64")
+    })
 }
 
 /// The maximum number of logs that can be returned in a single eth_getLogs response.
 /// This value can be configured via the `ETH_RPC_MAX_LOGS_PER_RESPONSE` environment variable.
 /// If the variable is not set, it defaults to `DEFAULT_MAX_LOGS_PER_RESPONSE`.
 pub fn get_max_logs_per_response() -> usize {
-    env::var("ETH_RPC_MAX_LOGS_PER_RESPONSE")
-        .map_or(DEFAULT_MAX_LOGS_PER_RESPONSE, |v| {
-            v.parse().expect("ETH_RPC_MAX_LOGS_PER_RESPONSE must be a valid usize")
-        })
+    env::var("ETH_RPC_MAX_LOGS_PER_RESPONSE").map_or(DEFAULT_MAX_LOGS_PER_RESPONSE, |v| {
+        v.parse()
+            .expect("ETH_RPC_MAX_LOGS_PER_RESPONSE must be a valid usize")
+    })
 }
 
 /// The maximum number of headers we read at once when handling a range filter.
 /// This value can be configured via the `ETH_RPC_MAX_HEADERS_RANGE` environment variable.
 /// If the variable is not set, it defaults to `DEFAULT_MAX_HEADERS_RANGE`.
 pub fn get_max_headers_range() -> u64 {
-    env::var("ETH_RPC_MAX_HEADERS_RANGE")
-        .map_or(DEFAULT_MAX_HEADERS_RANGE, |v| {
-            v.parse().expect("ETH_RPC_MAX_HEADERS_RANGE must be a valid u64")
-        })
+    env::var("ETH_RPC_MAX_HEADERS_RANGE").map_or(DEFAULT_MAX_HEADERS_RANGE, |v| {
+        v.parse()
+            .expect("ETH_RPC_MAX_HEADERS_RANGE must be a valid u64")
+    })
 }
 
 /// An iterator that yields _inclusive_ block ranges of a given step size

--- a/crates/evm/src/rpc_helpers/filter.rs
+++ b/crates/evm/src/rpc_helpers/filter.rs
@@ -12,7 +12,7 @@ pub const DEFAULT_MAX_BLOCKS_PER_FILTER: u64 = 1_000;
 /// The maximum number of logs that can be returned in a single eth_getLogs response.
 pub const DEFAULT_MAX_LOGS_PER_RESPONSE: usize = 5_000;
 /// The maximum number of headers we read at once when handling a range filter.
-pub const MAX_HEADERS_RANGE: u64 = 1_000; // with ~530bytes? per header this is ~500kb?
+pub const DEFAULT_MAX_HEADERS_RANGE: u64 = 1_000; // with ~530bytes? per header this is ~500kb?
 
 /// Retrieves the maximum number of blocks that can be queried in a single eth_getLogs request.
 /// This value can be configured via the `ETH_RPC_MAX_BLOCKS_PER_FILTER` environment variable.
@@ -36,10 +36,10 @@ pub fn get_max_logs_per_response() -> usize {
 
 /// The maximum number of headers we read at once when handling a range filter.
 /// This value can be configured via the `ETH_RPC_MAX_HEADERS_RANGE` environment variable.
-/// If the variable is not set, it defaults to `MAX_HEADERS_RANGE`.
+/// If the variable is not set, it defaults to `DEFAULT_MAX_HEADERS_RANGE`.
 pub fn get_max_headers_range() -> u64 {
     env::var("ETH_RPC_MAX_HEADERS_RANGE")
-        .map_or(MAX_HEADERS_RANGE, |v| {
+        .map_or(DEFAULT_MAX_HEADERS_RANGE, |v| {
             v.parse().expect("ETH_RPC_MAX_HEADERS_RANGE must be a valid u64")
         })
 }

--- a/crates/evm/src/rpc_helpers/filter.rs
+++ b/crates/evm/src/rpc_helpers/filter.rs
@@ -1,5 +1,6 @@
 // https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-types/src/eth/filter.rs
 
+use std::env;
 use std::iter::StepBy;
 use std::ops::RangeInclusive;
 
@@ -12,6 +13,36 @@ pub const DEFAULT_MAX_BLOCKS_PER_FILTER: u64 = 1_000;
 pub const DEFAULT_MAX_LOGS_PER_RESPONSE: usize = 5_000;
 /// The maximum number of headers we read at once when handling a range filter.
 pub const MAX_HEADERS_RANGE: u64 = 1_000; // with ~530bytes? per header this is ~500kb?
+
+/// Retrieves the maximum number of blocks that can be queried in a single eth_getLogs request.
+/// This value can be configured via the `ETH_RPC_MAX_BLOCKS_PER_FILTER` environment variable.
+/// If the variable is not set, it defaults to `DEFAULT_MAX_BLOCKS_PER_FILTER`.
+pub fn get_max_blocks_per_filter() -> u64 {
+    env::var("ETH_RPC_MAX_BLOCKS_PER_FILTER")
+        .map_or(DEFAULT_MAX_BLOCKS_PER_FILTER, |v| {
+            v.parse().expect("ETH_RPC_MAX_BLOCKS_PER_FILTER must be a valid u64")
+        })
+}
+
+/// The maximum number of logs that can be returned in a single eth_getLogs response.
+/// This value can be configured via the `ETH_RPC_MAX_LOGS_PER_RESPONSE` environment variable.
+/// If the variable is not set, it defaults to `DEFAULT_MAX_LOGS_PER_RESPONSE`.
+pub fn get_max_logs_per_response() -> usize {
+    env::var("ETH_RPC_MAX_LOGS_PER_RESPONSE")
+        .map_or(DEFAULT_MAX_LOGS_PER_RESPONSE, |v| {
+            v.parse().expect("ETH_RPC_MAX_LOGS_PER_RESPONSE must be a valid usize")
+        })
+}
+
+/// The maximum number of headers we read at once when handling a range filter.
+/// This value can be configured via the `ETH_RPC_MAX_HEADERS_RANGE` environment variable.
+/// If the variable is not set, it defaults to `MAX_HEADERS_RANGE`.
+pub fn get_max_headers_range() -> u64 {
+    env::var("ETH_RPC_MAX_HEADERS_RANGE")
+        .map_or(MAX_HEADERS_RANGE, |v| {
+            v.parse().expect("ETH_RPC_MAX_HEADERS_RANGE must be a valid u64")
+        })
+}
 
 /// An iterator that yields _inclusive_ block ranges of a given step size
 #[derive(Debug)]


### PR DESCRIPTION
# Description
Introduces env vars:
- `ETH_RPC_MAX_BLOCKS_PER_FILTER`
- `ETH_RPC_MAX_LOGS_PER_RESPONSE`
- `ETH_RPC_MAX_HEADERS_RANGE`

## Linked Issues
- Fixes #2614 

TODO:
- [x] Open an issue for max headers range limit not being meaningful.(#2616)
