### PR TITLE
fix: Assert withdraw recipient of `FeeVault`s' to not be `address(0)`

### DIFF
--- a/crates/evm/src/evm/system_contracts/src/FeeVault.sol
+++ b/crates/evm/src/evm/system_contracts/src/FeeVault.sol
@@ -19,6 +19,7 @@ abstract contract FeeVault is Ownable2StepUpgradeable {
 
     /// @notice Withdraws accumulated fees to recipient if enough funds are accumulated
     function withdraw() external {
+        require(recipient != address(0), "Recipient is not set");
         require(address(this).balance >= minWithdraw, "Withdrawal amount must be greater than minimum withdraw amount");
         (bool success, ) = payable(recipient).call{value: address(this).balance}("");
         require(success, "Transfer failed");

--- a/crates/evm/src/evm/system_contracts/test/FeeVault.t.sol
+++ b/crates/evm/src/evm/system_contracts/test/FeeVault.t.sol
@@ -24,6 +24,14 @@ abstract contract FeeVaultTest is Test {
         assertEq(address(recipient).balance, 1 ether);
     }
 
+    function testCannotWithdrawToZeroRecipient() public {
+        vm.deal(address(feeVault), 1 ether);
+        vm.prank(owner);
+        feeVault.setRecipient(address(0));
+        vm.expectRevert("Recipient is not set");
+        feeVault.withdraw();
+    }
+
     function testCannotWithdrawLessThanMinWithdraw() public {
         vm.deal(address(feeVault), 0.1 ether);
         vm.startPrank(owner);


### PR DESCRIPTION
# Description
`withdraw` can be called by anyone, so even though initial `recipient` is set at genesis state (there's no security risk), it's a good practice to check that `recipient` is set.

## Linked Issues
- Fixes #2678