### PR TITLE
Remove unnecessary TransactionRequest clones in call/env preparation

### DIFF
--- a/crates/evm/src/evm/call.rs
+++ b/crates/evm/src/evm/call.rs
@@ -168,7 +168,7 @@ pub(crate) fn prepare_call_env(
 
     create_txn_env(
         block_env,
-        request.clone(),
+        request,
         Some(cap_to_balance),
         nonce,
         chain_id_to_set,

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -722,13 +722,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let nonce = request.nonce.unwrap_or(account.nonce);
         let chain_id = cfg_env.chain_id();
 
-        let tx_env = create_txn_env(
-            &block_env,
-            request.clone(),
-            Some(account.balance),
-            nonce,
-            chain_id,
-        )?;
+        let tx_env = create_txn_env(&block_env, request, Some(account.balance), nonce, chain_id)?;
 
         // can consume the list since we're not using the request anymore
         let access_list = request.access_list.take().unwrap_or_default();


### PR DESCRIPTION
- Replace request.clone() with moves in prepare_call_env and trace-call path in query.rs.
- These clones were not needed because the request is not used after create_txn_env in those contexts.
- Keeps clone in access-list flow where request is reused (access_list take/update and subsequent estimate), preserving existing behavior and avoiding accidental semantics changes.