### PR TITLE
fix(ci): Downgrade Foundry version used in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -415,6 +415,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           cache: false
+          version: "v1.3.6"
 
       - name: Run Forge build
         run: |


### PR DESCRIPTION
# Description
Latest stable Foundry version has a [linter bug](https://github.com/foundry-rs/foundry/issues/12008) where their new Solar linter is applied on any contract even though Solar doesn't support Solidity <0.8 at the moment, which leads to compilation of WCBTC failing. Downgrading used Foundry version until Foundry fixes this in their next stable release.