### PR TITLE
feat: Add enable JsTracer option

### DIFF
--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -452,7 +452,7 @@ pub fn create_default_rollup_config(
             max_subscriptions_per_connection: 100,
             trace_chain_block_limit: None,
             timeout: 30,
-            disable_js_tracer: false,
+            enable_js_tracer: true,
             api_key: None,
         },
         runner: match node_mode {

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -452,6 +452,7 @@ pub fn create_default_rollup_config(
             max_subscriptions_per_connection: 100,
             trace_chain_block_limit: None,
             timeout: 30,
+            disable_js_tracer: false,
             api_key: None,
         },
         runner: match node_mode {

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -478,6 +478,7 @@ mod tests {
                 max_subscriptions_per_connection: 200,
                 trace_chain_block_limit: Some(100),
                 timeout: 30,
+                disable_js_tracer: false,
                 api_key: None,
             },
             public_keys: RollupPublicKeys {
@@ -666,6 +667,7 @@ mod tests {
                 max_subscriptions_per_connection: 200,
                 trace_chain_block_limit: None,
                 timeout: 30,
+                disable_js_tracer: false,
                 api_key: None,
             },
             storage: StorageConfig {

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -478,7 +478,7 @@ mod tests {
                 max_subscriptions_per_connection: 200,
                 trace_chain_block_limit: Some(100),
                 timeout: 30,
-                disable_js_tracer: false,
+                enable_js_tracer: true,
                 api_key: None,
             },
             public_keys: RollupPublicKeys {
@@ -634,7 +634,7 @@ mod tests {
         std::env::set_var("RPC_MAX_CONNECTIONS", "500");
         std::env::set_var("RPC_ENABLE_SUBSCRIPTIONS", "true");
         std::env::set_var("RPC_MAX_SUBSCRIPTIONS_PER_CONNECTION", "200");
-        std::env::set_var("RPC_DISABLE_JS_TRACER", "true");
+        std::env::set_var("RPC_ENABLE_JS_TRACER", "true");
         std::env::set_var("RPC_TIMEOUT", "30");
 
         std::env::set_var(
@@ -668,7 +668,7 @@ mod tests {
                 max_subscriptions_per_connection: 200,
                 trace_chain_block_limit: None,
                 timeout: 30,
-                disable_js_tracer: true,
+                enable_js_tracer: true,
                 api_key: None,
             },
             storage: StorageConfig {

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -634,6 +634,7 @@ mod tests {
         std::env::set_var("RPC_MAX_CONNECTIONS", "500");
         std::env::set_var("RPC_ENABLE_SUBSCRIPTIONS", "true");
         std::env::set_var("RPC_MAX_SUBSCRIPTIONS_PER_CONNECTION", "200");
+        std::env::set_var("RPC_DISABLE_JS_TRACER", "true");
         std::env::set_var("RPC_TIMEOUT", "30");
 
         std::env::set_var(
@@ -667,7 +668,7 @@ mod tests {
                 max_subscriptions_per_connection: 200,
                 trace_chain_block_limit: None,
                 timeout: 30,
-                disable_js_tracer: false,
+                disable_js_tracer: true,
                 api_key: None,
             },
             storage: StorageConfig {

--- a/crates/common/src/config/rpc.rs
+++ b/crates/common/src/config/rpc.rs
@@ -42,8 +42,8 @@ const fn default_timeout() -> u64 {
 }
 
 #[inline]
-const fn default_disable_js_tracer() -> bool {
-    false
+const fn default_enable_js_tracer() -> bool {
+    true
 }
 
 /// RPC configuration.
@@ -77,9 +77,9 @@ pub struct RpcConfig {
     /// RPC timeout in secs
     #[serde(default = "default_timeout")]
     pub timeout: u64,
-    /// Disable JS tracer in debug endpoints
-    #[serde(default = "default_disable_js_tracer")]
-    pub disable_js_tracer: bool,
+    /// Enable JS tracer in debug endpoints
+    #[serde(default = "default_enable_js_tracer")]
+    pub enable_js_tracer: bool,
     /// API key for protected JSON-RPC methods
     pub api_key: Option<String>,
 }
@@ -129,10 +129,10 @@ impl FromEnv for RpcConfig {
                 .ok()
                 .and_then(|val| val.parse().ok())
                 .unwrap_or_else(default_timeout),
-            disable_js_tracer: read_env("RPC_DISABLE_JS_TRACER")
+            enable_js_tracer: read_env("RPC_ENABLE_JS_TRACER")
                 .ok()
                 .and_then(|val| val.parse().ok())
-                .unwrap_or_else(default_disable_js_tracer),
+                .unwrap_or_else(default_enable_js_tracer),
             api_key: read_env("RPC_API_KEY").ok(),
         })
     }

--- a/crates/common/src/config/rpc.rs
+++ b/crates/common/src/config/rpc.rs
@@ -41,6 +41,11 @@ const fn default_timeout() -> u64 {
     30
 }
 
+#[inline]
+const fn default_disable_js_tracer() -> bool {
+    false
+}
+
 /// RPC configuration.
 #[derive(Debug, Clone, PartialEq, Deserialize, Default, Serialize)]
 pub struct RpcConfig {
@@ -72,6 +77,8 @@ pub struct RpcConfig {
     /// RPC timeout in secs
     #[serde(default = "default_timeout")]
     pub timeout: u64,
+    #[serde(default = "default_disable_js_tracer")]
+    pub disable_js_tracer: bool,
     /// API key for protected JSON-RPC methods
     pub api_key: Option<String>,
 }
@@ -121,6 +128,10 @@ impl FromEnv for RpcConfig {
                 .ok()
                 .and_then(|val| val.parse().ok())
                 .unwrap_or_else(default_timeout),
+            disable_js_tracer: read_env("RPC_DISABLE_JS_TRACER")
+                .ok()
+                .and_then(|val| val.parse().ok())
+                .unwrap_or_else(default_disable_js_tracer),
             api_key: read_env("RPC_API_KEY").ok(),
         })
     }

--- a/crates/common/src/config/rpc.rs
+++ b/crates/common/src/config/rpc.rs
@@ -77,6 +77,7 @@ pub struct RpcConfig {
     /// RPC timeout in secs
     #[serde(default = "default_timeout")]
     pub timeout: u64,
+    /// Disable JS tracer in debug endpoints
     #[serde(default = "default_disable_js_tracer")]
     pub disable_js_tracer: bool,
     /// API key for protected JSON-RPC methods

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -12,7 +12,8 @@ use alloy_rpc_types::{
     SyncStatus as EthSyncStatus, Transaction, TransactionRequest,
 };
 use alloy_rpc_types_trace::geth::{
-    GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
+    GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
+    TraceResult,
 };
 use citrea_common::RpcConfig;
 use citrea_evm::{generate_eth_proof, Evm};

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -9,9 +9,10 @@ use alloy_primitives::{keccak256, Address, Bytes, B256, U256, U64};
 use alloy_rpc_types::serde_helpers::JsonStorageKey;
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, EIP1186AccountProofResponse, FeeHistory, Filter, Index, SyncInfo,
-    SyncStatus as EthSyncStatus, Transaction,
+    SyncStatus as EthSyncStatus, Transaction, TransactionRequest,
 };
-use alloy_rpc_types_trace::geth::{GethDebugTracingOptions, GethTrace, TraceResult};
+use alloy_rpc_types_trace::geth::{GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult};
+use alloy_rpc_types_trace::geth::GethDebugTracerType::JsTracer;
 use citrea_common::RpcConfig;
 use citrea_evm::{generate_eth_proof, Evm};
 use citrea_sequencer::SequencerRpcClient;
@@ -128,6 +129,16 @@ pub trait EthereumRpc {
         &self,
         tx_hash: B256,
         opts: Option<GethDebugTracingOptions>,
+    ) -> RpcResult<GethTrace>;
+
+    /// Handler for `debug_traceCall`
+    #[method(name = "debug_traceCall")]
+    #[blocking]
+    fn debug_trace_call(
+        &self,
+        request: TransactionRequest,
+        block_id: Option<BlockId>,
+        opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<GethTrace>;
 
     /// Returns the transaction pool content.
@@ -406,6 +417,31 @@ where
                 Err(EthApiError::EvmCustom(error.clone()).into())
             }
         }
+    }
+
+    fn debug_trace_call(
+        &self,
+        request: TransactionRequest,
+        block_id: Option<BlockId>,
+        opts: Option<GethDebugTracingCallOptions>,
+    ) -> RpcResult<GethTrace>{
+        let mut working_set = WorkingSet::new(self.ethereum.storage.clone());
+        let evm = Evm::<C>::default();
+
+        let is_js_tracer = matches!(
+            opts.as_ref().and_then(|o| o.tracing_options.tracer.as_ref()),
+            Some(JsTracer(_))
+        );
+        if is_js_tracer && self.disable_js_tracer {
+            return Err(EthApiError::Unsupported("JsTracer is disabled").into());
+        }
+        evm.debug_trace_call(
+            request,
+            block_id,
+            opts,
+            &mut working_set,
+            &self.ethereum.ledger_db,
+        )
     }
 
     // This method is implemented only for full nodes.

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -11,8 +11,9 @@ use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, EIP1186AccountProofResponse, FeeHistory, Filter, Index, SyncInfo,
     SyncStatus as EthSyncStatus, Transaction, TransactionRequest,
 };
+use alloy_rpc_types_trace::geth::GethDebugTracerType::JsTracer;
 use alloy_rpc_types_trace::geth::{
-    GethDebugTracerType::JsTracer, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
+    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use citrea_common::RpcConfig;
 use citrea_evm::{generate_eth_proof, Evm};

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -11,9 +11,8 @@ use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, EIP1186AccountProofResponse, FeeHistory, Filter, Index, SyncInfo,
     SyncStatus as EthSyncStatus, Transaction, TransactionRequest,
 };
-use alloy_rpc_types_trace::geth::GethDebugTracerType::JsTracer;
 use alloy_rpc_types_trace::geth::{
-    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
+    GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use citrea_common::RpcConfig;
 use citrea_evm::{generate_eth_proof, Evm};
@@ -433,7 +432,7 @@ where
         let is_js_tracer = matches!(
             opts.as_ref()
                 .and_then(|o| o.tracing_options.tracer.as_ref()),
-            Some(JsTracer(_))
+            Some(GethDebugTracerType::JsTracer(_))
         );
         if is_js_tracer && !self.enable_js_tracer {
             return Err(EthApiError::Unsupported("JsTracer is disabled on this node").into());

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -203,7 +203,7 @@ where
     ethereum: Arc<Ethereum<C, Da>>,
     starting_l2_height: U64,
     trace_chain_block_limit: Option<u64>,
-    disable_js_tracer: bool,
+    enable_js_tracer: bool,
 }
 
 impl<C, Da> EthereumRpcServerImpl<C, Da>
@@ -215,13 +215,13 @@ where
         ethereum: Arc<Ethereum<C, Da>>,
         starting_l2_height: U64,
         trace_chain_block_limit: Option<u64>,
-        disable_js_tracer: bool,
+        enable_js_tracer: bool,
     ) -> Self {
         Self {
             ethereum,
             starting_l2_height,
             trace_chain_block_limit,
-            disable_js_tracer,
+            enable_js_tracer,
         }
     }
 }
@@ -339,7 +339,7 @@ where
             &evm,
             &mut working_set,
             opts,
-            self.disable_js_tracer,
+            self.enable_js_tracer,
         )
         .map_err(to_eth_rpc_error)
     }
@@ -368,7 +368,7 @@ where
             &evm,
             &mut working_set,
             opts,
-            self.disable_js_tracer,
+            self.enable_js_tracer,
         )
         .map_err(to_eth_rpc_error)
     }
@@ -407,7 +407,7 @@ where
             &evm,
             &mut working_set,
             opts,
-            self.disable_js_tracer,
+            self.enable_js_tracer,
         )
         .map_err(to_eth_rpc_error)?;
 
@@ -434,7 +434,7 @@ where
                 .and_then(|o| o.tracing_options.tracer.as_ref()),
             Some(JsTracer(_))
         );
-        if is_js_tracer && self.disable_js_tracer {
+        if is_js_tracer && !self.enable_js_tracer {
             return Err(EthApiError::Unsupported("JsTracer is disabled on this node").into());
         }
         evm.debug_trace_call(
@@ -635,7 +635,7 @@ where
                 pending,
                 self.ethereum.clone(),
                 self.trace_chain_block_limit,
-                self.disable_js_tracer,
+                self.enable_js_tracer,
             )
             .await;
         } else {
@@ -724,7 +724,7 @@ where
         ethereum,
         U64::from(head_l2_block),
         rpc_config.trace_chain_block_limit,
-        rpc_config.disable_js_tracer,
+        rpc_config.enable_js_tracer,
     );
 
     let mut module = EthereumRpcServer::into_rpc(server);

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -11,9 +11,8 @@ use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, EIP1186AccountProofResponse, FeeHistory, Filter, Index, SyncInfo,
     SyncStatus as EthSyncStatus, Transaction, TransactionRequest,
 };
-use alloy_rpc_types_trace::geth::GethDebugTracerType::JsTracer;
 use alloy_rpc_types_trace::geth::{
-    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
+    GethDebugTracerType::JsTracer, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use citrea_common::RpcConfig;
 use citrea_evm::{generate_eth_proof, Evm};

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -436,7 +436,7 @@ where
             Some(GethDebugTracerType::JsTracer(_))
         );
         if is_js_tracer && !self.enable_js_tracer {
-            return Err(EthApiError::Unsupported("JsTracer is disabled on this node").into());
+            return Err(EthApiError::Unsupported("JsTracer is disabled.").into());
         }
         evm.debug_trace_call(
             request,

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -191,6 +191,7 @@ where
     ethereum: Arc<Ethereum<C, Da>>,
     starting_l2_height: U64,
     trace_chain_block_limit: Option<u64>,
+    disable_js_tracer: bool,
 }
 
 impl<C, Da> EthereumRpcServerImpl<C, Da>
@@ -202,11 +203,13 @@ where
         ethereum: Arc<Ethereum<C, Da>>,
         starting_l2_height: U64,
         trace_chain_block_limit: Option<u64>,
+        disable_js_tracer: bool,
     ) -> Self {
         Self {
             ethereum,
             starting_l2_height,
             trace_chain_block_limit,
+            disable_js_tracer,
         }
     }
 }
@@ -324,6 +327,7 @@ where
             &evm,
             &mut working_set,
             opts,
+            self.disable_js_tracer,
         )
         .map_err(to_eth_rpc_error)
     }
@@ -352,6 +356,7 @@ where
             &evm,
             &mut working_set,
             opts,
+            self.disable_js_tracer,
         )
         .map_err(to_eth_rpc_error)
     }
@@ -390,6 +395,7 @@ where
             &evm,
             &mut working_set,
             opts,
+            self.disable_js_tracer
         )
         .map_err(to_eth_rpc_error)?;
 
@@ -591,6 +597,7 @@ where
                 pending,
                 self.ethereum.clone(),
                 self.trace_chain_block_limit,
+                self.disable_js_tracer,
             )
             .await;
         } else {
@@ -679,6 +686,7 @@ where
         ethereum,
         U64::from(head_l2_block),
         rpc_config.trace_chain_block_limit,
+        rpc_config.disable_js_tracer,
     );
 
     let mut module = EthereumRpcServer::into_rpc(server);

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -11,8 +11,10 @@ use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, EIP1186AccountProofResponse, FeeHistory, Filter, Index, SyncInfo,
     SyncStatus as EthSyncStatus, Transaction, TransactionRequest,
 };
-use alloy_rpc_types_trace::geth::{GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult};
 use alloy_rpc_types_trace::geth::GethDebugTracerType::JsTracer;
+use alloy_rpc_types_trace::geth::{
+    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
+};
 use citrea_common::RpcConfig;
 use citrea_evm::{generate_eth_proof, Evm};
 use citrea_sequencer::SequencerRpcClient;
@@ -406,7 +408,7 @@ where
             &evm,
             &mut working_set,
             opts,
-            self.disable_js_tracer
+            self.disable_js_tracer,
         )
         .map_err(to_eth_rpc_error)?;
 
@@ -424,12 +426,13 @@ where
         request: TransactionRequest,
         block_id: Option<BlockId>,
         opts: Option<GethDebugTracingCallOptions>,
-    ) -> RpcResult<GethTrace>{
+    ) -> RpcResult<GethTrace> {
         let mut working_set = WorkingSet::new(self.ethereum.storage.clone());
         let evm = Evm::<C>::default();
 
         let is_js_tracer = matches!(
-            opts.as_ref().and_then(|o| o.tracing_options.tracer.as_ref()),
+            opts.as_ref()
+                .and_then(|o| o.tracing_options.tracer.as_ref()),
             Some(JsTracer(_))
         );
         if is_js_tracer && self.disable_js_tracer {

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -436,7 +436,7 @@ where
             Some(JsTracer(_))
         );
         if is_js_tracer && self.disable_js_tracer {
-            return Err(EthApiError::Unsupported("JsTracer is disabled").into());
+            return Err(EthApiError::Unsupported("JsTracer is disabled on this node").into());
         }
         evm.debug_trace_call(
             request,

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -147,7 +147,7 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
         None => false,
         Some(GethDebugTracerType::JsTracer(_)) => {
             if disable_js_tracer {
-                return Err(EthApiError::Unsupported("JS tracer is disabled").into());
+                return Err(EthApiError::Unsupported("JsTracer is disabled on this node").into());
             }
             true
         }

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -141,8 +141,7 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
     enable_js_tracer: bool,
 ) -> Result<Vec<TraceResult>, ErrorObjectOwned> {
     let is_js_tracer = matches!(
-        opts.as_ref()
-            .and_then(|o| o.tracer.as_ref()),
+        opts.as_ref().and_then(|o| o.tracer.as_ref()),
         Some(GethDebugTracerType::JsTracer(_))
     );
     if is_js_tracer && !enable_js_tracer {
@@ -154,9 +153,9 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
         o.tracer.as_ref().is_none_or(|inner| match inner {
             GethDebugTracerType::JsTracer(_) => true,
             GethDebugTracerType::BuiltInTracer(bit) => matches!(
-            bit,
-            GethDebugBuiltInTracerType::MuxTracer | GethDebugBuiltInTracerType::PreStateTracer
-        ),
+                bit,
+                GethDebugBuiltInTracerType::MuxTracer | GethDebugBuiltInTracerType::PreStateTracer
+            ),
         })
     });
     if skip_cache {

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -140,6 +140,14 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
     opts: Option<GethDebugTracingOptions>,
     enable_js_tracer: bool,
 ) -> Result<Vec<TraceResult>, ErrorObjectOwned> {
+    let is_js_tracer = matches!(
+        opts.as_ref()
+            .and_then(|o| o.tracer.as_ref()),
+        Some(GethDebugTracerType::JsTracer(_))
+    );
+    if is_js_tracer && !enable_js_tracer {
+        return Err(EthApiError::Unsupported("JsTracer is disabled on this node").into());
+    }
     // If tracer option is not specified, or it is JsTracer, then do not check cache or insert cache, just perform the operation
     // Skip cache from JsTracer, MuxTracer and PreStateTracer
     let skip_cache = opts.as_ref().is_none_or(|o| {

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -146,7 +146,7 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
         Some(GethDebugTracerType::JsTracer(_))
     );
     if is_js_tracer && !enable_js_tracer {
-        return Err(EthApiError::Unsupported("JsTracer is disabled on this node").into());
+        return Err(EthApiError::Unsupported("JsTracer is disabled.").into());
     }
     // If tracer option is not specified, or it is JsTracer, then do not check cache or insert cache, just perform the operation
     // Skip cache from JsTracer, MuxTracer and PreStateTracer

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -142,21 +142,15 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
 ) -> Result<Vec<TraceResult>, ErrorObjectOwned> {
     // If tracer option is not specified, or it is JsTracer, then do not check cache or insert cache, just perform the operation
     // Skip cache from JsTracer, MuxTracer and PreStateTracer
-
-    let skip_cache = match opts.as_ref().and_then(|o| o.tracer.as_ref()) {
-        None => false,
-        Some(GethDebugTracerType::JsTracer(_)) => {
-            if !enable_js_tracer {
-                return Err(EthApiError::Unsupported("JsTracer is disabled on this node").into());
-            }
-            true
-        }
-        Some(GethDebugTracerType::BuiltInTracer(bit)) => matches!(
+    let skip_cache = opts.as_ref().is_none_or(|o| {
+        o.tracer.as_ref().is_none_or(|inner| match inner {
+            GethDebugTracerType::JsTracer(_) => true,
+            GethDebugTracerType::BuiltInTracer(bit) => matches!(
             bit,
             GethDebugBuiltInTracerType::MuxTracer | GethDebugBuiltInTracerType::PreStateTracer
         ),
-    };
-
+        })
+    });
     if skip_cache {
         let mut traces = evm.trace_block_transactions_by_number(
             block_number,

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -29,6 +29,7 @@ pub async fn handle_debug_trace_chain<C: sov_modules_api::Context, Da: DaService
     pending: PendingSubscriptionSink,
     ethereum: Arc<Ethereum<C, Da>>,
     max_blocks: Option<u64>,
+    disable_js_tracer: bool,
 ) {
     // start block is exclusive, hence latest is not supported
     let BlockNumberOrTag::Number(start_block) = start_block else {
@@ -96,6 +97,7 @@ pub async fn handle_debug_trace_chain<C: sov_modules_api::Context, Da: DaService
                 &evm,
                 &mut working_set,
                 opts.clone(),
+                disable_js_tracer,
             );
             match traces {
                 Ok(traces) => {
@@ -136,18 +138,34 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
     evm: &Evm<C>,
     working_set: &mut WorkingSet<C::Storage>,
     opts: Option<GethDebugTracingOptions>,
+    disable_js_tracer: bool,
 ) -> Result<Vec<TraceResult>, ErrorObjectOwned> {
     // If tracer option is not specified, or it is JsTracer, then do not check cache or insert cache, just perform the operation
     // Skip cache from JsTracer, MuxTracer and PreStateTracer
-    let skip_cache = opts.as_ref().is_none_or(|o| {
-        o.tracer.as_ref().is_none_or(|inner| match inner {
-            GethDebugTracerType::JsTracer(_) => true,
-            GethDebugTracerType::BuiltInTracer(bit) => matches!(
-                bit,
-                GethDebugBuiltInTracerType::MuxTracer | GethDebugBuiltInTracerType::PreStateTracer
-            ),
-        })
-    });
+
+    let skip_cache = match opts.as_ref().and_then(|o| o.tracer.as_ref()) {
+        None => { false }
+        Some(GethDebugTracerType::JsTracer(_)) => {
+            if disable_js_tracer {
+                return Err(EthApiError::Unsupported("JS tracer is disabled").into());
+            }
+            true
+        }
+        Some(GethDebugTracerType::BuiltInTracer(bit)) => matches!(
+            bit,
+            GethDebugBuiltInTracerType::MuxTracer | GethDebugBuiltInTracerType::PreStateTracer
+        ),
+    };
+
+    // let skip_cache = opts.as_ref().is_none_or(|o| {
+    //     o.tracer.as_ref().is_none_or(|inner| match inner {
+    //         GethDebugTracerType::JsTracer(_) => true,
+    //         GethDebugTracerType::BuiltInTracer(bit) => matches!(
+    //             bit,
+    //             GethDebugBuiltInTracerType::MuxTracer | GethDebugBuiltInTracerType::PreStateTracer
+    //         ),
+    //     })
+    // });
     if skip_cache {
         let mut traces = evm.trace_block_transactions_by_number(
             block_number,

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -144,7 +144,7 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
     // Skip cache from JsTracer, MuxTracer and PreStateTracer
 
     let skip_cache = match opts.as_ref().and_then(|o| o.tracer.as_ref()) {
-        None => { false }
+        None => false,
         Some(GethDebugTracerType::JsTracer(_)) => {
             if disable_js_tracer {
                 return Err(EthApiError::Unsupported("JS tracer is disabled").into());

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -157,15 +157,6 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
         ),
     };
 
-    // let skip_cache = opts.as_ref().is_none_or(|o| {
-    //     o.tracer.as_ref().is_none_or(|inner| match inner {
-    //         GethDebugTracerType::JsTracer(_) => true,
-    //         GethDebugTracerType::BuiltInTracer(bit) => matches!(
-    //             bit,
-    //             GethDebugBuiltInTracerType::MuxTracer | GethDebugBuiltInTracerType::PreStateTracer
-    //         ),
-    //     })
-    // });
     if skip_cache {
         let mut traces = evm.trace_block_transactions_by_number(
             block_number,

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -29,7 +29,7 @@ pub async fn handle_debug_trace_chain<C: sov_modules_api::Context, Da: DaService
     pending: PendingSubscriptionSink,
     ethereum: Arc<Ethereum<C, Da>>,
     max_blocks: Option<u64>,
-    disable_js_tracer: bool,
+    enable_js_tracer: bool,
 ) {
     // start block is exclusive, hence latest is not supported
     let BlockNumberOrTag::Number(start_block) = start_block else {
@@ -97,7 +97,7 @@ pub async fn handle_debug_trace_chain<C: sov_modules_api::Context, Da: DaService
                 &evm,
                 &mut working_set,
                 opts.clone(),
-                disable_js_tracer,
+                enable_js_tracer,
             );
             match traces {
                 Ok(traces) => {
@@ -138,7 +138,7 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
     evm: &Evm<C>,
     working_set: &mut WorkingSet<C::Storage>,
     opts: Option<GethDebugTracingOptions>,
-    disable_js_tracer: bool,
+    enable_js_tracer: bool,
 ) -> Result<Vec<TraceResult>, ErrorObjectOwned> {
     // If tracer option is not specified, or it is JsTracer, then do not check cache or insert cache, just perform the operation
     // Skip cache from JsTracer, MuxTracer and PreStateTracer
@@ -146,7 +146,7 @@ pub fn debug_trace_by_block_number<C: sov_modules_api::Context, Da: DaService>(
     let skip_cache = match opts.as_ref().and_then(|o| o.tracer.as_ref()) {
         None => false,
         Some(GethDebugTracerType::JsTracer(_)) => {
-            if disable_js_tracer {
+            if !enable_js_tracer {
                 return Err(EthApiError::Unsupported("JsTracer is disabled on this node").into());
             }
             true

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1358,9 +1358,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
     /// Returns the trace of a call
     /// Returns trace for given tx request call.
-    ///
-    /// Handler for `debug_traceCall`
-    #[rpc_method(name = "debug_traceCall")]
     pub fn debug_trace_call(
         &self,
         request: TransactionRequest,

--- a/resources/configs/testnet/rollup_config.toml
+++ b/resources/configs/testnet/rollup_config.toml
@@ -52,6 +52,10 @@ bind_port = 8080
 # no limit set by default.
 # trace_chain_block_limit = 100
 
+# disables JS tracer in debug endpoints
+# false by default
+# disable_js_tracer = false
+
 [runner]
 sequencer_client_url = "https://rpc.testnet.citrea.xyz"
 

--- a/resources/configs/testnet/rollup_config.toml
+++ b/resources/configs/testnet/rollup_config.toml
@@ -52,9 +52,9 @@ bind_port = 8080
 # no limit set by default.
 # trace_chain_block_limit = 100
 
-# disables JS tracer in debug endpoints
-# false by default
-# disable_js_tracer = false
+# enables JS tracer in debug endpoints
+# true by default
+# enable_js_tracer = true
 
 [runner]
 sequencer_client_url = "https://rpc.testnet.citrea.xyz"


### PR DESCRIPTION
# Description
Rather than applying a timeout, which seems like a difficult task, this PR adds `enable_js_tracer` to the `RpcConfig`.
Also moved `debug_traceCall` handler to `EthereumRpcServerImpl` to check the newly added option.

## Linked Issues
- Fixes #2667 
