### PR TITLE
Da Monitoring enhancements

### DIFF
--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -673,7 +673,7 @@ impl MonitoringService {
                 }
                 TxStatus::InMempool { height, .. } => {
                     let tx_result = self.client.get_transaction(txid, None).await?;
-                    let mut new_status = self
+                    let new_status = self
                         .determine_tx_status(&tx_result, &monitored_tx.status)
                         .await?;
 
@@ -681,9 +681,7 @@ impl MonitoringService {
                     if let TxStatus::InMempool { .. } = new_status {
                         let current_height = self.client.get_block_count().await?;
                         if (current_height.saturating_sub(*height)) >= REBROADCAST_EACH_N_BLOCK {
-                            new_status = self
-                                .attempt_rebroadcast(txid, &monitored_tx.tx, &new_status)
-                                .await?
+                            self.attempt_rebroadcast(txid, &new_status).await?
                         }
                     }
 
@@ -796,10 +794,7 @@ impl MonitoringService {
                 if *rebroadcast_attempts < self.config.max_rebroadcast_attempts {
                     let now = get_timestamp();
 
-                    match self
-                        .attempt_rebroadcast(txid, &monitored_tx.tx, &monitored_tx.status)
-                        .await
-                    {
+                    match self.attempt_rebroadcast(txid, &monitored_tx.status).await {
                         Ok(_) => {
                             info!("Successfully rebroadcast tx {txid}");
                             monitored_tx.status = TxStatus::Evicted {
@@ -839,7 +834,7 @@ impl MonitoringService {
             }
 
             let _ = self
-                .attempt_rebroadcast(&current_tx.0, &current_tx.1.tx, &current_tx.1.status)
+                .attempt_rebroadcast(&current_tx.0, &current_tx.1.status)
                 .await;
 
             let Some(prev_txid) = current_tx.1.prev_txid else {
@@ -860,17 +855,11 @@ impl MonitoringService {
         Ok(())
     }
 
-    async fn attempt_rebroadcast(
-        &self,
-        txid: &Txid,
-        _tx: &Transaction,
-        current_status: &TxStatus,
-    ) -> Result<TxStatus> {
+    async fn attempt_rebroadcast(&self, txid: &Txid, current_status: &TxStatus) -> Result<()> {
         warn!("Rebroadcasting txid: {txid} with current_status {current_status:?}");
-        let raw_tx_hex = self.client.get_raw_transaction_hex(txid, None).await?;
-        self.client.send_raw_transaction(raw_tx_hex).await?;
         let tx_result = self.client.get_transaction(txid, None).await?;
-        self.determine_tx_status(&tx_result, current_status).await
+        self.client.send_raw_transaction(&tx_result.hex).await?;
+        Ok(())
     }
 
     /// Get the status of a monitored transaction by its Txid

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -95,7 +95,7 @@ pub enum TxStatus {
 }
 
 /// The kind of transaction being monitored.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum MonitoredTxKind {
     /// Commit transaction, the first in a commit/reveal pair
     Commit,

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -737,8 +737,11 @@ impl MonitoringService {
                         height: entry.height,
                     }
                 }
+                // Tx not found in mempool
                 Err(_) => match current_status {
+                    // If transaction is queued or evicted, keep status as is
                     TxStatus::Queued | TxStatus::Evicted { .. } => current_status.clone(),
+                    // If transaction was previously in mempool or confirmed, re-org happened and it got evicted from mempool
                     _ => {
                         tracing::info!("Tx {} was evicted from mempool.", tx_result.info.txid);
                         TxStatus::Evicted {

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -484,15 +484,16 @@ impl MonitoringService {
         let txid = tx.id;
 
         {
-            let monitored_txs = self.monitored_txs.read().await;
+            let mut monitored_txs = self.monitored_txs.write().await;
             if monitored_txs.contains_key(&txid) {
                 return Err(MonitorError::AlreadyMonitored);
             }
 
             if let Some(prev_tx_id) = prev_txid {
-                if !monitored_txs.contains_key(&prev_tx_id) {
+                let Some(prev_tx) = monitored_txs.get_mut(&prev_tx_id) else {
                     return Err(MonitorError::PrevTxNotMonitored(prev_tx_id));
-                }
+                };
+                prev_tx.next_txid = Some(txid);
             }
         }
 

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -799,7 +799,7 @@ impl MonitoringService {
 
                     match self.attempt_rebroadcast(txid, &monitored_tx.status).await {
                         Ok(_) => {
-                            info!("Successfully rebroadcast tx {txid}");
+                            info!("Attempted to rebroadcast tx {txid}");
                             monitored_tx.status = TxStatus::Evicted {
                                 last_seen: now,
                                 rebroadcast_attempts: rebroadcast_attempts + 1,

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -660,6 +660,17 @@ impl MonitoringService {
 
                     monitored_tx.status = new_status;
                 }
+                // Check evicted TXs that have already been rebroadcasted at least once
+                TxStatus::Evicted {
+                    rebroadcast_attempts,
+                    ..
+                } if *rebroadcast_attempts > 0 => {
+                    let tx_result = self.client.get_transaction(txid, None).await?;
+                    let new_status = self
+                        .determine_tx_status(&tx_result, &monitored_tx.status)
+                        .await?;
+                    monitored_tx.status = new_status;
+                }
                 TxStatus::InMempool { height, .. } => {
                     let tx_result = self.client.get_transaction(txid, None).await?;
                     let mut new_status = self
@@ -728,18 +739,17 @@ impl MonitoringService {
                         height: entry.height,
                     }
                 }
-                Err(_) => {
-                    if *current_status == TxStatus::Queued {
-                        return Ok(current_status.clone());
+                Err(_) => match current_status {
+                    TxStatus::Queued | TxStatus::Evicted { .. } => current_status.clone(),
+                    _ => {
+                        tracing::info!("Tx {} was evicted from mempool.", tx_result.info.txid);
+                        TxStatus::Evicted {
+                            last_seen: get_timestamp(),
+                            rebroadcast_attempts: 0,
+                            last_error: None,
+                        }
                     }
-
-                    tracing::info!("Tx {} was evicted from mempool.", tx_result.info.txid);
-                    TxStatus::Evicted {
-                        last_seen: get_timestamp(),
-                        rebroadcast_attempts: 0,
-                        last_error: None,
-                    }
-                }
+                },
             }
         };
         Ok(status)
@@ -790,9 +800,13 @@ impl MonitoringService {
                         .attempt_rebroadcast(txid, &monitored_tx.tx, &monitored_tx.status)
                         .await
                     {
-                        Ok(new_status) => {
+                        Ok(_) => {
                             info!("Successfully rebroadcast tx {txid}");
-                            monitored_tx.status = new_status;
+                            monitored_tx.status = TxStatus::Evicted {
+                                last_seen: now,
+                                rebroadcast_attempts: rebroadcast_attempts + 1,
+                                last_error: None,
+                            }
                         }
                         Err(e) => {
                             info!("Failed to rebroadcast tx {txid}: {e}");

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -860,8 +860,14 @@ impl MonitoringService {
 
     async fn attempt_rebroadcast(&self, txid: &Txid, current_status: &TxStatus) -> Result<()> {
         warn!("Rebroadcasting txid: {txid} with current_status {current_status:?}");
-        let tx_result = self.client.get_transaction(txid, None).await?;
-        self.client.send_raw_transaction(&tx_result.hex).await?;
+        if let Ok(result) = self.client.get_transaction(txid, None).await {
+            self.client.send_raw_transaction(&result.hex).await?;
+        } else if let Ok(result) = self.client.get_raw_transaction_hex(txid, None).await {
+            self.client.send_raw_transaction(result).await?;
+        } else {
+            return Err(anyhow!("Failed to retrieve hex and rebroadcast {txid}").into());
+        }
+
         Ok(())
     }
 

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -12,7 +12,7 @@ use jsonrpsee::proc_macros::rpc;
 use serde::{Deserialize, Serialize};
 
 use crate::fee::BumpFeeMethod;
-use crate::monitoring::{MonitoredTx, TxStatus};
+use crate::monitoring::{MonitoredTx, MonitoredTxKind, TxStatus};
 use crate::service::BitcoinService;
 
 /// Response type for monitored transactions.
@@ -37,6 +37,8 @@ pub struct MonitoredTxResponse {
     /// Hex representation of the transaction, if requested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hex: Option<String>,
+    /// Transaction kind
+    pub kind: MonitoredTxKind,
 }
 
 impl From<(Txid, MonitoredTx, bool)> for MonitoredTxResponse {
@@ -60,6 +62,7 @@ impl From<(Txid, MonitoredTx, bool)> for MonitoredTxResponse {
             next_txid: tx.next_txid,
             status: tx.status,
             hex,
+            kind: tx.kind,
         }
     }
 }


### PR DESCRIPTION
# Description

- Fix missing `next_txid` in reveal txs
- Add kind to `MonitoredTxResponse`
- Clean up eviction handling. 
- Use `get_transaction` instead of `get_raw_transaction` to retrieve tx hex to prevent hitting `No such mempool or blockchain transaction. Use gettransaction for wallet transactions.\"` error
