### PR TITLE
Rollback prover jobs with commitments

### DIFF
--- a/crates/storage-ops/src/rollback/node/batch_prover.rs
+++ b/crates/storage-ops/src/rollback/node/batch_prover.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use sov_db::schema::tables::{
     CommitmentIndicesByJobId, CommitmentIndicesByL1, JobIdOfCommitment, L2BlockByHash,
     L2BlockByNumber, PendingL1SubmissionJobs, ProofByJobId, ProverLastScannedSlot,
-    ProverPendingCommitments, ProverStateDiffs, SequencerCommitmentByIndex, ShortHeaderProofBySlotHash,
-    SlotByHash,
+    ProverPendingCommitments, ProverStateDiffs, SequencerCommitmentByIndex,
+    ShortHeaderProofBySlotHash, SlotByHash,
 };
 use sov_db::schema::types::{L2BlockNumber, SlotNumber};
 use sov_schema_db::{ScanDirection, SchemaBatch, DB};

--- a/crates/storage-ops/src/rollback/node/batch_prover.rs
+++ b/crates/storage-ops/src/rollback/node/batch_prover.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 
 use sov_db::schema::tables::{
     CommitmentIndicesByJobId, CommitmentIndicesByL1, JobIdOfCommitment, L2BlockByHash,
-    L2BlockByNumber, ProverLastScannedSlot, ProverPendingCommitments, ProverStateDiffs,
-    SequencerCommitmentByIndex, ShortHeaderProofBySlotHash, SlotByHash,
+    L2BlockByNumber, PendingL1SubmissionJobs, ProofByJobId, ProverLastScannedSlot,
+    ProverPendingCommitments, ProverStateDiffs, SequencerCommitmentByIndex, ShortHeaderProofBySlotHash,
+    SlotByHash,
 };
 use sov_db::schema::types::{L2BlockNumber, SlotNumber};
 use sov_schema_db::{ScanDirection, SchemaBatch, DB};
@@ -61,6 +62,7 @@ impl BatchProverLedgerRollback {
     ) -> Result {
         let mut batch = SchemaBatch::new();
 
+        // First handle sequencer commitments
         let mut comm_iter = self
             .ledger_db
             .iter_with_direction::<SequencerCommitmentByIndex>(
@@ -69,6 +71,7 @@ impl BatchProverLedgerRollback {
             )?;
         comm_iter.seek_to_last();
 
+        // Delete individual commitment entries
         for record in comm_iter {
             let comm_idx = record?.key;
             if comm_idx <= last_sequencer_commitment_index {
@@ -83,24 +86,56 @@ impl BatchProverLedgerRollback {
 
             batch.delete::<ProverPendingCommitments>(&comm_idx)?;
             increment_table_counter!("ProverPendingCommitments", rollback_result);
+        }
 
-            let mut jobs_iter = self
-                .ledger_db
-                .iter_with_direction::<CommitmentIndicesByJobId>(
-                    Default::default(),
-                    ScanDirection::Backward,
-                )?;
-            jobs_iter.seek_to_last();
-            for job_record in jobs_iter {
-                let job_record = job_record?;
-                let job_id = job_record.key;
-                let job_commitment_indices = job_record.value;
-                if !job_commitment_indices.contains(&comm_idx) {
-                    continue;
-                }
-                batch.delete::<CommitmentIndicesByJobId>(&job_id)?;
-                increment_table_counter!("SequencerCommitmentByIndex", rollback_result);
+        // Now handle jobs that might contain commitments we're rolling back
+        let mut jobs_to_check = Vec::new();
+        let mut jobs_iter = self
+            .ledger_db
+            .iter_with_direction::<CommitmentIndicesByJobId>(
+                Default::default(),
+                ScanDirection::Backward,
+            )?;
+        jobs_iter.seek_to_last();
+
+        // Collect jobs that have any indices above our rollback point
+        for job_record in jobs_iter {
+            let job_record = job_record?;
+            let job_id = job_record.key;
+            let commitment_indices = job_record.value;
+
+            if commitment_indices
+                .iter()
+                .any(|&idx| idx > last_sequencer_commitment_index)
+            {
+                jobs_to_check.push((job_id, commitment_indices));
             }
+        }
+
+        // Process collected jobs
+        for (job_id, commitment_indices) in jobs_to_check {
+            // If ANY index should be preserved, skip the whole job
+            if commitment_indices
+                .iter()
+                .any(|&idx| idx <= last_sequencer_commitment_index)
+            {
+                tracing::warn!(
+                    "Preserving job {} that spans rollback boundary. Job indices: {:?}, rollback target: {}",
+                    job_id,
+                    commitment_indices,
+                    last_sequencer_commitment_index
+                );
+                continue;
+            }
+
+            batch.delete::<CommitmentIndicesByJobId>(&job_id)?;
+            increment_table_counter!("CommitmentIndicesByJobId", rollback_result);
+
+            batch.delete::<PendingL1SubmissionJobs>(&job_id)?;
+            increment_table_counter!("PendingL1SubmissionJobs", rollback_result);
+
+            batch.delete::<ProofByJobId>(&job_id)?;
+            increment_table_counter!("ProofByJobId", rollback_result);
         }
 
         self.ledger_db.write_schemas(batch)?;

--- a/crates/storage-ops/src/rollback/node/batch_prover.rs
+++ b/crates/storage-ops/src/rollback/node/batch_prover.rs
@@ -89,7 +89,6 @@ impl BatchProverLedgerRollback {
         }
 
         // Now handle jobs that might contain commitments we're rolling back
-        let mut jobs_to_check = Vec::new();
         let mut jobs_iter = self
             .ledger_db
             .iter_with_direction::<CommitmentIndicesByJobId>(
@@ -104,27 +103,21 @@ impl BatchProverLedgerRollback {
             let job_id = job_record.key;
             let commitment_indices = job_record.value;
 
-            if commitment_indices
+            if !commitment_indices
                 .iter()
-                .any(|&idx| idx > last_sequencer_commitment_index)
+                .all(|&idx| idx > last_sequencer_commitment_index)
             {
-                jobs_to_check.push((job_id, commitment_indices));
-            }
-        }
-
-        // Process collected jobs
-        for (job_id, commitment_indices) in jobs_to_check {
-            // If ANY index should be preserved, skip the whole job
-            if commitment_indices
-                .iter()
-                .any(|&idx| idx <= last_sequencer_commitment_index)
-            {
-                tracing::warn!(
-                    "Preserving job {} that spans rollback boundary. Job indices: {:?}, rollback target: {}",
-                    job_id,
-                    commitment_indices,
-                    last_sequencer_commitment_index
-                );
+                if commitment_indices
+                    .iter()
+                    .any(|&idx| idx > last_sequencer_commitment_index)
+                {
+                    tracing::warn!(
+                        "Preserving job {} that spans rollback boundary. Job indices: {:?}, rollback target: {}",
+                        job_id,
+                        commitment_indices,
+                        last_sequencer_commitment_index
+                    );
+                }
                 continue;
             }
 

--- a/crates/storage-ops/src/rollback/node/batch_prover.rs
+++ b/crates/storage-ops/src/rollback/node/batch_prover.rs
@@ -107,17 +107,12 @@ impl BatchProverLedgerRollback {
                 .iter()
                 .all(|&idx| idx > last_sequencer_commitment_index)
             {
-                if commitment_indices
-                    .iter()
-                    .any(|&idx| idx > last_sequencer_commitment_index)
-                {
-                    tracing::warn!(
-                        "Preserving job {} that spans rollback boundary. Job indices: {:?}, rollback target: {}",
-                        job_id,
-                        commitment_indices,
-                        last_sequencer_commitment_index
-                    );
-                }
+                tracing::warn!(
+                    "Preserving job {}. Job indices: {:?}, rollback target: {}",
+                    job_id,
+                    commitment_indices,
+                    last_sequencer_commitment_index
+                );
                 continue;
             }
 


### PR DESCRIPTION
# Description

We observed that Testnet Prover was stuck in recovery for long time even though we rolled back the state. We were sending proofs that we couldn't query from RPC. It seems that `PendingL1SubmissionJobs` and `ProofByJobId` tables are not rolled back and caused Prover to go into recovery even though it shouldn't.

There was also a bug in rollback of commitments, where if a job contains the commitment index whole job is deleted. But this was problematic for the case where the job is for indices [9, 10, 11] but the rollback is for index 10, we also delete the job that proves 9 and 10 even though we shouldn't. This PR also fixes that

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
