### PR TITLE
fix: Change wrong `WitnessUtils` error message

### DIFF
--- a/crates/evm/src/evm/system_contracts/lib/WitnessUtils.sol
+++ b/crates/evm/src/evm/system_contracts/lib/WitnessUtils.sol
@@ -114,7 +114,7 @@ library WitnessUtils {
         
         (_varIntDataLen, _nItems) = BTCUtils.parseVarInt(_witness);
         require(_varIntDataLen != BTCUtils.ERR_BAD_ARG, "Read overrun during VarInt parsing");
-        require(_index < _nItems, "Vin read overrun");
+        require(_index < _nItems, "Witness read overrun");
 
         uint256 _itemLen = 0;
         uint256 _offset = 1 + _varIntDataLen;


### PR DESCRIPTION
# Description
Error message was wrongly written as `Vin read overrun` while copying from `BTCUtils` but it should be `Witness read overrun`.

## Linked Issues
- Fixes #2747