### PR TITLE
fix: failed request lock stake bug

### DIFF
--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -567,6 +567,12 @@ impl BoundlessProver {
             }
         };
 
+        // This is usdc amount * 10^6 because usdc denomination is 6
+        // 1 usdc = 10^6 micro usdc (mwei)
+        let lock_stake = failed_request.offer.lockStake;
+        // Convert to usdc amount
+        let lock_stake = lock_stake.div_ceil(Unit::MWEI.wei_const());
+
         let new_request = self.build_proof_request(
             image_id,
             failed_request
@@ -588,7 +594,7 @@ impl BoundlessProver {
             (new_lock_timeout * 2) as u64,
             failed_request.offer.rampUpPeriod as u64,
             current_timestamp_as_secs(), // bidding start
-            failed_request.offer.lockStake.to::<u64>(),
+            lock_stake.to::<u64>(),
             // TODO: https://github.com/chainwayxyz/citrea/issues/2820
             None,
             None,


### PR DESCRIPTION
# Description
After fetching failed request I forgot to divide the lock stake by 10^6 because it will multiply with 10^6 in build proof request, that's why we've seen many requests with quadrillion usd stakes

