### PR TITLE
fix: Prevent RISC0_DEV_MODE from being set on mainnet

### DIFF
--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -14,6 +14,7 @@ use citrea_common::rpc::{register_healthcheck_rpc, register_healthcheck_rpc_ligh
 use citrea_common::{from_toml_path, FromEnv, FullNodeConfig, NodeType};
 use citrea_light_client_prover::circuit::initial_values::InitialValueProvider;
 use citrea_light_client_prover::da_block_handler::StartVariant;
+use citrea_risc0_adapter::is_dev_mode_enabled_via_environment;
 use citrea_stf::genesis_config::GenesisPaths;
 use citrea_stf::runtime::{CitreaRuntime, DefaultContext};
 use clap::Parser;
@@ -70,6 +71,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     info!("Starting node on {network}");
+
+    // Prevent dev mode on mainnet
+    if network == Network::Mainnet && is_dev_mode_enabled_via_environment() {
+        panic!("RISC0_DEV_MODE is enabled but network is set to Mainnet. Dev mode SHOULD NOT be used on mainnet.");
+    }
 
     match args.da_layer {
         SupportedDaLayer::Mock => {

--- a/crates/risc0/src/lib.rs
+++ b/crates/risc0/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) fn receipt_from_proof(serialized_proof: &[u8]) -> Result<Receipt, Res
 // However in prover and verifier config it does the check automatically,
 // and will panic if env var is set to values below while the feature flag is set in risc0-zkvm.
 #[cfg(feature = "native")]
-pub(crate) fn is_dev_mode_enabled_via_environment() -> bool {
+pub fn is_dev_mode_enabled_via_environment() -> bool {
     std::env::var("RISC0_DEV_MODE")
         .ok()
         .map(|x| x.to_lowercase())

--- a/crates/risc0/src/lib.rs
+++ b/crates/risc0/src/lib.rs
@@ -56,12 +56,18 @@ pub(crate) fn receipt_from_proof(serialized_proof: &[u8]) -> Result<Receipt, Res
     }
 }
 
-// Copy of https://github.com/risc0/risc0/blob/912c2e198f3abc1094fa55e45840febaee203c22/risc0/zkvm/src/lib.rs#L205
-// Utility function to check if dev mode is enabled via environment variable
-// This function is deprecated in risc0, but we still need it here.
-// Be aware that this function does not check risc0 disable-dev-mode feature flag
-// However in prover and verifier config it does the check automatically,
-// and will panic if env var is set to values below while the feature flag is set in risc0-zkvm.
+/// Check if RISC0_DEV_MODE is enabled via environment variable.
+///
+/// This is a copy of https://github.com/risc0/risc0/blob/912c2e198f3abc1094fa55e45840febaee203c22/risc0/zkvm/src/lib.rs#L205
+/// This function is deprecated in risc0, but we still need it here.
+///
+/// # Note
+/// Be aware that this function does not check risc0 disable-dev-mode feature flag.
+/// However in prover and verifier config it does the check automatically,
+/// and will panic if env var is set to values below while the feature flag is set in risc0-zkvm.
+///
+/// # Returns
+/// Returns `true` if RISC0_DEV_MODE environment variable is set to "1", "true", or "yes".
 #[cfg(feature = "native")]
 pub fn is_dev_mode_enabled_via_environment() -> bool {
     std::env::var("RISC0_DEV_MODE")


### PR DESCRIPTION
# Description
```
❯ RISC0_DEV_MODE=1 ./target/debug/citrea --network mainnet --sequencer resources/configs/bitcoin-regtest/sequencer_config.toml --da-layer bitcoin --rollup-config-path ./resources/configs/bitcoin-regtest/sequencer_rollup_config.toml --genesis-paths ./resources/genesis/bitcoin-regtest
2025-09-30T10:23:16.149746Z  INFO citrea: Starting node on Mainnet
2025-09-30T10:23:17.246945Z ERROR panic: thread 'main' panicked at 'RISC0_DEV_MODE is enabled but network is set to Mainnet. Dev mode SHOULD NOT be used on mainnet.': bin/citrea/src/main.rs:77
```

## Linked Issues
- Fixes #2822 