### PR TITLE
Remove direct_return in build_commit_transaction

### DIFF
--- a/crates/bitcoin-da/src/helpers/builders/mod.rs
+++ b/crates/bitcoin-da/src/helpers/builders/mod.rs
@@ -113,7 +113,6 @@ fn build_commit_transaction(
         let (chosen_utxos, sum, leftover_utxos) =
             choose_utxos(prev_utxo.clone(), &utxos, input_total)?;
         let has_change = (sum - input_total) >= REVEAL_OUTPUT_AMOUNT;
-        let direct_return = !has_change;
 
         let outputs = if !has_change {
             vec![
@@ -152,20 +151,9 @@ fn build_commit_transaction(
             })
             .collect();
 
-        if direct_return {
-            break (
-                leftover_utxos,
-                Transaction {
-                    lock_time: LockTime::ZERO,
-                    version: bitcoin::transaction::Version(2),
-                    input: inputs,
-                    output: outputs,
-                },
-            );
-        }
-
         let size = get_size_commit(&inputs, &outputs);
 
+        // Size didn't change on this iteration. Fee calculation can be trusted
         if size == last_size {
             break (
                 leftover_utxos,
@@ -237,6 +225,9 @@ fn build_reveal_transaction(
         input: inputs,
         output: outputs,
     };
+
+    println!("[reveal] fee : {:?}", fee);
+    println!("[reveal] tx.vsize() : {:?}", tx.vsize());
 
     Ok(tx)
 }

--- a/crates/bitcoin-da/src/helpers/builders/mod.rs
+++ b/crates/bitcoin-da/src/helpers/builders/mod.rs
@@ -153,7 +153,7 @@ fn build_commit_transaction(
 
         let size = get_size_commit(&inputs, &outputs);
 
-        // Size didn't change on this iteration. Fee calculation can be trusted
+        // Size didn't change on this iteration. Fee calculation was done against current transaction vsize
         if size == last_size {
             break (
                 leftover_utxos,
@@ -225,9 +225,6 @@ fn build_reveal_transaction(
         input: inputs,
         output: outputs,
     };
-
-    println!("[reveal] fee : {:?}", fee);
-    println!("[reveal] tx.vsize() : {:?}", tx.vsize());
 
     Ok(tx)
 }


### PR DESCRIPTION
# Description

- This lead to commit transaction not meeting expected fee rate.
- direct_return was short-circuiting the last size estimation and lead to tx having single input fee instead of the required double input
 
## Linked Issues
- Fixes #2722 