### PR TITLE
Pass down CITREA_VERBOSITY level to bitcoincore-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-rpc"
 version = "0.18.0"
-source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=b101677#b101677ec2d7a58e997d9ef762bac63fe49fdf6c"
+source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=72dbe74#72dbe748759a5129d877dcac117f70ecb28e676f"
 dependencies = [
  "async-trait",
  "bitcoincore-rpc-json",
@@ -1670,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-rpc-json"
 version = "0.18.0"
-source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=b101677#b101677ec2d7a58e997d9ef762bac63fe49fdf6c"
+source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=72dbe74#72dbe748759a5129d877dcac117f70ecb28e676f"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-rpc"
 version = "0.18.0"
-source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=0fe8a8b#0fe8a8b8811b9891b37fec2a305f1af6b324111f"
+source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=b101677#b101677ec2d7a58e997d9ef762bac63fe49fdf6c"
 dependencies = [
  "async-trait",
  "bitcoincore-rpc-json",
@@ -1670,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-rpc-json"
 version = "0.18.0"
-source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=0fe8a8b#0fe8a8b8811b9891b37fec2a305f1af6b324111f"
+source = "git+https://github.com/chainwayxyz/rust-bitcoincore-rpc.git?rev=b101677#b101677ec2d7a58e997d9ef762bac63fe49fdf6c"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ alloy-network = { version = "0.13", default-features = false }
 citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "859cddf" }
 
 [patch.crates-io]
-bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "b101677" }
+bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "72dbe74" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ alloy-network = { version = "0.13", default-features = false }
 citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "859cddf" }
 
 [patch.crates-io]
-bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "0fe8a8b" }
+bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "b101677" }
 
 [profile.release]
 opt-level = 3

--- a/bin/citrea/src/lib.rs
+++ b/bin/citrea/src/lib.rs
@@ -59,7 +59,7 @@ pub fn initialize_logging(level: Level) {
             "jsonrpsee-client=info".to_owned(),
             "sov_schema_db=info".to_owned(),
             "sov_prover_storage_manager=info".to_owned(),
-            "bitcoincore_rpc=info".to_owned(),
+            format!("bitcoincore_rpc={}", level.as_str()),
             "h2=info".to_owned(),
             "rustls=info".to_owned(),
         ];


### PR DESCRIPTION
# Description

- Bump bitcoincore-rpc to trace response time
- Pass down `CITREA_VERBOSITY` level to bitcoincore-rpc in `initialize_logging`
