### PR TITLE
perf(memory): Do not save l1 hashes to memory unnecessarily

### DIFF
--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -20,8 +20,7 @@ use clap::Parser;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use reth_tasks::TaskManager;
 use short_header_proof_provider::{
-    NativeShortHeaderProofProviderService, NotQueriedNativeShortHeaderProofProviderService,
-    SHORT_HEADER_PROOF_PROVIDER,
+    NativeShortHeaderProofProviderService, SHORT_HEADER_PROOF_PROVIDER,
 };
 use sov_db::ledger_db::SharedLedgerOps;
 use sov_db::rocks_db_config::RocksdbConfig;
@@ -214,17 +213,12 @@ where
         _ => None,
     };
 
-    match if matches!(node_type, NodeWithConfig::BatchProver(_)) {
-        SHORT_HEADER_PROOF_PROVIDER.set(Box::new(NativeShortHeaderProofProviderService::<
-            <S as RollupBlueprint>::DaSpec,
-        >::new(ledger_db.clone())))
-    } else {
-        SHORT_HEADER_PROOF_PROVIDER.set(Box::new(
-            NotQueriedNativeShortHeaderProofProviderService::<<S as RollupBlueprint>::DaSpec>::new(
-                ledger_db.clone(),
-            ),
-        ))
-    } {
+    match SHORT_HEADER_PROOF_PROVIDER.set(Box::new(NativeShortHeaderProofProviderService::<
+        <S as RollupBlueprint>::DaSpec,
+    >::new(
+        ledger_db.clone(),
+        matches!(node_type, NodeWithConfig::BatchProver(_)),
+    ))) {
         Ok(_) => tracing::debug!("Short header proof provider set"),
         Err(_) => tracing::error!("Short header proof provider already set"),
     }

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -20,7 +20,8 @@ use clap::Parser;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use reth_tasks::TaskManager;
 use short_header_proof_provider::{
-    NativeShortHeaderProofProviderService, SHORT_HEADER_PROOF_PROVIDER,
+    NativeShortHeaderProofProviderService, NotQueriedNativeShortHeaderProofProviderService,
+    SHORT_HEADER_PROOF_PROVIDER,
 };
 use sov_db::ledger_db::SharedLedgerOps;
 use sov_db::rocks_db_config::RocksdbConfig;
@@ -213,13 +214,20 @@ where
         _ => None,
     };
 
-    match SHORT_HEADER_PROOF_PROVIDER.set(Box::new(NativeShortHeaderProofProviderService::<
-        <S as RollupBlueprint>::DaSpec,
-    >::new(ledger_db.clone())))
-    {
+    match if matches!(node_type, NodeWithConfig::BatchProver(_)) {
+        SHORT_HEADER_PROOF_PROVIDER.set(Box::new(NativeShortHeaderProofProviderService::<
+            <S as RollupBlueprint>::DaSpec,
+        >::new(ledger_db.clone())))
+    } else {
+        SHORT_HEADER_PROOF_PROVIDER.set(Box::new(
+            NotQueriedNativeShortHeaderProofProviderService::<<S as RollupBlueprint>::DaSpec>::new(
+                ledger_db.clone(),
+            ),
+        ))
+    } {
         Ok(_) => tracing::debug!("Short header proof provider set"),
         Err(_) => tracing::error!("Short header proof provider already set"),
-    };
+    }
 
     let rpc_storage = storage_manager.create_final_view_storage();
     let mut rpc_module = rollup_blueprint.create_rpc_methods(

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -18,8 +18,7 @@ use citrea_primitives::TEST_PRIVATE_KEY;
 use citrea_stf::genesis_config::GenesisPaths;
 use reth_tasks::TaskManager;
 use short_header_proof_provider::{
-    NativeShortHeaderProofProviderService, NotQueriedNativeShortHeaderProofProviderService,
-    SHORT_HEADER_PROOF_PROVIDER,
+    NativeShortHeaderProofProviderService, SHORT_HEADER_PROOF_PROVIDER,
 };
 use sov_db::ledger_db::SharedLedgerOps;
 use sov_db::rocks_db_config::RocksdbConfig;
@@ -150,15 +149,12 @@ pub async fn start_rollup(
         .await
         .expect("Dependencies setup should work");
 
-    match if rollup_prover_config.is_some() {
-        SHORT_HEADER_PROOF_PROVIDER.set(Box::new(
-            NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone()),
-        ))
-    } else {
-        SHORT_HEADER_PROOF_PROVIDER.set(Box::new(
-            NotQueriedNativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone()),
-        ))
-    } {
+    match SHORT_HEADER_PROOF_PROVIDER.set(Box::new(NativeShortHeaderProofProviderService::<
+        MockDaSpec,
+    >::new(
+        ledger_db.clone(),
+        rollup_prover_config.is_some(),
+    ))) {
         Ok(_) => tracing::debug!("Short header proof provider set"),
         Err(_) => tracing::error!("Short header proof provider already set"),
     }
@@ -179,17 +175,10 @@ pub async fn start_rollup(
             let boxed_trait: Box<dyn ShortHeaderProofProvider> =
                 Box::from_raw(leaked as *const _ as *mut _);
 
-            if rollup_prover_config.is_some() {
-                let mut concrete: Box<NativeShortHeaderProofProviderService<MockDaSpec>> =
-                    downcast_box(boxed_trait);
-                concrete.ledger_db = ledger_db.clone();
-                std::mem::forget(concrete);
-            } else {
-                let mut concrete: Box<NotQueriedNativeShortHeaderProofProviderService<MockDaSpec>> =
-                    downcast_box(boxed_trait);
-                concrete.ledger_db = ledger_db.clone();
-                std::mem::forget(concrete);
-            }
+            let mut concrete: Box<NativeShortHeaderProofProviderService<MockDaSpec>> =
+                downcast_box(boxed_trait);
+            concrete.ledger_db = ledger_db.clone();
+            std::mem::forget(concrete);
         }
     }
 

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -151,10 +151,8 @@ pub async fn start_rollup(
 
     match SHORT_HEADER_PROOF_PROVIDER.set(Box::new(NativeShortHeaderProofProviderService::<
         MockDaSpec,
-    >::new(
-        ledger_db.clone(),
-        rollup_prover_config.is_some(),
-    ))) {
+    >::new(ledger_db.clone(), true)))
+    {
         Ok(_) => tracing::debug!("Short header proof provider set"),
         Err(_) => tracing::error!("Short header proof provider already set"),
     }

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -18,7 +18,8 @@ use citrea_primitives::TEST_PRIVATE_KEY;
 use citrea_stf::genesis_config::GenesisPaths;
 use reth_tasks::TaskManager;
 use short_header_proof_provider::{
-    NativeShortHeaderProofProviderService, SHORT_HEADER_PROOF_PROVIDER,
+    NativeShortHeaderProofProviderService, NotQueriedNativeShortHeaderProofProviderService,
+    SHORT_HEADER_PROOF_PROVIDER,
 };
 use sov_db::ledger_db::SharedLedgerOps;
 use sov_db::rocks_db_config::RocksdbConfig;
@@ -148,13 +149,19 @@ pub async fn start_rollup(
         )
         .await
         .expect("Dependencies setup should work");
-    match SHORT_HEADER_PROOF_PROVIDER.set(Box::new(NativeShortHeaderProofProviderService::<
-        MockDaSpec,
-    >::new(ledger_db.clone())))
-    {
+
+    match if rollup_prover_config.is_some() {
+        SHORT_HEADER_PROOF_PROVIDER.set(Box::new(
+            NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone()),
+        ))
+    } else {
+        SHORT_HEADER_PROOF_PROVIDER.set(Box::new(
+            NotQueriedNativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone()),
+        ))
+    } {
         Ok(_) => tracing::debug!("Short header proof provider set"),
         Err(_) => tracing::error!("Short header proof provider already set"),
-    };
+    }
 
     let task_executor = task_manager.executor();
 
@@ -172,12 +179,17 @@ pub async fn start_rollup(
             let boxed_trait: Box<dyn ShortHeaderProofProvider> =
                 Box::from_raw(leaked as *const _ as *mut _);
 
-            let mut concrete: Box<NativeShortHeaderProofProviderService<MockDaSpec>> =
-                downcast_box(boxed_trait);
-
-            concrete.ledger_db = ledger_db.clone();
-
-            std::mem::forget(concrete);
+            if rollup_prover_config.is_some() {
+                let mut concrete: Box<NativeShortHeaderProofProviderService<MockDaSpec>> =
+                    downcast_box(boxed_trait);
+                concrete.ledger_db = ledger_db.clone();
+                std::mem::forget(concrete);
+            } else {
+                let mut concrete: Box<NotQueriedNativeShortHeaderProofProviderService<MockDaSpec>> =
+                    downcast_box(boxed_trait);
+                concrete.ledger_db = ledger_db.clone();
+                std::mem::forget(concrete);
+            }
         }
     }
 

--- a/crates/short-header-proof-provider/src/native.rs
+++ b/crates/short-header-proof-provider/src/native.rs
@@ -7,7 +7,7 @@ use borsh::BorshDeserialize;
 use parking_lot::Mutex;
 use sov_db::ledger_db::{LedgerDB, SharedLedgerOps};
 use sov_modules_api::DaSpec;
-use sov_rollup_interface::da::{L1UpdateSystemTransactionInfo, VerifiableShortHeaderProof};
+use sov_rollup_interface::da::VerifiableShortHeaderProof;
 
 use super::{ShortHeaderProofProvider, ShortHeaderProofProviderError};
 
@@ -15,14 +15,16 @@ pub struct NativeShortHeaderProofProviderService<Da: DaSpec> {
     pub queried_and_verified_hashes: Arc<Mutex<HashMap<u64, Vec<[u8; 32]>>>>,
     pub ledger_db: LedgerDB,
     pub _phantom: PhantomData<Da>,
+    save_hashes: bool,
 }
 
 impl<Da: DaSpec> NativeShortHeaderProofProviderService<Da> {
-    pub fn new(ledger_db: LedgerDB) -> Self {
+    pub fn new(ledger_db: LedgerDB, save_hashes: bool) -> Self {
         Self {
             ledger_db,
             queried_and_verified_hashes: Arc::new(Mutex::new(HashMap::new())),
             _phantom: PhantomData,
+            save_hashes,
         }
     }
 }
@@ -47,16 +49,18 @@ impl<Da: DaSpec> ShortHeaderProofProvider for NativeShortHeaderProofProviderServ
                 .expect("Should deserialize short header proof");
 
             if let Ok(l1_update_info) = shp.verify() {
-                let return_cond = verify_against_l1_update(
-                    prev_block_hash,
-                    &l1_update_info,
-                    txs_commitment,
-                    block_hash,
-                    l1_height,
-                    coinbase_depth,
-                );
+                // the contract will return 0000...00 if we are pushing the first L1 block
+                // hence we accept given prev_hash
+                let prev_hash_cond = prev_block_hash == [0; 32]
+                    || prev_block_hash == l1_update_info.prev_header_hash;
 
-                if return_cond {
+                let return_cond = txs_commitment == l1_update_info.tx_commitment
+                    && block_hash == l1_update_info.header_hash
+                    && prev_hash_cond
+                    && l1_height == l1_update_info.block_height
+                    && coinbase_depth == l1_update_info.coinbase_txid_merkle_proof_height;
+
+                if return_cond && self.save_hashes {
                     let mut queried_hashes_map = self.queried_and_verified_hashes.lock();
 
                     queried_hashes_map.try_reserve(1).map_err(|e| {
@@ -117,97 +121,4 @@ impl<Da: DaSpec> ShortHeaderProofProvider for NativeShortHeaderProofProviderServ
             "take_last_queried_hash is not implemented for NativeShortHeaderProofProviderService"
         );
     }
-}
-
-/// This is for full node and sequencer
-/// Because they do not generate input, they do not take the queried hashes and those hashes remain in memory until a restart
-/// This will not keep unnecessary data in memory
-pub struct NotQueriedNativeShortHeaderProofProviderService<Da: DaSpec> {
-    pub ledger_db: LedgerDB,
-    pub _phantom: PhantomData<Da>,
-}
-
-impl<Da: DaSpec> NotQueriedNativeShortHeaderProofProviderService<Da> {
-    pub fn new(ledger_db: LedgerDB) -> Self {
-        Self {
-            ledger_db,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<Da: DaSpec> ShortHeaderProofProvider for NotQueriedNativeShortHeaderProofProviderService<Da> {
-    fn get_and_verify_short_header_proof_by_l1_hash(
-        &self,
-        block_hash: [u8; 32],
-        prev_block_hash: [u8; 32],
-        l1_height: u64,
-        txs_commitment: [u8; 32],
-        coinbase_depth: u8,
-        _l2_height: u64,
-    ) -> Result<bool, ShortHeaderProofProviderError> {
-        if let Some(shp_serialized) = self
-            .ledger_db
-            .get_short_header_proof_by_l1_hash(&block_hash)
-            // TODO: Return error here and make process l2 block run again
-            .expect("Should save short header proof")
-        {
-            let shp = Da::ShortHeaderProof::try_from_slice(&shp_serialized)
-                .expect("Should deserialize short header proof");
-
-            if let Ok(l1_update_info) = shp.verify() {
-                let return_cond = verify_against_l1_update(
-                    prev_block_hash,
-                    &l1_update_info,
-                    txs_commitment,
-                    block_hash,
-                    l1_height,
-                    coinbase_depth,
-                );
-
-                return Ok(return_cond);
-            }
-            return Ok(false);
-        }
-        Err(ShortHeaderProofProviderError::ShortHeaderProofNotFound)
-    }
-
-    fn clear_queried_hashes(&self) {
-        unimplemented!(
-            "clear_queried_hashes is not implemented for NotQueriedNativeShortHeaderProofProviderService"
-        );
-    }
-    fn take_queried_hashes(
-        &self,
-        _l2_range: RangeInclusive<u64>,
-    ) -> Result<Vec<[u8; 32]>, ShortHeaderProofProviderError> {
-        unimplemented!(
-            "take_queried_hashes is not implemented for NotQueriedNativeShortHeaderProofProviderService"
-        );
-    }
-    fn take_last_queried_hash(&self) -> Option<[u8; 32]> {
-        unimplemented!(
-            "take_last_queried_hash is not implemented for NativeShortHeaderProofProviderService"
-        );
-    }
-}
-
-fn verify_against_l1_update(
-    prev_block_hash: [u8; 32],
-    l1_update_info: &L1UpdateSystemTransactionInfo,
-    txs_commitment: [u8; 32],
-    block_hash: [u8; 32],
-    l1_height: u64,
-    coinbase_depth: u8,
-) -> bool {
-    // the contract will return 0000...00 if we are pushing the first L1 block
-    // hence we accept given prev_hash
-    let prev_hash_cond =
-        prev_block_hash == [0; 32] || prev_block_hash == l1_update_info.prev_header_hash;
-
-    txs_commitment == l1_update_info.tx_commitment
-        && block_hash == l1_update_info.header_hash
-        && prev_hash_cond
-        && l1_height == l1_update_info.block_height
-        && coinbase_depth == l1_update_info.coinbase_txid_merkle_proof_height
 }

--- a/crates/short-header-proof-provider/src/native.rs
+++ b/crates/short-header-proof-provider/src/native.rs
@@ -7,7 +7,7 @@ use borsh::BorshDeserialize;
 use parking_lot::Mutex;
 use sov_db::ledger_db::{LedgerDB, SharedLedgerOps};
 use sov_modules_api::DaSpec;
-use sov_rollup_interface::da::VerifiableShortHeaderProof;
+use sov_rollup_interface::da::{L1UpdateSystemTransactionInfo, VerifiableShortHeaderProof};
 
 use super::{ShortHeaderProofProvider, ShortHeaderProofProviderError};
 
@@ -47,16 +47,14 @@ impl<Da: DaSpec> ShortHeaderProofProvider for NativeShortHeaderProofProviderServ
                 .expect("Should deserialize short header proof");
 
             if let Ok(l1_update_info) = shp.verify() {
-                // the contract will return 0000...00 if we are pushing the first L1 block
-                // hence we accept given prev_hash
-                let prev_hash_cond = prev_block_hash == [0; 32]
-                    || prev_block_hash == l1_update_info.prev_header_hash;
-
-                let return_cond = txs_commitment == l1_update_info.tx_commitment
-                    && block_hash == l1_update_info.header_hash
-                    && prev_hash_cond
-                    && l1_height == l1_update_info.block_height
-                    && coinbase_depth == l1_update_info.coinbase_txid_merkle_proof_height;
+                let return_cond = verify_against_l1_update(
+                    prev_block_hash,
+                    &l1_update_info,
+                    txs_commitment,
+                    block_hash,
+                    l1_height,
+                    coinbase_depth,
+                );
 
                 if return_cond {
                     let mut queried_hashes_map = self.queried_and_verified_hashes.lock();
@@ -119,4 +117,97 @@ impl<Da: DaSpec> ShortHeaderProofProvider for NativeShortHeaderProofProviderServ
             "take_last_queried_hash is not implemented for NativeShortHeaderProofProviderService"
         );
     }
+}
+
+/// This is for full node and sequencer
+/// Because they do not generate input, they do not take the queried hashes and those hashes remain in memory until a restart
+/// This will not keep unnecessary data in memory
+pub struct NotQueriedNativeShortHeaderProofProviderService<Da: DaSpec> {
+    pub ledger_db: LedgerDB,
+    pub _phantom: PhantomData<Da>,
+}
+
+impl<Da: DaSpec> NotQueriedNativeShortHeaderProofProviderService<Da> {
+    pub fn new(ledger_db: LedgerDB) -> Self {
+        Self {
+            ledger_db,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Da: DaSpec> ShortHeaderProofProvider for NotQueriedNativeShortHeaderProofProviderService<Da> {
+    fn get_and_verify_short_header_proof_by_l1_hash(
+        &self,
+        block_hash: [u8; 32],
+        prev_block_hash: [u8; 32],
+        l1_height: u64,
+        txs_commitment: [u8; 32],
+        coinbase_depth: u8,
+        _l2_height: u64,
+    ) -> Result<bool, ShortHeaderProofProviderError> {
+        if let Some(shp_serialized) = self
+            .ledger_db
+            .get_short_header_proof_by_l1_hash(&block_hash)
+            // TODO: Return error here and make process l2 block run again
+            .expect("Should save short header proof")
+        {
+            let shp = Da::ShortHeaderProof::try_from_slice(&shp_serialized)
+                .expect("Should deserialize short header proof");
+
+            if let Ok(l1_update_info) = shp.verify() {
+                let return_cond = verify_against_l1_update(
+                    prev_block_hash,
+                    &l1_update_info,
+                    txs_commitment,
+                    block_hash,
+                    l1_height,
+                    coinbase_depth,
+                );
+
+                return Ok(return_cond);
+            }
+            return Ok(false);
+        }
+        Err(ShortHeaderProofProviderError::ShortHeaderProofNotFound)
+    }
+
+    fn clear_queried_hashes(&self) {
+        unimplemented!(
+            "clear_queried_hashes is not implemented for NotQueriedNativeShortHeaderProofProviderService"
+        );
+    }
+    fn take_queried_hashes(
+        &self,
+        _l2_range: RangeInclusive<u64>,
+    ) -> Result<Vec<[u8; 32]>, ShortHeaderProofProviderError> {
+        unimplemented!(
+            "take_queried_hashes is not implemented for NotQueriedNativeShortHeaderProofProviderService"
+        );
+    }
+    fn take_last_queried_hash(&self) -> Option<[u8; 32]> {
+        unimplemented!(
+            "take_last_queried_hash is not implemented for NativeShortHeaderProofProviderService"
+        );
+    }
+}
+
+fn verify_against_l1_update(
+    prev_block_hash: [u8; 32],
+    l1_update_info: &L1UpdateSystemTransactionInfo,
+    txs_commitment: [u8; 32],
+    block_hash: [u8; 32],
+    l1_height: u64,
+    coinbase_depth: u8,
+) -> bool {
+    // the contract will return 0000...00 if we are pushing the first L1 block
+    // hence we accept given prev_hash
+    let prev_hash_cond =
+        prev_block_hash == [0; 32] || prev_block_hash == l1_update_info.prev_header_hash;
+
+    txs_commitment == l1_update_info.tx_commitment
+        && block_hash == l1_update_info.header_hash
+        && prev_hash_cond
+        && l1_height == l1_update_info.block_height
+        && coinbase_depth == l1_update_info.coinbase_txid_merkle_proof_height
 }

--- a/crates/short-header-proof-provider/tests/shp_integration.rs
+++ b/crates/short-header-proof-provider/tests/shp_integration.rs
@@ -39,6 +39,32 @@ fn test_proof_not_found() {
 }
 
 #[test]
+fn test_should_not_save_queried_hashes() {
+    let (_temp_dir, ledger_db) = setup_test_db();
+    let native_service =
+    // The save hashes field is false, so it should not save
+        NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone(), false);
+
+    let block_hash = [1u8; 32];
+    let mock_proof = MockShortHeaderProof {
+        header_hash: block_hash,
+        prev_header_hash: [2u8; 32],
+        txs_commitment: [3u8; 32],
+        height: 100,
+    };
+    let proof_bytes = borsh::to_vec(&mock_proof).unwrap();
+    ledger_db
+        .put_short_header_proof_by_l1_hash(&block_hash, proof_bytes)
+        .unwrap();
+
+    native_service
+        .get_and_verify_short_header_proof_by_l1_hash(block_hash, [2u8; 32], 100, [3u8; 32], 1, 50)
+        .unwrap();
+
+    assert!(native_service.queried_and_verified_hashes.lock().is_empty());
+}
+
+#[test]
 fn test_native_clear_and_take_queried_hashes() {
     let (_temp_dir, ledger_db) = setup_test_db();
     let native_service =

--- a/crates/short-header-proof-provider/tests/shp_integration.rs
+++ b/crates/short-header-proof-provider/tests/shp_integration.rs
@@ -22,7 +22,7 @@ fn setup_test_db() -> (TempDir, sov_db::ledger_db::LedgerDB) {
 #[should_panic(expected = "Should have short header proof for l1 hash")]
 fn test_proof_not_found() {
     let (_temp_dir, ledger_db) = setup_test_db();
-    let native_service = NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db);
+    let native_service = NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db, true);
 
     let block_hash = [1u8; 32];
     let result = native_service
@@ -42,7 +42,7 @@ fn test_proof_not_found() {
 fn test_native_clear_and_take_queried_hashes() {
     let (_temp_dir, ledger_db) = setup_test_db();
     let native_service =
-        NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone());
+        NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone(), true);
 
     let block_hash = [1u8; 32];
     let mock_proof = MockShortHeaderProof {
@@ -138,7 +138,7 @@ fn test_zk_take_last_queried_hash() {
 fn test_native_to_zk_proof_flow() {
     let (_temp_dir, ledger_db) = setup_test_db();
     let native_service =
-        NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone());
+        NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone(), true);
 
     let block_hashes = vec![[1u8; 32], [2u8; 32], [3u8; 32]];
     let mut proofs = Vec::new();
@@ -215,7 +215,7 @@ fn test_native_to_zk_proof_flow() {
 fn test_native_to_zk_invalid_proof_flow() {
     let (_temp_dir, ledger_db) = setup_test_db();
     let native_service =
-        NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone());
+        NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone(), true);
 
     // create and store an invalid proof
     let block_hash = [1u8; 32];
@@ -291,7 +291,7 @@ fn test_native_to_zk_invalid_proof_flow() {
 fn test_native_to_zk_first_block_flow() {
     let (_temp_dir, ledger_db) = setup_test_db();
     let native_service =
-        NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone());
+        NativeShortHeaderProofProviderService::<MockDaSpec>::new(ledger_db.clone(), true);
 
     let block_hash = [1u8; 32];
     let mock_proof = MockShortHeaderProof {


### PR DESCRIPTION
# Description
Do not save l1 hashes to memory unnecessarily by shp provider  for sequencer and full node
Creates another native short header proof provider to be used by full node and sequencer, does not save queried hashes on those nodes as it won't need them




## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

