### PR TITLE
fix: Assert `depositAmount` / `SAT_TO_WEI` not overflowing `uint64`

### DIFF
--- a/crates/evm/src/evm/system_contracts/src/Bridge.sol
+++ b/crates/evm/src/evm/system_contracts/src/Bridge.sol
@@ -97,6 +97,7 @@ contract Bridge is Ownable2StepUpgradeable {
         require(_depositAmount != 0, "Deposit amount cannot be 0");
         require(_depositPrefix.length != 0, "Deposit script cannot be empty");
         require(_depositAmount % SAT_TO_WEI == 0, "Deposit amount must have valid satoshi value");
+        require(_depositAmount / SAT_TO_WEI <= type(uint64).max, "Deposit amount divided by SAT_TO_WEI must fit in uint64");
 
         initialized = true;
         depositPrefix = _depositPrefix;

--- a/crates/evm/src/evm/system_contracts/test/Bridge.t.sol
+++ b/crates/evm/src/evm/system_contracts/test/Bridge.t.sol
@@ -653,4 +653,14 @@ contract BridgeTest is Test {
         address attacker = 0x3100000000000000000000000000000000000069;
         assertEq(attacker.balance, 0 ether);
     }
+
+    function testDepositAmountDividedBySatToWeiCannotOverflowUint64() public {
+        // Clear out the initilization flag so we can re-initialize
+        vm.store(address(bridge), bytes32(uint256(0)), bytes32(uint256(0)));
+        vm.startPrank(SYSTEM_CALLER);
+        uint256 overflowingDepositAmount = (uint256(type(uint64).max) + 1) * bridge.SAT_TO_WEI();
+        vm.expectRevert("Deposit amount divided by SAT_TO_WEI must fit in uint64");
+        bridge.initialize(depositPrefix, depositSuffix, overflowingDepositAmount);
+        vm.stopPrank();
+    }
 }


### PR DESCRIPTION
# Description
Fixes an operationally impossible issue that results in signature verification problems due to `uint64` downcasting in `shaAmounts` calculation if the deposit amount is 184 billion BTC or more for code correctness.

## Linked Issues
- Fixes #2676

## Testing
Added a unit test.
