### PR TITLE
feat: Add optional block count limit to debug_traceChain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,6 +3708,7 @@ dependencies = [
  "alloy-serde",
  "async-trait",
  "borsh",
+ "citrea-common",
  "citrea-evm",
  "citrea-primitives",
  "citrea-sequencer",

--- a/bin/citrea/src/eth.rs
+++ b/bin/citrea/src/eth.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Context as _;
+use citrea_common::RpcConfig;
 use ethereum_rpc::{EthRpcConfig, FeeHistoryCacheConfig, GasPriceOracleConfig};
 use sov_db::ledger_db::LedgerDB;
 use sov_modules_api::default_context::DefaultContext;
@@ -12,6 +13,7 @@ use tokio::sync::broadcast;
 pub fn register_ethereum<Da: DaService>(
     da_service: Arc<Da>,
     storage: ProverStorage,
+    rpc_config: RpcConfig,
     ledger_db: LedgerDB,
     methods: &mut jsonrpsee::RpcModule<()>,
     sequencer_client_url: Option<String>,
@@ -27,6 +29,7 @@ pub fn register_ethereum<Da: DaService>(
     let ethereum_rpc = ethereum_rpc::create_rpc_module::<DefaultContext, Da>(
         da_service,
         eth_rpc_config,
+        rpc_config,
         storage,
         ledger_db,
         sequencer_client_url,

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -241,6 +241,7 @@ where
         register_ethereum(
             da_service.clone(),
             rpc_storage,
+            rollup_config.rpc.clone(),
             ledger_db.clone(),
             &mut rpc_module,
             sequencer_client_url,

--- a/bin/citrea/tests/common/client.rs
+++ b/bin/citrea/tests/common/client.rs
@@ -22,7 +22,7 @@ use citrea_batch_prover::rpc::{BatchProverRpcClient, ProvingJobResponse};
 use citrea_batch_prover::PartitionMode;
 use citrea_evm::EstimatedDiffSize;
 use ethereum_rpc::SyncStatus;
-use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
+use jsonrpsee::core::client::{ClientT, SubscriptionClientT, Error};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::{PingConfig, WsClient, WsClientBuilder};
@@ -700,7 +700,7 @@ impl TestClient {
         start_block: BlockNumberOrTag,
         end_block: BlockNumberOrTag,
         opts: Option<GethDebugTracingOptions>,
-    ) -> Vec<TraceResult> {
+    ) -> Result<Vec<TraceResult>, Error> {
         let mut subscription = self
             .ws_client
             .subscribe(
@@ -708,8 +708,7 @@ impl TestClient {
                 rpc_params!["traceChain", start_block, end_block, opts],
                 "debug_unsubscribe",
             )
-            .await
-            .unwrap();
+            .await?;
 
         let BlockNumberOrTag::Number(start_block) = start_block else {
             panic!("Only numbers for start block");
@@ -725,7 +724,7 @@ impl TestClient {
             traces.push(block_traces);
         }
 
-        traces.into_iter().flatten().collect()
+        Ok(traces.into_iter().flatten().collect())
     }
 
     pub(crate) async fn subscribe_new_heads(&self) -> mpsc::Receiver<WithOtherFields<Block>> {

--- a/bin/citrea/tests/common/client.rs
+++ b/bin/citrea/tests/common/client.rs
@@ -22,7 +22,7 @@ use citrea_batch_prover::rpc::{BatchProverRpcClient, ProvingJobResponse};
 use citrea_batch_prover::PartitionMode;
 use citrea_evm::EstimatedDiffSize;
 use ethereum_rpc::SyncStatus;
-use jsonrpsee::core::client::{ClientT, SubscriptionClientT, Error};
+use jsonrpsee::core::client::{ClientT, Error, SubscriptionClientT};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::{PingConfig, WsClient, WsClientBuilder};

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -211,6 +211,7 @@ pub async fn start_rollup(
         citrea::register_ethereum(
             da_service.clone(),
             rpc_storage,
+            rollup_config.rpc.clone(),
             ledger_db.clone(),
             &mut rpc_module,
             sequencer_client_url,
@@ -449,6 +450,7 @@ pub fn create_default_rollup_config(
             batch_requests_limit: 50,
             enable_subscriptions: true,
             max_subscriptions_per_connection: 100,
+            trace_chain_block_limit: None,
             api_key: None,
         },
         runner: match node_mode {

--- a/bin/citrea/tests/mock/evm/tracing.rs
+++ b/bin/citrea/tests/mock/evm/tracing.rs
@@ -1492,15 +1492,18 @@ async fn test_trace_chain_block_limit() -> Result<(), Box<dyn std::error::Error>
         test_client.send_publish_batch_request().await;
     }
 
-    let result = test_client.debug_trace_chain(
-        BlockNumberOrTag::Number(0), BlockNumberOrTag::Number(15), None
-    )
-    .await
-    .expect_err("Expected error due to exceeding block limit");
+    let result = test_client
+        .debug_trace_chain(
+            BlockNumberOrTag::Number(0),
+            BlockNumberOrTag::Number(15),
+            None,
+        )
+        .await
+        .expect_err("Expected error due to exceeding block limit");
 
-    assert!(
-        result.to_string().contains("Block range too large. Maximum allowed range is 10 blocks")
-    );
+    assert!(result
+        .to_string()
+        .contains("Block range too large. Maximum allowed range is 10 blocks"));
     rollup_task.graceful_shutdown();
 
     Ok(())

--- a/bin/citrea/tests/mock/evm/tracing.rs
+++ b/bin/citrea/tests/mock/evm/tracing.rs
@@ -499,6 +499,7 @@ async fn test_call_tracer() -> Result<(), Box<dyn std::error::Error>> {
             )),
         )
         .await
+        .expect("Trace chain rpc failed")
         .into_iter()
         .map(|trace| match trace {
             TraceResult::Success { result, .. } => Ok(result),
@@ -1448,6 +1449,59 @@ async fn test_noop_tracer() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     task_manager.graceful_shutdown();
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trace_chain_block_limit() -> Result<(), Box<dyn std::error::Error>> {
+    let storage_dir = tempdir_with_children(&["DA", "sequencer"]);
+    let da_db_dir = storage_dir.path().join("DA").to_path_buf();
+    let sequencer_db_dir = storage_dir.path().join("sequencer").to_path_buf();
+
+    let (port_tx, port_rx) = tokio::sync::oneshot::channel();
+
+    let mut rollup_config = create_default_rollup_config(
+        true,
+        &sequencer_db_dir,
+        &da_db_dir,
+        NodeMode::SequencerNode,
+        None,
+    );
+    rollup_config.rpc.trace_chain_block_limit = Some(10); // set the limit to 10 blocks
+    let sequencer_config = SequencerConfig::default();
+
+    let rollup_task = start_rollup(
+        port_tx,
+        GenesisPaths::from_dir(TEST_DATA_GENESIS_PATH),
+        None,
+        None,
+        rollup_config,
+        Some(sequencer_config),
+        None,
+        false,
+    )
+    .await;
+
+    // Wait for rollup task to start:
+    let port = port_rx.await.unwrap();
+
+    let test_client = make_test_client(port).await?;
+
+    for _ in 0..15 {
+        test_client.send_publish_batch_request().await;
+    }
+
+    let result = test_client.debug_trace_chain(
+        BlockNumberOrTag::Number(0), BlockNumberOrTag::Number(10), None
+    )
+    .await
+    .expect_err("Expected error due to exceeding block limit");
+
+    assert!(
+        result.to_string().contains("Block range too large. Maximum allowed range is 10 blocks")
+    );
+    rollup_task.graceful_shutdown();
 
     Ok(())
 }

--- a/bin/citrea/tests/mock/evm/tracing.rs
+++ b/bin/citrea/tests/mock/evm/tracing.rs
@@ -1493,7 +1493,7 @@ async fn test_trace_chain_block_limit() -> Result<(), Box<dyn std::error::Error>
     }
 
     let result = test_client.debug_trace_chain(
-        BlockNumberOrTag::Number(0), BlockNumberOrTag::Number(10), None
+        BlockNumberOrTag::Number(0), BlockNumberOrTag::Number(15), None
     )
     .await
     .expect_err("Expected error due to exceeding block limit");

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -425,6 +425,7 @@ mod tests {
             max_connections = 500
             enable_subscriptions = true
             max_subscriptions_per_connection = 200
+            trace_chain_block_limit = 100
 
             [da]
             sender_address = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -475,7 +476,7 @@ mod tests {
                 batch_requests_limit: 50,
                 enable_subscriptions: true,
                 max_subscriptions_per_connection: 200,
-                trace_chain_block_limit: None,
+                trace_chain_block_limit: Some(100),
                 api_key: None,
             },
             public_keys: RollupPublicKeys {

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -475,6 +475,7 @@ mod tests {
                 batch_requests_limit: 50,
                 enable_subscriptions: true,
                 max_subscriptions_per_connection: 200,
+                trace_chain_block_limit: None,
                 api_key: None,
             },
             public_keys: RollupPublicKeys {
@@ -660,6 +661,7 @@ mod tests {
                 batch_requests_limit: default_batch_requests_limit(),
                 enable_subscriptions: true,
                 max_subscriptions_per_connection: 200,
+                trace_chain_block_limit: None,
                 api_key: None,
             },
             storage: StorageConfig {

--- a/crates/common/src/config/rpc.rs
+++ b/crates/common/src/config/rpc.rs
@@ -62,6 +62,8 @@ pub struct RpcConfig {
     /// Maximum number of subscription connections
     #[serde(default = "default_max_subscriptions_per_connection")]
     pub max_subscriptions_per_connection: u32,
+    /// Maximum number of L2 blocks to be traced with debug_traceChain
+    pub trace_chain_block_limit: Option<u64>,
     /// API key for protected JSON-RPC methods
     pub api_key: Option<String>,
 }
@@ -104,6 +106,9 @@ impl FromEnv for RpcConfig {
                 .ok()
                 .and_then(|val| val.parse().ok())
                 .unwrap_or_else(default_max_subscriptions_per_connection),
+            trace_chain_block_limit: read_env("RPC_TRACE_CHAIN_BLOCK_LIMIT")
+                .ok()
+                .and_then(|val| val.parse().ok()),
             api_key: read_env("RPC_API_KEY").ok(),
         })
     }

--- a/crates/ethereum-rpc/Cargo.toml
+++ b/crates/ethereum-rpc/Cargo.toml
@@ -15,6 +15,7 @@ resolver = "2"
 # 3rd-party dependencies
 async-trait = { workspace = true }
 borsh = { workspace = true }
+citrea-common = { path = "../common" }
 citrea-evm = { path = "../evm", features = ["native"] }
 citrea-primitives = { path = "../primitives" }
 citrea-sequencer = { path = "../sequencer" }

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -198,7 +198,11 @@ where
     C: sov_modules_api::Context,
     Da: DaService,
 {
-    pub fn new(ethereum: Arc<Ethereum<C, Da>>, starting_l2_height: U64, trace_chain_block_limit: Option<u64>) -> Self {
+    pub fn new(
+        ethereum: Arc<Ethereum<C, Da>>,
+        starting_l2_height: U64,
+        trace_chain_block_limit: Option<u64>,
+    ) -> Self {
         Self {
             ethereum,
             starting_l2_height,
@@ -580,8 +584,15 @@ where
         opts: Option<GethDebugTracingOptions>,
     ) -> SubscriptionResult {
         if &topic == "traceChain" {
-            handle_debug_trace_chain(start_block, end_block, opts, pending, self.ethereum.clone(), self.trace_chain_block_limit)
-                .await;
+            handle_debug_trace_chain(
+                start_block,
+                end_block,
+                opts,
+                pending,
+                self.ethereum.clone(),
+                self.trace_chain_block_limit,
+            )
+            .await;
         } else {
             pending
                 .reject(to_eth_rpc_error("Unsupported subscription topic"))
@@ -665,9 +676,9 @@ where
         l2_block_rx,
     ));
     let server = EthereumRpcServerImpl::new(
-        ethereum, 
+        ethereum,
         U64::from(head_l2_block),
-        rpc_config.trace_chain_block_limit
+        rpc_config.trace_chain_block_limit,
     );
 
     let mut module = EthereumRpcServer::into_rpc(server);

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -183,7 +183,7 @@ fn to_eth_rpc_error(err: impl ToString) -> ErrorObjectOwned {
     to_jsonrpsee_error_object(ETH_RPC_ERROR, err)
 }
 
-pub struct EthereumRpcConfig {
+pub struct EthereumRpcServerConfig {
     starting_l2_height: u64,
     trace_chain_block_limit: Option<u64>,
 }
@@ -194,7 +194,7 @@ where
     Da: DaService,
 {
     ethereum: Arc<Ethereum<C, Da>>,
-    config: EthereumRpcConfig,
+    config: EthereumRpcServerConfig,
 }
 
 impl<C, Da> EthereumRpcServerImpl<C, Da>
@@ -202,7 +202,7 @@ where
     C: sov_modules_api::Context,
     Da: DaService,
 {
-    pub fn new(ethereum: Arc<Ethereum<C, Da>>, config: EthereumRpcConfig) -> Self {
+    pub fn new(ethereum: Arc<Ethereum<C, Da>>, config: EthereumRpcServerConfig) -> Self {
         Self { ethereum, config }
     }
 }
@@ -664,7 +664,7 @@ where
         sequencer_client_url.map(|url| HttpClientBuilder::default().build(url).unwrap()),
         l2_block_rx,
     ));
-    let config = EthereumRpcConfig {
+    let config = EthereumRpcServerConfig {
         starting_l2_height: head_l2_block,
         trace_chain_block_limit: rpc_config.trace_chain_block_limit,
     };

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -12,6 +12,7 @@ use alloy_rpc_types::{
     SyncStatus as EthSyncStatus, Transaction,
 };
 use alloy_rpc_types_trace::geth::{GethDebugTracingOptions, GethTrace, TraceResult};
+use citrea_common::RpcConfig;
 use citrea_evm::{generate_eth_proof, Evm};
 use citrea_sequencer::SequencerRpcClient;
 pub use ethereum::{EthRpcConfig, Ethereum};
@@ -182,13 +183,18 @@ fn to_eth_rpc_error(err: impl ToString) -> ErrorObjectOwned {
     to_jsonrpsee_error_object(ETH_RPC_ERROR, err)
 }
 
+pub struct EthereumRpcConfig {
+    starting_l2_height: u64,
+    trace_chain_block_limit: Option<u64>,
+}
+
 pub struct EthereumRpcServerImpl<C, Da>
 where
     C: sov_modules_api::Context,
     Da: DaService,
 {
     ethereum: Arc<Ethereum<C, Da>>,
-    starting_l2_height: U64,
+    config: EthereumRpcConfig,
 }
 
 impl<C, Da> EthereumRpcServerImpl<C, Da>
@@ -196,11 +202,8 @@ where
     C: sov_modules_api::Context,
     Da: DaService,
 {
-    pub fn new(ethereum: Arc<Ethereum<C, Da>>, starting_l2_height: U64) -> Self {
-        Self {
-            ethereum,
-            starting_l2_height,
-        }
+    pub fn new(ethereum: Arc<Ethereum<C, Da>>, config: EthereumRpcConfig) -> Self {
+        Self { ethereum, config }
     }
 }
 
@@ -497,7 +500,7 @@ where
             EthSyncStatus::None
         } else {
             EthSyncStatus::Info(Box::new(SyncInfo {
-                starting_block: U256::from(self.starting_l2_height),
+                starting_block: U256::from(self.config.starting_l2_height),
                 current_block: U256::from(head_l2_block),
                 highest_block: U256::from(highest_block),
                 warp_chunks_amount: None,
@@ -577,7 +580,7 @@ where
         opts: Option<GethDebugTracingOptions>,
     ) -> SubscriptionResult {
         if &topic == "traceChain" {
-            handle_debug_trace_chain(start_block, end_block, opts, pending, self.ethereum.clone())
+            handle_debug_trace_chain(start_block, end_block, opts, pending, self.ethereum.clone(), self.config.trace_chain_block_limit)
                 .await;
         } else {
             pending
@@ -625,6 +628,7 @@ where
 pub fn create_rpc_module<C, Da>(
     da_service: Arc<Da>,
     eth_rpc_config: EthRpcConfig,
+    rpc_config: RpcConfig,
     storage: C::Storage,
     ledger_db: LedgerDB,
     sequencer_client_url: Option<String>,
@@ -660,7 +664,11 @@ where
         sequencer_client_url.map(|url| HttpClientBuilder::default().build(url).unwrap()),
         l2_block_rx,
     ));
-    let server = EthereumRpcServerImpl::new(ethereum, U64::from(head_l2_block));
+    let config = EthereumRpcConfig {
+        starting_l2_height: head_l2_block,
+        trace_chain_block_limit: rpc_config.trace_chain_block_limit,
+    };
+    let server = EthereumRpcServerImpl::new(ethereum, config);
 
     let mut module = EthereumRpcServer::into_rpc(server);
 

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -183,8 +183,12 @@ fn to_eth_rpc_error(err: impl ToString) -> ErrorObjectOwned {
     to_jsonrpsee_error_object(ETH_RPC_ERROR, err)
 }
 
+/// Configuration for Ethereum RPC server.
 pub struct EthereumRpcServerConfig {
+    /// Head L2 height at the time of starting the server.
+    /// Used in `eth_syncing` endpoint.
     starting_l2_height: u64,
+    /// Maximum number of L2 blocks to be traced with debug_traceChain
     trace_chain_block_limit: Option<u64>,
 }
 

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -183,22 +183,14 @@ fn to_eth_rpc_error(err: impl ToString) -> ErrorObjectOwned {
     to_jsonrpsee_error_object(ETH_RPC_ERROR, err)
 }
 
-/// Configuration for Ethereum RPC server.
-pub struct EthereumRpcServerConfig {
-    /// Head L2 height at the time of starting the server.
-    /// Used in `eth_syncing` endpoint.
-    starting_l2_height: u64,
-    /// Maximum number of L2 blocks to be traced with debug_traceChain
-    trace_chain_block_limit: Option<u64>,
-}
-
 pub struct EthereumRpcServerImpl<C, Da>
 where
     C: sov_modules_api::Context,
     Da: DaService,
 {
     ethereum: Arc<Ethereum<C, Da>>,
-    config: EthereumRpcServerConfig,
+    starting_l2_height: U64,
+    trace_chain_block_limit: Option<u64>,
 }
 
 impl<C, Da> EthereumRpcServerImpl<C, Da>
@@ -206,8 +198,12 @@ where
     C: sov_modules_api::Context,
     Da: DaService,
 {
-    pub fn new(ethereum: Arc<Ethereum<C, Da>>, config: EthereumRpcServerConfig) -> Self {
-        Self { ethereum, config }
+    pub fn new(ethereum: Arc<Ethereum<C, Da>>, starting_l2_height: U64, trace_chain_block_limit: Option<u64>) -> Self {
+        Self {
+            ethereum,
+            starting_l2_height,
+            trace_chain_block_limit,
+        }
     }
 }
 
@@ -504,7 +500,7 @@ where
             EthSyncStatus::None
         } else {
             EthSyncStatus::Info(Box::new(SyncInfo {
-                starting_block: U256::from(self.config.starting_l2_height),
+                starting_block: U256::from(self.starting_l2_height),
                 current_block: U256::from(head_l2_block),
                 highest_block: U256::from(highest_block),
                 warp_chunks_amount: None,
@@ -584,7 +580,7 @@ where
         opts: Option<GethDebugTracingOptions>,
     ) -> SubscriptionResult {
         if &topic == "traceChain" {
-            handle_debug_trace_chain(start_block, end_block, opts, pending, self.ethereum.clone(), self.config.trace_chain_block_limit)
+            handle_debug_trace_chain(start_block, end_block, opts, pending, self.ethereum.clone(), self.trace_chain_block_limit)
                 .await;
         } else {
             pending
@@ -668,11 +664,11 @@ where
         sequencer_client_url.map(|url| HttpClientBuilder::default().build(url).unwrap()),
         l2_block_rx,
     ));
-    let config = EthereumRpcServerConfig {
-        starting_l2_height: head_l2_block,
-        trace_chain_block_limit: rpc_config.trace_chain_block_limit,
-    };
-    let server = EthereumRpcServerImpl::new(ethereum, config);
+    let server = EthereumRpcServerImpl::new(
+        ethereum, 
+        U64::from(head_l2_block),
+        rpc_config.trace_chain_block_limit
+    );
 
     let mut module = EthereumRpcServer::into_rpc(server);
 

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -28,6 +28,7 @@ pub async fn handle_debug_trace_chain<C: sov_modules_api::Context, Da: DaService
     opts: Option<GethDebugTracingOptions>,
     pending: PendingSubscriptionSink,
     ethereum: Arc<Ethereum<C, Da>>,
+    max_blocks: Option<u64>,
 ) {
     // start block is exclusive, hence latest is not supported
     let BlockNumberOrTag::Number(start_block) = start_block else {
@@ -43,6 +44,8 @@ pub async fn handle_debug_trace_chain<C: sov_modules_api::Context, Da: DaService
         .block_number(&mut working_set)
         .expect("Expected at least one block")
         .saturating_to();
+    let max_blocks = max_blocks.unwrap_or(u64::MAX);
+
     let end_block = match end_block {
         BlockNumberOrTag::Number(end_block) => {
             if end_block > latest_block_number {
@@ -66,6 +69,15 @@ pub async fn handle_debug_trace_chain<C: sov_modules_api::Context, Da: DaService
 
     if start_block >= end_block {
         pending.reject(EthApiError::InvalidBlockRange).await;
+        return;
+    } else if (end_block - start_block) > max_blocks {
+        pending
+            .reject(EthApiError::InvalidParams(
+                format!(
+                    "Block range too large. Maximum allowed range is {} blocks",
+                    max_blocks
+                )
+            )).await;
         return;
     }
 

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -70,7 +70,8 @@ pub async fn handle_debug_trace_chain<C: sov_modules_api::Context, Da: DaService
     if start_block >= end_block {
         pending.reject(EthApiError::InvalidBlockRange).await;
         return;
-    } else if (end_block - start_block) > max_blocks {
+    } 
+    if (end_block - start_block) > max_blocks {
         pending
             .reject(EthApiError::InvalidParams(
                 format!(

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -70,15 +70,14 @@ pub async fn handle_debug_trace_chain<C: sov_modules_api::Context, Da: DaService
     if start_block >= end_block {
         pending.reject(EthApiError::InvalidBlockRange).await;
         return;
-    } 
+    }
     if (end_block - start_block) > max_blocks {
         pending
-            .reject(EthApiError::InvalidParams(
-                format!(
-                    "Block range too large. Maximum allowed range is {} blocks",
-                    max_blocks
-                )
-            )).await;
+            .reject(EthApiError::InvalidParams(format!(
+                "Block range too large. Maximum allowed range is {} blocks",
+                max_blocks
+            )))
+            .await;
         return;
     }
 

--- a/resources/configs/testnet/rollup_config.toml
+++ b/resources/configs/testnet/rollup_config.toml
@@ -48,6 +48,10 @@ bind_port = 8080
 # max subscriptions per connection is default to 100
 # max_subscriptions_per_connection = 100
 
+# maximum number of L2 blocks to be traced with debug_traceChain,
+# no limit set by default.
+# trace_chain_block_limit = 100
+
 [runner]
 sequencer_client_url = "https://rpc.testnet.citrea.xyz"
 


### PR DESCRIPTION
# Description 
Adds `trace_chain_block_limit` to `RpcConfig`.
This limits DOS attacks where they open multiple web socket connections that `debug_subscribe` to `traceChain`, and trace big L2 ranges. 
Tested locally to observe that if the L2 range is limited, CPU and memory usage stays under control, and the node is able to respond to other RPCs.

## Linked Issues
- Fixes #2698 