### PR TITLE
fix(da-monitoring): Continue status updates on TxStatus::Queued not found

### DIFF
--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -650,12 +650,13 @@ impl MonitoringService {
             match &monitored_tx.status {
                 // Check non-finalized TXs
                 TxStatus::Queued | TxStatus::Confirmed { .. } | TxStatus::Replaced { .. } => {
-                    let tx_result = self.client.get_transaction(txid, None).await?;
-                    let new_status = self
-                        .determine_tx_status(&tx_result, &monitored_tx.status)
-                        .await?;
+                    if let Ok(tx_result) = self.client.get_transaction(txid, None).await {
+                        let new_status = self
+                            .determine_tx_status(&tx_result, &monitored_tx.status)
+                            .await?;
 
-                    monitored_tx.status = new_status;
+                        monitored_tx.status = new_status;
+                    }
                 }
                 // Check evicted TXs that have already been rebroadcasted at least once
                 TxStatus::Evicted {


### PR DESCRIPTION
# Description

- Don't early exit on TxStatus::Queued not found

## Linked Issues
- Fixes #2869 
- Fixes https://cantina.xyz/code/49b9e08d-4f8f-4103-b6e5-f5f43cf9faa1/findings/639