### PR TITLE
fix: add mantissa size check

### DIFF
--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -605,7 +605,8 @@ fn bits_to_target(bits: u32) -> [u8; 32] {
     let size = (bits >> 24) as usize;
     let mantissa = bits & 0x00ffffff;
 
-    // Mantissa should not be negative
+    // Mantissa is signed in Bitcoin core, if the sign bit is set, the target is set to 0.
+    // https://github.com/bitcoin/bitcoin/blob/ee42d59d4de970769ebabf77b89ff4269498f61e/src/arith_uint256.cpp#L175
     if mantissa > 0x7F_FFFF {
         return [0; 32];
     }

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -605,6 +605,11 @@ fn bits_to_target(bits: u32) -> [u8; 32] {
     let size = (bits >> 24) as usize;
     let mantissa = bits & 0x00ffffff;
 
+    // Mantissa should not be negative
+    if mantissa > 0x7F_FFFF {
+        return [0; 32];
+    }
+
     // Prepare U256 target
     let target =
     // If the size is less than or equal to 3, we need to shift the word to the right,


### PR DESCRIPTION
# Description
Sets the target to zero if mantissa sign bit is set.

## Linked Issues
- Fixes #2814 
