### PR TITLE
Replace L1 Syncer interval with notification

### DIFF
--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -5,7 +5,7 @@
 
 use std::collections::VecDeque;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;

--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -119,8 +119,6 @@ where
         tokio::pin!(l1_sync_worker);
 
         let backup_manager = self.backup_manager.clone();
-        let mut interval = tokio::time::interval(Duration::from_secs(1));
-        interval.tick().await;
         loop {
             select! {
                 biased;

--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -5,7 +5,7 @@
 
 use std::collections::VecDeque;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;

--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -119,6 +119,8 @@ where
         tokio::pin!(l1_sync_worker);
 
         let backup_manager = self.backup_manager.clone();
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        interval.tick().await;
         loop {
             select! {
                 biased;

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -132,6 +132,8 @@ where
     /// * `shutdown_signal` - Signal to gracefully shut down
     #[instrument(name = "L1BlockHandler", skip_all)]
     pub async fn run(mut self, start_l1_height: u64, mut shutdown_signal: GracefulShutdown) {
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        interval.tick().await;
         let notifier = Arc::new(Notify::new());
 
         let l1_sync_worker = sync_l1(

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -6,7 +6,7 @@
 use core::panic;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use citrea_common::backup::BackupManager;
@@ -143,6 +143,7 @@ where
         );
         tokio::pin!(l1_sync_worker);
 
+        tokio::time::sleep(Duration::from_secs(1)).await; // Gives time for queue to fill up on startup
         loop {
             select! {
                 biased;

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -29,8 +29,7 @@ use sov_rollup_interface::zk::batch_proof::output::BatchProofCircuitOutput;
 use sov_rollup_interface::zk::{Proof, ZkvmHost};
 use sov_rollup_interface::Network;
 use tokio::select;
-use tokio::sync::Mutex;
-use tokio::time::Duration;
+use tokio::sync::{Mutex, Notify};
 use tracing::{debug, error, info, instrument, warn};
 
 use crate::error::{CommitmentError, HaltingError, ProcessingError, ProofError, SkippableError};
@@ -133,14 +132,14 @@ where
     /// * `shutdown_signal` - Signal to gracefully shut down
     #[instrument(name = "L1BlockHandler", skip_all)]
     pub async fn run(mut self, start_l1_height: u64, mut shutdown_signal: GracefulShutdown) {
-        let mut interval = tokio::time::interval(Duration::from_secs(1));
-        interval.tick().await;
+        let notifier = Arc::new(Notify::new());
 
         let l1_sync_worker = sync_l1(
             start_l1_height,
             self.da_service.clone(),
             self.queued_l1_blocks.clone(),
             self.l1_block_cache.clone(),
+            notifier.clone(),
         );
         tokio::pin!(l1_sync_worker);
 
@@ -152,7 +151,7 @@ where
                     return;
                 }
                 _ = &mut l1_sync_worker => {},
-                _ = interval.tick() => {
+                _ = notifier.notified() => {
                     if let Err(e) = self.process_queued_l1_blocks().await {
                         error!("{e}");
                         return;

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -6,7 +6,7 @@
 use core::panic;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use citrea_common::backup::BackupManager;

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -132,8 +132,6 @@ where
     /// * `shutdown_signal` - Signal to gracefully shut down
     #[instrument(name = "L1BlockHandler", skip_all)]
     pub async fn run(mut self, start_l1_height: u64, mut shutdown_signal: GracefulShutdown) {
-        let mut interval = tokio::time::interval(Duration::from_secs(1));
-        interval.tick().await;
         let notifier = Arc::new(Notify::new());
 
         let l1_sync_worker = sync_l1(

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -6,7 +6,7 @@
 use core::panic;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anyhow::anyhow;
 use citrea_common::backup::BackupManager;

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -167,8 +167,6 @@ where
 
         let backup_manager = self.backup_manager.clone();
 
-        let mut interval = tokio::time::interval(Duration::from_secs(2));
-        interval.tick().await;
         loop {
             select! {
                 biased;

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -167,6 +167,8 @@ where
 
         let backup_manager = self.backup_manager.clone();
 
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        interval.tick().await;
         loop {
             select! {
                 biased;

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -4,7 +4,7 @@
 //! and maintaining the light client state.
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -4,7 +4,7 @@
 //! and maintaining the light client state.
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;
@@ -166,7 +166,7 @@ where
         tokio::pin!(l1_sync_worker);
 
         let backup_manager = self.backup_manager.clone();
-
+        tokio::time::sleep(Duration::from_secs(1)).await; // Gives time for queue to fill up on startup
         loop {
             select! {
                 biased;

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -4,7 +4,7 @@
 //! and maintaining the light client state.
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -26,8 +26,7 @@ use sov_rollup_interface::zk::light_client_proof::output::LightClientCircuitOutp
 use sov_rollup_interface::zk::{ReceiptType, ZkvmHost};
 use sov_rollup_interface::Network;
 use tokio::select;
-use tokio::sync::Mutex;
-use tokio::time::Duration;
+use tokio::sync::{Mutex, Notify};
 use tracing::{error, instrument};
 
 use crate::circuit::initial_values::InitialValueProvider;
@@ -154,18 +153,20 @@ where
             StartVariant::LastScanned(height) => height + 1, // last scanned block + 1
             StartVariant::FromBlock(height) => height,       // first block to scan
         };
+
+        let notifier = Arc::new(Notify::new());
+
         let l1_sync_worker = sync_l1(
             start_l1_height,
             self.da_service.clone(),
             self.queued_l1_blocks.clone(),
             self.l1_block_cache.clone(),
+            notifier.clone(),
         );
         tokio::pin!(l1_sync_worker);
 
         let backup_manager = self.backup_manager.clone();
 
-        let mut interval = tokio::time::interval(Duration::from_secs(2));
-        interval.tick().await;
         loop {
             select! {
                 biased;
@@ -173,7 +174,7 @@ where
                     return;
                 }
                 _ = &mut l1_sync_worker => {},
-                _ = interval.tick() => {
+                _ = notifier.notified() => {
                     let _l1_guard = backup_manager.start_l1_processing().await;
                     if let Err(e) = self.process_queued_l1_blocks().await {
                         error!("Could not process queued L1 blocks and generate proof: {:?}", e);


### PR DESCRIPTION
# Description

- Replaces interval with notification as soon as block is available
- Results in ~100x faster L1 sync performance locally during initial sync and catch-up scenarios