### PR TITLE
fix: ensure graceful shutdown in batch-prover L1/L2 syncers

### DIFF
--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -127,7 +127,20 @@ where
                     return;
                 }
                 _ = notifier.notified() => {
+                    // Check shutdown signal before acquiring lock to ensure graceful shutdown
+                    if shutdown_signal.is_shutdown() {
+                        info!("Shutdown signal received, stopping L1 block processing");
+                        return;
+                    }
+                    
                     let _l1_guard = backup_manager.start_l1_processing().await;
+                    
+                    // Check shutdown signal again after acquiring lock
+                    if shutdown_signal.is_shutdown() {
+                        info!("Shutdown signal received, stopping L1 block processing");
+                        return;
+                    }
+                    
                     if let Err(e) = self.process_l1_blocks().await {
                         error!("Could not process L1 blocks: {:?}", e);
                     }

--- a/crates/batch-prover/src/l2_syncer.rs
+++ b/crates/batch-prover/src/l2_syncer.rs
@@ -167,7 +167,20 @@ where
                     for l2_block in l2_blocks {
                         let mut backoff = ExponentialBackoff::default();
                         loop {
+                            // Check shutdown signal before acquiring lock to ensure graceful shutdown
+                            if shutdown_signal.is_shutdown() {
+                                info!("Shutdown signal received, stopping L2 block processing");
+                                return;
+                            }
+                            
                             let _l2_lock = backup_manager.start_l2_processing().await;
+                            
+                            // Check shutdown signal again after acquiring lock
+                            if shutdown_signal.is_shutdown() {
+                                info!("Shutdown signal received, stopping L2 block processing");
+                                return;
+                            }
+                            
                             match self.process_l2_block(&l2_block).await {
                                 Ok(_) => break,
                                 Err(e) => {


### PR DESCRIPTION
# Fix graceful shutdown issue in batch-prover L1 and L2 syncers

The batch-prover L1Syncer and L2Syncer components had a critical flaw where shutdown signals were only checked at the beginning of each select! iteration. 
This meant that during long-running block processing operations (which can take minutes due to STF computations, database operations, and exponential backoff retries), the components would not respond to shutdown signals, potentially causing:

1. Violation of the 5-second graceful shutdown timeout requirement
2. Data inconsistency from incomplete operations during forced termination
3. BackupManager lock contention blocking other components
4. Inconsistent behavior compared to other components (Prover, Fullnode)

Changes:
- Add shutdown signal checks before and after acquiring BackupManager locks
- Ensure immediate response to shutdown signals during block processing
- Maintain data integrity by stopping processing at safe points
- Align shutdown behavior with other components in the codebase