### PR TITLE
ci: migrate to tenki runners

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   linux_amd64_binary_extraction:
-    runs-on: tenki-standard-large-plus-16c-32g
+    runs-on: ubicloud-standard-30
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   linux_amd64_binary_extraction:
-    runs-on: ubicloud-standard-30
+    runs-on: tenki-standard-large-plus-16c-32g
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,7 +76,7 @@ concurrency:
 jobs:
   build:
     name: build
-    runs-on: ubicloud-standard-30
+    runs-on: tenki-standard-xlarge-32c-128g
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
@@ -115,7 +115,7 @@ jobs:
 
   check:
     name: check
-    runs-on: ubicloud-standard-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
@@ -148,7 +148,7 @@ jobs:
 
   udeps:
     name: udeps
-    runs-on: ubicloud-standard-8
+    runs-on: tenki-standard-large-8c-16g
     timeout-minutes: 60
     if: github.event.pull_request.draft == false
     steps:
@@ -180,7 +180,7 @@ jobs:
           args: "--workspace --all-features --all-targets"
 
   deny:
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-small-2c-4g
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v5
@@ -192,7 +192,7 @@ jobs:
   coverage:
     needs:
       - docker-setup
-    runs-on: ubicloud-standard-30
+    runs-on: tenki-standard-xlarge-32c-128g
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.85.0
@@ -245,7 +245,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   uniswap:
-    runs-on: ubicloud-standard-2
+    runs-on: tenki-standard-small-2c-4g
     needs: build
     if: github.event.pull_request.draft == false
     steps:
@@ -287,7 +287,7 @@ jobs:
           fi
 
   web3_py:
-    runs-on: ubicloud-standard-2
+    runs-on: tenki-standard-small-2c-4g
     needs: build
     if: github.event.pull_request.draft == false
     steps:
@@ -316,7 +316,7 @@ jobs:
           python test.py
 
   ethers_js:
-    runs-on: ubicloud-standard-2
+    runs-on: tenki-standard-small-2c-4g
     needs: build
     if: github.event.pull_request.draft == false
     steps:
@@ -349,7 +349,7 @@ jobs:
     needs:
       - docker-setup
     name: nextest
-    runs-on: ubicloud-standard-30
+    runs-on: tenki-standard-xlarge-32c-128g
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
@@ -405,7 +405,7 @@ jobs:
     strategy:
       fail-fast: true
     name: Foundry project
-    runs-on: ubicloud-standard-2
+    runs-on: tenki-standard-small-2c-4g
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v5
@@ -433,7 +433,7 @@ jobs:
     strategy:
       fail-fast: true
     name: Check Genesis Files
-    runs-on: ubicloud-standard-2
+    runs-on: tenki-standard-small-2c-4g
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v5
@@ -455,7 +455,7 @@ jobs:
         shell: bash
 
   docker-setup:
-    runs-on: ubicloud-standard-2
+    runs-on: tenki-standard-small-2c-4g
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -491,7 +491,7 @@ jobs:
 
   codespell:
     name: codespell
-    runs-on: ubicloud-standard-2
+    runs-on: tenki-standard-small-2c-4g
     steps:
       - uses: actions/checkout@v5
 
@@ -510,7 +510,7 @@ jobs:
 
   proving-stats:
     name: Proving stats
-    runs-on: ubicloud-standard-2
+    runs-on: tenki-standard-small-2c-4g
     needs: [build, docker-setup]
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'guest-code')
     steps:


### PR DESCRIPTION
<img width="1600" height="380" alt="PR Banner Option 3" src="https://github.com/user-attachments/assets/6569baa5-3b7c-4849-bee8-2af2620acb62" />

# PR: Migrate CI Workflows to Tenki Runners

## About Tenki  
[Tenki](https://tenki.cloud) provides high-performance, flexible GitHub Runners that replace self-hosted or legacy CI solutions with a faster, more secure, and cost-efficient alternative.  

With Tenki, teams benefit from:  
- ⚡ **Faster pipelines**: ~30% average improvement in job execution time through optimized infrastructure  
- 💰 **Significant savings**: up to ~90% cheaper compared to traditional CI runner solutions  
- 🔒 **Stronger security**: runners run on ephemeral VMs, ensuring clean, isolated environments for every job  
- 📈 **Scalable options**: a broad catalog of runner types with built-in autoscaling to match workload demand  

---

## Modifications in This PR  
- [x] Updated GitHub Actions workflows to use Tenki runner labels 

---

✅ This PR completes the initial migration to **Tenki runners**.