### PR TITLE
fix: Bitcoin rpc timeout

### DIFF
--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -6,6 +6,7 @@ use bitcoin_da::fee::FeeService;
 use bitcoin_da::monitoring::MonitoringService;
 use bitcoin_da::network_constants::get_network_constants;
 use bitcoin_da::rpc::create_rpc_module as create_da_rpc_module;
+use bitcoin_da::rpc_client::BitcoinRpcClient;
 use bitcoin_da::service::{
     network_to_bitcoin_network, BitcoinService, BitcoinServiceConfig, TxidWrapper,
 };
@@ -113,7 +114,7 @@ impl RollupBlueprint for BitcoinRollup {
             network,
         };
         let da_config = &rollup_config.da;
-        let client = Arc::new(
+        let bitcoin_rpc_client = Arc::new(
             Client::new(
                 &da_config.node_url,
                 Auth::UserPass(
@@ -124,23 +125,31 @@ impl RollupBlueprint for BitcoinRollup {
             .await?,
         );
 
+        let client = Arc::new(BitcoinRpcClient::new(
+            bitcoin_rpc_client.clone(),
+            da_config.rpc_timeout_seconds,
+        ));
+
         let network = network_to_bitcoin_network(&chain_params.network);
         let network_constants = get_network_constants(&network);
         let (monitoring_service, block_rx) = MonitoringService::new(
-            client.clone(),
+            bitcoin_rpc_client.clone(),
             da_config.monitoring.clone(),
             network_constants.finality_depth,
         );
         let monitoring_service = Arc::new(monitoring_service);
 
-        let fee_service =
-            FeeService::new(client.clone(), network, da_config.mempool_space_url.clone());
+        let fee_service = FeeService::new(
+            bitcoin_rpc_client.clone(),
+            network,
+            da_config.mempool_space_url.clone(),
+        );
 
         let service = Arc::new(
             BitcoinService::from_config(
                 da_config,
                 chain_params,
-                client.clone(),
+                client,
                 network,
                 network_constants,
                 monitoring_service,

--- a/bin/citrea/tests/bitcoin/utils.rs
+++ b/bin/citrea/tests/bitcoin/utils.rs
@@ -8,6 +8,7 @@ use anyhow::bail;
 use bitcoin_da::fee::FeeService;
 use bitcoin_da::monitoring::{MonitoringConfig, MonitoringService};
 use bitcoin_da::network_constants::get_network_constants;
+use bitcoin_da::rpc_client::BitcoinRpcClient;
 use bitcoin_da::service::{
     network_to_bitcoin_network, BitcoinService, BitcoinServiceConfig, UtxoSelectionMode,
 };
@@ -174,6 +175,7 @@ pub async fn spawn_bitcoin_da_service(
         }),
         mempool_space_url: None,
         utxo_selection_mode,
+        rpc_timeout_seconds: Some(30),
     };
 
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -184,7 +186,7 @@ pub async fn spawn_bitcoin_da_service(
         network,
     };
 
-    let client = Arc::new(
+    let bitcoin_rpc_client = Arc::new(
         Client::new(
             &da_config.node_url,
             Auth::UserPass(
@@ -196,16 +198,25 @@ pub async fn spawn_bitcoin_da_service(
         .unwrap(),
     );
 
+    let client = Arc::new(BitcoinRpcClient::new(
+        bitcoin_rpc_client.clone(),
+        da_config.rpc_timeout_seconds,
+    ));
+
     let network = network_to_bitcoin_network(&chain_params.network);
     let network_constants = get_network_constants(&network);
     let (monitoring_service, block_rx) = MonitoringService::new(
-        client.clone(),
+        bitcoin_rpc_client.clone(),
         da_config.monitoring.clone(),
         network_constants.finality_depth,
     );
     let monitoring_service = Arc::new(monitoring_service);
 
-    let fee_service = FeeService::new(client.clone(), network, da_config.mempool_space_url.clone());
+    let fee_service = FeeService::new(
+        bitcoin_rpc_client.clone(),
+        network,
+        da_config.mempool_space_url.clone(),
+    );
 
     let service = Arc::new(
         BitcoinService::from_config(

--- a/crates/bitcoin-da/src/lib.rs
+++ b/crates/bitcoin-da/src/lib.rs
@@ -69,6 +69,9 @@ pub mod fee;
 #[cfg(feature = "native")]
 pub mod rpc;
 
+#[cfg(feature = "native")]
+pub mod rpc_client;
+
 #[cfg(feature = "testing")]
 pub mod test_utils;
 

--- a/crates/bitcoin-da/src/rpc_client.rs
+++ b/crates/bitcoin-da/src/rpc_client.rs
@@ -28,11 +28,6 @@ impl BitcoinRpcClient {
             timeout_duration,
         }
     }
-
-    /// Get inner client
-    pub fn inner(&self) -> &Arc<Client> {
-        &self.inner
-    }
 }
 
 #[async_trait]

--- a/crates/bitcoin-da/src/rpc_client.rs
+++ b/crates/bitcoin-da/src/rpc_client.rs
@@ -1,0 +1,59 @@
+//! Bitcoin RPC client wrapper with timeout protection
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bitcoincore_rpc::{Client, RpcApi};
+use serde_json::Value;
+use tokio::time::timeout;
+
+/// Default timeout for RPC calls in seconds
+const DEFAULT_RPC_TIMEOUT_SECONDS: u64 = 30;
+
+/// A wrapper around bitcoincore_rpc::Client that adds timeout to all RPC calls
+#[derive(Clone, Debug)]
+pub struct BitcoinRpcClient {
+    inner: Arc<Client>,
+    timeout_duration: Duration,
+}
+
+impl BitcoinRpcClient {
+    /// Create a new BitcoinRpcClient with the specified timeout
+    pub fn new(client: Arc<Client>, timeout_seconds: Option<u64>) -> Self {
+        let timeout_duration =
+            Duration::from_secs(timeout_seconds.unwrap_or(DEFAULT_RPC_TIMEOUT_SECONDS));
+        Self {
+            inner: client,
+            timeout_duration,
+        }
+    }
+
+    /// Get inner client
+    pub fn inner(&self) -> &Arc<Client> {
+        &self.inner
+    }
+}
+
+#[async_trait]
+impl RpcApi for BitcoinRpcClient {
+    async fn call<T: for<'a> serde::de::Deserialize<'a>>(
+        &self,
+        cmd: &str,
+        args: &[Value],
+    ) -> bitcoincore_rpc::Result<T> {
+        timeout(self.timeout_duration, self.inner.call(cmd, args))
+            .await
+            .map_err(|_| {
+                // Create an IO timeout error and convert it to bitcoincore_rpc Error
+                let io_err = std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!(
+                        "RPC call '{}' timed out after {:?}",
+                        cmd, self.timeout_duration
+                    ),
+                );
+                bitcoincore_rpc::Error::Io(io_err)
+            })?
+    }
+}

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -184,7 +184,7 @@ impl BitcoinService {
         utxo_selection_mode: UtxoSelectionMode,
     ) -> Self {
         Self {
-            tx_signer: TxSigner::new(client.inner().clone()),
+            tx_signer: TxSigner::new(client.clone()),
             client,
             network_constants,
             network,

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -21,7 +21,7 @@ use bitcoin::consensus::Decodable;
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::SecretKey;
 use bitcoin::{Amount, BlockHash, CompactTarget, Transaction, Txid, Wtxid};
-use bitcoincore_rpc::{Client, Error as BitcoinError, Error, RpcApi, RpcError};
+use bitcoincore_rpc::{Error as BitcoinError, Error, RpcApi, RpcError};
 use borsh::BorshDeserialize;
 use citrea_common::utils::read_env;
 use citrea_primitives::compression::{compress_blob, decompress_blob};
@@ -50,6 +50,7 @@ use crate::helpers::{merkle_tree, TransactionKind};
 use crate::metrics::BITCOIN_DA_METRICS as BM;
 use crate::monitoring::{MonitoredTxKind, MonitoringConfig, MonitoringService, TxStatus};
 use crate::network_constants::NetworkConstants;
+use crate::rpc_client::BitcoinRpcClient;
 use crate::spec::blob::BlobWithSender;
 use crate::spec::block::BitcoinBlock;
 use crate::spec::header::HeaderWrapper;
@@ -118,6 +119,9 @@ pub struct BitcoinServiceConfig {
 
     /// UTXO selection mode
     pub utxo_selection_mode: Option<UtxoSelectionMode>,
+
+    /// RPC timeout in seconds (default: 30)
+    pub rpc_timeout_seconds: Option<u64>,
 }
 
 impl citrea_common::FromEnv for BitcoinServiceConfig {
@@ -137,6 +141,11 @@ impl citrea_common::FromEnv for BitcoinServiceConfig {
                         .map_err(|e| anyhow!(e).context("Invalid UTXO_SELECTION_MODE"))
                 })
                 .transpose()?,
+            rpc_timeout_seconds: read_env("BITCOIN_RPC_TIMEOUT")
+                .ok()
+                .map(|v| v.parse::<u64>())
+                .transpose()
+                .context("Invalid BITCOIN_RPC_TIMEOUT")?,
         })
     }
 }
@@ -144,7 +153,7 @@ impl citrea_common::FromEnv for BitcoinServiceConfig {
 /// A service that provides data and data availability proofs for Bitcoin
 #[derive(Debug)]
 pub struct BitcoinService {
-    client: Arc<Client>,
+    client: Arc<BitcoinRpcClient>,
     pub(crate) network: bitcoin::Network,
     network_constants: NetworkConstants,
     pub(crate) da_private_key: Option<SecretKey>,
@@ -163,7 +172,7 @@ pub struct BitcoinService {
 impl BitcoinService {
     #[allow(clippy::too_many_arguments)]
     fn new(
-        client: Arc<Client>,
+        client: Arc<BitcoinRpcClient>,
         network: bitcoin::Network,
         network_constants: NetworkConstants,
         monitoring: Arc<MonitoringService>,
@@ -175,7 +184,7 @@ impl BitcoinService {
         utxo_selection_mode: UtxoSelectionMode,
     ) -> Self {
         Self {
-            tx_signer: TxSigner::new(client.clone()),
+            tx_signer: TxSigner::new(client.inner().clone()),
             client,
             network_constants,
             network,
@@ -198,7 +207,7 @@ impl BitcoinService {
     pub async fn from_config(
         config: &BitcoinServiceConfig,
         chain_params: RollupParams,
-        client: Arc<Client>,
+        client: Arc<BitcoinRpcClient>,
         network: bitcoin::Network,
         network_constants: NetworkConstants,
         monitoring: Arc<MonitoringService>,

--- a/crates/bitcoin-da/src/tx_signer.rs
+++ b/crates/bitcoin-da/src/tx_signer.rs
@@ -6,13 +6,14 @@ use std::sync::Arc;
 use bitcoin::consensus::encode;
 use bitcoin::{Transaction, Txid};
 use bitcoincore_rpc::json::SignRawTransactionInput;
-use bitcoincore_rpc::{Client, RpcApi};
+use bitcoincore_rpc::RpcApi;
 use tracing::trace;
 
 use crate::error::BitcoinServiceError;
 use crate::helpers::builders::body_builders::DaTxs;
 use crate::helpers::builders::TxWithId;
 use crate::helpers::TransactionKind;
+use crate::rpc_client::BitcoinRpcClient;
 
 pub(crate) type Result<T> = std::result::Result<T, BitcoinServiceError>;
 
@@ -62,11 +63,11 @@ impl SignedTxPair {
 
 #[derive(Debug)]
 pub(crate) struct TxSigner {
-    client: Arc<Client>,
+    client: Arc<BitcoinRpcClient>,
 }
 
 impl TxSigner {
-    pub fn new(client: Arc<Client>) -> Self {
+    pub fn new(client: Arc<BitcoinRpcClient>) -> Self {
         Self { client }
     }
 


### PR DESCRIPTION
# Description

This introduces a wrapper RPC client around `bitcoincore-rpc::Client` to make sure all calls go through a predefined timeout.