### PR TITLE
fix: Check the address set is not `address(0)` in system contract setters

### DIFF
--- a/crates/evm/src/evm/system_contracts/src/Bridge.sol
+++ b/crates/evm/src/evm/system_contracts/src/Bridge.sol
@@ -308,6 +308,7 @@ contract Bridge is Ownable2StepUpgradeable {
     /// @notice Sets the operator address that can process user deposits
     /// @param _operator Address of the privileged operator
     function setOperator(address _operator) external onlyOwner {
+        require(_operator != address(0), "Operator cannot be zero address");
         address oldOperator = operator;
         operator = _operator;
         emit OperatorUpdated(oldOperator, _operator);

--- a/crates/evm/src/evm/system_contracts/src/FeeVault.sol
+++ b/crates/evm/src/evm/system_contracts/src/FeeVault.sol
@@ -28,6 +28,7 @@ abstract contract FeeVault is Ownable2StepUpgradeable {
     /// @notice Sets the new recipient address for the withdrawn fees
     /// @param _recipient New recipient address
     function setRecipient(address _recipient) external onlyOwner {
+        require(_recipient != address(0), "Recipient cannot be zero address");
         address oldRecipient = recipient;
         recipient = _recipient;
         emit RecipientUpdated(oldRecipient, _recipient);

--- a/crates/evm/src/evm/system_contracts/test/Bridge.t.sol
+++ b/crates/evm/src/evm/system_contracts/test/Bridge.t.sol
@@ -366,6 +366,12 @@ contract BridgeTest is Test {
         doDeposit();
     }
 
+    function testCannotSetOperatorToZeroAddress() public {
+        vm.prank(owner);
+        vm.expectRevert("Operator cannot be zero address");
+        bridge.setOperator(address(0));
+    }
+
     function testSetOperatorEmitsCorrectEvent() public {
         address currentOperator = bridge.operator();
         address newOperator = makeAddr("new_operator");

--- a/crates/evm/src/evm/system_contracts/test/FeeVault.t.sol
+++ b/crates/evm/src/evm/system_contracts/test/FeeVault.t.sol
@@ -24,10 +24,17 @@ abstract contract FeeVaultTest is Test {
         assertEq(address(recipient).balance, 1 ether);
     }
 
+    function testCannotSetRecipientToZeroAddress() public {
+        vm.prank(owner);
+        vm.expectRevert("Recipient cannot be zero address");
+        feeVault.setRecipient(address(0));
+    }
+
     function testCannotWithdrawToZeroRecipient() public {
         vm.deal(address(feeVault), 1 ether);
         vm.prank(owner);
-        feeVault.setRecipient(address(0));
+        // Directly store as `setRecipient` will revert if zero address is provided
+        vm.store(address(feeVault), bytes32(uint256(0)), bytes32(uint256(0)));
         vm.expectRevert("Recipient is not set");
         feeVault.withdraw();
     }


### PR DESCRIPTION
## Linked Issues
- Fixes #2677

## Testing
Added unit tests.
