### PR TITLE
Proving stats: Use SIGKILL for stopping citrea

### DIFF
--- a/.github/scripts/run-proving-test.sh
+++ b/.github/scripts/run-proving-test.sh
@@ -11,12 +11,14 @@ docker exec bitcoin-regtest bitcoin-cli -regtest -rpcuser=citrea -rpcpassword=ci
 docker exec bitcoin-regtest bitcoin-cli -regtest -rpcuser=citrea -rpcpassword=citrea loadwallet batch-prover
 
 RUST_LOG=off target/debug/citrea --dev --da-layer bitcoin --rollup-config-path $TEST_DIR/configs/sequencer_rollup_config.toml --sequencer $TEST_DIR/configs/sequencer_config.toml --genesis-paths bin/citrea/tests/bitcoin/test-data/gen-proof-input-genesis &
+PID_SEQUENCER=$!
 PARALLEL_PROOF_LIMIT=2 target/debug/citrea --dev --da-layer bitcoin --rollup-config-path $TEST_DIR/configs/batch_prover_rollup_config.toml --batch-prover $TEST_DIR/configs/batch_prover_config.toml --genesis-paths bin/citrea/tests/bitcoin/test-data/gen-proof-input-genesis >> batch-prover.log &
+PID_BATCH_PROVER=$!
 
 mkdir -p $TEST_DIR/results
 python3 $TEST_DIR/get-proving-stats.py batch-prover.log $TEST_DIR/results/$OUT_FILE_NAME
 
-pkill -9 citrea
+kill -9 $PID_SEQUENCER $PID_BATCH_PROVER
 docker compose -f $TEST_DIR/docker-compose.regtest.yml down
 sleep 2 
 # After running the container, change ownership back to the user

--- a/.github/scripts/run-proving-test.sh
+++ b/.github/scripts/run-proving-test.sh
@@ -16,13 +16,13 @@ PARALLEL_PROOF_LIMIT=2 target/debug/citrea --dev --da-layer bitcoin --rollup-con
 mkdir -p $TEST_DIR/results
 python3 $TEST_DIR/get-proving-stats.py batch-prover.log $TEST_DIR/results/$OUT_FILE_NAME
 
-pkill citrea
+pkill -9 citrea
 docker compose -f $TEST_DIR/docker-compose.regtest.yml down
+sleep 2 
 # After running the container, change ownership back to the user
 sudo chown -R $USER:$USER $TEST_DIR/bitcoin 
 
-# Give some time for the processes to terminate
-sleep 2 
-# clean the batch prover db for the next run
-rm -rf $TEST_DIR/dbs/batch-prover-db
+# we must clean batch prover db but we also clean
+# the sequencer db as there may be corruption due to the kill -9
+rm -rf $TEST_DIR/dbs/
 rm batch-prover.log

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -582,6 +582,7 @@ jobs:
       - name: Download nightly build artifact
         id: download-artifact
         if: steps.restore-nightly.outputs.cache-hit != 'true'
+        continue-on-error: true
         uses: dawidd6/action-download-artifact@v11
         with:
           name: citrea-build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -627,6 +627,11 @@ jobs:
         if: steps.restore-nightly.outputs.cache-hit != 'true' && steps.download-artifact.outputs.found_artifact != 'true'
         run: git checkout ${{ steps.current-commit.outputs.head-hash }}
 
+      # Sequencer DB is removed in run-proving-test.sh to avoid state corruption
+      - name: Restore sequencer DB from test data
+        if: steps.restore-nightly.outputs.cache-hit != 'true'
+        run: |
+          unzip archive.zip "dbs/*" -d proving-stats/
       - name: Make citrea executable
         if: steps.restore-nightly.outputs.cache-hit != 'true'
         run: chmod +x target/debug/citrea


### PR DESCRIPTION
# Description
When citrea instances do not shut down, downloading nightly artifact fails.
With this PR, we use `kill -9`, clean dbs, and restore sequencer DB when running tests on nightly build.

Also, continues building on nightly if downloading nightly artifact step fails.