### PR TITLE
fix: Assert aggregated key of `replacePrefix` is same as `depositPrefix`

### DIFF
--- a/crates/evm/src/evm/system_contracts/src/Bridge.sol
+++ b/crates/evm/src/evm/system_contracts/src/Bridge.sol
@@ -133,6 +133,7 @@ contract Bridge is Ownable2StepUpgradeable {
     /// @param _replaceSuffix The part of the replace script that succeeds the txId
     function setReplaceScript(bytes calldata _replacePrefix, bytes calldata _replaceSuffix) external onlyOwner {
         require(_replacePrefix.length != 0, "Replace script cannot be empty");
+        require(bytesToBytes32(_replacePrefix.slice(2, 32)) == bytesToBytes32(getAggregatedKey()), "Replace prefix must contain the same aggregated key as deposit prefix");
 
         replacePrefix = _replacePrefix;
         replaceSuffix = _replaceSuffix;

--- a/crates/evm/src/evm/system_contracts/test/Bridge.t.sol
+++ b/crates/evm/src/evm/system_contracts/test/Bridge.t.sol
@@ -415,6 +415,12 @@ contract BridgeTest is Test {
         assertEq(bridge.depositTxIds(0), hex"6a1d18b80867c0bc84cb9a20ec88922cf17a7bdd50e5237d67b6fad11d70fe95");
     }
 
+    function testCannotSetReplaceScriptWithMismatchingAggregatedKey() public {
+        vm.prank(owner);
+        vm.expectRevert("Replace prefix must contain the same aggregated key as deposit prefix");
+        bridge.setReplaceScript(hex"54203c48ffb437c2ee08ceb8b9bb9e5555c002fb304c112e7e1233fe233f2a3dfc1dac00630d6369747265615265706c61636520", hex"68");
+    }
+
     function testBytesEqual() public view {
         bytes memory a = hex"1234";
         bytes memory b = hex"1234";


### PR DESCRIPTION
# Description
In `verifySigInTx`, aggregated key from `depositPrefix` is used even if the call is coming from `replaceDeposit`. This is logically correct as there can be one valid N-of-N at any moment and both prefixes should be constructed from the aggregated derived from that N-of-N. But to prevent failure in the case of misconfiguration, `setReplaceScript` checks if `replacePrefix` contains the same aggregated key as `depositPrefix`.

This makes the script upgrade flow in case of N-of-N change to be `setDepositScript` first followed by `setReplaceScript`.

## Linked Issues
- Fixes #2711

## Testing
Added a unit test.
