### PR TITLE
chore: Use correct order of modifiers for `bytesToBytes32`

### DIFF
--- a/crates/evm/src/evm/system_contracts/src/Bridge.sol
+++ b/crates/evm/src/evm/system_contracts/src/Bridge.sol
@@ -481,7 +481,7 @@ contract Bridge is Ownable2StepUpgradeable, PausableUpgradeable {
         return true;
     }
 
-    function bytesToBytes32(bytes memory _source) pure internal returns (bytes32 result) {
+    function bytesToBytes32(bytes memory _source) internal pure returns (bytes32 result) {
         if (_source.length == 0) {
             return 0x0;
         }


### PR DESCRIPTION
Fixes Cantina automated findings [NonCritical-19].
