### PR TITLE
Handle TaskManager critical tasks panics 

### DIFF
--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -148,6 +148,7 @@ where
             select! {
                 biased;
                 _ = &mut shutdown_signal => {
+                    info!("Shutting down L1BlockHandler");
                     return;
                 }
                 _ = &mut l1_sync_worker => {},


### PR DESCRIPTION
# Description

- Await TaskManager to handle panics in critical task. Any panic in any critical tasks should send shutdown signal to other tasks.
- Sets prover L1/L2 syncer as critical as prover cannot continue functionning correctly without any of them
- Sets fullnode L1 syncer as critical.

Both points above are changed since it can lead to confusing behaviour where the node keeps running and ticking along on one layer while the other layer syncer crashed out.
