### PR TITLE
chore: give more detail on proof processing logs

### DIFF
--- a/crates/batch-prover/src/prover.rs
+++ b/crates/batch-prover/src/prover.rs
@@ -820,7 +820,7 @@ where
                 ledger_db
                     .finalize_proving_job(job_id, tx_id.into())
                     .expect("Should update proving job tx id");
-                tracing::info!("Finalized recovered proving job: {}", job_id);
+                info!("Finalized recovered proving job: {}", job_id);
             });
         }
     }

--- a/crates/batch-prover/src/prover.rs
+++ b/crates/batch-prover/src/prover.rs
@@ -691,7 +691,10 @@ where
         tokio::spawn(async move {
             while let Some((job_id, rx)) = proving_jobs.recv().await {
                 let proof_with_duration = rx.await.expect("Proof channel should never close");
-                info!("Proving job finished {}", job_id);
+                info!(
+                    "Proving job finished {}, took {:?} seconds",
+                    job_id, proof_with_duration.duration
+                );
 
                 let output = extract_proof_output::<Vm>(
                     &job_id,
@@ -811,12 +814,13 @@ where
                     .submit_proof(proof, job_id)
                     .await
                     .expect("Failed to submit transaction");
-                info!("Job {} proof sent to DA", job_id);
+                info!("Recovered Job {} proof sent to DA", job_id);
 
                 // stores tx id and removes job from pending da submission
                 ledger_db
                     .finalize_proving_job(job_id, tx_id.into())
                     .expect("Should update proving job tx id");
+                tracing::error!("Finalized recovered proving job: {}", job_id);
             });
         }
     }

--- a/crates/batch-prover/src/prover.rs
+++ b/crates/batch-prover/src/prover.rs
@@ -820,7 +820,7 @@ where
                 ledger_db
                     .finalize_proving_job(job_id, tx_id.into())
                     .expect("Should update proving job tx id");
-                tracing::error!("Finalized recovered proving job: {}", job_id);
+                tracing::info!("Finalized recovered proving job: {}", job_id);
             });
         }
     }

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -990,6 +990,7 @@ impl DaService for BitcoinService {
                         if complete.public_key() == prover_da_pub_key
                             && complete.get_sig_verified_hash().is_some()
                         {
+                            tracing::info!("Found complete tx with tx id: {}", tx_id);
                             let Ok(data) = DataOnDa::try_from_slice(&complete.body) else {
                                 warn!("{tx_id}: Failed to parse complete data");
                                 continue;
@@ -1013,6 +1014,7 @@ impl DaService for BitcoinService {
                         if aggregate.public_key() == prover_da_pub_key
                             && aggregate.get_sig_verified_hash().is_some()
                         {
+                            tracing::info!("Found aggregate tx with tx id: {}", tx_id);
                             // push only when signature is correct
                             // collect tx ids
                             aggregate_idxs.push((i, tx_id, aggregate));
@@ -1021,6 +1023,7 @@ impl DaService for BitcoinService {
                     ParsedTransaction::Chunk(_chunk) => {
                         // This is stored so we can see which chunk has what index
                         // This will help determine which comes first if in the same block aggregate or chunk
+                        tracing::info!("Found chunk tx with tx id: {}", tx_id);
                         chunks.insert(tx_id, i);
                     }
                     ParsedTransaction::BatchProverMethodId(_) => {

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -565,6 +565,13 @@ where
             return Ok(ProcessingResult::Discarded);
         };
 
+        tracing::info!(
+            "Extracted batch proof output with last L2 height: {}, commitment index range: {}-{}",
+            batch_proof_output.last_l2_height(),
+            batch_proof_output.sequencer_commitment_index_range().0,
+            batch_proof_output.sequencer_commitment_index_range().1
+        );
+
         // Get the code commitment for the appropriate fork
         let spec_id = fork_from_block_number(batch_proof_output.last_l2_height()).spec_id;
         let code_commitment = self


### PR DESCRIPTION
# Description
The full node used to only log:
`Processing zk proof at height: n`
I added some more info

Batch prover logs the same exact thing for recovered and normal proofs, I added "Recovered" prefix to that log

