### PR TITLE
Skip all fields in run_da_queue instrument macro

### DIFF
--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -213,7 +213,7 @@ impl BitcoinService {
     }
 
     /// Run the task to process the DA commands from the queue.
-    #[instrument(name = "BitcoinDA", skip(self))]
+    #[instrument(name = "BitcoinDA", skip_all)]
     pub async fn run_da_queue(
         self: Arc<Self>,
         mut rx: UnboundedReceiver<TxRequestWithNotifier<TxidWrapper>>,


### PR DESCRIPTION
# Description

- Remove clutter, current log line :
`BitcoinDA{rx=UnboundedReceiver { chan: Rx { inner: Chan { tx: Tx { block_tail: 0x5df245c66360, tail_position: 0 }, semaphore: Semaphore(0), rx_waker: AtomicWaker, tx_count: 1, rx_fields: "..." } } } new_block_rx=UnboundedReceiver { chan: Rx { inner: Chan { tx: Tx { block_tail: 0x5df245bfc670, tail_position: 0 }, semaphore: Semaphore(0), rx_waker: AtomicWaker, tx_count: 1, rx_fields: "..." } } } shutdown=GracefulShutdown { shutdown: Shutdown(Shared { inner: Some(Inner), waker_key: 18446744073709551615 }), guard: Some(GracefulShutdownGuard(2)) }}:`
