### PR TITLE
fix: ensure database backups are created atomically under L1/L2 locks

### DIFF
--- a/crates/common/src/backup/manager.rs
+++ b/crates/common/src/backup/manager.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, RwLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, ensure, Context};
+use futures::future;
 use rocksdb::backup::BackupEngineInfo;
 use serde::{Deserialize, Serialize};
 use sov_db::ledger_db::{LedgerDB, SharedLedgerOps};
@@ -194,13 +195,15 @@ impl BackupManager {
             }
         }
 
-        // Wait for all dbs to start backing up under lock before releasing
+        // Wait for all database backups to complete while holding locks to ensure consistency
+        let results = future::join_all(handles).await;
+        for result in results {
+            result??;
+        }
+
+        // Release locks after all database snapshots are taken
         drop(l2_lock);
         drop(l1_lock);
-
-        for handle in handles {
-            handle.await??;
-        }
 
         if let Err(e) = self.validate_backup(backup_path) {
             warn!("Error validating backup: {e}");


### PR DESCRIPTION
Previously, L1/L2 processing locks were released immediately after spawning backup tasks, allowing block processing to resume before all database snapshots were actually created. This could result in inconsistent backup state across databases.

Changes:
- Hold L1/L2 processing locks until all database backup operations complete
- Use futures::future::join_all to wait for all spawn_blocking tasks atomically
- Update misleading comment to accurately reflect the synchronization behavior
- Maintain parallel backup execution while ensuring atomic snapshot timing

This ensures all databases have consistent snapshots taken at the same point in time relative to L1/L2 block processing, eliminating potential backup inconsistencies under high load or aggressive RocksDB background operations.