### PR TITLE
fix(cli): exit with non-zero status on invalid rollback targets

### DIFF
--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -108,8 +108,8 @@ async fn main() -> anyhow::Result<()> {
             sequencer_commitment_index,
         } => {
             if l2_target.is_none() && l1_target.is_none() && sequencer_commitment_index.is_none() {
-                println!("Missing L2/L1 target or sequencer commitment");
-                return Ok(());
+                // Invalid CLI usage: at least one rollback target must be provided
+                return Err(anyhow::anyhow!("Missing L2/L1 target or sequencer commitment"));
             }
             commands::rollback(
                 node_type,


### PR DESCRIPTION


Description
- **Summary**: Ensure `citrea-cli rollback` exits with a non-zero status when no rollback target is provided, instead of silently succeeding.
- **Rationale**: Correct CLI semantics improve scripting and automation reliability; invalid user input must not be treated as success.
- **Change**: In `bin/cli/src/main.rs`, replace a `println!` + `Ok(())` branch with `Err(anyhow!(...))` when all rollback targets are missing.
