### PR TITLE
chore: optimize sealed block read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,6 +2473,7 @@ dependencies = [
  "borsh",
  "bytes",
  "citrea-primitives",
+ "criterion",
  "hex",
  "itertools 0.13.0",
  "jsonrpsee",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -62,6 +62,7 @@ alloy-eips = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
 citrea-primitives = { path = "../primitives", features = ["testing"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 hex = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
@@ -110,3 +111,7 @@ native = [
   "dep:serde_json",
   "dep:tracing",
 ]
+
+[[bench]]
+name = "seal_slow_bench"
+harness = false

--- a/crates/evm/benches/seal_slow_bench.rs
+++ b/crates/evm/benches/seal_slow_bench.rs
@@ -1,0 +1,76 @@
+extern crate criterion;
+
+use alloy_consensus::constants::EMPTY_WITHDRAWALS;
+use alloy_consensus::EMPTY_OMMER_ROOT_HASH;
+use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
+use alloy_primitives::{Address, Bloom, Bytes, Sealable, B256, B64, U256};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use reth_primitives::Header;
+
+fn create_header(number: u64, gas_used: u64, tx_count: usize, extra_data_size: usize) -> Header {
+    let mut transactions_root = [0u8; 32];
+    transactions_root[0] = tx_count as u8;
+
+    Header {
+        parent_hash: B256::random(),
+        ommers_hash: EMPTY_OMMER_ROOT_HASH,
+        beneficiary: Address::random(),
+        state_root: B256::random(),
+        transactions_root: B256::from(transactions_root),
+        receipts_root: B256::random(),
+        withdrawals_root: Some(EMPTY_WITHDRAWALS),
+        logs_bloom: Bloom::default(),
+        difficulty: U256::ZERO,
+        number,
+        gas_limit: 30_000_000,
+        gas_used,
+        timestamp: 1234567890,
+        mix_hash: B256::ZERO,
+        nonce: B64::ZERO,
+        base_fee_per_gas: Some(1_000_000_000),
+        extra_data: Bytes::from(vec![0x42u8; extra_data_size]),
+        blob_gas_used: Some(0),
+        excess_blob_gas: Some(0),
+        parent_beacon_block_root: Some(B256::ZERO),
+        requests_hash: Some(EMPTY_REQUESTS_HASH),
+    }
+}
+
+fn bench_seal_slow_empty_block(c: &mut Criterion) {
+    let header = create_header(1, 0, 0, 0);
+    c.bench_function("seal_slow_empty_block", |b| {
+        b.iter(|| black_box(header.clone().seal_slow()))
+    });
+}
+
+fn bench_seal_slow_varying_tx_count(c: &mut Criterion) {
+    let mut group = c.benchmark_group("seal_slow_tx_count");
+
+    for tx_count in [0, 10, 100, 500, 1000] {
+        let header = create_header(1, 15_000_000, tx_count, 0);
+        group.bench_with_input(BenchmarkId::from_parameter(tx_count), &header, |b, h| {
+            b.iter(|| black_box(h.clone().seal_slow()))
+        });
+    }
+    group.finish();
+}
+
+fn bench_seal_slow_varying_extra_data(c: &mut Criterion) {
+    let mut group = c.benchmark_group("seal_slow_extra_data");
+
+    for size in [0, 32, 64, 128, 256] {
+        let header = create_header(1, 15_000_000, 100, size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &header, |b, h| {
+            b.iter(|| black_box(h.clone().seal_slow()))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_seal_slow_empty_block,
+    bench_seal_slow_varying_tx_count,
+    bench_seal_slow_varying_extra_data,
+);
+criterion_main!(benches);

--- a/crates/evm/src/evm/primitive_types.rs
+++ b/crates/evm/src/evm/primitive_types.rs
@@ -60,6 +60,11 @@ impl<H> Block<H> {
     pub fn transaction_range(&self) -> Range<u64> {
         self.transactions.clone()
     }
+
+    /// Get the header of this block
+    pub fn header(&self) -> &H {
+        &self.header
+    }
 }
 
 impl Block<AlloyHeader> {

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use std::vec;
 
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
-use alloy_primitives::{keccak256, Address, Bytes, TxHash, U256};
+use alloy_primitives::{keccak256, Address, Bytes, Sealable, TxHash, U256};
 use anyhow::{anyhow, bail};
 use backoff::future::retry as retry_backoff;
 use backoff::ExponentialBackoffBuilder;
@@ -558,7 +558,7 @@ where
         self.instrumented_apply_l2_block_txs(&l2_block_info, &signed_txs, &mut working_set)?;
         self.instrumented_end_l2_block(l2_block_info, &mut working_set)?;
 
-        let receipts = self.extract_receipts_from_working_set(l2_height, &mut working_set);
+        let receipts = self.extract_receipts_from_working_set(&mut working_set);
 
         assert_eq!(
             receipts.len(),
@@ -567,6 +567,9 @@ where
             evm_txs_count,
             receipts.len()
         );
+
+        let (reth_block, evm_block_hash) =
+            self.build_reth_block_from_working_set(&txs_to_run, &mut working_set);
 
         let l2_block_result =
             self.instrumented_finalize_l2_block(active_fork_spec, working_set, prestate);
@@ -624,18 +627,13 @@ where
         // Build notification using in-memory data instead of reading from DB
         let start_canonical_notification = Instant::now();
 
-        // Use the transactions we already have from dry_run (txs_to_run)
-        // and build block structure without DB reads
-        let (reth_block, reth_receipts, evm_block_hash) =
-            self.build_reth_block_data(l2_height, &txs_to_run, &senders, &receipts);
-
         // Create the Chain notification with the produced block data
         let chain = self.create_chain_notification(
             l2_height,
             evm_block_hash,
             reth_block,
             senders,
-            reth_receipts,
+            receipts.clone(),
             bundle_state,
         );
         // Send canonical state notification for mempool maintenance task
@@ -778,7 +776,6 @@ where
     /// Extracts receipts from the working set's accessory cache after end_l2_block
     fn extract_receipts_from_working_set(
         &self,
-        _l2_height: u64,
         working_set: &mut WorkingSet<ProverStorage>,
     ) -> Vec<reth_primitives::Receipt> {
         let block = self
@@ -799,6 +796,44 @@ where
             .iter()
             .map(|r| r.receipt.receipt.clone())
             .collect()
+    }
+
+    /// Builds reth block from the working set after end_l2_block
+    fn build_reth_block_from_working_set(
+        &self,
+        txs: &[RlpEvmTransaction],
+        working_set: &mut WorkingSet<ProverStorage>,
+    ) -> (reth_primitives::Block, alloy_primitives::B256) {
+        // Get the unsealed block from working set
+        let citrea_block = self
+            .db_provider
+            .evm
+            .get_head_block(working_set)
+            .expect("Head block must exist after end_l2_block");
+
+        // Seal the header to compute the hash
+        let sealed_header = citrea_block.header().clone().seal_slow();
+        let (header, evm_block_hash) = sealed_header.into_parts();
+
+        let reth_transactions: Vec<reth_primitives::TransactionSigned> = txs
+            .iter()
+            .map(|tx| {
+                // Decode RLP bytes to TransactionSigned
+                reth_primitives::TransactionSigned::decode_2718(&mut tx.rlp.as_ref())
+                    .expect("Transaction decoding should succeed")
+            })
+            .collect();
+
+        let block = reth_primitives::Block {
+            header,
+            body: reth_primitives::BlockBody {
+                transactions: reth_transactions,
+                ommers: Vec::new(),
+                withdrawals: None,
+            },
+        };
+
+        (block, evm_block_hash)
     }
 
     /// Finalizes the L2 block and records the time taken
@@ -956,52 +991,6 @@ where
         }
 
         bundle_state
-    }
-
-    /// Build block data from in-memory transactions without DB reads
-    fn build_reth_block_data(
-        &self,
-        l2_height: u64,
-        txs: &[RlpEvmTransaction],
-        _senders: &[alloy_primitives::Address],
-        receipts: &[reth_primitives::Receipt],
-    ) -> (reth_primitives::Block, Vec<Receipt>, alloy_primitives::B256) {
-        // For now, we still need one DB read to get the block header
-        // In a future optimization, we could cache this in memory too
-        let mut working_set = WorkingSet::new(self.db_provider.storage.clone());
-
-        let citrea_block = self
-            .db_provider
-            .evm
-            .get_block_by_height(l2_height, &mut working_set)
-            .unwrap_or_else(|| panic!("Block {} must exist after saving", l2_height));
-
-        let evm_block_hash = citrea_block.header.hash();
-
-        let header = citrea_block.header.clone().unseal();
-
-        let reth_transactions: Vec<reth_primitives::TransactionSigned> = txs
-            .iter()
-            .map(|tx| {
-                // Decode RLP bytes to TransactionSigned
-                reth_primitives::TransactionSigned::decode_2718(&mut tx.rlp.as_ref())
-                    .expect("Transaction decoding should succeed")
-            })
-            .collect();
-
-        // Use receipts directly - no DB reads or serialization needed!
-        let reth_receipts = receipts.to_vec();
-
-        let block = reth_primitives::Block {
-            header,
-            body: reth_primitives::BlockBody {
-                transactions: reth_transactions,
-                ommers: Vec::new(),
-                withdrawals: None,
-            },
-        };
-
-        (block, reth_receipts, evm_block_hash)
     }
 
     /// Creates a Chain notification from the produced L2 block

--- a/crates/sovereign-sdk/full-node/db/sov-db/Cargo.toml
+++ b/crates/sovereign-sdk/full-node/db/sov-db/Cargo.toml
@@ -44,3 +44,7 @@ tempfile = { workspace = true }
 name = "state_db_single_snapshot"
 path = "benches/state_db_bench.rs"
 harness = false
+
+[[bench]]
+name = "db_operations_bench"
+harness = false

--- a/crates/sovereign-sdk/full-node/db/sov-db/benches/db_operations_bench.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/benches/db_operations_bench.rs
@@ -1,0 +1,141 @@
+extern crate criterion;
+
+use std::sync::Arc;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use jmt::storage::TreeWriter;
+use jmt::{JellyfishMerkleTree, KeyHash};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use sov_db::rocks_db_config::RocksdbConfig;
+use sov_db::state_db::StateDB;
+
+fn generate_random_bytes(count: usize, size: usize) -> Vec<Vec<u8>> {
+    let seed: [u8; 32] = [1; 32];
+    let mut rng = StdRng::from_seed(seed);
+    (0..count)
+        .map(|_| (0..size).map(|_| rng.gen::<u8>()).collect())
+        .collect()
+}
+
+fn prepare_state_db(size: usize) -> (StateDB, tempfile::TempDir, Vec<Vec<u8>>) {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let raw_db = StateDB::setup_schema_db(&RocksdbConfig::new(tmpdir.path(), None, None)).unwrap();
+    let db = StateDB::new(Arc::new(raw_db));
+
+    let keys = generate_random_bytes(size, 32);
+    let values = generate_random_bytes(size, 64);
+
+    let mut key_preimages = Vec::with_capacity(size);
+    let mut batch = Vec::with_capacity(size);
+
+    for (key, value) in keys.iter().zip(values.iter()) {
+        let key_hash = KeyHash::with::<sha2::Sha256>(&key);
+        key_preimages.push((key_hash, key.as_slice()));
+        batch.push((key_hash, Some(value.clone())));
+    }
+
+    let jmt = JellyfishMerkleTree::<_, sha2::Sha256>::new(&db);
+    let (_root, _proof, tree_update) = jmt.put_value_set_with_proof(batch, 1).unwrap();
+
+    db.put_preimages(key_preimages).unwrap();
+    db.write_node_batch(&tree_update.node_batch).unwrap();
+
+    (db, tmpdir, keys)
+}
+
+fn bench_single_read(c: &mut Criterion) {
+    let test_data: Vec<_> = [100, 1000, 10_000]
+        .iter()
+        .map(|&size| {
+            let (db, tmpdir, keys) = prepare_state_db(size);
+            let key = keys[size / 2].clone();
+            (size, db, tmpdir, key)
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("single_read");
+
+    for (size, db, _tmpdir, key) in test_data {
+        group.bench_function(BenchmarkId::from_parameter(size), |b| {
+            b.iter(|| black_box(db.get_value_option_by_key(1, &key).unwrap()))
+        });
+    }
+    group.finish();
+}
+
+fn bench_sequential_reads(c: &mut Criterion) {
+    let test_data: Vec<_> = [10, 100]
+        .iter()
+        .map(|&size| {
+            let (db, tmpdir, keys) = prepare_state_db(size);
+            (size, db, tmpdir, keys)
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("sequential_reads");
+
+    for (size, db, _tmpdir, keys) in test_data {
+        group.bench_function(BenchmarkId::from_parameter(size), |b| {
+            b.iter(|| {
+                for key in &keys {
+                    black_box(db.get_value_option_by_key(1, key).unwrap());
+                }
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_random_reads(c: &mut Criterion) {
+    let test_data: Vec<_> = [100, 1000]
+        .iter()
+        .map(|&size| {
+            let (db, tmpdir, keys) = prepare_state_db(size);
+            let random_keys: Vec<_> = (0..100).map(|i| keys[(i * 17) % size].clone()).collect();
+            (size, db, tmpdir, random_keys)
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("random_reads");
+
+    for (size, db, _tmpdir, keys) in test_data {
+        group.bench_function(BenchmarkId::from_parameter(size), |b| {
+            b.iter(|| {
+                for key in &keys {
+                    black_box(db.get_value_option_by_key(1, key).unwrap());
+                }
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_miss_reads(c: &mut Criterion) {
+    let test_data: Vec<_> = [100, 1000, 10_000]
+        .iter()
+        .map(|&size| {
+            let (db, tmpdir, _) = prepare_state_db(size);
+            (size, db, tmpdir)
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("miss_reads");
+    let non_existent_key = vec![0xFFu8; 32];
+
+    for (size, db, _tmpdir) in test_data {
+        group.bench_function(BenchmarkId::from_parameter(size), |b| {
+            b.iter(|| black_box(db.get_value_option_by_key(1, &non_existent_key).unwrap()))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_single_read,
+    bench_sequential_reads,
+    bench_random_reads,
+    bench_miss_reads,
+);
+criterion_main!(benches);


### PR DESCRIPTION
# Benchmarks
## DB reads
```
❯ SKIP_GUEST_BUILD=1 cargo bench --bench db_operations_bench -p sov-db
   Compiling sov-db v0.7.4 (/home/rakan/Work/Chainway/citrea/crates/sovereign-sdk/full-node/db/sov-db)
    Finished `bench` profile [optimized] target(s) in 16.29s
     Running benches/db_operations_bench.rs (target/release/deps/db_operations_bench-86cc56588f63987b)
Gnuplot not found, using plotters backend
single_read/100         time:   [414.72 ns 418.32 ns 422.81 ns]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
single_read/1000        time:   [434.84 ns 436.45 ns 437.99 ns]
single_read/10000       time:   [428.23 ns 430.12 ns 432.02 ns]

sequential_reads/10     time:   [4.1761 µs 4.1948 µs 4.2144 µs]
sequential_reads/100    time:   [45.910 µs 45.965 µs 46.046 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

random_reads/100        time:   [47.263 µs 47.443 µs 47.654 µs]
Found 18 outliers among 100 measurements (18.00%)
  5 (5.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild
  6 (6.00%) high severe
random_reads/1000       time:   [47.982 µs 48.075 µs 48.149 µs]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild

miss_reads/100          time:   [445.66 ns 447.51 ns 449.34 ns]
miss_reads/1000         time:   [462.58 ns 464.81 ns 467.00 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
miss_reads/10000        time:   [471.90 ns 473.85 ns 475.81 ns]
```

## seal_slow calls
```
❯ SKIP_GUEST_BUILD=1 cargo bench --bench seal_slow_bench -p citrea-evm
   Compiling citrea-evm v0.7.4 (/home/rakan/Work/Chainway/citrea/crates/evm)
    Finished `bench` profile [optimized] target(s) in 15.63s
     Running benches/seal_slow_bench.rs (target/release/deps/seal_slow_bench-b2a38c795d7fce6a)
Gnuplot not found, using plotters backend
seal_slow_empty_block   time:   [1.9332 µs 1.9356 µs 1.9380 µs]
                        change: [-1.5617% -1.4579% -1.3647%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) low mild

seal_slow_tx_count/0    time:   [1.9669 µs 1.9709 µs 1.9742 µs]
                        change: [-1.4410% -1.0831% -0.7103%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  9 (9.00%) low severe
  6 (6.00%) low mild
seal_slow_tx_count/10   time:   [1.9659 µs 1.9724 µs 1.9786 µs]
                        change: [-4.6087% -4.1943% -3.7801%] (p = 0.00 < 0.05)
                        Performance has improved.
seal_slow_tx_count/100  time:   [1.9706 µs 1.9779 µs 1.9852 µs]
                        change: [-5.0616% -4.7239% -4.4268%] (p = 0.00 < 0.05)
                        Performance has improved.
seal_slow_tx_count/500  time:   [1.9589 µs 1.9674 µs 1.9757 µs]
                        change: [-3.9383% -3.5125% -3.0862%] (p = 0.00 < 0.05)
                        Performance has improved.
seal_slow_tx_count/1000 time:   [1.9701 µs 1.9788 µs 1.9870 µs]
                        change: [-4.0346% -3.6302% -3.2452%] (p = 0.00 < 0.05)
                        Performance has improved.

seal_slow_extra_data/0  time:   [1.9637 µs 1.9713 µs 1.9787 µs]
                        change: [-1.2122% -0.8563% -0.4834%] (p = 0.00 < 0.05)
                        Change within noise threshold.
seal_slow_extra_data/32 time:   [1.9887 µs 1.9978 µs 2.0066 µs]
                        change: [-1.9671% -1.5923% -1.2045%] (p = 0.00 < 0.05)
                        Performance has improved.
seal_slow_extra_data/64 time:   [1.9777 µs 1.9900 µs 2.0028 µs]
                        change: [-3.3267% -2.8028% -2.2540%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
seal_slow_extra_data/128
                        time:   [2.2201 µs 2.2299 µs 2.2402 µs]
                        change: [-2.7223% -2.3110% -1.9102%] (p = 0.00 < 0.05)
                        Performance has improved.
seal_slow_extra_data/256
                        time:   [2.4115 µs 2.4223 µs 2.4337 µs]
                        change: [-5.2321% -4.8444% -4.4402%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# Conclusion

Based on this, this PR is a demonstration that DB reads are around 4 times faster so we don't need this optimization of DB reads.

The reason why we thought this before was to make sure we don't need DB reads to collect mempool maintenance information. However, trying to remove the one DB read means that we have to read data PRIOR to the cache / working_set being committed. In this case, we won't have access to `SealedBlock` since it hasn't been sealed before committing it to DB.

## Linked Issues
- Fixes #2907 