### PR TITLE
chore: remove unnecessary use core::panic;

### DIFF
--- a/crates/evm/src/call.rs
+++ b/crates/evm/src/call.rs
@@ -1,5 +1,3 @@
-use core::panic;
-
 use alloy_consensus::TxReceipt;
 use reth_primitives::{Recovered, TransactionSigned};
 use revm::context::CfgEnv;


### PR DESCRIPTION
Delete redundant use core::panic; from crates/evm/src/call.rs.
The code only uses the panic! macro, which is available without importing core::panic.
Suppresses unused import warning and aligns with Rust idioms.