### PR TITLE
feat: impl Debug for HookL2BlockInfo

### DIFF
--- a/crates/sovereign-sdk/module-system/sov-keys/src/default_signature.rs
+++ b/crates/sovereign-sdk/module-system/sov-keys/src/default_signature.rs
@@ -99,7 +99,7 @@ pub mod k256_private_key {
 }
 
 #[cfg_attr(feature = "native", derive(schemars::JsonSchema))]
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct K256PublicKey {
     #[cfg_attr(feature = "native", schemars(with = "&[u8]", length(equal = 33)))]
     pub pub_key: k256::ecdsa::VerifyingKey,
@@ -142,10 +142,18 @@ impl TryFrom<&[u8]> for K256PublicKey {
 
 #[cfg_attr(feature = "native", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct K256Signature {
     #[cfg_attr(feature = "native", schemars(with = "&[u8]", length(equal = 64)))]
     pub(crate) msg_sig: k256::ecdsa::Signature,
+}
+
+impl Debug for K256Signature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("K256Signature")
+            .field(&hex::encode(self.msg_sig.to_bytes()))
+            .finish()
+    }
 }
 
 impl BorshDeserialize for K256Signature {
@@ -169,6 +177,14 @@ impl BorshSerialize for K256Signature {
 impl std::fmt::Display for K256PublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", hex::encode(self.pub_key.to_sec1_bytes()))
+    }
+}
+
+impl Debug for K256PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("K256PublicKey")
+            .field(&hex::encode(self.pub_key.to_sec1_bytes()))
+            .finish()
     }
 }
 

--- a/crates/sovereign-sdk/module-system/sov-modules-api/src/hooks.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-api/src/hooks.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_keys::default_signature::K256PublicKey;
@@ -63,7 +65,7 @@ pub trait ApplyL2BlockHooks<Da: DaSpec> {
 
 /// Post fork 2 Information about the l2 block block
 /// Does not include l1 data
-#[derive(Debug, PartialEq, Clone, BorshDeserialize, BorshSerialize, Serialize, Deserialize, Eq)]
+#[derive(PartialEq, Clone, BorshDeserialize, BorshSerialize, Serialize, Deserialize, Eq)]
 pub struct HookL2BlockInfo {
     // L2 block height
     pub l2_height: u64,
@@ -77,6 +79,19 @@ pub struct HookL2BlockInfo {
     pub l1_fee_rate: u128,
     /// Timestamp
     pub timestamp: u64,
+}
+
+impl Debug for HookL2BlockInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HookL2BlockInfo")
+            .field("l2_height", &self.l2_height)
+            .field("pre_state_root", &hex::encode(self.pre_state_root))
+            .field("current_spec", &self.current_spec)
+            .field("sequencer_pub_key", &self.sequencer_pub_key)
+            .field("l1_fee_rate", &self.l1_fee_rate)
+            .field("timestamp", &self.timestamp)
+            .finish()
+    }
 }
 
 impl HookL2BlockInfo {


### PR DESCRIPTION
To get pretty logs.

BEFORE:

`2025-09-02T19:50:35.250987Z TRACE Sequencer:begin_l2_block_inner:begin_l2_block_hook{l2_block_info=HookL2BlockInfo { l2_height: 4, pre_state_root: [18, 75, 193, 30, 215, 46, 121, 30, 226, 124, 174, 227, 52, 118, 24, 213, 217, 74, 175, 123, 254, 218, 227, 99, 223, 83, 110, 64, 215, 35, 20, 37], current_spec: Fork3, sequencer_pub_key: K256PublicKey { pub_key: VerifyingKey { inner: PublicKey { point: AffinePoint { x: FieldElement(FieldElementImpl { value: FieldElement5x52([3695674923119607, 2266737069084123, 3518920256149164, 4043081666782015, 109267865973004]), magnitude: 1, normalized: true }), y: FieldElement(FieldElementImpl { value: FieldElement5x52([4310874134972579, 4205096890695389, 1337703425209261, 23331463193065, 258506154616409]), magnitude: 1, normalized: true }), infinity: 0 } } } }, l1_fee_rate: 10, timestamp: 1756842635 }}: citrea_stf::hooks_impl: return=()`

AFTER:

`2025-09-02T19:45:01.416401Z TRACE Sequencer:begin_l2_block_inner:begin_l2_block_hook{l2_block_info=HookL2BlockInfo { l2_height: 4, pre_state_root: "06866a2828d5e6cdf94ef2725d5638bf1a391ade3eb3acac473c109a1606e986", current_spec: Fork3, sequencer_pub_key: K256PublicKey("036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f7"), l1_fee_rate: 10, timestamp: 1756842301 }}: citrea_stf::hooks_impl: return=()`