### PR TITLE
pruning: add runtime-gated state DB pruning

### DIFF
--- a/bin/citrea/tests/mock/mod.rs
+++ b/bin/citrea/tests/mock/mod.rs
@@ -128,7 +128,10 @@ async fn test_all_flow() {
         &fullnode_db_dir,
         &da_db_dir,
         NodeMode::FullNode(seq_port),
-        Some(PruningConfig { distance: 20 }),
+        Some(PruningConfig {
+            distance: 20,
+            ..Default::default()
+        }),
     );
     let full_node_task = start_rollup(
         full_node_port_tx,

--- a/bin/citrea/tests/mock/pruning.rs
+++ b/bin/citrea/tests/mock/pruning.rs
@@ -37,7 +37,10 @@ async fn test_state_db_pruning() -> Result<(), anyhow::Error> {
             da_path: da_db_dir,
             sequencer_path: sequencer_db_dir,
             fullnode_path: fullnode_db_dir,
-            pruning_config: Some(PruningConfig { distance: 20 }),
+            pruning_config: Some(PruningConfig {
+                distance: 20,
+                ..Default::default()
+            }),
             ..Default::default()
         })
         .await;
@@ -163,7 +166,10 @@ async fn test_native_db_pruning() -> Result<(), anyhow::Error> {
             da_path: da_db_dir,
             sequencer_path: sequencer_db_dir,
             fullnode_path: fullnode_db_dir,
-            pruning_config: Some(PruningConfig { distance: 20 }),
+            pruning_config: Some(PruningConfig {
+                distance: 20,
+                ..Default::default()
+            }),
             ..Default::default()
         })
         .await;

--- a/bin/cli/src/commands/prune.rs
+++ b/bin/cli/src/commands/prune.rs
@@ -22,7 +22,10 @@ pub(crate) async fn prune(
         db_path.display(),
         distance
     );
-    let config = PruningConfig { distance };
+    let config = PruningConfig {
+        distance,
+        ..Default::default()
+    };
 
     let column_families = cfs_from_node_type(node_type);
 

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -19,6 +19,11 @@ impl FromEnv for PruningConfig {
     fn from_env() -> anyhow::Result<Self> {
         Ok(PruningConfig {
             distance: read_env("PRUNING_DISTANCE")?.parse()?,
+            enable_state_pruning: read_env("ENABLE_STATE_PRUNING")
+                .ok()
+                .map(|v| v.parse())
+                .transpose()?
+                .unwrap_or(false),
         })
     }
 }
@@ -387,11 +392,17 @@ impl<'de> Deserialize<'de> for ProverGuestRunConfig {
 pub struct PruningConfig {
     /// Defines the number of blocks from the tip of the chain to remove.
     pub distance: u64,
+    /// Enables pruning of the state DB (JMT). Disabled by default for safety until fully validated.
+    #[serde(default)]
+    pub enable_state_pruning: bool,
 }
 
 impl Default for PruningConfig {
     fn default() -> Self {
-        Self { distance: 256 }
+        Self {
+            distance: 256,
+            enable_state_pruning: false,
+        }
     }
 }
 

--- a/crates/storage-ops/src/pruning/mod.rs
+++ b/crates/storage-ops/src/pruning/mod.rs
@@ -23,10 +23,11 @@ pub struct Pruner {
     /// Access to native DB.
     native_db: Arc<sov_schema_db::DB>,
     /// Access to state DB.
-    #[allow(dead_code)]
     state_db: Arc<sov_schema_db::DB>,
     /// Criteria to decide pruning
     criteria: Box<dyn Criteria + Send + Sync>,
+    /// If true, prune state DB alongside ledger/native.
+    enable_state_pruning: bool,
 }
 
 impl Pruner {
@@ -45,6 +46,7 @@ impl Pruner {
             state_db,
             native_db,
             criteria,
+            enable_state_pruning: config.enable_state_pruning,
         }
     }
 
@@ -61,30 +63,33 @@ impl Pruner {
             .should_prune(last_pruned_l2_height, current_l2_height)
     }
 
-    /// Prune everything
+    /// Prune everything up to the provided L2 block. State pruning is gated by configuration.
     pub async fn prune(&self, node_type: NodeType, up_to_block: u64) {
         info!("Pruning up to L2 block: {}", up_to_block);
         let ledger_db = self.ledger_db.clone();
 
         let native_db = self.native_db.clone();
 
-        // let state_db = self.state_db.clone();
+        let state_db = self.state_db.clone();
 
         let ledger_pruning_handle =
             tokio::task::spawn_blocking(move || prune_ledger(node_type, ledger_db, up_to_block));
 
-        // TODO: Fix me
-        // let state_db_pruning_handle =
-        //     tokio::task::spawn_blocking(move || prune_state_db(state_db, up_to_block));
+        let maybe_state_handle = if self.enable_state_pruning {
+            Some(tokio::task::spawn_blocking(move || {
+                state::prune_state_db(state_db, up_to_block)
+            }))
+        } else {
+            None
+        };
 
         let native_db_pruning_handle =
             tokio::task::spawn_blocking(move || prune_native_db(native_db, up_to_block));
 
-        future::join_all([
-            ledger_pruning_handle,
-            // state_db_pruning_handle,
-            native_db_pruning_handle,
-        ])
-        .await;
+        let mut handles = vec![ledger_pruning_handle, native_db_pruning_handle];
+        if let Some(h) = maybe_state_handle {
+            handles.push(h);
+        }
+        let _ = future::join_all(handles).await;
     }
 }

--- a/crates/storage-ops/src/tests.rs
+++ b/crates/storage-ops/src/tests.rs
@@ -41,7 +41,10 @@ async fn test_pruning_simple_run() {
         let state_db = StateDB::setup_schema_db(&rocksdb_config).unwrap();
 
         let pruner = Pruner::new(
-            PruningConfig { distance: 5 },
+            PruningConfig {
+                distance: 5,
+                ..Default::default()
+            },
             ledger_db.inner(),
             Arc::new(state_db),
             Arc::new(native_db),


### PR DESCRIPTION
- Add enable_state_pruning to PruningConfig (default false, supports ENABLE_STATE_PRUNING env).
- Propagate flag into Pruner; conditionally spawn prune_state_db at runtime.
- Remove #[allow(dead_code)] from state_db; keep progress semantics unchanged.
- Replace “TODO: Fix me” with explicit gated state pruning logic and join handling.
- Update callers to use PruningConfig { distance, ..Default::default() }.