### PR TITLE
docs: fix outdated links

### DIFF
--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1581,7 +1581,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         Ok(all_logs)
     }
 
-    // https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/logs_utils.rs#L21
+    // https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-eth-types/src/logs_utils.rs#L69
     fn append_matching_block_logs(
         &self,
         working_set: &mut WorkingSet<C::Storage>,

--- a/crates/evm/src/rpc_helpers/log_utils.rs
+++ b/crates/evm/src/rpc_helpers/log_utils.rs
@@ -1,4 +1,4 @@
-// https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/logs_utils.rs
+// https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-eth-types/src/logs_utils.rs
 
 /// Computes the block range based on the filter range and current block numbers
 pub fn get_filter_block_range(


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/logs_utils.rs#L21 - deprecated
https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-eth-types/src/logs_utils.rs#L69 - correct
https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/logs_utils.rs - deprecated
https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-eth-types/src/logs_utils.rs - correct