### PR TITLE
fix: Rollback slots using last scanned l1 height

### DIFF
--- a/crates/storage-ops/src/rollback/node/fullnode.rs
+++ b/crates/storage-ops/src/rollback/node/fullnode.rs
@@ -88,7 +88,7 @@ impl FullNodeLedgerRollback {
             .ledger_db
             .get::<ProverLastScannedSlot>(&())?
             .unwrap_or_default();
-        for i in l1_target..=last_scanned_l1_height.0 {
+        for i in l1_target + 1..=last_scanned_l1_height.0 {
             batch.delete::<L2RangeByL1Height>(&SlotNumber(i))?;
             increment_table_counter!("L2RangeByL1Height", rollback_result);
 

--- a/crates/storage-ops/src/rollback/node/fullnode.rs
+++ b/crates/storage-ops/src/rollback/node/fullnode.rs
@@ -83,69 +83,36 @@ impl FullNodeLedgerRollback {
     fn rollback_slots(&self, l1_target: u64, mut rollback_result: RollbackResult) -> Result {
         let mut batch = SchemaBatch::new();
         let l1_cache = self.construct_l1_cache()?;
-        let mut commitments_by_number = self.ledger_db.iter_with_direction::<CommitmentsByNumber>(
-            Default::default(),
-            ScanDirection::Backward,
-        )?;
-        commitments_by_number.seek_to_last();
 
-        let mut last_deleted_slot = None;
-        for record in commitments_by_number {
-            let Ok(record) = record else {
-                continue;
-            };
+        let last_scanned_l1_height = self
+            .ledger_db
+            .get::<ProverLastScannedSlot>(&())?
+            .unwrap_or_default();
+        for i in l1_target..=last_scanned_l1_height.0 {
+            batch.delete::<L2RangeByL1Height>(&SlotNumber(i))?;
+            increment_table_counter!("L2RangeByL1Height", rollback_result);
 
-            let slot_height = record.key;
+            batch.delete::<CommitmentsByNumber>(&SlotNumber(i))?;
+            increment_table_counter!("CommitmentsByNumber", rollback_result);
 
-            if slot_height <= SlotNumber(l1_target) {
-                break;
+            batch.delete::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(i))?;
+            increment_table_counter!("VerifiedBatchProofsBySlotNumber", rollback_result);
+
+            batch.delete::<L2StatusHeights>(&(L2HeightStatus::Committed, i))?;
+            increment_table_counter!("L2StatusHeights", rollback_result);
+
+            batch.delete::<L2StatusHeights>(&(L2HeightStatus::Proven, i))?;
+            increment_table_counter!("L2StatusHeights", rollback_result);
+
+            if let Some(slot_hash) = l1_cache.get(&i) {
+                batch.delete::<ShortHeaderProofBySlotHash>(slot_hash)?;
+                increment_table_counter!("ShortHeaderProofBySlotHash", rollback_result);
+                batch.delete::<SlotByHash>(slot_hash)?;
+                increment_table_counter!("SlotByHash", rollback_result);
             }
-
-            let iter_end = last_deleted_slot.unwrap_or(slot_height.0);
-            for i in slot_height.0..=iter_end {
-                batch.delete::<L2RangeByL1Height>(&SlotNumber(i))?;
-                increment_table_counter!("L2RangeByL1Height", rollback_result);
-
-                batch.delete::<CommitmentsByNumber>(&SlotNumber(i))?;
-                increment_table_counter!("CommitmentsByNumber", rollback_result);
-
-                batch.delete::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(i))?;
-                increment_table_counter!("VerifiedBatchProofsBySlotNumber", rollback_result);
-
-                if let Some(slot_hash) = l1_cache.get(&i) {
-                    batch.delete::<ShortHeaderProofBySlotHash>(slot_hash)?;
-                    increment_table_counter!("ShortHeaderProofBySlotHash", rollback_result);
-                    batch.delete::<SlotByHash>(slot_hash)?;
-                    increment_table_counter!("SlotByHash", rollback_result);
-                }
-            }
-
-            last_deleted_slot = Some(slot_height.0);
         }
 
         self.ledger_db.write_schemas(batch)?;
-        Ok(rollback_result)
-    }
-
-    fn rollback_l2_status_heights(
-        &self,
-        l1_target: u64,
-        mut rollback_result: RollbackResult,
-    ) -> Result {
-        let mut batch = SchemaBatch::new();
-
-        let last_scanned_l1_height = self.ledger_db.get::<ProverLastScannedSlot>(&())?;
-        let last_scanned_l1_height = last_scanned_l1_height.unwrap_or_default();
-        for l1_height in (l1_target..=last_scanned_l1_height.0).rev() {
-            batch.delete::<L2StatusHeights>(&(L2HeightStatus::Committed, l1_height))?;
-            increment_table_counter!("L2StatusHeights", rollback_result);
-
-            batch.delete::<L2StatusHeights>(&(L2HeightStatus::Proven, l1_height))?;
-            increment_table_counter!("L2StatusHeights", rollback_result);
-        }
-
-        self.ledger_db.write_schemas(batch)?;
-
         Ok(rollback_result)
     }
 
@@ -240,7 +207,6 @@ impl LedgerNodeRollback for FullNodeLedgerRollback {
 
         if let Some(l1_target) = context.l1_target {
             rollback_result = self.rollback_slots(l1_target, rollback_result)?;
-            rollback_result = self.rollback_l2_status_heights(l1_target, rollback_result)?;
             rollback_result = self.clear_pending_proofs(l1_target, rollback_result)?;
             rollback_result =
                 self.clear_pending_sequencer_commitments(l1_target, rollback_result)?;


### PR DESCRIPTION
# Description

- Rollback all slots between `target_l1` height and `last_scanned_l1_height`.
- It was previously iterating over `CommitmentsByNumber` expecting it to be in order but this table uses `define_table_with_default_codec` which cannot be used for ordered iteration. See #2771 and #2782


## Linked Issues
- Fixes #2795
