### PR TITLE
ci: Run CI checks on all PRs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,7 +52,7 @@ on:
   merge_group:
     types: ["checks_requested"]
   push:
-    branches: ["nightly", "devnet-freeze", "release-v*"]
+    branches: ["nightly", "release-v*"]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,7 +54,6 @@ on:
   push:
     branches: ["nightly", "devnet-freeze", "release-v*"]
   pull_request:
-    branches: ["nightly", "devnet-freeze", "release-v*"]
     types: [opened, synchronize, reopened, ready_for_review]
 
 run-name: ${{ inputs.custom_name || github.event.pull_request.title || github.sha }}


### PR DESCRIPTION
# Description

In the very few cases where multiple people working on a feature create sub-PRs, we need those sub-PRs to actually run the CI checks before merging them into the feature PR.
