### PR TITLE
L2Syncer enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "sov-schema-db",
  "sov-state",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
  "tower 0.4.13",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -30,6 +30,7 @@ reth-tasks = { workspace = true }
 rocksdb = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tower = { workspace = true }

--- a/crates/common/src/l2/error.rs
+++ b/crates/common/src/l2/error.rs
@@ -1,0 +1,33 @@
+use sov_rollup_interface::stf::StateTransitionError;
+use thiserror::Error;
+
+/// Error types that can occur during L2 block synchronization
+#[derive(Debug, Error)]
+pub enum L2SyncerError {
+    /// DA not synced yet
+    #[error("Blockhash not found: {0:?}")]
+    MissingDaBlock([u8; 32]),
+
+    #[error("Previous hash mismatch at height {height}: expected {expected}, got {got}")]
+    PreviousHashMismatch {
+        height: u64,
+        expected: String,
+        got: String,
+    },
+
+    #[error("Post state root mismatch at height {height}: expected {expected}, got {got}")]
+    PostStateRootMismatch {
+        height: u64,
+        expected: String,
+        got: String,
+    },
+
+    #[error("STF error: {0}")]
+    ApplyBlockError(StateTransitionError),
+
+    #[error(transparent)]
+    SliceConversion(#[from] std::array::TryFromSliceError),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}

--- a/crates/common/src/l2/mod.rs
+++ b/crates/common/src/l2/mod.rs
@@ -328,7 +328,8 @@ async fn sync_l2(
         let blocks_len = l2_blocks.len() as u64;
         match block_buffer.lock().await.extend_blocks(l2_blocks) {
             Ok(()) => start_l2_height += blocks_len,
-            Err(_) => {
+            Err(e) => {
+                warn!("{e}, Waiting for block buffer to be processed");
                 sleep(Duration::from_secs(2)).await;
                 continue;
             }

--- a/crates/common/src/l2/mod.rs
+++ b/crates/common/src/l2/mod.rs
@@ -42,11 +42,17 @@ use tracing::{debug, error, info, instrument, warn};
 
 use crate::backup::BackupManager;
 use crate::cache::L1BlockCache;
-use crate::utils::decode_sov_tx_and_update_short_header_proofs;
+use crate::l2::error::L2SyncerError;
+use crate::l2::utils::decode_sov_tx_and_update_short_header_proofs;
 use crate::{InitParams, RollupPublicKeys};
+
+mod error;
+mod utils;
 
 /// Maximum number of L2BlockResponse ahead of next_expected_height to buffer from subscription
 const SUBSCRIPTION_LOOKAHEAD_LIMIT: u64 = 100;
+/// Maximum number of L2BlockResponse held in buffer
+const MAX_BUFFER_SIZE: usize = 2_000;
 
 pub struct ProcessL2BlockResult {
     pub l2_height: u64,
@@ -95,7 +101,12 @@ impl SequentialL2BlockBuffer {
         self.notify.notify_one();
     }
 
-    fn extend_blocks(&mut self, blocks: BTreeMap<u64, L2BlockResponse>) {
+    fn extend_blocks(&mut self, blocks: BTreeMap<u64, L2BlockResponse>) -> anyhow::Result<()> {
+        if self.blocks.len() >= MAX_BUFFER_SIZE {
+            self.notify.notify_one(); // Queue is full, send signal to process it
+            bail!("Max buffer size hit")
+        }
+
         let mut should_notify = false;
 
         for (height, block) in blocks {
@@ -108,6 +119,8 @@ impl SequentialL2BlockBuffer {
         if should_notify {
             self.notify.notify_one();
         }
+
+        Ok(())
     }
 
     /// Drain from next_expected_height until the first gap or until the buffer is fully consumed
@@ -140,7 +153,7 @@ pub async fn process_l2_block<Da: DaService, DB: SharedLedgerOps>(
     current_state_root: StorageRootHash,
     sequencer_pub_key: &K256PublicKey,
     include_tx_body: bool,
-) -> anyhow::Result<ProcessL2BlockResult> {
+) -> Result<ProcessL2BlockResult, L2SyncerError> {
     let start = Instant::now();
 
     let l2_height = l2_block_response.header.height.to();
@@ -152,7 +165,11 @@ pub async fn process_l2_block<Da: DaService, DB: SharedLedgerOps>(
     );
 
     if current_l2_block_hash != l2_block_response.header.prev_hash {
-        bail!("Previous hash mismatch at height: {}", l2_height);
+        return Err(L2SyncerError::PreviousHashMismatch {
+            height: l2_height,
+            expected: hex::encode(current_l2_block_hash),
+            got: hex::encode(l2_block_response.header.prev_hash),
+        });
     }
 
     let pre_state = storage_manager.create_storage_for_next_l2_height();
@@ -199,13 +216,19 @@ pub async fn process_l2_block<Da: DaService, DB: SharedLedgerOps>(
             Default::default(),
             Default::default(),
             &l2_block,
-        )?
+        )
+        .map_err(L2SyncerError::ApplyBlockError)?
     };
 
     let next_state_root = l2_block_result.state_root_transition.final_root;
+
     // Check if post state root is the same as the one in the l2 block
     if next_state_root.as_ref().to_vec() != l2_block.state_root() {
-        bail!("Post state root mismatch at height: {}", l2_height)
+        return Err(L2SyncerError::PostStateRootMismatch {
+            height: l2_height,
+            expected: hex::encode(l2_block.state_root()),
+            got: hex::encode(next_state_root),
+        });
     }
 
     storage_manager.finalize_storage(l2_block_result.change_set);
@@ -252,7 +275,6 @@ async fn sync_l2(
         }
 
         let end_l2_height = start_l2_height + current_sync_blocks_count - 1;
-
         let inner_client = &sequencer_client;
         let l2_blocks = match get_l2_blocks_range(inner_client, start_l2_height, end_l2_height)
             .await
@@ -299,13 +321,18 @@ async fn sync_l2(
                 start_l2_height
             );
 
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(2)).await;
             continue;
         }
 
-        start_l2_height += l2_blocks.len() as u64;
-
-        block_buffer.lock().await.extend_blocks(l2_blocks);
+        let blocks_len = l2_blocks.len() as u64;
+        match block_buffer.lock().await.extend_blocks(l2_blocks) {
+            Ok(()) => start_l2_height += blocks_len,
+            Err(_) => {
+                sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+        };
     }
 }
 
@@ -513,6 +540,7 @@ where
         let backup_manager = self.backup_manager.clone();
 
         let notifier = self.block_queue.lock().await.notifier();
+
         loop {
             select! {
                 biased;
@@ -530,12 +558,21 @@ where
                         let mut backoff = ExponentialBackoff::default();
                         loop {
                             let _l2_lock = backup_manager.start_l2_processing().await;
+
                             match self.process_l2_block(&l2_block).await {
                                 Ok(_) => break,
-                                Err(e) => {
-                                    error!("Failed to process L2 block {}: {}", l2_block.header.height, e);
+                                Err(L2SyncerError::MissingDaBlock(block)) => {
+                                    warn!("Missing DA block hash {block:?} for block {}, waiting for DA sync", l2_block.header.height);
                                     let backoff_duration = backoff.next_backoff().expect("Failed to process L2 block multiple times. Killing L2Syncer...");
-                                    tokio::time::sleep(backoff_duration).await;
+
+                                    select! {
+                                        _ = &mut shutdown_signal => { info!("Shutting down L2 syncer"); return; },
+                                       _ = tokio::time::sleep(backoff_duration) => {}
+                                    }
+                                }
+                                // Unrecoverable error
+                                Err(e) => {
+                                    panic!("Unrecoverable L2 syncer error on block {}: {}", l2_block.header.height, e);
                                 }
                             }
                         }
@@ -555,7 +592,7 @@ where
     async fn process_l2_block(
         &mut self,
         l2_block_response: &L2BlockResponse,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), L2SyncerError> {
         let l2_block_result = process_l2_block(
             l2_block_response,
             &self.storage_manager,

--- a/crates/common/src/l2/utils.rs
+++ b/crates/common/src/l2/utils.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+
+use alloy_consensus::transaction::Transaction as _;
+use alloy_sol_types::SolCall;
+use anyhow::{anyhow, Context as _};
+use borsh::BorshDeserialize;
+use citrea_evm::system_contracts::{BitcoinLightClientContract, BridgeContract};
+use citrea_evm::{CallMessage as EvmCallMessage, SYSTEM_SIGNER};
+use reth_primitives::{Recovered, TransactionSigned};
+use sov_db::ledger_db::SharedLedgerOps;
+use sov_modules_api::DaSpec;
+use sov_rollup_interface::rpc::block::L2BlockResponse;
+use sov_rollup_interface::services::da::DaService;
+use sov_rollup_interface::transaction::Transaction;
+
+use crate::l2::error::L2SyncerError;
+
+async fn update_short_header_proof_from_sys_tx<Da: DaService, DB: SharedLedgerOps>(
+    tx: &Recovered<TransactionSigned>,
+    ledger_db: &DB,
+    da_service: Arc<Da>,
+) -> Result<(), L2SyncerError> {
+    let function_selector: [u8; 4] = tx
+        .input()
+        .get(0..4)
+        .ok_or(anyhow!("System tx should have func. selector"))?
+        .try_into()?;
+
+    match function_selector {
+        BitcoinLightClientContract::initializeBlockNumberCall::SELECTOR => {
+            tracing::info!("Initialize Bitcoin Light Client contract system tx found inside block");
+        }
+        BitcoinLightClientContract::setBlockInfoCall::SELECTOR => {
+            tracing::info!("setBlockInfo system tx found inside block");
+
+            let l1_block_hash: [u8; 32] = tx
+                .input()
+                .get(4..36)
+                .ok_or(anyhow!("Set block info call should have 32 bytes input"))?
+                .try_into()?;
+
+            // Check if shp exists for this l1 block hash
+            if ledger_db
+                .get_short_header_proof_by_l1_hash(&l1_block_hash)?
+                .is_some()
+            {
+                return Ok(());
+            }
+
+            let da_block = da_service
+                .get_block_by_hash(l1_block_hash.into())
+                .await
+                .map_err(|_| L2SyncerError::MissingDaBlock(l1_block_hash))?;
+
+            let short_header_proof: <<Da as DaService>::Spec as DaSpec>::ShortHeaderProof =
+                Da::block_to_short_header_proof(da_block);
+            ledger_db
+                .put_short_header_proof_by_l1_hash(
+                    &l1_block_hash,
+                    borsh::to_vec(&short_header_proof)
+                        .expect("Should serialize short header proof"),
+                )
+                .expect("Should save short header proof to ledger db");
+        }
+        BridgeContract::initializeCall::SELECTOR => {
+            tracing::info!("Initialize Bridge contract system tx found inside block");
+        }
+        BridgeContract::depositCall::SELECTOR => {
+            tracing::info!("Deposit system tx found inside block");
+        }
+        // TODO: https://github.com/chainwayxyz/citrea/issues/2442
+        unexpected_selector => {
+            tracing::warn!(
+                "Unexpected function selector at system tx: {unexpected_selector:?} , tx input: {:?}, tx hash: {:?}, tx nonce: {:?}", tx.inner().transaction().input(), tx.inner().hash(), tx.inner().transaction().nonce()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// This does not check for misplaced sys txs etc. but they will be rejected by the stf if they are misplaced when the transactions are run
+pub async fn decode_sov_tx_and_update_short_header_proofs<Da: DaService, DB: SharedLedgerOps>(
+    l2_block_response: &L2BlockResponse,
+    ledger_db: &DB,
+    da_service: Arc<Da>,
+) -> Result<(), L2SyncerError> {
+    for tx in &l2_block_response.txs {
+        let tx = &tx.tx;
+        let tx = Transaction::try_from_slice(tx).context("Should deserialize transaction")?;
+        let runtime_msg = tx.runtime_msg();
+
+        if runtime_msg.len() < 2 {
+            return Err(anyhow!("Invalid runtime message").into());
+        }
+
+        if runtime_msg[0] == 1 {
+            // This is evm call message
+            let evm_call_message = EvmCallMessage::try_from_slice(&runtime_msg[1..])
+                .context("Should deserialize evm call message")?;
+            let evm_txs = evm_call_message.txs;
+            for tx in evm_txs {
+                let tx = Recovered::try_from(tx)
+                    .map_err(|_| anyhow!("Should be able to recover evm tx"))?;
+                if tx.signer() == SYSTEM_SIGNER {
+                    update_short_header_proof_from_sys_tx(&tx, ledger_db, da_service.clone())
+                        .await?;
+                } else {
+                    // if we have a different sender, we can skip decoding other txs
+                    // as the sys-tx can only be in the beginning of the block check is also done in evm
+                    // we don't need to check for that here.
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -5,7 +5,6 @@ pub mod backup;
 pub mod cache;
 pub mod config;
 pub mod da;
-pub mod db_migrations;
 pub mod l2;
 pub mod rpc;
 pub mod utils;

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -2,21 +2,10 @@ use std::collections::HashMap;
 use std::env;
 use std::sync::Arc;
 
-use alloy_consensus::transaction::Transaction as _;
-use alloy_sol_types::SolCall;
-use anyhow::{anyhow, Context as _};
-use borsh::BorshDeserialize;
-use citrea_evm::system_contracts::{BitcoinLightClientContract, BridgeContract};
-use citrea_evm::{CallMessage as EvmCallMessage, SYSTEM_SIGNER};
 use citrea_primitives::forks::get_forks;
-use reth_primitives::{Recovered, TransactionSigned};
 use sov_db::ledger_db::SharedLedgerOps;
-use sov_modules_api::DaSpec;
-use sov_rollup_interface::rpc::block::L2BlockResponse;
-use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::spec::SpecId;
 use sov_rollup_interface::stf::StateDiff;
-use sov_rollup_interface::transaction::Transaction;
 
 pub fn merge_state_diffs(old_diff: StateDiff, new_diff: StateDiff) -> StateDiff {
     let mut new_diff_map: HashMap<Arc<[u8]>, Option<Arc<[u8]>>> = HashMap::from_iter(old_diff);
@@ -34,106 +23,6 @@ pub fn check_l2_block_exists<DB: SharedLedgerOps>(ledger_db: &DB, l2_height: u64
     };
 
     head_l2_height >= l2_height
-}
-
-async fn update_short_header_proof_from_sys_tx<Da: DaService, DB: SharedLedgerOps>(
-    tx: &Recovered<TransactionSigned>,
-    ledger_db: &DB,
-    da_service: Arc<Da>,
-) -> anyhow::Result<()> {
-    let function_selector: [u8; 4] = tx
-        .input()
-        .get(0..4)
-        .ok_or(anyhow!("System tx should have func. selector"))?
-        .try_into()?;
-
-    match function_selector {
-        BitcoinLightClientContract::initializeBlockNumberCall::SELECTOR => {
-            tracing::info!("Initialize Bitcoin Light Client contract system tx found inside block");
-        }
-        BitcoinLightClientContract::setBlockInfoCall::SELECTOR => {
-            tracing::info!("setBlockInfo system tx found inside block");
-
-            let l1_block_hash: [u8; 32] = tx
-                .input()
-                .get(4..36)
-                .ok_or(anyhow!("Set block info call should have 32 bytes input"))?
-                .try_into()?;
-            // Check if shp exists for this l1 block hash
-            if ledger_db
-                .get_short_header_proof_by_l1_hash(&l1_block_hash)?
-                .is_some()
-            {
-                return Ok(());
-            }
-            let da_block = da_service
-                .get_block_by_hash(l1_block_hash.into())
-                .await
-                .map_err(|e| anyhow!(e))?;
-            let short_header_proof: <<Da as DaService>::Spec as DaSpec>::ShortHeaderProof =
-                Da::block_to_short_header_proof(da_block);
-            ledger_db
-                .put_short_header_proof_by_l1_hash(
-                    &l1_block_hash,
-                    borsh::to_vec(&short_header_proof)
-                        .expect("Should serialize short header proof"),
-                )
-                .expect("Should save short header proof to ledger db");
-        }
-        BridgeContract::initializeCall::SELECTOR => {
-            tracing::info!("Initialize Bridge contract system tx found inside block");
-        }
-        BridgeContract::depositCall::SELECTOR => {
-            tracing::info!("Deposit system tx found inside block");
-        }
-        // TODO: https://github.com/chainwayxyz/citrea/issues/2442
-        unexpected_selector => {
-            tracing::warn!(
-                "Unexpected function selector at system tx: {unexpected_selector:?} , tx input: {:?}, tx hash: {:?}, tx nonce: {:?}", tx.inner().transaction().input(), tx.inner().hash(), tx.inner().transaction().nonce()
-            );
-        }
-    }
-
-    Ok(())
-}
-
-/// This does not check for misplaced sys txs etc. but they will be rejected by the stf if they are misplaced when the transactions are run
-pub async fn decode_sov_tx_and_update_short_header_proofs<Da: DaService, DB: SharedLedgerOps>(
-    l2_block_response: &L2BlockResponse,
-    ledger_db: &DB,
-    da_service: Arc<Da>,
-) -> anyhow::Result<()> {
-    for tx in &l2_block_response.txs {
-        let tx = &tx.tx;
-        let tx = Transaction::try_from_slice(tx).context("Should deserialize transaction")?;
-        let runtime_msg = tx.runtime_msg();
-
-        if runtime_msg.len() < 2 {
-            return Err(anyhow!("Invalid runtime message"));
-        }
-
-        if runtime_msg[0] == 1 {
-            // This is evm call message
-            let evm_call_message = EvmCallMessage::try_from_slice(&runtime_msg[1..])
-                .context("Should deserialize evm call message")?;
-            let evm_txs = evm_call_message.txs;
-            for tx in evm_txs {
-                let tx = Recovered::try_from(tx)
-                    .map_err(|_| anyhow!("Should be able to recover evm tx"))?;
-                if tx.signer() == SYSTEM_SIGNER {
-                    update_short_header_proof_from_sys_tx(&tx, ledger_db, da_service.clone())
-                        .await?;
-                } else {
-                    // if we have a different sender, we can skip decoding other txs
-                    // as the sys-tx can only be in the beginning of the block check is also done in evm
-                    // we don't need to check for that here.
-                    return Ok(());
-                }
-            }
-        }
-    }
-
-    Ok(())
 }
 
 pub fn read_env(key: &str) -> anyhow::Result<String> {


### PR DESCRIPTION
# Description

- L2SyncerError enum 
- Add a `MAX_BUFFER_SIZE` bound to buffer
- Panic and exit tasks on unrecoverable L2Syncer error
- Only retry on recoverable error (only missing DA block for now)
- Refactor and move to L2 subfolder

## Linked Issues
- Fixes #2629 