### PR TITLE
Make method id network identifier chain id

### DIFF
--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -22,7 +22,7 @@ use citrea_e2e::framework::TestFramework;
 use citrea_e2e::test_case::{TestCase, TestCaseRunner};
 use citrea_e2e::Result;
 use citrea_fullnode::rpc::FullNodeRpcClient;
-use citrea_light_client_prover::circuit::citrea_network_to_method_id_upgrade_identifier;
+use citrea_light_client_prover::circuit::citrea_network_to_chain_id;
 use citrea_light_client_prover::rpc::LightClientProverRpcClient;
 use citrea_primitives::compression::{compress_blob, decompress_blob};
 use citrea_primitives::REVEAL_TX_PREFIX;
@@ -661,7 +661,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
         let method_id_body = BatchProofMethodIdBody {
             method_id: new_batch_proof_method_id,
             activation_l2_height: 210,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
 
         let pk_bytes_arr: [[u8; 32]; 5] = BATCH_PROOF_METHOD_ID_UPDATE_AUTHORITY_TEST_PRIVATE_KEYS
@@ -888,7 +888,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateSecurityCouncilTest {
         let method_id_body = BatchProofMethodIdBody {
             method_id: new_batch_proof_method_id,
             activation_l2_height: 220,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let pk_bytes_arr: [[u8; 32]; 5] = BATCH_PROOF_METHOD_ID_UPDATE_AUTHORITY_TEST_PRIVATE_KEYS
             .map(|s| hex::decode(s).unwrap().try_into().unwrap());
@@ -931,7 +931,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateSecurityCouncilTest {
         let method_id_body2 = BatchProofMethodIdBody {
             method_id: new_batch_proof_method_id2,
             activation_l2_height: 230,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let msg2 = method_id_body2.serialize();
         let prehash2 = eip191_hash_message(msg2.as_slice());
@@ -973,7 +973,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateSecurityCouncilTest {
         let method_id_body3 = BatchProofMethodIdBody {
             method_id: new_batch_proof_method_id3,
             activation_l2_height: 240,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let msg3 = method_id_body3.serialize();
         let prehash3 = eip191_hash_message(msg3.as_slice());
@@ -1013,7 +1013,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateSecurityCouncilTest {
         let method_id_body3 = BatchProofMethodIdBody {
             method_id: new_batch_proof_method_id3,
             activation_l2_height: 240,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let msg3 = method_id_body3.serialize();
         let prehash3 = eip191_hash_message(msg3.as_slice());
@@ -1053,7 +1053,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateSecurityCouncilTest {
         let method_id_body3 = BatchProofMethodIdBody {
             method_id: new_batch_proof_method_id3,
             activation_l2_height: 240,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let msg3 = method_id_body3.serialize();
         let prehash3 = eip191_hash_message(msg3.as_slice());
@@ -1097,7 +1097,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateSecurityCouncilTest {
         let method_id_body4 = BatchProofMethodIdBody {
             method_id: new_batch_proof_method_id4,
             activation_l2_height: 250,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Mainnet),
+            chain_id: citrea_network_to_chain_id(Network::Mainnet),
         };
         let msg4 = method_id_body4.serialize();
         let prehash4 = eip191_hash_message(msg4.as_slice());
@@ -1134,7 +1134,7 @@ impl TestCase for LightClientBatchProofMethodIdUpdateSecurityCouncilTest {
             method_id: new_batch_proof_method_id5,
             activation_l2_height: 260,
 
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let msg5 = method_id_body5.serialize();
         let prehash5 = eip191_hash_message(msg5.as_slice());

--- a/crates/bitcoin-da/tests/test_utils.rs
+++ b/crates/bitcoin-da/tests/test_utils.rs
@@ -150,7 +150,7 @@ pub async fn generate_mock_txs(
     let method_id_body = BatchProofMethodIdBody {
         method_id: [0; 8],
         activation_l2_height: 0,
-        network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+        chain_id: citrea_network_to_chain_id(Network::Nightly),
     };
 
     let msg = method_id_body.serialize();
@@ -271,7 +271,7 @@ pub async fn generate_mock_txs(
     let method_id_body = BatchProofMethodIdBody {
         method_id: [1; 8],
         activation_l2_height: 100,
-        network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+        chain_id: citrea_network_to_chain_id(Network::Nightly),
     };
 
     let msg = method_id_body.serialize();
@@ -537,12 +537,18 @@ pub mod macros {
 }
 
 // This will be removed in nightly since we moved these tests under binary
-fn citrea_network_to_method_id_upgrade_identifier(network: sov_rollup_interface::Network) -> u8 {
+/// These are chain ids for the citrea networks
+/// This function is mainly used to check the chain id of the
+/// method id upgrade transactions and to prevent cross network replay attacks
+/// The method id upgrade identifiers are not strictly tied to chain ids
+/// but for simplicity we use the same values
+pub fn citrea_network_to_chain_id(network: sov_rollup_interface::Network) -> u64 {
     match network {
+        // TODO: Change when decided
         sov_rollup_interface::Network::Mainnet => 1,
-        sov_rollup_interface::Network::Testnet => 10,
-        sov_rollup_interface::Network::Devnet => 100,
-        sov_rollup_interface::Network::Nightly => 105,
-        sov_rollup_interface::Network::TestNetworkWithForks => 106,
+        sov_rollup_interface::Network::Testnet => 5115,
+        sov_rollup_interface::Network::Devnet => 62298,
+        sov_rollup_interface::Network::Nightly => 5665,
+        sov_rollup_interface::Network::TestNetworkWithForks => 5665,
     }
 }

--- a/crates/light-client-prover/src/circuit/method_id_verifier.rs
+++ b/crates/light-client-prover/src/circuit/method_id_verifier.rs
@@ -74,7 +74,7 @@ mod tests {
     use sov_rollup_interface::Network;
 
     use super::*;
-    use crate::circuit::citrea_network_to_method_id_upgrade_identifier;
+    use crate::circuit::citrea_network_to_chain_id;
     use crate::{create_valid_signatures, generate_initial_pub_keys_with_signers};
 
     #[test]
@@ -82,7 +82,7 @@ mod tests {
         let body = BatchProofMethodIdBody {
             method_id: [0u32; 8],
             activation_l2_height: 0,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let msg = body.serialize();
         let prehash = eip191_hash_message(msg);
@@ -95,7 +95,7 @@ mod tests {
             body: BatchProofMethodIdBody {
                 method_id: [0u32; 8],
                 activation_l2_height: 0,
-                network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+                chain_id: citrea_network_to_chain_id(Network::Nightly),
             },
             signatures_with_index,
         };
@@ -112,7 +112,7 @@ mod tests {
         let body = BatchProofMethodIdBody {
             method_id: [0u32; 8],
             activation_l2_height: 0,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let msg = body.serialize();
         let prehash = eip191_hash_message(msg);
@@ -140,7 +140,7 @@ mod tests {
         let body = BatchProofMethodIdBody {
             method_id: [0u32; 8],
             activation_l2_height: 0,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let msg = body.serialize();
         let prehash = eip191_hash_message(msg);
@@ -168,7 +168,7 @@ mod tests {
         let body = BatchProofMethodIdBody {
             method_id: [0u32; 8],
             activation_l2_height: 0,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let msg = body.serialize();
         let prehash = eip191_hash_message(msg);
@@ -192,7 +192,7 @@ mod tests {
         let body = BatchProofMethodIdBody {
             method_id: [0u32; 8],
             activation_l2_height: 0,
-            network_id: citrea_network_to_method_id_upgrade_identifier(Network::Nightly),
+            chain_id: citrea_network_to_chain_id(Network::Nightly),
         };
         let msg = body.serialize();
         let prehash = eip191_hash_message(msg);

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -430,10 +430,9 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
                         continue;
                     }
 
-                    let circuit_network_id =
-                        citrea_network_to_method_id_upgrade_identifier(network);
-                    if circuit_network_id != batch_proof_method_id.body.network_id {
-                        log!("Method ID upgrade transactions network ID does not match circuit network ID");
+                    let circuit_chain_id = citrea_network_to_chain_id(network);
+                    if circuit_chain_id != batch_proof_method_id.body.chain_id {
+                        log!("Method ID upgrade transactions chain ID does not match circuit chain ID");
                         continue;
                     }
 
@@ -622,14 +621,18 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> Default for LightClientProofCircuit<S, DS,
     }
 }
 
-pub fn citrea_network_to_method_id_upgrade_identifier(
-    network: sov_rollup_interface::Network,
-) -> u8 {
+/// These are chain ids for the citrea networks
+/// This function is mainly used to check the chain id of the
+/// method id upgrade transactions and to prevent cross network replay attacks
+/// The method id upgrade identifiers are not strictly tied to chain ids
+/// but for simplicity we use the same values
+pub fn citrea_network_to_chain_id(network: sov_rollup_interface::Network) -> u64 {
     match network {
+        // TODO: Change when decided
         sov_rollup_interface::Network::Mainnet => 1,
-        sov_rollup_interface::Network::Testnet => 10,
-        sov_rollup_interface::Network::Devnet => 100,
-        sov_rollup_interface::Network::Nightly => 105,
-        sov_rollup_interface::Network::TestNetworkWithForks => 106,
+        sov_rollup_interface::Network::Testnet => 5115,
+        sov_rollup_interface::Network::Devnet => 62298,
+        sov_rollup_interface::Network::Nightly => 5665,
+        sov_rollup_interface::Network::TestNetworkWithForks => 5665,
     }
 }

--- a/crates/light-client-prover/src/tests/test_utils.rs
+++ b/crates/light-client-prover/src/tests/test_utils.rs
@@ -23,8 +23,8 @@ use sov_rollup_interface::Network;
 
 use crate::circuit::accessors::ChunkAccessor;
 use crate::circuit::{
-    citrea_network_to_method_id_upgrade_identifier, LightClientProofCircuit,
-    SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE, SECURITY_COUNCIL_MEMBER_COUNT,
+    citrea_network_to_chain_id, LightClientProofCircuit, SECURITY_COUNCIL_COMPRESSED_PUBKEY_SIZE,
+    SECURITY_COUNCIL_MEMBER_COUNT,
 };
 
 /// Test private keys used for generating signatures in tests
@@ -285,7 +285,7 @@ pub(crate) fn create_new_method_id_tx(
     let msg = borsh::to_vec(&BatchProofMethodIdBody {
         activation_l2_height: activation_height,
         method_id: new_method_id,
-        network_id: citrea_network_to_method_id_upgrade_identifier(network),
+        chain_id: citrea_network_to_chain_id(network),
     })
     .unwrap();
 
@@ -297,7 +297,7 @@ pub(crate) fn create_new_method_id_tx(
         body: BatchProofMethodIdBody {
             method_id: new_method_id,
             activation_l2_height: activation_height,
-            network_id: citrea_network_to_method_id_upgrade_identifier(network),
+            chain_id: citrea_network_to_chain_id(network),
         },
         signatures_with_index,
     });

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
@@ -46,7 +46,7 @@ pub struct BatchProofMethodIdBody {
     /// Activation L2 height of the new method id
     pub activation_l2_height: u64,
     /// Network identifier to prevent cross network replay attacks
-    pub network_id: u8,
+    pub chain_id: u64,
 }
 
 impl BatchProofMethodIdBody {


### PR DESCRIPTION
# Description
We now use chain id instead of a random network identifier for batch proof method id
