### PR TITLE
BitcoinService: Choose prev_utxo based off UtxoSelectionMode

### DIFF
--- a/bin/citrea/tests/bitcoin/da_queue.rs
+++ b/bin/citrea/tests/bitcoin/da_queue.rs
@@ -1,10 +1,13 @@
 use std::time::Duration;
 
+use crate::bitcoin::utils::spawn_bitcoin_da_prover_service;
+use crate::bitcoin::utils::spawn_bitcoin_da_prover_service_with_utxo_selection_mode;
 use alloy_primitives::{U32, U64};
 use async_trait::async_trait;
 use bitcoin::hashes::Hash;
 use bitcoin_da::error::BitcoinServiceError;
 use bitcoin_da::service::BitcoinService;
+use bitcoin_da::service::UtxoSelectionMode;
 use bitcoincore_rpc::RpcApi;
 use citrea_e2e::bitcoin::{BitcoinNode, DEFAULT_FINALITY_DEPTH};
 use citrea_e2e::config::{BitcoinConfig, LightClientProverConfig, TestCaseConfig};
@@ -21,7 +24,6 @@ use sov_rollup_interface::services::da::DaService;
 use super::light_client_test::create_random_state_diff;
 use super::{get_citrea_cli_path, get_citrea_path};
 use crate::bitcoin::full_node::create_serialized_fake_receipt_batch_proof_with_state_roots;
-use crate::bitcoin::utils::spawn_bitcoin_da_prover_service;
 
 struct DaTransactionQueueingTest {
     task_manager: TaskManager,
@@ -93,6 +95,7 @@ impl DaTransactionQueueingTest {
                 1,
             )
             .await;
+
         assert!(matches!(res, Err(BitcoinServiceError::QueueNotEmpty)));
 
         // Send transaction hangs until a new block is detected
@@ -167,9 +170,17 @@ impl DaTransactionQueueingTest {
 
         // This over the mempool limit proof should be accepted and split up over multiple blocks
         let res = da_service
-            .send_transaction_with_fee_rate(DaTxRequest::ZKProof(verifiable_400kb_batch_proof), 1)
+            .send_transaction_with_fee_rate(
+                DaTxRequest::ZKProof(verifiable_400kb_batch_proof.clone()),
+                1,
+            )
             .await;
         assert!(res.is_ok());
+
+        let res = da_service
+            .send_transaction_with_fee_rate(DaTxRequest::ZKProof(verifiable_400kb_batch_proof), 1)
+            .await;
+        assert!(res.is_err());
 
         da.wait_mempool_len(18, None).await?;
         assert_eq!(da.get_raw_mempool().await?.len(), 18);
@@ -368,6 +379,372 @@ impl TestCase for DaTransactionQueueingTest {
 #[tokio::test]
 async fn test_queue_da_transactions() -> Result<()> {
     TestCaseRunner::new(DaTransactionQueueingTest {
+        task_manager: TaskManager::current(),
+    })
+    .set_citrea_path(get_citrea_path())
+    .set_citrea_cli_path(get_citrea_cli_path())
+    .run()
+    .await
+}
+
+struct DaTransactionQueueingUtxoSelectionModeOldestTest {
+    task_manager: TaskManager,
+}
+
+impl DaTransactionQueueingUtxoSelectionModeOldestTest {
+    // Test for `MempoolRejection("package-mempool-limits, possibly exceeds descendant size limit for tx 6a0c9e3c2fed9cbac73c88031e7333d0ce2242a664e3141ba028b765b0b1e562 [limit: 101000]` error
+    // Send 4 100kb proofs. The 4th one will be tipping the total package size over the 101kvb limit and be rejected with package-too-large error
+    #[allow(clippy::too_many_arguments)]
+    async fn test_package_mempool_limits(
+        &self,
+        da: &BitcoinNode,
+        da_service: &BitcoinService,
+        finalized_height: u64,
+        genesis_state_root: [u8; 32],
+        batch_proof_method_ids: &[BatchProofMethodIdRpcResponse],
+        commitment_1: &SequencerCommitment,
+        commitment_1_state_root: [u8; 32],
+    ) -> Result<()> {
+        let state_diff_100kb = create_random_state_diff(100);
+        let l1_hash = da.get_block_hash(finalized_height).await?;
+
+        // Create a 100kb batch proof
+        let verifiable_100kb_batch_proof =
+            create_serialized_fake_receipt_batch_proof_with_state_roots(
+                genesis_state_root,
+                20,
+                batch_proof_method_ids[0].method_id.into(),
+                Some(state_diff_100kb.clone()),
+                false,
+                l1_hash.as_raw_hash().to_byte_array(),
+                vec![commitment_1.clone()],
+                vec![commitment_1_state_root],
+                None,
+            );
+
+        // Fill mempool
+        for i in 1..=3 {
+            da_service
+                .send_transaction_with_fee_rate(
+                    DaTxRequest::ZKProof(verifiable_100kb_batch_proof.clone()),
+                    1,
+                )
+                .await?;
+            da.wait_mempool_len(8 * i, None).await?;
+        }
+
+        da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::ZKProof(verifiable_100kb_batch_proof.clone()),
+                1,
+            )
+            .await?;
+
+        // Last tx chunk should hit mempool policy `DEFAULT_DESCENDANT_SIZE_LIMIT_KVB` limit
+        // The three first proofs should hit the mempool + 1 chunk
+        da.wait_mempool_len(8 * 3 + 2, None).await?;
+        assert_eq!(da.get_raw_mempool().await?.len(), 26);
+
+        // Assert that all queued txs are monitored
+        let monitored_txs = da_service.monitoring.get_monitored_txs().await;
+        assert_eq!(monitored_txs.len(), 32);
+
+        // Try to send when queue is already filled up.
+        // This is to test that utxos is correctly selected and that it's doesn't hang on waiting for list of queued txids to be returned
+        let res = da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::ZKProof(verifiable_100kb_batch_proof.clone()),
+                1,
+            )
+            .await;
+
+        assert!(res.is_ok());
+
+        let monitored_txs = da_service.monitoring.get_monitored_txs().await;
+        assert_eq!(monitored_txs.len(), 40);
+
+        // Txs starting from a new chain should be accepted to mempool
+        da.wait_mempool_len(8 * 3 + 2 + 8, None).await?;
+
+        // We mine the first three proofs + the 1 chunk pair + the extra proof starting another UTXO chain
+        // and make sure that the remaining chunks and aggregate and sent on next block when mempool size is freed
+        // Assert that all chunks were mined and mempool space is freed
+        assert_eq!(da.get_raw_mempool().await?.len(), 34);
+        da.generate(1).await?;
+
+        let height = da.get_block_count().await?;
+        let hash = da.get_block_hash(height).await?;
+        let block = da_service.get_block_by_hash(hash.into()).await?;
+        let (relevant_txs, _, _) = da_service.extract_relevant_blobs_with_proof(&block);
+
+        assert_eq!(relevant_txs.len(), 17);
+
+        // Remaining chunks and aggregate
+        da.wait_mempool_len(6, None).await?;
+        assert_eq!(da.get_raw_mempool().await?.len(), 6);
+        da.generate(1).await?;
+        assert_eq!(da.get_raw_mempool().await?.len(), 0);
+
+        let height = da.get_block_count().await?;
+        let hash = da.get_block_hash(height).await?;
+        let block = da_service.get_block_by_hash(hash.into()).await?;
+        let (relevant_txs, _, _) = da_service.extract_relevant_blobs_with_proof(&block);
+        assert_eq!(relevant_txs.len(), 3);
+
+        da.generate(1).await?;
+
+        Ok(())
+    }
+
+    // Test for `MempoolRejection("package-too-large")` error
+    // Single 400kb state diff
+    #[allow(clippy::too_many_arguments)]
+    async fn test_package_too_large(
+        &self,
+        da: &BitcoinNode,
+        da_service: &BitcoinService,
+        finalized_height: u64,
+        genesis_state_root: [u8; 32],
+        batch_proof_method_ids: &[BatchProofMethodIdRpcResponse],
+        commitment_1: &SequencerCommitment,
+        commitment_1_state_root: [u8; 32],
+    ) -> Result<()> {
+        let state_diff_400kb = create_random_state_diff(400);
+
+        let l1_hash = da.get_block_hash(finalized_height).await?;
+
+        // Create a 400kb batch proof
+        let verifiable_400kb_batch_proof =
+            create_serialized_fake_receipt_batch_proof_with_state_roots(
+                genesis_state_root,
+                20,
+                batch_proof_method_ids[0].method_id.into(),
+                Some(state_diff_400kb.clone()),
+                false,
+                l1_hash.as_raw_hash().to_byte_array(),
+                vec![commitment_1.clone()],
+                vec![commitment_1_state_root],
+                None,
+            );
+
+        // This over the mempool limit proof should be accepted and split up over multiple blocks
+        let res = da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::ZKProof(verifiable_400kb_batch_proof.clone()),
+                1,
+            )
+            .await;
+        assert!(res.is_ok());
+
+        // Should be able to send another proof that is also split up over multiple blocks
+        let res = da_service
+            .send_transaction_with_fee_rate(DaTxRequest::ZKProof(verifiable_400kb_batch_proof), 1)
+            .await;
+        assert!(res.is_ok());
+
+        da.wait_mempool_len(18 * 2, None).await?;
+        assert_eq!(da.get_raw_mempool().await?.len(), 18 * 2);
+
+        // Assert that all queued txs are monitored
+        let monitored_txs = da_service.monitoring.get_monitored_txs().await;
+        assert_eq!(monitored_txs.len(), 88);
+
+        da.generate(1).await?;
+        // Assert that all chunks were mined and mempool space is freed
+        assert_eq!(da.get_raw_mempool().await?.len(), 0);
+
+        let height = da.get_block_count().await?;
+        let hash = da.get_block_hash(height).await?;
+        let block = da_service.get_block_by_hash(hash.into()).await?;
+        let (relevant_txs, _, _) = da_service.extract_relevant_blobs_with_proof(&block);
+        assert_eq!(relevant_txs.len(), 9 * 2);
+
+        // Keep track of hash in which chunks start to be mined
+        let rollback_first_hash = hash;
+
+        da.wait_mempool_len(6 * 2, None).await?;
+        assert_eq!(da.get_raw_mempool().await?.len(), 6 * 2);
+        da.generate(1).await?;
+        // Assert that all chunks and aggregate were mined
+        assert_eq!(da.get_raw_mempool().await?.len(), 0);
+
+        let height = da.get_block_count().await?;
+        let hash = da.get_block_hash(height).await?;
+        let block = da_service.get_block_by_hash(hash.into()).await?;
+        let (relevant_txs, _, _) = da_service.extract_relevant_blobs_with_proof(&block);
+        assert_eq!(relevant_txs.len(), 3 * 2);
+
+        // Test re-org behaviour when over mempool policy limit
+        // Assert that the two utxo chains are independent
+
+        // Invalidate last block and make sure txs are back in mempool
+        da.invalidate_block(&hash).await?;
+        assert_eq!(da.get_raw_mempool().await?.len(), 6 * 2);
+
+        // Track that 5 last txs of each utxo chain will be dropped on next block invalidation
+        let dropped_txs = &da.get_raw_mempool().await?[2..];
+
+        da.invalidate_block(&rollback_first_hash).await?;
+        // Should be (6 + 18) * 2 if all mined txs were restored to mempool but 5 * 2 txs are dropped due to being over mempool policy limit
+        assert_eq!(da.get_raw_mempool().await?.len(), (18 + 1) * 2);
+        let remaining_txs = da.get_raw_mempool().await?;
+
+        assert!(dropped_txs.iter().all(|tx| !remaining_txs.contains(tx)));
+
+        da.generate(1).await?;
+
+        // Make sure txs are rebroadcasted from monitoring service
+        da.wait_mempool_len(5 * 2, None).await?;
+        let raw_mempool = da.get_raw_mempool().await?;
+        assert_eq!(dropped_txs, raw_mempool);
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl TestCase for DaTransactionQueueingUtxoSelectionModeOldestTest {
+    fn test_config() -> TestCaseConfig {
+        TestCaseConfig {
+            with_full_node: true,
+            with_sequencer: true,
+            with_light_client_prover: true,
+            ..Default::default()
+        }
+    }
+
+    fn bitcoin_config() -> BitcoinConfig {
+        BitcoinConfig {
+            extra_args: vec![
+                "-persistmempool=0",
+                "-walletbroadcast=0",
+                "-limitancestorcount=100", // Prevent test from hitting default ancestor count limit of 25
+                "-limitdescendantcount=100", // Prevent test from hitting default descendant count limit of 25
+                "-fallbackfee=0.00001",
+            ],
+            ..Default::default()
+        }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(170)
+    }
+
+    fn light_client_prover_config() -> LightClientProverConfig {
+        LightClientProverConfig {
+            initial_da_height: 171,
+            ..Default::default()
+        }
+    }
+
+    async fn cleanup(self) -> Result<()> {
+        self.task_manager
+            .graceful_shutdown_with_timeout(Duration::from_secs(1));
+        Ok(())
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        let task_executor = self.task_manager.executor();
+
+        let da = f.bitcoin_nodes.get_mut(0).unwrap();
+        let sequencer = f.sequencer.as_mut().unwrap();
+        let full_node = f.full_node.as_mut().unwrap();
+        let light_client_prover = f.light_client_prover.as_mut().unwrap();
+
+        let da_service = spawn_bitcoin_da_prover_service_with_utxo_selection_mode(
+            &task_executor,
+            &da.config,
+            Self::test_config().dir,
+            UtxoSelectionMode::Oldest,
+        )
+        .await;
+        let max_l2_blocks_per_commitment = sequencer.max_l2_blocks_per_commitment();
+
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
+
+        // Wait for light client prover to create light client proof.
+        light_client_prover
+            .wait_for_l1_height(finalized_height, None)
+            .await
+            .unwrap();
+
+        // Expect light client prover to have generated light client proof
+        let lcp = light_client_prover
+            .client
+            .http_client()
+            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
+            .await?;
+        let lcp_output = lcp.unwrap().light_client_proof_output;
+
+        // Get initial method ids and genesis state root
+        let batch_proof_method_ids = light_client_prover
+            .client
+            .http_client()
+            .get_batch_proof_method_ids()
+            .await?;
+        let genesis_state_root = lcp_output.l2_state_root;
+
+        let sequencer_client = sequencer.client.clone();
+
+        for _ in 0..max_l2_blocks_per_commitment {
+            sequencer_client.send_publish_batch_request().await?;
+        }
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
+
+        // Wait for full node to process sequencer commitments
+        full_node.wait_for_l1_height(finalized_height, None).await?;
+
+        let commitment_1 = full_node
+            .client
+            .http_client()
+            .get_sequencer_commitment_by_index(U32::from(1))
+            .await?
+            .map(|c| SequencerCommitment {
+                merkle_root: c.merkle_root,
+                l2_end_block_number: c.l2_end_block_number.to::<u64>(),
+                index: c.index.to::<u32>(),
+            })
+            .unwrap();
+        let commitment_1_state_root = sequencer_client
+            .http_client()
+            .get_l2_block_by_number(U64::from(commitment_1.l2_end_block_number))
+            .await?
+            .unwrap()
+            .header
+            .state_root;
+
+        self.test_package_mempool_limits(
+            da,
+            &da_service,
+            finalized_height,
+            genesis_state_root,
+            &batch_proof_method_ids,
+            &commitment_1,
+            commitment_1_state_root,
+        )
+        .await?;
+
+        self.test_package_too_large(
+            da,
+            &da_service,
+            finalized_height,
+            genesis_state_root,
+            &batch_proof_method_ids,
+            &commitment_1,
+            commitment_1_state_root,
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_queue_da_transactions_oldest_mode() -> Result<()> {
+    TestCaseRunner::new(DaTransactionQueueingUtxoSelectionModeOldestTest {
         task_manager: TaskManager::current(),
     })
     .set_citrea_path(get_citrea_path())

--- a/bin/citrea/tests/bitcoin/da_queue.rs
+++ b/bin/citrea/tests/bitcoin/da_queue.rs
@@ -1,13 +1,10 @@
 use std::time::Duration;
 
-use crate::bitcoin::utils::spawn_bitcoin_da_prover_service;
-use crate::bitcoin::utils::spawn_bitcoin_da_prover_service_with_utxo_selection_mode;
 use alloy_primitives::{U32, U64};
 use async_trait::async_trait;
 use bitcoin::hashes::Hash;
 use bitcoin_da::error::BitcoinServiceError;
-use bitcoin_da::service::BitcoinService;
-use bitcoin_da::service::UtxoSelectionMode;
+use bitcoin_da::service::{BitcoinService, UtxoSelectionMode};
 use bitcoincore_rpc::RpcApi;
 use citrea_e2e::bitcoin::{BitcoinNode, DEFAULT_FINALITY_DEPTH};
 use citrea_e2e::config::{BitcoinConfig, LightClientProverConfig, TestCaseConfig};
@@ -24,6 +21,9 @@ use sov_rollup_interface::services::da::DaService;
 use super::light_client_test::create_random_state_diff;
 use super::{get_citrea_cli_path, get_citrea_path};
 use crate::bitcoin::full_node::create_serialized_fake_receipt_batch_proof_with_state_roots;
+use crate::bitcoin::utils::{
+    spawn_bitcoin_da_prover_service, spawn_bitcoin_da_prover_service_with_utxo_selection_mode,
+};
 
 struct DaTransactionQueueingTest {
     task_manager: TaskManager,

--- a/bin/citrea/tests/bitcoin/da_queue.rs
+++ b/bin/citrea/tests/bitcoin/da_queue.rs
@@ -177,6 +177,7 @@ impl DaTransactionQueueingTest {
             .await;
         assert!(res.is_ok());
 
+        // Qeuue is already not empty and proof cannot be sent.
         let res = da_service
             .send_transaction_with_fee_rate(DaTxRequest::ZKProof(verifiable_400kb_batch_proof), 1)
             .await;

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -578,6 +578,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
                 "79122E48DF1A002FB6584B2E94D0D50F95037416C82DAF280F21CD67D17D9077".to_string(),
             ),
             REVEAL_TX_PREFIX.to_vec(),
+            None,
         )
         .await;
 
@@ -2218,6 +2219,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
                 "1212121212121212121212121212121212121212121212121212121212121212".to_string(),
             ),
             REVEAL_TX_PREFIX.to_vec(),
+            None,
         )
         .await;
 

--- a/bin/citrea/tests/bitcoin/utils.rs
+++ b/bin/citrea/tests/bitcoin/utils.rs
@@ -131,6 +131,7 @@ pub async fn spawn_bitcoin_da_service(
             rebroadcast_delay: 1,
         }),
         mempool_space_url: None,
+        utxo_selection_mode: None,
     };
 
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();

--- a/crates/bitcoin-da/src/error.rs
+++ b/crates/bitcoin-da/src/error.rs
@@ -66,6 +66,9 @@ pub enum MempoolRejection {
     /// Sent package of txs resulted in too many transactions in mempool. (ascendant/descendant limit)
     #[error("Transaction rejected: package-mempool-limits")]
     PackageMempoolLimits,
+    #[error("Transaction rejected: too-long-mempool-chain")]
+    /// Sent package of txs resulted in too long mempool chain. (ascendant/descendant limit)
+    TooLongMempoolChain,
     /// Other mempool rejection reason.
     #[error("Transaction rejected by mempool: {0}")]
     Other(String),
@@ -82,6 +85,8 @@ impl MempoolRejection {
             MempoolRejection::PackageTooManyTransactions
         } else if reason.contains("package-mempool-limits") {
             MempoolRejection::PackageMempoolLimits
+        } else if reason.contains("too-long-mempool-chain") {
+            MempoolRejection::TooLongMempoolChain
         } else {
             MempoolRejection::Other(reason.to_string())
         }

--- a/crates/bitcoin-da/src/rpc.rs
+++ b/crates/bitcoin-da/src/rpc.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use bitcoin::consensus::Encodable;
 use bitcoin::Txid;
 use citrea_common::rpc::utils::internal_rpc_error;
 use jsonrpsee::core::RpcResult;
@@ -49,8 +50,13 @@ impl From<(Txid, MonitoredTx, bool)> for MonitoredTxResponse {
             None
         };
 
-        let raw_tx_bytes = bitcoin::consensus::encode::serialize(&tx.tx);
-        let hex = with_hex.then(|| hex::encode(&raw_tx_bytes));
+        let hex = with_hex.then(|| {
+            let mut buf = Vec::new();
+            tx.tx
+                .consensus_encode(&mut buf)
+                .expect("Transaction encoding should not fail");
+            hex::encode(&buf)
+        });
 
         MonitoredTxResponse {
             txid,

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -371,7 +371,7 @@ impl BitcoinService {
                 Err(BitcoinServiceError::QueueNotEmpty)
             }
             UtxoSelectionMode::Oldest => Ok(if prev_utxo.is_some() {
-                // Latest monitored TX has been succesfully accepted to mempool and can be used as starting point for another utxo chain
+                // Latest monitored TX has been successfully accepted to mempool and can be used as starting point for another utxo chain
                 prev_utxo
             } else {
                 // Latest monitored TX has `Queued` status and internal `get_tx_out` errors.

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -371,8 +371,10 @@ impl BitcoinService {
                 Err(BitcoinServiceError::QueueNotEmpty)
             }
             UtxoSelectionMode::Oldest => Ok(if prev_utxo.is_some() {
+                // Latest monitored TX has been succesfully accepted to mempool and can be used as starting point for another utxo chain
                 prev_utxo
             } else {
+                // Latest monitored TX has `Queued` status and internal `get_tx_out` errors.
                 self.get_highest_confirmation_utxo().await?
             }),
         }

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -533,7 +533,7 @@ impl BitcoinService {
                 tx.reveal_txid()
             );
             if let Err(e) = self.test_mempool_accept(&tx.as_raw_txs()).await {
-                warn!(?e, "Rejected by mempool");
+                debug!(?e, "Rejected by mempool");
                 break;
             }
 

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -606,12 +606,12 @@ impl BitcoinService {
 
         for result in results {
             if !result.allowed.unwrap_or(false) {
+                debug!("Mempool rejection result {result:?}");
                 let reason = result
                     .reject_reason
                     .or(result.package_error)
                     .unwrap_or_else(|| "[testmempoolaccept] Unknown rejection".to_string());
 
-                debug!("Mempool rejection result {result:?}");
                 return Err(MempoolRejection::from_reason(reason).into());
             }
         }

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -611,6 +611,7 @@ impl BitcoinService {
                     .or(result.package_error)
                     .unwrap_or_else(|| "[testmempoolaccept] Unknown rejection".to_string());
 
+                debug!("Mempool rejection result {result:?}");
                 return Err(MempoolRejection::from_reason(reason).into());
             }
         }

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -379,7 +379,7 @@ impl BitcoinService {
                 // If last tx in queue is prev_utxo, that means that prev_utxo is waiting in queue.
                 // In that case, pick an UTXO with the highest amount of confirmation to start a new utxo chain
                 if queue_back_reveal_id == chain_utxo_id {
-                    self.get_oldest_utxo().await
+                    self.get_highest_confirmation_utxo().await
                 } else {
                     Ok(prev_utxo)
                 }
@@ -430,7 +430,7 @@ impl BitcoinService {
 
     /// Returns the UTXO with the highest number of confirmations
     #[instrument(level = "trace", skip_all, ret)]
-    async fn get_oldest_utxo(&self) -> Result<Option<UTXO>> {
+    async fn get_highest_confirmation_utxo(&self) -> Result<Option<UTXO>> {
         let mut utxos = self.get_utxos().await?;
         utxos.sort_by(|a, b| b.confirmations.cmp(&a.confirmations));
         Ok(utxos.into_iter().next())

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -78,10 +78,14 @@ pub fn network_to_bitcoin_network(network: &Network) -> bitcoin::Network {
     }
 }
 
+/// Utxo selection mode.
+/// How previous utxo should be chosen when tx queue is not empty
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum UtxoSelectionMode {
+    /// Default behaviour, always use latest utxo and keep transactions chained
     Chained,
+    /// Choose the utxo with the highest amount of confirmations
     Oldest,
 }
 

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -423,10 +423,16 @@ impl BitcoinService {
                 utxo.spendable
                     && utxo.solvable
                     && utxo.amount > Amount::from_sat(REVEAL_OUTPUT_AMOUNT)
-                    // Remove utxo already in use by queued txs
-                    && !txids.contains(&utxo.txid)
-                    // Only keep finalized change output
-                    && (utxo.vout == 0 || utxo.confirmations as u64 >= self.network_constants.finality_depth)
+            })
+            .filter(|utxo| {
+                    self.utxo_selection_mode == UtxoSelectionMode::Chained ||
+                    // Additional condition when running as UtxoSelectionMode::Oldest
+                    (
+                        // Remove utxo already in use by queued txs
+                        !txids.contains(&utxo.txid)
+                        // Only keep finalized change output
+                        && (utxo.vout == 0 || utxo.confirmations as u64 >= self.network_constants.finality_depth)
+                    )
             })
             .map(Into::into)
             .collect();

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -414,6 +414,10 @@ impl BitcoinService {
                 .map(Into::into)
                 .collect(),
 
+            // When running in UtxoSelectionMode::Oldest, we're creating multiple utxos chain in parallel
+            // to be able to send multiple proofs in the same block without hitting mempool policy limits.
+            // To make sure there are no conflicts between parallel utxos chain,
+            // this additional filters out any UTXO used by queued txs and any change UTXO that are not finalized
             UtxoSelectionMode::Oldest => {
                 let txids = self
                     .tx_queue

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -438,7 +438,7 @@ impl BitcoinService {
                     && utxo.solvable
                     && utxo.amount > Amount::from_sat(REVEAL_OUTPUT_AMOUNT)
                     // Remove utxo already in use by queued txs
-                    && txids.contains(&utxo.txid)
+                    && !txids.contains(&utxo.txid)
                     // Only keep finalized change output
                     && (utxo.vout == 0 || utxo.confirmations as u64 >= self.network_constants.finality_depth)
                 })


### PR DESCRIPTION
# Description

- Introduces new enum `UtxoSelectionMode` that can be run either as `Chained` (current behaviour) or `Oldest`.
New selection mode `Oldest` will choose the UTXO with the highest amount of confirmations when prev_utxo is still part of the sending queue.
- Changes available utxos selection logic. Filters out of the `list_unspent` all txs that are in use by queued tx or non-finalized change outputs (so that we don't end up selecting potential change output from existing utxo chain). Choosing to keep only finalized as even confirmed could be impacted by re-org and end up being over mempool policy limit 
