### PR TITLE
fix: rpc bind ports should be different than full node for local testing

### DIFF
--- a/resources/configs/bitcoin-regtest/batch_prover_rollup_config.toml
+++ b/resources/configs/bitcoin-regtest/batch_prover_rollup_config.toml
@@ -21,7 +21,7 @@ db_max_open_files = 5000
 [rpc]
 # the host and port to bind the rpc server for
 bind_host = "127.0.0.1"
-bind_port = 12346
+bind_port = 12347
 enable_subscriptions = false
 
 [runner]

--- a/resources/configs/bitcoin-regtest/light_client_prover_rollup_config.toml
+++ b/resources/configs/bitcoin-regtest/light_client_prover_rollup_config.toml
@@ -20,5 +20,5 @@ db_max_open_files = 5000
 [rpc]
 # the host and port to bind the rpc server for
 bind_host = "127.0.0.1"
-bind_port = 12346
+bind_port = 12348
 enable_subscriptions = false


### PR DESCRIPTION
# Description
rpc bind ports should be different than full node for local testing on the same machine

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
