### PR TITLE
docs: fix incorrect path to BitcoinLightClient.sol in bridge-circuit-lcp-relation.md

### DIFF
--- a/docs/bridge-circuit-lcp-relation.md
+++ b/docs/bridge-circuit-lcp-relation.md
@@ -28,7 +28,7 @@ Through the **Clementine bridge** Citrea has BTC as its native asset. This bridg
    `citrea_sendRawDepositTransaction`
     This generates a **Citrea system transaction** calling the [`deposit`](./bridge-contract.md) function of the Bridge Contract with:
     - The `MoveToVault` transaction
-    - Merkle proof of its Bitcoin block inclusion (verified via the [`verifyInclusion`](crates/evm/src/evm/system_contracts/src/BitcoinLightClient.sol) function  of the Light Client Contract)
+    - Merkle proof of its Bitcoin block inclusion (verified via the [`verifyInclusion`](../crates/evm/src/evm/system_contracts/src/BitcoinLightClient.sol) function  of the Light Client Contract)
     - SHA script pubkeys (for verifying Schnorr signatures in the MoveTx)
 
 4. **Finalization**  


### PR DESCRIPTION
Fixed the broken file reference path in the bridge-circuit-lcp-relation.md documentation.

- Changed from: crates/evm/src/evm/system_contracts/src/BitcoinLightClient.sol
- Changed to: ../crates/evm/src/evm/system_contracts/src/BitcoinLightClient.sol