### PR TITLE
Remove sensitive params from RPC request logs to prevent API key leakage

### DIFF
--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -146,7 +146,7 @@ where
         let req_id = req.id();
         let req_method = req.method_name().to_string();
 
-        tracing::debug!(id = ?req_id, method = ?req_method, params = ?req.params().as_str(), "rpc_request");
+        tracing::debug!(id = ?req_id, method = ?req_method, "rpc_request");
 
         let service = self.0.clone();
         async move {


### PR DESCRIPTION

### Description
- Summary: Stop logging JSON-RPC request params to avoid leaking sensitive data (e.g., API keys) in logs.
- Motivation: Protected methods pass API key as the last param; logging params exposes credentials in log storage and aggregators.
- Changes:
  - Remove `params` from `rpc_request` debug logs in `Logger::call`.

