### PR TITLE
chore: Update GitHub Action to setup-node@v5

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -250,7 +250,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 18
       - name: Download artifact
@@ -321,7 +321,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 18
       - name: Download artifact


### PR DESCRIPTION
uses: actions/setup-node@v4 → uses: actions/setup-node@v5

Reason:
Version v5 improves caching, adds Node.js 22 support, and includes key security updates.
Release notes: https://github.com/actions/setup-node/releases/tag/v5.0.0