### PR TITLE
Remove unused `pruning/components/mod.rs` module

### DIFF
--- a/crates/storage-ops/src/pruning/components/mod.rs
+++ b/crates/storage-ops/src/pruning/components/mod.rs
@@ -1,8 +1,0 @@
-mod ledger_db;
-mod native_db;
-mod state_db;
-
-pub(crate) use ledger_db::*;
-pub(crate) use native_db::*;
-#[allow(unused_imports)]
-pub(crate) use state_db::*;


### PR DESCRIPTION

## Summary
Removes dead code module that references non-existent submodules and is no longer used.

## Changes
- Deleted `crates/storage-ops/src/pruning/components/mod.rs`
- Module contained references to non-existent `ledger_db`, `native_db`, `state_db` modules
- Actual pruning logic lives in `pruning/ledger`, `pruning/native.rs`, `pruning/state.rs`

