### PR TITLE
Use constants instead of some magic numbers in method id update

### DIFF
--- a/bin/citrea/tests/bitcoin/utils.rs
+++ b/bin/citrea/tests/bitcoin/utils.rs
@@ -11,9 +11,15 @@ use bitcoin_da::spec::RollupParams;
 use citrea_batch_prover::rpc::BatchProverRpcClient;
 use citrea_e2e::config::BitcoinConfig;
 use citrea_e2e::node::{BatchProver, FullNode, NodeKind};
+use citrea_light_client_prover::circuit::{
+    SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS,
+};
 use citrea_primitives::REVEAL_TX_PREFIX;
 use reth_tasks::TaskExecutor;
 use sov_ledger_rpc::LedgerRpcClient;
+use sov_rollup_interface::da::{
+    SECURITY_COUNCIL_SIGNATURE_SIZE, SECURITY_COUNCIL_SIGNATURE_THRESHOLD,
+};
 use sov_rollup_interface::rpc::{JobRpcResponse, VerifiedBatchProofResponse};
 use sov_rollup_interface::Network;
 use tokio::time::sleep;
@@ -178,7 +184,9 @@ pub async fn wait_for_prover_job_count(
 }
 
 /// Converts a vector of signatures in Vec<u8> format to an array of signatures in [u8; 64] format
-fn from_vec_to_sigs(vec: Vec<(Vec<u8>, u8)>) -> [([u8; 64], u8); 3] {
+fn from_vec_to_sigs(
+    vec: Vec<(Vec<u8>, u8)>,
+) -> [([u8; SECURITY_COUNCIL_SIGNATURE_SIZE], u8); SECURITY_COUNCIL_SIGNATURE_THRESHOLD] {
     let mut sigs = Vec::new();
     for (v, i) in vec.into_iter() {
         sigs.push((v.try_into().unwrap(), i));
@@ -189,8 +197,12 @@ fn from_vec_to_sigs(vec: Vec<(Vec<u8>, u8)>) -> [([u8; 64], u8); 3] {
 /// Generates 5 valid keypairs and returns the public keys and signers from the given private keys
 pub(crate) fn generate_initial_pub_keys_with_signers_from_pks(
     private_keys: [[u8; 32]; 5],
-) -> ([[u8; 33]; 5], Vec<PrivateKeySigner>) {
-    let mut initial_da_pubkeys = [[0u8; 33]; 5];
+) -> (
+    [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS],
+    Vec<PrivateKeySigner>,
+) {
+    let mut initial_da_pubkeys =
+        [[0u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS];
     let mut signers = Vec::new();
 
     // Generate 5 valid keypairs and signatures
@@ -209,12 +221,12 @@ pub(crate) fn generate_initial_pub_keys_with_signers_from_pks(
 pub(crate) fn create_valid_signatures(
     signers: &[PrivateKeySigner],
     prehash: &B256,
-) -> [([u8; 64], u8); 3] {
+) -> [([u8; SECURITY_COUNCIL_SIGNATURE_SIZE], u8); SECURITY_COUNCIL_SIGNATURE_THRESHOLD] {
     let mut signatures_in_inscription = Vec::new();
 
     for (i, signer) in signers.iter().enumerate().take(3) {
         let sig = signer.sign_hash_sync(prehash).unwrap();
-        let signature = sig.as_bytes()[0..64].to_vec();
+        let signature = sig.as_bytes()[0..SECURITY_COUNCIL_SIGNATURE_SIZE].to_vec();
         signatures_in_inscription.push((signature, i as u8));
     }
 

--- a/bin/citrea/tests/bitcoin/utils.rs
+++ b/bin/citrea/tests/bitcoin/utils.rs
@@ -12,7 +12,7 @@ use citrea_batch_prover::rpc::BatchProverRpcClient;
 use citrea_e2e::config::BitcoinConfig;
 use citrea_e2e::node::{BatchProver, FullNode, NodeKind};
 use citrea_light_client_prover::circuit::{
-    SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS,
+    SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBER_COUNT,
 };
 use citrea_primitives::REVEAL_TX_PREFIX;
 use reth_tasks::TaskExecutor;
@@ -198,11 +198,11 @@ fn from_vec_to_sigs(
 pub(crate) fn generate_initial_pub_keys_with_signers_from_pks(
     private_keys: [[u8; 32]; 5],
 ) -> (
-    [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS],
+    [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBER_COUNT],
     Vec<PrivateKeySigner>,
 ) {
     let mut initial_da_pubkeys =
-        [[0u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS];
+        [[0u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBER_COUNT];
     let mut signers = Vec::new();
 
     // Generate 5 valid keypairs and signatures

--- a/crates/bitcoin-da/tests/test_utils.rs
+++ b/crates/bitcoin-da/tests/test_utils.rs
@@ -23,6 +23,7 @@ use citrea_primitives::{MAX_TX_BODY_SIZE, REVEAL_TX_PREFIX};
 use reth_tasks::TaskExecutor;
 use sov_rollup_interface::da::{
     BatchProofMethodId, BatchProofMethodIdBody, DaTxRequest, SequencerCommitment,
+    SECURITY_COUNCIL_SIGNATURE_SIZE, SECURITY_COUNCIL_SIGNATURE_THRESHOLD,
 };
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::Network;
@@ -305,7 +306,9 @@ pub async fn generate_mock_txs(
     (block, valid_commitments, valid_proofs, valid_method_ids)
 }
 
-pub(crate) fn from_vec_to_sigs(vec: Vec<(Vec<u8>, u8)>) -> [([u8; 64], u8); 3] {
+pub(crate) fn from_vec_to_sigs(
+    vec: Vec<(Vec<u8>, u8)>,
+) -> [([u8; SECURITY_COUNCIL_SIGNATURE_SIZE], u8); SECURITY_COUNCIL_SIGNATURE_THRESHOLD] {
     let mut sigs = Vec::new();
     for (v, i) in vec.into_iter() {
         sigs.push((v.try_into().unwrap(), i));
@@ -336,12 +339,12 @@ pub(crate) fn generate_initial_pub_keys_with_signers_from_pks(
 pub(crate) fn create_valid_signatures(
     signers: &[PrivateKeySigner],
     prehash: &B256,
-) -> [([u8; 64], u8); 3] {
+) -> [([u8; SECURITY_COUNCIL_SIGNATURE_SIZE], u8); SECURITY_COUNCIL_SIGNATURE_THRESHOLD] {
     let mut signatures_in_inscription = Vec::new();
 
     for (i, signer) in signers.iter().enumerate().take(3) {
         let sig = signer.sign_hash_sync(prehash).unwrap();
-        let signature = sig.as_bytes()[0..64].to_vec();
+        let signature = sig.as_bytes()[0..SECURITY_COUNCIL_SIGNATURE_SIZE].to_vec();
         signatures_in_inscription.push((signature, i as u8));
     }
 

--- a/crates/light-client-prover/src/circuit/initial_values.rs
+++ b/crates/light-client-prover/src/circuit/initial_values.rs
@@ -9,7 +9,7 @@ use sov_rollup_interface::Network;
 
 use self::non_empty_slice::NonEmptySlice;
 #[cfg(feature = "native")]
-use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS};
+use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBER_COUNT};
 
 /// Genesis root for the Light Client Prover's Jellyfish Merkle Tree.
 pub(crate) const LCP_JMT_GENESIS_ROOT: [u8; 32] = match const_hex::const_decode_to_array(
@@ -30,7 +30,7 @@ const fn decode_to_u32_array(hex: &str) -> [u32; 8] {
 /// Module containing initial values for the mock DA specification.
 pub mod mockda {
     use super::non_empty_slice::NonEmptySlice;
-    use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS};
+    use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBER_COUNT};
 
     /// Genesis L2 genesis root for the mock DA.
     pub const GENESIS_ROOT: [u8; 32] = match const_hex::const_decode_to_array(
@@ -62,7 +62,7 @@ pub mod mockda {
     /// 3 out of 5 signatures are required to upgrade method IDs.
     pub const METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
         SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
-        SECURITY_COUNCIL_MEMBERS] = [
+        SECURITY_COUNCIL_MEMBER_COUNT] = [
         // Private key: 79122E48DF1A002FB6584B2E94D0D50F95037416C82DAF280F21CD67D17D9077
         match const_hex::const_decode_to_array(
             b"0313c4ff65eb94999e0ac41cfe21592baa52910f5a5ada9074b816de4f560189db",
@@ -104,7 +104,7 @@ pub mod mockda {
 pub mod bitcoinda {
     use super::decode_to_u32_array;
     use super::non_empty_slice::NonEmptySlice;
-    use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS};
+    use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBER_COUNT};
 
     pub const MAINNET_GENESIS_ROOT: [u8; 32] = match const_hex::const_decode_to_array(
         b"0000000000000000000000000000000000000000000000000000000000000000",
@@ -304,7 +304,7 @@ pub mod bitcoinda {
     /// 3 out of 5 signatures are required to upgrade method IDs.
     pub const MAINNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
         SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
-        SECURITY_COUNCIL_MEMBERS] = [
+        SECURITY_COUNCIL_MEMBER_COUNT] = [
         match const_hex::const_decode_to_array(
             b"000000000000000000000000000000000000000000000000000000000000000000",
         ) {
@@ -351,7 +351,7 @@ pub mod bitcoinda {
     /// 3 out of 5 signatures are required to upgrade method IDs.
     pub const TESTNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
         SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
-        SECURITY_COUNCIL_MEMBERS] = [
+        SECURITY_COUNCIL_MEMBER_COUNT] = [
         match const_hex::const_decode_to_array(
             b"000000000000000000000000000000000000000000000000000000000000000000",
         ) {
@@ -398,7 +398,7 @@ pub mod bitcoinda {
     /// 3 out of 5 signatures are required to upgrade method IDs.
     pub const DEVNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
         SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
-        SECURITY_COUNCIL_MEMBERS] = [
+        SECURITY_COUNCIL_MEMBER_COUNT] = [
         match const_hex::const_decode_to_array(
             b"03fd24a8555cd34585b80c826f25f7df42862a4f97b6bdaf263a3d1bb368f09790",
         ) {
@@ -447,7 +447,7 @@ pub mod bitcoinda {
     /// 3 out of 5 signatures are required to upgrade method IDs.
     pub const NIGHTLY_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
         SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
-        SECURITY_COUNCIL_MEMBERS] = [
+        SECURITY_COUNCIL_MEMBER_COUNT] = [
         {
             let hex_pub_key = match option_env!("METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEY_1") {
                 Some(k) => k,
@@ -521,7 +521,7 @@ pub mod bitcoinda {
     /// 3 out of 5 signatures are required to upgrade method IDs.
     pub const TEST_NETWORK_WITH_FORKS_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
         SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
-        SECURITY_COUNCIL_MEMBERS] = [
+        SECURITY_COUNCIL_MEMBER_COUNT] = [
         {
             let hex_pub_key = match option_env!("METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEY_1") {
                 Some(k) => k,
@@ -604,7 +604,7 @@ pub trait InitialValueProvider<Das: DaSpec> {
     /// Returns the public key of the method ID upgrade authority.
     fn method_id_upgrade_authority_da_public_keys(
         &self,
-    ) -> [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS];
+    ) -> [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBER_COUNT];
 }
 
 #[cfg(feature = "native")]
@@ -626,7 +626,7 @@ impl InitialValueProvider<MockDaSpec> for Network {
 
     fn method_id_upgrade_authority_da_public_keys(
         &self,
-    ) -> [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS] {
+    ) -> [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBER_COUNT] {
         assert_eq!(self, &Network::Nightly, "Only nightly allowed on mock da!");
         mockda::METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS
     }
@@ -675,7 +675,7 @@ impl InitialValueProvider<BitcoinSpec> for Network {
 
     fn method_id_upgrade_authority_da_public_keys(
         &self,
-    ) -> [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS] {
+    ) -> [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBER_COUNT] {
         match self {
             Network::Mainnet => bitcoinda::MAINNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS,
             Network::Testnet => bitcoinda::TESTNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS,

--- a/crates/light-client-prover/src/circuit/initial_values.rs
+++ b/crates/light-client-prover/src/circuit/initial_values.rs
@@ -8,6 +8,8 @@ use sov_modules_api::DaSpec;
 use sov_rollup_interface::Network;
 
 use self::non_empty_slice::NonEmptySlice;
+#[cfg(feature = "native")]
+use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS};
 
 /// Genesis root for the Light Client Prover's Jellyfish Merkle Tree.
 pub(crate) const LCP_JMT_GENESIS_ROOT: [u8; 32] = match const_hex::const_decode_to_array(
@@ -28,6 +30,7 @@ const fn decode_to_u32_array(hex: &str) -> [u32; 8] {
 /// Module containing initial values for the mock DA specification.
 pub mod mockda {
     use super::non_empty_slice::NonEmptySlice;
+    use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS};
 
     /// Genesis L2 genesis root for the mock DA.
     pub const GENESIS_ROOT: [u8; 32] = match const_hex::const_decode_to_array(
@@ -57,7 +60,9 @@ pub mod mockda {
 
     /// Public keys of the method ID upgrade authority in the mock DA.
     /// 3 out of 5 signatures are required to upgrade method IDs.
-    pub const METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8; 33]; 5] = [
+    pub const METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
+        SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+        SECURITY_COUNCIL_MEMBERS] = [
         // Private key: 79122E48DF1A002FB6584B2E94D0D50F95037416C82DAF280F21CD67D17D9077
         match const_hex::const_decode_to_array(
             b"0313c4ff65eb94999e0ac41cfe21592baa52910f5a5ada9074b816de4f560189db",
@@ -99,6 +104,7 @@ pub mod mockda {
 pub mod bitcoinda {
     use super::decode_to_u32_array;
     use super::non_empty_slice::NonEmptySlice;
+    use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS};
 
     pub const MAINNET_GENESIS_ROOT: [u8; 32] = match const_hex::const_decode_to_array(
         b"0000000000000000000000000000000000000000000000000000000000000000",
@@ -296,7 +302,9 @@ pub mod bitcoinda {
     // TODO: Update with real keys
     /// Public keys of the method ID upgrade authority in the Bitcoin DA on Mainnet.
     /// 3 out of 5 signatures are required to upgrade method IDs.
-    pub const MAINNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8; 33]; 5] = [
+    pub const MAINNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
+        SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+        SECURITY_COUNCIL_MEMBERS] = [
         match const_hex::const_decode_to_array(
             b"000000000000000000000000000000000000000000000000000000000000000000",
         ) {
@@ -341,7 +349,9 @@ pub mod bitcoinda {
     // TODO: Update with real keys
     /// Public keys of the method ID upgrade authority in the Bitcoin DA on Testnet.
     /// 3 out of 5 signatures are required to upgrade method IDs.
-    pub const TESTNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8; 33]; 5] = [
+    pub const TESTNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
+        SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+        SECURITY_COUNCIL_MEMBERS] = [
         match const_hex::const_decode_to_array(
             b"000000000000000000000000000000000000000000000000000000000000000000",
         ) {
@@ -386,7 +396,9 @@ pub mod bitcoinda {
 
     /// Public keys of the method ID upgrade authority in the Bitcoin DA on Devnet.
     /// 3 out of 5 signatures are required to upgrade method IDs.
-    pub const DEVNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8; 33]; 5] = [
+    pub const DEVNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
+        SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+        SECURITY_COUNCIL_MEMBERS] = [
         match const_hex::const_decode_to_array(
             b"03fd24a8555cd34585b80c826f25f7df42862a4f97b6bdaf263a3d1bb368f09790",
         ) {
@@ -433,7 +445,9 @@ pub mod bitcoinda {
     /// This public key is set at compile time via the `METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEY` environment variable.
     /// If the variable is not set, it defaults to a predefined value.
     /// 3 out of 5 signatures are required to upgrade method IDs.
-    pub const NIGHTLY_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8; 33]; 5] = [
+    pub const NIGHTLY_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
+        SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+        SECURITY_COUNCIL_MEMBERS] = [
         {
             let hex_pub_key = match option_env!("METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEY_1") {
                 Some(k) => k,
@@ -505,7 +519,9 @@ pub mod bitcoinda {
     /// This public key is set at compile time via the `METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEY` environment variable.
     /// If the variable is not set, it defaults to a predefined value.
     /// 3 out of 5 signatures are required to upgrade method IDs.
-    pub const TEST_NETWORK_WITH_FORKS_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8; 33]; 5] = [
+    pub const TEST_NETWORK_WITH_FORKS_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
+        SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+        SECURITY_COUNCIL_MEMBERS] = [
         {
             let hex_pub_key = match option_env!("METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEY_1") {
                 Some(k) => k,
@@ -586,7 +602,9 @@ pub trait InitialValueProvider<Das: DaSpec> {
     fn sequencer_da_public_key(&self) -> [u8; 33];
 
     /// Returns the public key of the method ID upgrade authority.
-    fn method_id_upgrade_authority_da_public_keys(&self) -> [[u8; 33]; 5];
+    fn method_id_upgrade_authority_da_public_keys(
+        &self,
+    ) -> [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS];
 }
 
 #[cfg(feature = "native")]
@@ -606,7 +624,9 @@ impl InitialValueProvider<MockDaSpec> for Network {
         mockda::BATCH_PROVER_DA_PUBLIC_KEY
     }
 
-    fn method_id_upgrade_authority_da_public_keys(&self) -> [[u8; 33]; 5] {
+    fn method_id_upgrade_authority_da_public_keys(
+        &self,
+    ) -> [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS] {
         assert_eq!(self, &Network::Nightly, "Only nightly allowed on mock da!");
         mockda::METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS
     }
@@ -653,7 +673,9 @@ impl InitialValueProvider<BitcoinSpec> for Network {
         }
     }
 
-    fn method_id_upgrade_authority_da_public_keys(&self) -> [[u8; 33]; 5] {
+    fn method_id_upgrade_authority_da_public_keys(
+        &self,
+    ) -> [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS] {
         match self {
             Network::Mainnet => bitcoinda::MAINNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS,
             Network::Testnet => bitcoinda::TESTNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS,

--- a/crates/light-client-prover/src/circuit/method_id_verifier.rs
+++ b/crates/light-client-prover/src/circuit/method_id_verifier.rs
@@ -5,13 +5,14 @@ use sov_rollup_interface::da::{
     SECURITY_COUNCIL_SIGNATURE_SIZE, SECURITY_COUNCIL_SIGNATURE_THRESHOLD,
 };
 
-use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS};
+use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBER_COUNT};
 
 /// The three out of 5 signatures should be verified for the method id upgrade to be valid.
 /// For each signature, the corresponding public key from the initial values constants is used to verify the signature.
 /// If there are less than 3 valid signatures, the verification fails.
 pub fn verify_method_id_security_council(
-    initial_da_pubkeys: [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS],
+    initial_da_pubkeys: [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+        SECURITY_COUNCIL_MEMBER_COUNT],
     msg: &[u8],
     signatures_with_idx: &[([u8; SECURITY_COUNCIL_SIGNATURE_SIZE], u8);
          SECURITY_COUNCIL_SIGNATURE_THRESHOLD],

--- a/crates/light-client-prover/src/circuit/method_id_verifier.rs
+++ b/crates/light-client-prover/src/circuit/method_id_verifier.rs
@@ -1,14 +1,20 @@
 use alloy_primitives::eip191_hash_message;
 use k256::ecdsa::signature::hazmat::PrehashVerifier;
 use k256::ecdsa::{Signature, VerifyingKey};
+use sov_rollup_interface::da::{
+    SECURITY_COUNCIL_SIGNATURE_SIZE, SECURITY_COUNCIL_SIGNATURE_THRESHOLD,
+};
+
+use crate::circuit::{SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS};
 
 /// The three out of 5 signatures should be verified for the method id upgrade to be valid.
 /// For each signature, the corresponding public key from the initial values constants is used to verify the signature.
 /// If there are less than 3 valid signatures, the verification fails.
 pub fn verify_method_id_security_council(
-    initial_da_pubkeys: [[u8; 33]; 5],
+    initial_da_pubkeys: [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS],
     msg: &[u8],
-    signatures_with_idx: &[([u8; 64], u8); 3],
+    signatures_with_idx: &[([u8; SECURITY_COUNCIL_SIGNATURE_SIZE], u8);
+         SECURITY_COUNCIL_SIGNATURE_THRESHOLD],
 ) -> bool {
     // EIP-191 prefix + keccak256 → 32-byte prehash
     let prehash = eip191_hash_message(msg);

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -23,7 +23,7 @@ use crate::circuit::method_id_verifier::verify_method_id_security_council;
 pub const SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE: usize = 33;
 
 /// Total number of security council members.
-pub const SECURITY_COUNCIL_MEMBERS: usize = 5;
+pub const SECURITY_COUNCIL_MEMBER_COUNT: usize = 5;
 
 /// Accessor (helpers) that are used inside the light client proof circuit.
 /// To access certain information that was saved to its state at one point.
@@ -291,7 +291,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
         batch_prover_da_public_key: &[u8],
         sequencer_da_public_key: &[u8],
         method_id_upgrade_authority_da_public_keys: &[[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
-             SECURITY_COUNCIL_MEMBERS],
+             SECURITY_COUNCIL_MEMBER_COUNT],
         network: Network,
     ) -> RunL1BlockResult<S> {
         let mut working_set =
@@ -545,7 +545,7 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
         batch_prover_da_public_key: &[u8],
         sequencer_da_public_key: &[u8],
         method_id_upgrade_authority_da_public_keys: &[[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
-             SECURITY_COUNCIL_MEMBERS],
+             SECURITY_COUNCIL_MEMBER_COUNT],
     ) -> Result<LightClientCircuitOutput, LightClientVerificationError<DaV>>
     where
         DaV: DaVerifier<Spec = DS>,

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -19,6 +19,12 @@ use sov_rollup_interface::Network;
 
 use crate::circuit::method_id_verifier::verify_method_id_security_council;
 
+/// Size of a compressed public key in bytes.
+pub const SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE: usize = 33;
+
+/// Total number of security council members.
+pub const SECURITY_COUNCIL_MEMBERS: usize = 5;
+
 /// Accessor (helpers) that are used inside the light client proof circuit.
 /// To access certain information that was saved to its state at one point.
 pub(crate) mod accessors;
@@ -284,7 +290,8 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
         initial_batch_proof_method_ids: InitialBatchProofMethodIds,
         batch_prover_da_public_key: &[u8],
         sequencer_da_public_key: &[u8],
-        method_id_upgrade_authority_da_public_keys: &[[u8; 33]; 5],
+        method_id_upgrade_authority_da_public_keys: &[[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+             SECURITY_COUNCIL_MEMBERS],
         network: Network,
     ) -> RunL1BlockResult<S> {
         let mut working_set =
@@ -537,7 +544,8 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
         initial_batch_proof_method_ids: InitialBatchProofMethodIds,
         batch_prover_da_public_key: &[u8],
         sequencer_da_public_key: &[u8],
-        method_id_upgrade_authority_da_public_keys: &[[u8; 33]; 5],
+        method_id_upgrade_authority_da_public_keys: &[[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+             SECURITY_COUNCIL_MEMBERS],
     ) -> Result<LightClientCircuitOutput, LightClientVerificationError<DaV>>
     where
         DaV: DaVerifier<Spec = DS>,

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -13,7 +13,7 @@ use sov_modules_core::Storage;
 use sov_prover_storage_manager::{Config, ProverStorage, ProverStorageManager};
 use sov_rollup_interface::da::{
     BatchProofMethodId, BatchProofMethodIdBody, BlobReaderTrait, DaVerifier, DataOnDa,
-    SequencerCommitment,
+    SequencerCommitment, SECURITY_COUNCIL_SIGNATURE_SIZE, SECURITY_COUNCIL_SIGNATURE_THRESHOLD,
 };
 use sov_rollup_interface::zk::batch_proof::output::v3::BatchProofCircuitOutputV3;
 use sov_rollup_interface::zk::batch_proof::output::{BatchProofCircuitOutput, CumulativeStateDiff};
@@ -22,7 +22,10 @@ use sov_rollup_interface::zk::light_client_proof::output::LightClientCircuitOutp
 use sov_rollup_interface::Network;
 
 use crate::circuit::accessors::ChunkAccessor;
-use crate::circuit::{citrea_network_to_method_id_upgrade_identifier, LightClientProofCircuit};
+use crate::circuit::{
+    citrea_network_to_method_id_upgrade_identifier, LightClientProofCircuit,
+    SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS,
+};
 
 /// Test private keys used for generating signatures in tests
 pub const TEST_PRIVATE_KEYS: [&str; 5] = [
@@ -199,7 +202,9 @@ pub(crate) fn create_prev_lcp_serialized(
 }
 
 /// Converts a vector of signatures in Vec<u8> format to an array of signatures in [u8; 64] format
-pub(crate) fn from_vec_to_sigs(vec: Vec<(Vec<u8>, u8)>) -> [([u8; 64], u8); 3] {
+pub(crate) fn from_vec_to_sigs(
+    vec: Vec<(Vec<u8>, u8)>,
+) -> [([u8; SECURITY_COUNCIL_SIGNATURE_SIZE], u8); SECURITY_COUNCIL_SIGNATURE_THRESHOLD] {
     let mut sigs = Vec::new();
     for (v, i) in vec.into_iter() {
         sigs.push((v.try_into().unwrap(), i));
@@ -210,8 +215,12 @@ pub(crate) fn from_vec_to_sigs(vec: Vec<(Vec<u8>, u8)>) -> [([u8; 64], u8); 3] {
 /// Generates 5 valid keypairs and returns the public keys and signers from the given private keys
 pub(crate) fn generate_initial_pub_keys_with_signers_from_pks(
     private_keys: [[u8; 32]; 5],
-) -> ([[u8; 33]; 5], Vec<PrivateKeySigner>) {
-    let mut initial_da_pubkeys = [[0u8; 33]; 5];
+) -> (
+    [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS],
+    Vec<PrivateKeySigner>,
+) {
+    let mut initial_da_pubkeys =
+        [[0u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS];
     let mut signers = Vec::new();
 
     // Generate 5 valid keypairs and signatures
@@ -227,8 +236,12 @@ pub(crate) fn generate_initial_pub_keys_with_signers_from_pks(
 }
 
 /// Generates 5 valid keypairs and returns the public keys and signers
-pub(crate) fn generate_initial_pub_keys_with_signers() -> ([[u8; 33]; 5], Vec<PrivateKeySigner>) {
-    let mut initial_da_pubkeys = [[0u8; 33]; 5];
+pub(crate) fn generate_initial_pub_keys_with_signers() -> (
+    [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS],
+    Vec<PrivateKeySigner>,
+) {
+    let mut initial_da_pubkeys =
+        [[0u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS];
     let mut signers = Vec::new();
 
     // Generate 5 valid keypairs and signatures
@@ -248,12 +261,12 @@ pub(crate) fn generate_initial_pub_keys_with_signers() -> ([[u8; 33]; 5], Vec<Pr
 pub(crate) fn create_valid_signatures(
     signers: &[PrivateKeySigner],
     prehash: &B256,
-) -> [([u8; 64], u8); 3] {
+) -> [([u8; SECURITY_COUNCIL_SIGNATURE_SIZE], u8); SECURITY_COUNCIL_SIGNATURE_THRESHOLD] {
     let mut signatures_in_inscription = Vec::new();
 
     for (i, signer) in signers.iter().enumerate().take(3) {
         let sig = signer.sign_hash_sync(prehash).unwrap();
-        let signature = sig.as_bytes()[0..64].to_vec();
+        let signature = sig.as_bytes()[0..SECURITY_COUNCIL_SIGNATURE_SIZE].to_vec();
         signatures_in_inscription.push((signature, i as u8));
     }
 
@@ -368,7 +381,8 @@ impl NativeCircuitRunner {
         inital_batch_proof_method_ids: Vec<(u64, [u32; 8])>,
         batch_prover_da_pub_key: &[u8],
         sequencer_da_pub_key: &[u8],
-        method_id_upgrade_authority: &[[u8; 33]; 5],
+        method_id_upgrade_authority: &[[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+             SECURITY_COUNCIL_MEMBERS],
         network: Network,
     ) -> LightClientCircuitInput<MockDaSpec> {
         let prover_storage = self

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -24,7 +24,7 @@ use sov_rollup_interface::Network;
 use crate::circuit::accessors::ChunkAccessor;
 use crate::circuit::{
     citrea_network_to_method_id_upgrade_identifier, LightClientProofCircuit,
-    SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS,
+    SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBER_COUNT,
 };
 
 /// Test private keys used for generating signatures in tests
@@ -216,11 +216,11 @@ pub(crate) fn from_vec_to_sigs(
 pub(crate) fn generate_initial_pub_keys_with_signers_from_pks(
     private_keys: [[u8; 32]; 5],
 ) -> (
-    [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS],
+    [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBER_COUNT],
     Vec<PrivateKeySigner>,
 ) {
     let mut initial_da_pubkeys =
-        [[0u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS];
+        [[0u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBER_COUNT];
     let mut signers = Vec::new();
 
     // Generate 5 valid keypairs and signatures
@@ -237,11 +237,11 @@ pub(crate) fn generate_initial_pub_keys_with_signers_from_pks(
 
 /// Generates 5 valid keypairs and returns the public keys and signers
 pub(crate) fn generate_initial_pub_keys_with_signers() -> (
-    [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS],
+    [[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBER_COUNT],
     Vec<PrivateKeySigner>,
 ) {
     let mut initial_da_pubkeys =
-        [[0u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBERS];
+        [[0u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE]; SECURITY_COUNCIL_MEMBER_COUNT];
     let mut signers = Vec::new();
 
     // Generate 5 valid keypairs and signatures
@@ -382,7 +382,7 @@ impl NativeCircuitRunner {
         batch_prover_da_pub_key: &[u8],
         sequencer_da_pub_key: &[u8],
         method_id_upgrade_authority: &[[u8; SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
-             SECURITY_COUNCIL_MEMBERS],
+             SECURITY_COUNCIL_MEMBER_COUNT],
         network: Network,
     ) -> LightClientCircuitInput<MockDaSpec> {
         let prover_storage = self

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
@@ -10,6 +10,11 @@ use sha2::{Digest, Sha256};
 use crate::zk::Proof;
 use crate::{BasicAddress, Network};
 
+/// Minimum number of verified signatures required to approve a method id upgrade.
+pub const SECURITY_COUNCIL_SIGNATURE_THRESHOLD: usize = 3;
+/// Size of a signature in bytes.
+pub const SECURITY_COUNCIL_SIGNATURE_SIZE: usize = 64;
+
 /// Commitments made to the DA layer from the sequencer.
 /// Has merkle root of l2 block hashes from L1 start block to L1 end block (inclusive)
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, BorshDeserialize, BorshSerialize)]
@@ -63,12 +68,15 @@ pub struct BatchProofMethodId {
     /// With it the indexes of the pubkeys that should be used to verify the signatures
     /// The indexes point to the pubkeys in the light client circuit initial values
     /// If one signature verification fails the whole method id update is invalid
-    pub signatures_with_index: [([u8; 64], u8); 3],
+    pub signatures_with_index:
+        [([u8; SECURITY_COUNCIL_SIGNATURE_SIZE], u8); SECURITY_COUNCIL_SIGNATURE_THRESHOLD],
 }
 
 impl BatchProofMethodId {
     /// Returns the signatures in the transaction.
-    pub fn signatures_with_index(&self) -> &[([u8; 64], u8); 3] {
+    pub fn signatures_with_index(
+        &self,
+    ) -> &[([u8; SECURITY_COUNCIL_SIGNATURE_SIZE], u8); SECURITY_COUNCIL_SIGNATURE_THRESHOLD] {
         &self.signatures_with_index
     }
 

--- a/guests/risc0/light-client-proof/bitcoin/src/bin/light_client_proof_bitcoin.rs
+++ b/guests/risc0/light-client-proof/bitcoin/src/bin/light_client_proof_bitcoin.rs
@@ -3,7 +3,9 @@ use bitcoin_da::spec::{BitcoinSpec, RollupParams};
 use bitcoin_da::verifier::BitcoinVerifier;
 use citrea_light_client_prover::circuit::initial_values::bitcoinda;
 use citrea_light_client_prover::circuit::initial_values::non_empty_slice::NonEmptySlice;
-use citrea_light_client_prover::circuit::LightClientProofCircuit;
+use citrea_light_client_prover::circuit::{
+    LightClientProofCircuit, SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBERS,
+};
 use citrea_primitives::REVEAL_TX_PREFIX;
 use citrea_risc0_adapter::guest::Risc0Guest;
 use sov_rollup_interface::da::DaVerifier;
@@ -65,7 +67,9 @@ const BATCH_PROVER_DA_PUBLIC_KEY: [u8; 33] = {
     }
 };
 
-pub const METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8; 33]; 5] = {
+pub const METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS: [[u8;
+    SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE];
+    SECURITY_COUNCIL_MEMBERS] = {
     match NETWORK {
         Network::Mainnet => bitcoinda::MAINNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS,
         Network::Testnet => bitcoinda::TESTNET_METHOD_ID_UPGRADE_AUTHORITY_DA_PUBLIC_KEYS,


### PR DESCRIPTION
# Description
Uses constants instead of some magic numbers in method id update
