### PR TITLE
feat: Restore bitcoin-da tx queue from tx_backup_dir

### DIFF
--- a/bin/citrea/tests/bitcoin/bitcoin_service.rs
+++ b/bin/citrea/tests/bitcoin/bitcoin_service.rs
@@ -53,7 +53,8 @@ impl TestCase for BitcoinServiceTest {
 
         let da_node = f.bitcoin_nodes.get(0).unwrap();
 
-        let service = get_default_service(&task_executor, &da_node.config).await;
+        let test_dir = Self::test_config().dir;
+        let service = get_default_service(&task_executor, &da_node.config, test_dir).await;
         let verifier = BitcoinVerifier::new(RollupParams {
             reveal_tx_prefix: REVEAL_TX_PREFIX.to_vec(),
             network: Network::Nightly,

--- a/bin/citrea/tests/bitcoin/bitcoin_verifier.rs
+++ b/bin/citrea/tests/bitcoin/bitcoin_verifier.rs
@@ -115,7 +115,9 @@ impl TestCase for BitcoinVerifierTest {
 
         let da_node = f.bitcoin_nodes.get(0).unwrap();
 
-        let service = get_default_service(&task_executor, &da_node.config).await;
+        let test_dir = Self::test_config().dir;
+        let service = get_default_service(&task_executor, &da_node.config, test_dir).await;
+
         let (block, _, _, _) = generate_mock_txs(&service, da_node, &task_executor).await;
 
         let (mut txs, inclusion_proof, completeness_proof) =

--- a/bin/citrea/tests/bitcoin/da_queue.rs
+++ b/bin/citrea/tests/bitcoin/da_queue.rs
@@ -391,9 +391,7 @@ async fn test_queue_da_transactions() -> Result<()> {
     .await
 }
 
-struct DaTransactionQueueingUtxoSelectionModeOldestTest {
-    task_manager: TaskManager,
-}
+struct DaTransactionQueueingUtxoSelectionModeOldestTest;
 
 impl DaTransactionQueueingUtxoSelectionModeOldestTest {
     // Test for `MempoolRejection("package-mempool-limits, possibly exceeds descendant size limit for tx 6a0c9e3c2fed9cbac73c88031e7333d0ce2242a664e3141ba028b765b0b1e562 [limit: 101000]` error
@@ -641,24 +639,21 @@ impl TestCase for DaTransactionQueueingUtxoSelectionModeOldestTest {
         }
     }
 
-    async fn cleanup(self) -> Result<()> {
-        self.task_manager
-            .graceful_shutdown_with_timeout(Duration::from_secs(1));
-        Ok(())
-    }
-
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
-        let task_executor = self.task_manager.executor();
+        let task_manager = TaskManager::current();
+        let task_executor = task_manager.executor();
 
         let da = f.bitcoin_nodes.get_mut(0).unwrap();
         let sequencer = f.sequencer.as_mut().unwrap();
         let full_node = f.full_node.as_mut().unwrap();
         let light_client_prover = f.light_client_prover.as_mut().unwrap();
 
+        let tx_backup_dir = Self::test_config().dir;
+
         let da_service = spawn_bitcoin_da_prover_service_with_utxo_selection_mode(
             &task_executor,
             &da.config,
-            Self::test_config().dir,
+            tx_backup_dir.clone(),
             UtxoSelectionMode::Oldest,
         )
         .await;
@@ -745,17 +740,72 @@ impl TestCase for DaTransactionQueueingUtxoSelectionModeOldestTest {
             commitment_1_state_root,
         )
         .await?;
+
+        // Clear up mempool
+        da.generate(1).await?;
+
+        let state_diff_400kb = create_random_state_diff(400);
+
+        let l1_hash = da.get_block_hash(finalized_height).await?;
+
+        // Create a 400kb batch proof
+        let verifiable_400kb_batch_proof =
+            create_serialized_fake_receipt_batch_proof_with_state_roots(
+                genesis_state_root,
+                20,
+                batch_proof_method_ids[0].method_id.into(),
+                Some(state_diff_400kb.clone()),
+                false,
+                l1_hash.as_raw_hash().to_byte_array(),
+                vec![commitment_1.clone()],
+                vec![commitment_1_state_root],
+                None,
+            );
+
+        // This over the mempool limit proof should be accepted and split up over multiple blocks
+        let res = da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::ZKProof(verifiable_400kb_batch_proof.clone()),
+                1,
+            )
+            .await;
+        assert!(res.is_ok());
+
+        da.wait_mempool_len(18, None).await?;
+        assert_eq!(da.get_raw_mempool().await?.len(), 18);
+
+        // Test restore queue behaviour. Drop and shutdown the existing da_service.
+        drop(da_service);
+        task_manager.graceful_shutdown_with_timeout(Duration::from_secs(1));
+
+        let task_manager = TaskManager::current();
+        let task_executor = task_manager.executor();
+        // Spawn to make sure it restores previous queued txs from tx_backup_dir
+        let _new_da_service = spawn_bitcoin_da_prover_service_with_utxo_selection_mode(
+            &task_executor,
+            &da.config,
+            tx_backup_dir,
+            UtxoSelectionMode::Oldest,
+        )
+        .await;
+
+        da.generate(1).await?;
+
+        // Make sure queued txs are properly restore on BitcoinService creation and re-sent
+        da.wait_mempool_len(6, None).await?;
+        assert_eq!(da.get_raw_mempool().await?.len(), 6);
+
+        task_manager.graceful_shutdown_with_timeout(Duration::from_secs(1));
+
         Ok(())
     }
 }
 
 #[tokio::test]
 async fn test_queue_da_transactions_oldest_mode() -> Result<()> {
-    TestCaseRunner::new(DaTransactionQueueingUtxoSelectionModeOldestTest {
-        task_manager: TaskManager::current(),
-    })
-    .set_citrea_path(get_citrea_path())
-    .set_citrea_cli_path(get_citrea_cli_path())
-    .run()
-    .await
+    TestCaseRunner::new(DaTransactionQueueingUtxoSelectionModeOldestTest)
+        .set_citrea_path(get_citrea_path())
+        .set_citrea_cli_path(get_citrea_cli_path())
+        .run()
+        .await
 }

--- a/bin/citrea/tests/bitcoin/sequencer_commitments.rs
+++ b/bin/citrea/tests/bitcoin/sequencer_commitments.rs
@@ -348,10 +348,12 @@ impl TestCase for SequencerCommitmentsFromDaTest {
         let sequencer = f.sequencer.as_mut().unwrap();
         let da = f.bitcoin_nodes.get(0).expect("DA not running.");
 
+        let test_dir = Self::test_config().dir;
         let da_service = spawn_bitcoin_da_with_wallet(
             &self.task_manager.executor(),
             &da.config,
             NodeKind::Sequencer.to_string(),
+            test_dir,
         )
         .await;
 

--- a/bin/citrea/tests/bitcoin/utils.rs
+++ b/bin/citrea/tests/bitcoin/utils.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -41,31 +40,15 @@ pub const SEQUENCER_DA_PRIVATE_KEY: &str =
 pub const PROVER_DA_PRIVATE_KEY: &str =
     "56D08C2DDE7F412F80EC99A0A328F76688C904BD4D1435281EFC9270EC8C8707";
 
-fn get_workspace_root() -> PathBuf {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    manifest_dir
-        .ancestors()
-        .nth(2)
-        .expect("Failed to find workspace root")
-        .to_path_buf()
-}
-
-fn get_tx_backup_dir() -> PathBuf {
-    get_workspace_root()
-        .join("resources")
-        .join("bitcoin")
-        .join("inscription_txs")
-        .to_path_buf()
-}
-
 pub async fn get_default_service(
     task_executor: &TaskExecutor,
     config: &BitcoinConfig,
+    test_dir: PathBuf,
 ) -> Arc<BitcoinService> {
     spawn_bitcoin_da_service(
         task_executor,
         config,
-        get_tx_backup_dir(),
+        test_dir,
         DaServiceKeyKind::Sequencer,
         REVEAL_TX_PREFIX.to_vec(),
         None,
@@ -78,11 +61,12 @@ pub async fn spawn_bitcoin_da_with_wallet(
     task_executor: &TaskExecutor,
     config: &BitcoinConfig,
     wallet: String,
+    test_dir: PathBuf,
 ) -> Arc<BitcoinService> {
     spawn_bitcoin_da_service(
         task_executor,
         config,
-        get_tx_backup_dir(),
+        test_dir,
         DaServiceKeyKind::Sequencer,
         REVEAL_TX_PREFIX.to_vec(),
         None,
@@ -364,8 +348,8 @@ pub async fn generate_mock_txs(
 ) {
     // Funding wallet requires block generation, hence we do funding at the beginning
     // to be able to write all transactions into the same block.
+    let wrong_prefix_wallet = tempfile::tempdir().unwrap().path().to_path_buf();
     let prefix_str = "wrong_prefix";
-    let wrong_prefix_wallet = PathBuf::from_str(prefix_str).unwrap();
     create_and_fund_wallet(prefix_str.to_string(), da_node).await;
     let wrong_prefix_da_service = spawn_bitcoin_da_service(
         task_executor,
@@ -378,9 +362,10 @@ pub async fn generate_mock_txs(
     )
     .await;
 
+    let wrong_key_wallet = tempfile::tempdir().unwrap().path().to_path_buf();
     let wrong_key_str = "wrong_key";
-    let wrong_key_wallet = PathBuf::from_str(wrong_key_str).unwrap();
     create_and_fund_wallet(wrong_key_str.to_string(), da_node).await;
+
     let wrong_key_da_service = spawn_bitcoin_da_service(
         task_executor,
         &da_node.config,
@@ -407,6 +392,7 @@ pub async fn generate_mock_txs(
         method_id: [0; 8],
         activation_l2_height: 0,
     };
+
     valid_method_ids.push(method_id.clone());
     da_service
         .send_transaction(DaTxRequest::BatchProofMethodId(method_id))
@@ -420,6 +406,7 @@ pub async fn generate_mock_txs(
     };
     seq_index += 1;
     valid_commitments.push(commitment.clone());
+
     da_service
         .send_transaction(DaTxRequest::SequencerCommitment(commitment))
         .await
@@ -432,6 +419,7 @@ pub async fn generate_mock_txs(
     };
     seq_index += 1;
     valid_commitments.push(commitment.clone());
+
     da_service
         .send_transaction(DaTxRequest::SequencerCommitment(commitment))
         .await

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -6,9 +6,9 @@
 use core::result::Result::Ok;
 use core::str::FromStr;
 use core::time::Duration;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::num::NonZeroUsize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -45,7 +45,9 @@ use crate::helpers::backup::backup_txs_to_file;
 use crate::helpers::builders::body_builders::{create_inscription_transactions, DaTxs, RawTxData};
 use crate::helpers::builders::TxWithId;
 use crate::helpers::merkle_tree::BitcoinMerkleTree;
-use crate::helpers::parsers::{parse_relevant_transaction, ParsedTransaction, VerifyParsed};
+use crate::helpers::parsers::{
+    parse_hex_transaction, parse_relevant_transaction, ParsedTransaction, VerifyParsed,
+};
 use crate::helpers::{merkle_tree, TransactionKind};
 use crate::metrics::BITCOIN_DA_METRICS as BM;
 use crate::monitoring::{MonitoredTxKind, MonitoringConfig, MonitoringService, TxStatus};
@@ -58,7 +60,7 @@ use crate::spec::short_proof::BitcoinHeaderShortProof;
 use crate::spec::transaction::TransactionWrapper;
 use crate::spec::utxo::UTXO;
 use crate::spec::{BitcoinSpec, RollupParams};
-use crate::tx_signer::{SignedTxPair, TxSigner};
+use crate::tx_signer::{SignedTxPair, SignedTxWithId, TxSigner};
 use crate::verifier::{
     BitcoinVerifier, MINIMUM_WITNESS_COMMITMENT_SIZE, WITNESS_COMMITMENT_PREFIX,
 };
@@ -172,6 +174,7 @@ impl BitcoinService {
         da_private_key: Option<SecretKey>,
         reveal_tx_prefix: Vec<u8>,
         tx_backup_dir: PathBuf,
+        tx_queue: Arc<Mutex<VecDeque<SignedTxPair>>>,
         utxo_selection_mode: UtxoSelectionMode,
     ) -> Self {
         Self {
@@ -188,7 +191,7 @@ impl BitcoinService {
             l1_block_hash_to_height: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(100).unwrap(),
             ))),
-            tx_queue: Arc::new(Mutex::new(VecDeque::new())),
+            tx_queue,
             utxo_selection_mode,
         }
     }
@@ -222,6 +225,8 @@ impl BitcoinService {
                 .context("Failed to create tx backup directory")?;
         }
 
+        let tx_queue = restore_tx_queue(&client, tx_backup_dir).await?;
+
         let da_private_key = config
             .da_private_key
             .as_ref()
@@ -240,6 +245,7 @@ impl BitcoinService {
             da_private_key,
             chain_params.reveal_tx_prefix,
             tx_backup_dir.to_path_buf(),
+            tx_queue,
             utxo_selection_mode,
         ))
     }
@@ -1509,4 +1515,94 @@ fn calculate_witness_root(txdata: &[TransactionWrapper], tx_count: usize) -> [u8
         })
         .collect();
     BitcoinMerkleTree::new(hashes).root()
+}
+
+async fn restore_tx_queue(
+    client: &Arc<Client>,
+    tx_backup_dir: &Path,
+) -> anyhow::Result<Arc<Mutex<VecDeque<SignedTxPair>>>> {
+    let mempool_txids = client.get_raw_mempool().await?;
+    let all_known_txids = client
+        .list_transactions(None, Some(1_000_000_000), None, None)
+        .await?
+        .into_iter()
+        .map(|tx| tx.info.txid)
+        .chain(mempool_txids.into_iter())
+        .collect::<HashSet<Txid>>();
+
+    let mut queue = VecDeque::new();
+
+    // Extract .txs file and sort them by creation time
+    let mut files: Vec<_> = std::fs::read_dir(tx_backup_dir)?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if path.extension()?.to_str()? == "txs" {
+                let metadata = entry.metadata().ok()?;
+                Some((path, metadata))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Sort by creation time
+    files.sort_by_key(|(_, metadata)| {
+        metadata
+            .created()
+            .or_else(|_| metadata.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+
+    for (path, _) in files {
+        let content = std::fs::read_to_string(&path)?;
+        let lines: Vec<&str> = content.lines().collect();
+
+        for chunk in lines.chunks(4) {
+            if let [commit, commit_hex, reveal, reveal_hex] = chunk {
+                let commit_txid = commit
+                    .split_ascii_whitespace()
+                    .last()
+                    .map(|txid| txid.parse::<Txid>())
+                    .context("Missing commit txid")??;
+
+                let reveal_txid = reveal
+                    .split_ascii_whitespace()
+                    .last()
+                    .map(|txid| txid.parse::<Txid>())
+                    .context("Missing reveal txid")??;
+
+                // Only restore if neither transaction is already known, they should be brought back to queue
+                if !all_known_txids.contains(&commit_txid)
+                    && !all_known_txids.contains(&reveal_txid)
+                {
+                    let commit_tx = parse_hex_transaction(commit_hex)?;
+                    let commit_hex = hex::decode(commit_hex)?;
+                    let commit_tx = SignedTxWithId::new(commit_hex, commit_tx, commit_txid);
+
+                    let reveal_tx = parse_hex_transaction(reveal_hex)?;
+                    let reveal_hex = hex::decode(reveal_hex)?;
+                    let reveal_tx = SignedTxWithId::new(reveal_hex, reveal_tx, reveal_txid);
+
+                    let tx_pair = SignedTxPair {
+                        commit: commit_tx,
+                        reveal: reveal_tx,
+                        kind: if commit.contains("chunk") {
+                            TransactionKind::Chunks
+                        } else if commit.contains("aggregate") {
+                            TransactionKind::Aggregate
+                        } else {
+                            TransactionKind::Complete
+                        },
+                    };
+
+                    queue.push_back(tx_pair);
+                }
+            }
+        }
+    }
+
+    info!("Restoring queue from tx_backup_dir {queue:?}");
+
+    Ok(Arc::new(Mutex::new(queue)))
 }

--- a/crates/bitcoin-da/src/tx_signer.rs
+++ b/crates/bitcoin-da/src/tx_signer.rs
@@ -23,6 +23,12 @@ pub(crate) struct SignedTxWithId {
     pub id: Txid,
 }
 
+impl SignedTxWithId {
+    pub fn new(hex: Vec<u8>, tx: Transaction, id: Txid) -> Self {
+        Self { hex, tx, id }
+    }
+}
+
 /// Pair of commit/reveal signed transactions
 #[derive(Debug, Clone)]
 pub(crate) struct SignedTxPair {


### PR DESCRIPTION
# Description

- Queued txs that were never broadcasted to bitcoin mempool (due to mempool policy limit) were not properly restored on startup via `listunspent`.
- Add an additional step that goes through tx_backup_dir, parses all the txs and put back tx in queue that are not found in `listtransactions` nor mempool
