### PR TITLE
DA Monitoring: Fix rebroadcast of evicted txs logic

### DIFF
--- a/bin/citrea/tests/bitcoin/da_queue.rs
+++ b/bin/citrea/tests/bitcoin/da_queue.rs
@@ -218,6 +218,13 @@ impl DaTransactionQueueingTest {
         let remaining_txs = da.get_raw_mempool().await?;
         assert!(dropped_txs.iter().all(|tx| !remaining_txs.contains(tx)));
 
+        da.generate(1).await?;
+
+        // Make sure txs are rebroadcasted from monitoring service
+        da.wait_mempool_len(5, None).await?;
+        let raw_mempool = da.get_raw_mempool().await?;
+        assert_eq!(dropped_txs, raw_mempool);
+
         Ok(())
     }
 }

--- a/bin/citrea/tests/bitcoin/da_queue.rs
+++ b/bin/citrea/tests/bitcoin/da_queue.rs
@@ -218,7 +218,6 @@ impl DaTransactionQueueingTest {
         let remaining_txs = da.get_raw_mempool().await?;
         assert!(dropped_txs.iter().all(|tx| !remaining_txs.contains(tx)));
 
-<<<<<<< HEAD
         da.generate(1).await?;
 
         // Make sure txs are rebroadcasted from monitoring service
@@ -226,8 +225,6 @@ impl DaTransactionQueueingTest {
         let raw_mempool = da.get_raw_mempool().await?;
         assert_eq!(dropped_txs, raw_mempool);
 
-=======
->>>>>>> 1d2bc2bf6d79a6ac9636fba8a2e01cf258133986
         Ok(())
     }
 }

--- a/bin/citrea/tests/bitcoin/da_queue.rs
+++ b/bin/citrea/tests/bitcoin/da_queue.rs
@@ -188,6 +188,9 @@ impl DaTransactionQueueingTest {
         let (relevant_txs, _, _) = da_service.extract_relevant_blobs_with_proof(&block);
         assert_eq!(relevant_txs.len(), 9);
 
+        // Keep track of hash in which chunks start to be mined
+        let rollback_first_hash = hash;
+
         da.wait_mempool_len(6, None).await?;
         assert_eq!(da.get_raw_mempool().await?.len(), 6);
         da.generate(1).await?;
@@ -200,7 +203,21 @@ impl DaTransactionQueueingTest {
         let (relevant_txs, _, _) = da_service.extract_relevant_blobs_with_proof(&block);
         assert_eq!(relevant_txs.len(), 3);
 
-        da.generate(1).await?;
+        // Test re-org behaviour when over mempool policy limit
+
+        // Invalidate last block and make sure txs are back in mempool
+        da.invalidate_block(&hash).await?;
+        assert_eq!(da.get_raw_mempool().await?.len(), 6);
+
+        // Track that 5 last txs that will be dropped on next block invalidation
+        let dropped_txs = &da.get_raw_mempool().await?[1..]; // first commmit will still be part of the mempool
+
+        da.invalidate_block(&rollback_first_hash).await?;
+        // Should be 6 + 18 if all mined txs were restored to mempool but 5 txs are dropped due to being over mempool policy limit
+        assert_eq!(da.get_raw_mempool().await?.len(), 18 + 1);
+        let remaining_txs = da.get_raw_mempool().await?;
+        assert!(dropped_txs.iter().all(|tx| !remaining_txs.contains(tx)));
+
         Ok(())
     }
 }

--- a/bin/citrea/tests/bitcoin/da_queue.rs
+++ b/bin/citrea/tests/bitcoin/da_queue.rs
@@ -210,7 +210,7 @@ impl DaTransactionQueueingTest {
         assert_eq!(da.get_raw_mempool().await?.len(), 6);
 
         // Track that 5 last txs that will be dropped on next block invalidation
-        let dropped_txs = &da.get_raw_mempool().await?[1..]; // first commmit will still be part of the mempool
+        let dropped_txs = &da.get_raw_mempool().await?[1..]; // first commit will still be part of the mempool
 
         da.invalidate_block(&rollback_first_hash).await?;
         // Should be 6 + 18 if all mined txs were restored to mempool but 5 txs are dropped due to being over mempool policy limit

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -799,7 +799,6 @@ impl MonitoringService {
                             };
                         }
                     }
-                } else {
                 }
             }
         }

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -216,7 +216,7 @@ mod monitoring_defaults {
     }
 
     pub const fn max_rebroadcast_attempts() -> u32 {
-        5 // Maximum number of rebroadcast attempts for evicted txs
+        15 // Maximum number of rebroadcast attempts for evicted txs
     }
 
     pub const fn rebroadcast_delay() -> u64 {

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -419,15 +419,15 @@ impl MonitoringService {
     }
 
     /// Run monitoring to keep track of TX status and chain re-orgs
-    pub async fn run(self: Arc<Self>, mut token: GracefulShutdown) {
+    pub async fn run(self: Arc<Self>, mut shutdown_signal: GracefulShutdown) {
         let mut check_interval = interval(Duration::from_secs(self.config.check_interval));
         let mut evicted_interval = interval(Duration::from_secs(self.config.rebroadcast_delay));
         loop {
             select! {
                 biased;
-                _ = &mut token => {
-                    debug!("Monitoring service received shutdown signal");
-                    break;
+                _ = &mut shutdown_signal => {
+                    info!("Shutting down monitoring service");
+                    return;
                 }
                 _ = check_interval.tick() => {
                     if let Err(e) = self.check_chain_state().await {
@@ -648,10 +648,7 @@ impl MonitoringService {
         for (txid, monitored_tx) in txs.iter_mut() {
             match &monitored_tx.status {
                 // Check non-finalized TXs
-                TxStatus::Queued
-                | TxStatus::Evicted { .. }
-                | TxStatus::Confirmed { .. }
-                | TxStatus::Replaced { .. } => {
+                TxStatus::Queued | TxStatus::Confirmed { .. } | TxStatus::Replaced { .. } => {
                     let tx_result = self.client.get_transaction(txid, None).await?;
                     let new_status = self
                         .determine_tx_status(&tx_result, &monitored_tx.status)
@@ -778,7 +775,6 @@ impl MonitoringService {
 
         for (txid, monitored_tx) in txs.iter_mut() {
             if let TxStatus::Evicted {
-                last_seen,
                 rebroadcast_attempts,
                 ..
             } = &monitored_tx.status
@@ -786,25 +782,24 @@ impl MonitoringService {
                 if *rebroadcast_attempts < self.config.max_rebroadcast_attempts {
                     let now = get_timestamp();
 
-                    if now.saturating_sub(*last_seen) >= self.config.rebroadcast_delay {
-                        match self
-                            .attempt_rebroadcast(txid, &monitored_tx.tx, &monitored_tx.status)
-                            .await
-                        {
-                            Ok(new_status) => {
-                                info!("Successfully rebroadcast tx {txid}");
-                                monitored_tx.status = new_status;
-                            }
-                            Err(e) => {
-                                info!("Failed to rebroadcast tx {txid}: {e}");
-                                monitored_tx.status = TxStatus::Evicted {
-                                    last_seen: now,
-                                    rebroadcast_attempts: rebroadcast_attempts + 1,
-                                    last_error: Some(e.to_string()),
-                                };
-                            }
+                    match self
+                        .attempt_rebroadcast(txid, &monitored_tx.tx, &monitored_tx.status)
+                        .await
+                    {
+                        Ok(new_status) => {
+                            info!("Successfully rebroadcast tx {txid}");
+                            monitored_tx.status = new_status;
+                        }
+                        Err(e) => {
+                            info!("Failed to rebroadcast tx {txid}: {e}");
+                            monitored_tx.status = TxStatus::Evicted {
+                                last_seen: now,
+                                rebroadcast_attempts: rebroadcast_attempts + 1,
+                                last_error: Some(e.to_string()),
+                            };
                         }
                     }
+                } else {
                 }
             }
         }
@@ -815,11 +810,11 @@ impl MonitoringService {
     async fn attempt_rebroadcast(
         &self,
         txid: &Txid,
-        tx: &Transaction,
+        _tx: &Transaction,
         current_status: &TxStatus,
     ) -> Result<TxStatus> {
         warn!("Rebroadcasting txid: {txid} with current_status {current_status:?}");
-        let raw_tx_hex = bitcoin::consensus::encode::serialize_hex(tx);
+        let raw_tx_hex = self.client.get_raw_transaction_hex(txid, None).await?;
         self.client.send_raw_transaction(raw_tx_hex).await?;
         let tx_result = self.client.get_transaction(txid, None).await?;
         self.determine_tx_status(&tx_result, current_status).await


### PR DESCRIPTION
# Description

- Don't handle evicted txs in `check_transactions` but solely in dedicated `handle_evicted` or it would conflict on re-setting status
- Don't check against `rebroadcast_delay` in `handle_evicted` itself since this is already used by `evicted_interval`
- Rebroadcast from `get_raw_transaction_hex` or it could lose witness data on re-serialization
- Extend test from #2666 to prove that dropped txs are rebroadcasted and back in mempool after mining a block (and freeing some mempool policy)
- Bump `max_rebroadcast_attempts` to 15 

## Linked Issues
- needs #2666
