### PR TITLE
chore: mark spawn_bitcoin_da_prover_service_with_utxo_selection_mode for testing only

### DIFF
--- a/bin/citrea/tests/bitcoin/utils.rs
+++ b/bin/citrea/tests/bitcoin/utils.rs
@@ -125,6 +125,7 @@ pub async fn spawn_bitcoin_da_prover_service(
     .await
 }
 
+#[cfg(feature = "testing")]
 pub async fn spawn_bitcoin_da_prover_service_with_utxo_selection_mode(
     task_executor: &TaskExecutor,
     config: &BitcoinConfig,


### PR DESCRIPTION
To get rid of compiler warnings in vscode.