### PR TITLE
Update GitHub Action to setup-node@v6

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -320,7 +320,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
       - name: Download artifact


### PR DESCRIPTION
Replaced uses: actions/setup-node@v5 → uses: actions/setup-node@v6

Reason:
Version v6 improves compatibility with Node.js 22+, enhances cache performance, and supports the latest GitHub Actions runtime optimizations.
Release notes: https://github.com/actions/setup-node/releases/tag/v6.0.0
