### PR TITLE
fix: Add additional safe check to UTXO selection

### DIFF
--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -428,6 +428,7 @@ impl BitcoinService {
                 .filter(|utxo| {
                     utxo.spendable
                         && utxo.solvable
+                        && utxo.safe
                         && utxo.amount > Amount::from_sat(REVEAL_OUTPUT_AMOUNT)
                 })
                 .map(Into::into)
@@ -455,6 +456,7 @@ impl BitcoinService {
                 utxos.into_iter().filter(|utxo| {
                     utxo.spendable
                     && utxo.solvable
+                    && utxo.safe
                     && utxo.amount > Amount::from_sat(REVEAL_OUTPUT_AMOUNT)
                     // Remove utxo already in use by queued txs
                     && !txids.contains(&utxo.txid)


### PR DESCRIPTION
# Description

- Fixes cantina finding https://cantina.xyz/code/49b9e08d-4f8f-4103-b6e5-f5f43cf9faa1/findings/322
- Prevent choosing a RBF-able TX from outside keys

## Linked Issues
- Fixes #2866 