### PR TITLE
fix: Revert with correct message in `WitnessUtils`

### DIFF
--- a/crates/evm/src/evm/system_contracts/lib/WitnessUtils.sol
+++ b/crates/evm/src/evm/system_contracts/lib/WitnessUtils.sol
@@ -73,7 +73,7 @@ library WitnessUtils {
 
         for (uint256 i = 0; i < _nStackItems; i++) {
             (_varIntDataLen, _itemLen) = BTCUtils.parseVarIntAt(_witness, _at + _offset);
-            if (_itemLen == BTCUtils.ERR_BAD_ARG) {
+            if (_varIntDataLen == BTCUtils.ERR_BAD_ARG) {
                 return BTCUtils.ERR_BAD_ARG;
             }
 
@@ -121,12 +121,12 @@ library WitnessUtils {
 
         for (uint256 i = 0; i < _index; i++) {
             (_varIntDataLen, _itemLen) = BTCUtils.parseVarIntAt(_witness, _offset);
-            require(_itemLen != BTCUtils.ERR_BAD_ARG, "Bad VarInt in item");
+            require(_varIntDataLen != BTCUtils.ERR_BAD_ARG, "Bad VarInt in item");
             _offset += 1 + _varIntDataLen + _itemLen;
         }
 
         (_varIntDataLen, _itemLen) = BTCUtils.parseVarIntAt(_witness, _offset);
-        require(_itemLen != BTCUtils.ERR_BAD_ARG, "Bad VarInt in item");
+        require(_varIntDataLen != BTCUtils.ERR_BAD_ARG, "Bad VarInt in item");
         return _witness.slice(_offset, _itemLen + _varIntDataLen + 1);
     }
 }

--- a/crates/evm/src/evm/system_contracts/test/WitnessUtils.t.sol
+++ b/crates/evm/src/evm/system_contracts/test/WitnessUtils.t.sol
@@ -5,6 +5,20 @@ import {Test, console} from "forge-std/Test.sol";
 import "forge-std/console.sol";
 import "../lib/WitnessUtils.sol";
 
+contract WitnessUtilsHarness {
+    function determineWitnessLengthAt(bytes memory _witness, uint256 _at) public pure returns (uint256) {
+        return WitnessUtils.determineWitnessLengthAt(_witness, _at);
+    }
+
+    function extractWitnessAtIndex(bytes memory _witness, uint256 _index) public pure returns (bytes memory) {
+        return WitnessUtils.extractWitnessAtIndex(_witness, _index);
+    }
+
+    function extractItemFromWitness(bytes memory _witness, uint256 _index) public pure returns (bytes memory) {
+        return WitnessUtils.extractItemFromWitness(_witness, _index);
+    }
+}
+
 contract WitnessUtilsTest is Test {
     bytes4 version = hex"01000000";
     bytes2 flag = hex"0001";
@@ -20,6 +34,12 @@ contract WitnessUtilsTest is Test {
     bytes badWitness3 = hex"06096af9822fdb33bbfb940c6e6ea3d182c36de9c428de5606dbb8f257b63a10b66f7e408fcf8ed73ce3c3abf2aa28d809ef64e1bc35146424d00e072631fe3a08749c3380609e8fcd080582e984c1b5026351016404031f73220a964e3d835c33a0be6ca70206c9044dbc1b2c04b3411e";
     bytes badArgWitness = hex"0101ff";
     bytes badArgWitness2 = hex"0101ff01ff";
+    WitnessUtilsHarness witnessUtils;
+
+    function setUp() public {
+        witnessUtils = new WitnessUtilsHarness();
+    }
+
     // Helper function to run Python script and get its output
     function getRandomWitness() public returns (bytes memory) {
         string[] memory inputs = new string[](2);
@@ -152,7 +172,21 @@ contract WitnessUtilsTest is Test {
         }
 
         assertEq(randomStackItemArray[x], WitnessUtils.extractItemFromWitness(randomWits, x));
-    } 
+    }
+
+    function testExtractWitnessAtIndexMalformedItemVarInt() public {
+        // Expects varInt to have 2 bytes as it starts with `0xfd`
+        bytes memory witnessMalformedItemVarInt = hex"01fd00";
+        vm.expectRevert("Bad VarInt in witness");
+        witnessUtils.extractWitnessAtIndex(witnessMalformedItemVarInt, 0);
+    }
+
+    function testExtractItemFromWitnessMalformedItemVarInt() public {
+        // Expects varInt to have 2 bytes as it starts with `0xfd`
+        bytes memory witnessMalformedItemVarInt = hex"01fd00";
+        vm.expectRevert("Bad VarInt in item");
+        witnessUtils.extractItemFromWitness(witnessMalformedItemVarInt, 0);
+    }
 }
 
 


### PR DESCRIPTION
# Description
`BTCUtils.parseVarIntAt` returns `ERR_BAD_ARG`, which is max uint256, as its first return value in the case of varInt's length identifier being followed by fewer bytes than it should have (e.g. `fdaa` as `fd` should be followed by two bytes) 

## Linked Issues
- Fixes #2687