### PR TITLE
fix(test): correct typo in test function name

### DIFF
--- a/crates/evm/src/evm/system_contracts/test/BitcoinLightClient.t.sol
+++ b/crates/evm/src/evm/system_contracts/test/BitcoinLightClient.t.sol
@@ -46,7 +46,7 @@ contract BitcoinLightClientTest is Test {
         assertEq(bitcoinLightClient.getWitnessRootByNumber(INITIAL_BLOCK_NUMBER), mockWitnessRoot);
     }
 
-    function testCannotReinitalize() public {
+    function testCannotReinitialize() public {
         bitcoinLightClient.initializeBlockNumber(INITIAL_BLOCK_NUMBER);
         vm.expectRevert("Already initialized");
         bitcoinLightClient.initializeBlockNumber(INITIAL_BLOCK_NUMBER - 10);


### PR DESCRIPTION

# Description

Fixed a typo in the test function name from `testCannotReinitalize` to `testCannotReinitialize` in the BitcoinLightClient test suite.

