### PR TITLE
fix: tests use `SpecId::latest()`

### DIFF
--- a/crates/citrea-stf/tests/blueprint.rs
+++ b/crates/citrea-stf/tests/blueprint.rs
@@ -93,7 +93,7 @@ fn create_l2_block(
     let l2_block_info = HookL2BlockInfo {
         l2_height: height,
         pre_state_root: prev_state_root,
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: sequencer_public_key.clone(),
         l1_fee_rate: 128u128,
         timestamp: 10 * (height - 1),
@@ -106,7 +106,7 @@ fn create_l2_block(
         .end_l2_block(l2_block_info, &mut working_set)
         .unwrap();
     let l2_block_result =
-        stf_blueprint.finalize_l2_block(SpecId::Tangerine, working_set, prover_storage);
+        stf_blueprint.finalize_l2_block(SpecId::latest(), working_set, prover_storage);
 
     let header = L2Header::new(
         height,
@@ -1194,7 +1194,7 @@ fn test_panic_state_root_assertion_failure() {
     let l2_block_info = HookL2BlockInfo {
         l2_height: 1,
         pre_state_root: state_root,
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: sequencer_public_key.clone(),
         l1_fee_rate: 128u128,
         timestamp: 0,
@@ -1207,7 +1207,7 @@ fn test_panic_state_root_assertion_failure() {
         .end_l2_block(l2_block_info, &mut working_set)
         .unwrap();
     let l2_block_result =
-        stf_blueprint.finalize_l2_block(SpecId::Tangerine, working_set, prover_storage);
+        stf_blueprint.finalize_l2_block(SpecId::latest(), working_set, prover_storage);
 
     // Create input with corrupted block
     let mut input: Vec<u8> = vec![];
@@ -1448,7 +1448,7 @@ fn test_panic_state_root_mismatch_assertion() {
     let l2_block_info = HookL2BlockInfo {
         l2_height: 1,
         pre_state_root: state_root,
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: sequencer_public_key.clone(),
         l1_fee_rate: u128::MAX, // This should match the block's gas fee rate
         timestamp: 0,
@@ -1461,7 +1461,7 @@ fn test_panic_state_root_mismatch_assertion() {
         .end_l2_block(l2_block_info, &mut working_set)
         .unwrap();
     let l2_block_result =
-        stf_blueprint.finalize_l2_block(SpecId::Tangerine, working_set, prover_storage);
+        stf_blueprint.finalize_l2_block(SpecId::latest(), working_set, prover_storage);
 
     // Create input with the problematic block
     let mut input: Vec<u8> = vec![];

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -137,8 +137,8 @@ pub struct Evm<C: sov_modules_api::Context> {
     #[state(rename = "h")]
     pub(crate) head: sov_modules_api::StateValue<Block<AlloyHeader>, RlpCodec>,
 
-    /// Last 256 block hashes. Latest blockhash is populated in `begin_slot_hook`.
-    /// Removes the oldest blockhash in `finalize_hook`
+    /// Last 256 block hashes. A ring buffer with size 256.
+    /// See `blockhash_set` in `provider_functions.rs`.
     /// Used by the EVM to calculate the `blockhash` opcode.
     #[state(rename = "H")]
     pub(crate) latest_block_hashes: sov_modules_api::StateMap<u64, B256, BorshCodec>,

--- a/crates/evm/src/tests/call_tests.rs
+++ b/crates/evm/src/tests/call_tests.rs
@@ -66,7 +66,7 @@ fn call_multiple_test() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -78,7 +78,7 @@ fn call_multiple_test() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let transactions: Vec<RlpEvmTransaction> = vec![
             create_contract_transaction(&dev_signer1, 0, SimpleStorageContract::default()),
@@ -200,7 +200,7 @@ fn call_test() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -211,7 +211,7 @@ fn call_test() {
     let set_arg = 999;
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let rlp_transactions = vec![
             create_contract_message(&dev_signer, 0, SimpleStorageContract::default()),
@@ -278,7 +278,7 @@ fn failed_transaction_test() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -287,7 +287,7 @@ fn failed_transaction_test() {
     evm.begin_l2_block_hook(&l2_block_info, working_set);
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
         let rlp_transactions = vec![create_contract_message(
             &dev_signer,
             0,
@@ -339,14 +339,14 @@ fn self_destruct_test() {
         get_evm_config(U256::from_str("100000000000000000000").unwrap(), None);
 
     let (mut evm, mut working_set, _spec_id, _ledger_db) =
-        get_evm_with_spec(&config, SovSpecId::Tangerine);
+        get_evm_with_spec(&config, SovSpecId::latest());
     let l1_fee_rate = 0;
     let mut l2_height = 2;
 
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -355,7 +355,7 @@ fn self_destruct_test() {
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         // deploy selfdestruct contract
         // send some money to the selfdestruct contract
@@ -413,18 +413,18 @@ fn self_destruct_test() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
     };
 
     // Switch to another fork
-    let _spec_id = SovSpecId::Tangerine;
+    let _spec_id = SovSpecId::latest();
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
         // selfdestruct to die to address with someone other than the creator of the contract
         evm.call(
             CallMessage {
@@ -501,7 +501,7 @@ fn test_block_hash_in_evm() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -510,7 +510,7 @@ fn test_block_hash_in_evm() {
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message = create_contract_message(&dev_signer, 0, BlockHashContract::default());
 
@@ -534,7 +534,7 @@ fn test_block_hash_in_evm() {
         let l2_block_info = HookL2BlockInfo {
             l2_height,
             pre_state_root: [99u8; 32],
-            current_spec: SovSpecId::Tangerine,
+            current_spec: SovSpecId::latest(),
             sequencer_pub_key: get_test_seq_pub_key(),
             l1_fee_rate,
             timestamp: 0,
@@ -654,7 +654,7 @@ fn test_block_gas_limit() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -663,7 +663,7 @@ fn test_block_gas_limit() {
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         // deploy logs contract
         let mut rlp_transactions = vec![create_contract_message(
@@ -715,7 +715,7 @@ fn test_block_gas_limit() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -724,7 +724,7 @@ fn test_block_gas_limit() {
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         // deploy logs contract
         let mut rlp_transactions = vec![create_contract_message(
@@ -875,7 +875,7 @@ fn test_l1_fee_success() {
         let l2_block_info = HookL2BlockInfo {
             l2_height: 2,
             pre_state_root: [10u8; 32],
-            current_spec: SovSpecId::Tangerine,
+            current_spec: SovSpecId::latest(),
             sequencer_pub_key: get_test_seq_pub_key(),
             l1_fee_rate,
             timestamp: 0,
@@ -885,7 +885,7 @@ fn test_l1_fee_success() {
         {
             let sender_address = generate_address::<C>("sender");
 
-            let context = C::new(sender_address, 2, SovSpecId::Tangerine, l1_fee_rate);
+            let context = C::new(sender_address, 2, SovSpecId::latest(), l1_fee_rate);
 
             let deploy_message = create_contract_message_with_priority_fee(
                 &dev_signer,
@@ -947,18 +947,18 @@ fn test_l1_fee_success() {
 
     run_tx(
         0,
-        U256::from(100000000000000u64 - gas_fee_paid * 10000001),
+        U256::from(100000000000000u64 - gas_fee_paid * 1000001),
         // priority fee goes to coinbase
         U256::from(gas_fee_paid),
-        U256::from(gas_fee_paid * 10000000),
+        U256::from(gas_fee_paid * 1000000),
         U256::from(0),
     );
     run_tx(
         1,
-        U256::from(100000000000000u64 - gas_fee_paid * 10000001 - 36 - L1_FEE_OVERHEAD as u64),
+        U256::from(100000000000000u64 - gas_fee_paid * 1000001 - 36 - L1_FEE_OVERHEAD as u64),
         // priority fee goes to coinbase
         U256::from(gas_fee_paid),
-        U256::from(gas_fee_paid * 10000000),
+        U256::from(gas_fee_paid * 1000000),
         U256::from(36 + L1_FEE_OVERHEAD as u64),
     );
 }
@@ -966,9 +966,9 @@ fn test_l1_fee_success() {
 #[test]
 fn test_l1_fee_not_enough_funds() {
     let (mut config, dev_signer, _, _ledger_db) = get_evm_config_starting_base_fee(
-        U256::from_str("1142350000000").unwrap(), // only covers base fee
+        U256::from_str("114235000000").unwrap(), // only covers base fee
         None,
-        min_base_fee_per_gas(SovSpecId::Tangerine),
+        min_base_fee_per_gas(SovSpecId::latest()),
     );
     config_push_contracts(&mut config, None);
 
@@ -980,7 +980,7 @@ fn test_l1_fee_not_enough_funds() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -990,7 +990,7 @@ fn test_l1_fee_not_enough_funds() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message = create_contract_message_with_fee_and_gas_limit(
             &dev_signer,
@@ -1029,7 +1029,7 @@ fn test_l1_fee_not_enough_funds() {
         .unwrap();
 
     // The account balance is unchanged
-    assert_eq!(db_account.balance, U256::from(1142350000000u64));
+    assert_eq!(db_account.balance, U256::from(114235000000u64));
     assert_eq!(db_account.nonce, 0);
 
     // The coinbase balance is zero
@@ -1053,7 +1053,7 @@ fn test_l1_fee_halt() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1063,7 +1063,7 @@ fn test_l1_fee_halt() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message = create_contract_message_with_fee(
             &dev_signer,
@@ -1132,7 +1132,7 @@ fn test_l1_fee_halt() {
         .account_info(&dev_signer.address(), &mut working_set)
         .unwrap();
 
-    let expenses = 1106947_u64 * 10000000 + // evm gas
+    let expenses = 1106947_u64 * 1000000 + // evm gas
         36 + // l1 contract deploy fee
         7 + // l1 contract call fee
         2 * L1_FEE_OVERHEAD as u64; // l1 fee overhead *2
@@ -1146,7 +1146,7 @@ fn test_l1_fee_halt() {
     let base_fee_vault = evm.account_info(&BASE_FEE_VAULT, &mut working_set).unwrap();
     let l1_fee_vault = evm.account_info(&L1_FEE_VAULT, &mut working_set).unwrap();
 
-    assert_eq!(base_fee_vault.balance, U256::from(1106947_u64 * 10000000));
+    assert_eq!(base_fee_vault.balance, U256::from(1106947_u64 * 1000000));
     assert_eq!(
         l1_fee_vault.balance,
         U256::from(36 + 7 + 2 * L1_FEE_OVERHEAD as u64)
@@ -1161,13 +1161,13 @@ fn test_l1_fee_compression_discount() {
     config_push_contracts(&mut config, None);
 
     let (mut evm, mut working_set, _spec_id, _ledger_db) =
-        get_evm_with_spec(&config, SovSpecId::Tangerine);
+        get_evm_with_spec(&config, SovSpecId::latest());
     let l1_fee_rate = 1;
 
     let l2_block_info = HookL2BlockInfo {
         l2_height: 2,
         pre_state_root: [99u8; 32],
-        current_spec: SovSpecId::Tangerine, // Compression discount is enabled
+        current_spec: SovSpecId::latest(), // Compression discount is enabled
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1176,7 +1176,7 @@ fn test_l1_fee_compression_discount() {
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, 3, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, 3, SovSpecId::latest(), l1_fee_rate);
         let simple_tx = dev_signer
             .sign_default_transaction_with_priority_fee(
                 TxKind::Call(Address::random()),
@@ -1215,9 +1215,9 @@ fn test_l1_fee_compression_discount() {
     let tx_gas = 21000;
 
     let expected_db_balance = U256::from(
-        100000000000000u64 - 1000 - tx_gas * 10000001 - tx2_diff_size - L1_FEE_OVERHEAD as u64,
+        100000000000000u64 - 1000 - tx_gas * 1000001 - tx2_diff_size - L1_FEE_OVERHEAD as u64,
     );
-    let expected_base_fee_vault_balance = U256::from(tx_gas * 10000000);
+    let expected_base_fee_vault_balance = U256::from(tx_gas * 1000000);
     let expected_coinbase_balance = U256::from(tx_gas);
     let expected_l1_fee_vault_balance = U256::from(tx2_diff_size + L1_FEE_OVERHEAD as u64);
 
@@ -1256,7 +1256,7 @@ fn test_blob_tx() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine, // won't be Tangerine at height 2 currently but we can trick the spec id
+        current_spec: SovSpecId::latest(), // won't be Tangerine at height 2 currently but we can trick the spec id
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1265,7 +1265,7 @@ fn test_blob_tx() {
     let sender_address = generate_address::<C>("sender");
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let blob_message = dev_signer
             .sign_blob_transaction(Address::ZERO, vec![B256::random()], 0)
@@ -1332,7 +1332,7 @@ fn test_eip7702_tx() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1343,7 +1343,7 @@ fn test_eip7702_tx() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let transactions: Vec<RlpEvmTransaction> = vec![
             create_contract_transaction(&signer1, 0, LogsContract::default()),
@@ -1378,7 +1378,7 @@ fn test_eip7702_tx() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1389,7 +1389,7 @@ fn test_eip7702_tx() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let transactions: Vec<RlpEvmTransaction> = vec![signer2
             .sign_eip7702_transaction(
@@ -1458,7 +1458,7 @@ fn test_eip7702_tx() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let transactions: Vec<RlpEvmTransaction> = vec![signer2
             .sign_default_transaction(
@@ -1502,7 +1502,7 @@ fn test_eip7702_tx() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1513,7 +1513,7 @@ fn test_eip7702_tx() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let transactions: Vec<RlpEvmTransaction> = vec![
             signer2
@@ -1608,7 +1608,7 @@ fn test_eip7702_tx() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1619,7 +1619,7 @@ fn test_eip7702_tx() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let transactions: Vec<RlpEvmTransaction> = vec![signer2
             .sign_eip7702_transaction(

--- a/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
+++ b/crates/evm/src/tests/ef_tests/cases/blockchain_test.rs
@@ -198,7 +198,7 @@ impl Case for BlockchainTestCase {
 
                 let root = case.genesis_block_header.state_root;
 
-                let current_spec = SovSpecId::Tangerine;
+                let current_spec = SovSpecId::latest();
                 // Decode and insert blocks, creating a chain of blocks for the test case.
                 for block in case.blocks.iter() {
                     let decoded = SealedBlock::<RethBlock>::decode(&mut block.rlp.as_ref())?;

--- a/crates/evm/src/tests/fork_tests.rs
+++ b/crates/evm/src/tests/fork_tests.rs
@@ -1,5 +1,4 @@
 use std::str::FromStr;
-use std::thread::sleep;
 
 use alloy_consensus::TxReceipt;
 use alloy_primitives::{address, keccak256, Address, Bytes, TxKind};
@@ -20,9 +19,7 @@ use crate::smart_contracts::{
 };
 use crate::tests::get_test_seq_pub_key;
 use crate::tests::test_signer::TestSigner;
-use crate::tests::utils::{
-    create_contract_message, get_evm, get_evm_config, get_evm_with_spec, set_arg_message,
-};
+use crate::tests::utils::{create_contract_message, get_evm, get_evm_config, get_evm_with_spec};
 use crate::{Evm, RlpEvmTransaction};
 type C = DefaultContext;
 
@@ -117,19 +114,19 @@ fn call_schnorr_verify_transaction(
 }
 
 #[test]
-fn test_cancun_transient_storage_activation() {
+fn test_cancun_transient_storage_works() {
     let (config, dev_signer, contract_addr) =
         get_evm_config(U256::from_str("100000000000000000000").unwrap(), None);
 
     let (mut evm, mut working_set, _spec_id, _ledger_db) =
-        get_evm_with_spec(&config, SovSpecId::Tangerine);
+        get_evm_with_spec(&config, SovSpecId::latest());
     let l1_fee_rate = 0;
     let mut l2_height = 2;
 
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -139,7 +136,7 @@ fn test_cancun_transient_storage_activation() {
     let sender_address = generate_address::<C>("sender");
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message =
             create_contract_message(&dev_signer, 0, TransientStorageContract::default());
@@ -161,7 +158,7 @@ fn test_cancun_transient_storage_activation() {
     // Send money to transient storage contract
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
         let call_tx =
             send_money_to_contract_message(contract_addr, &dev_signer, 1, 10000000000000000000);
 
@@ -180,7 +177,7 @@ fn test_cancun_transient_storage_activation() {
     // Call claim gift from transient storage contract
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
         let call_tx =
             claim_gift_from_transient_storage_contract_transaction(contract_addr, &dev_signer, 2);
 
@@ -194,55 +191,28 @@ fn test_cancun_transient_storage_activation() {
     evm.end_l2_block_hook(&l2_block_info, &mut working_set);
     evm.finalize_hook(&[99u8; 32], &mut working_set.accessory_state());
 
-    l2_height += 1;
-
     let receipts: Vec<_> = evm
         .receipts
         .iter(&mut working_set.accessory_state())
         .collect();
 
-    // Last tx should have failed because cancun is not activated
     assert!(receipts.last().unwrap().receipt.status());
-
-    evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
-    {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
-        let call_tx =
-            claim_gift_from_transient_storage_contract_transaction(contract_addr, &dev_signer, 3);
-
-        evm.call(
-            CallMessage { txs: vec![call_tx] },
-            &context,
-            &mut working_set,
-        )
-        .unwrap();
-    }
-    evm.end_l2_block_hook(&l2_block_info, &mut working_set);
-    evm.finalize_hook(&[99u8; 32], &mut working_set.accessory_state());
-
-    let receipts: Vec<_> = evm
-        .receipts
-        .iter(&mut working_set.accessory_state())
-        .collect();
-
-    // This tx should fail as the contract has already been claimed
-    assert!(!receipts.last().unwrap().receipt.status());
 }
 
 #[test]
-fn test_cancun_mcopy_activation() {
+fn test_cancun_mcopy_works() {
     let (config, dev_signer, contract_addr) =
         get_evm_config(U256::from_str("100000000000000000000").unwrap(), None);
 
     let (mut evm, mut working_set, _spec_id, _ledger_db) =
-        get_evm_with_spec(&config, SovSpecId::Tangerine);
+        get_evm_with_spec(&config, SovSpecId::latest());
     let l1_fee_rate = 0;
     let mut l2_height = 2;
 
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -251,7 +221,7 @@ fn test_cancun_mcopy_activation() {
     let sender_address = generate_address::<C>("sender");
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message = create_contract_message(&dev_signer, 0, McopyContract::default());
 
@@ -269,10 +239,9 @@ fn test_cancun_mcopy_activation() {
 
     l2_height += 1;
 
-    // Send money to transient storage contract
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
         let call_tx = call_mcopy(contract_addr, &dev_signer, 1);
 
         evm.call(
@@ -284,8 +253,6 @@ fn test_cancun_mcopy_activation() {
     }
     evm.end_l2_block_hook(&l2_block_info, &mut working_set);
     evm.finalize_hook(&[99u8; 32], &mut working_set.accessory_state());
-
-    // l2_height += 1;
 
     let receipts: Vec<_> = evm
         .receipts
@@ -318,7 +285,7 @@ fn test_self_destructing_constructor() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -330,7 +297,7 @@ fn test_self_destructing_constructor() {
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         // deploy selfdestruct contract
         let rlp_transactions = vec![create_contract_message_with_bytecode(
@@ -391,14 +358,14 @@ fn test_blob_base_fee_should_return_1() {
         get_evm_config(U256::from_str("100000000000000000000").unwrap(), None);
 
     let (mut evm, mut working_set, _spec_id, _ledger_db) =
-        get_evm_with_spec(&config, SovSpecId::Tangerine);
+        get_evm_with_spec(&config, SovSpecId::latest());
     let l1_fee_rate = 0;
     let mut l2_height = 2;
 
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -407,7 +374,7 @@ fn test_blob_base_fee_should_return_1() {
     let sender_address = generate_address::<C>("sender");
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message =
             create_contract_message(&dev_signer, 0, BlobBaseFeeContract::default());
@@ -435,7 +402,7 @@ fn test_blob_base_fee_should_return_1() {
 
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
         let call_tx = store_blob_base_fee_transaction(contract_addr, &dev_signer, 1);
 
         evm.call(
@@ -475,7 +442,7 @@ fn test_kzg_point_eval_should_revert() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -484,7 +451,7 @@ fn test_kzg_point_eval_should_revert() {
     let sender_address = generate_address::<C>("sender");
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message =
             create_contract_message(&dev_signer, 0, KZGPointEvaluationCallerContract::default());
@@ -530,7 +497,7 @@ fn test_kzg_point_eval_should_revert() {
 
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message = call_kzg_point_evaluation_transaction(
             contract_addr,
@@ -571,20 +538,22 @@ fn test_kzg_point_eval_should_revert() {
 }
 
 // 1. deploy p256verify contract on fork1 (any fork will work)
-// 2. call p256verify with a valid data on tangerine (it must succeed because p256verify is enabled)
+// 2. call p256verify with a valid data after tangerine (it must succeed because p256verify is enabled)
+// this test also shows schnorr verify precompile works only after tangerine, see prague() in handler.rs
 #[test]
 fn test_p256_verify() {
     let (config, dev_signer, contract_addr) =
         get_evm_config(U256::from_str("100000000000000000000").unwrap(), None);
 
-    let (mut evm, mut working_set, _spec_id, _ledger_db) = get_evm(&config);
+    let (mut evm, mut working_set, _spec_id, _ledger_db) =
+        get_evm_with_spec(&config, SovSpecId::Kumquat);
     let l1_fee_rate = 0;
-    let l2_height = 2;
+    let mut l2_height = 2;
 
-    let l2_block_info = HookL2BlockInfo {
+    let mut l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::Kumquat,
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -593,14 +562,14 @@ fn test_p256_verify() {
     let sender_address = generate_address::<C>("sender");
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::Kumquat, l1_fee_rate);
 
         let deploy_message =
             create_contract_message(&dev_signer, 0, P256VerifyCallerContract::default());
 
         let input = Bytes::from_str("b5a77e7a90aa14e0bf5f337f06f597148676424fae26e175c6e5621c34351955289f319789da424845c9eac935245fcddd805950e2f02506d09be7e411199556d262144475b1fa46ad85250728c600c53dfd10f8b3f4adf140e27241aec3c2da3a81046703fccf468b48b145f939efdbb96c3786db712b3113bb2488ef286cdcef8afe82d200a5bb36b5462166e8ce77f2d831a52ef2135b2af188110beaefb1").unwrap();
 
-        // This one should fail in Tangerine
+        // This one should fail in Kumquat because p256 precompile is not enabled
         let call_message = call_p256_verify_transaction(contract_addr, &dev_signer, 1, input);
 
         evm.call(
@@ -615,7 +584,7 @@ fn test_p256_verify() {
     evm.end_l2_block_hook(&l2_block_info, &mut working_set);
     evm.finalize_hook(&[99u8; 32], &mut working_set.accessory_state());
 
-    // expect this call to success because we enabled the p256 feature of revm enabled on tangerine
+    // expect this call to fail because we enabled the p256 feature of revm enabled on tangerine
     let receipts: Vec<_> = evm
         .receipts
         .iter(&mut working_set.accessory_state())
@@ -623,7 +592,45 @@ fn test_p256_verify() {
 
     let storage_value = evm
         .storage_get(&contract_addr, &U256::ZERO, &mut working_set)
+        .unwrap_or_default();
+    assert_eq!(storage_value, U256::from(0));
+    assert!(!receipts.last().unwrap().receipt.status());
+
+    l2_block_info.current_spec = SovSpecId::Tangerine;
+    l2_block_info.l2_height += 1;
+    l2_height += 1;
+
+    let sender_address = generate_address::<C>("sender");
+    evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
+    {
+        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+
+        let input = Bytes::from_str("b5a77e7a90aa14e0bf5f337f06f597148676424fae26e175c6e5621c34351955289f319789da424845c9eac935245fcddd805950e2f02506d09be7e411199556d262144475b1fa46ad85250728c600c53dfd10f8b3f4adf140e27241aec3c2da3a81046703fccf468b48b145f939efdbb96c3786db712b3113bb2488ef286cdcef8afe82d200a5bb36b5462166e8ce77f2d831a52ef2135b2af188110beaefb1").unwrap();
+
+        // This one should fail in Kumquat because p256 precompile is not enabled
+        let call_message = call_p256_verify_transaction(contract_addr, &dev_signer, 2, input);
+
+        evm.call(
+            CallMessage {
+                txs: vec![call_message],
+            },
+            &context,
+            &mut working_set,
+        )
         .unwrap();
+    }
+    evm.end_l2_block_hook(&l2_block_info, &mut working_set);
+    evm.finalize_hook(&[99u8; 32], &mut working_set.accessory_state());
+
+    // expect this call to succeed because we enabled the p256 feature of revm enabled on tangerine
+    let receipts: Vec<_> = evm
+        .receipts
+        .iter(&mut working_set.accessory_state())
+        .collect();
+
+    let storage_value = evm
+        .storage_get(&contract_addr, &U256::ZERO, &mut working_set)
+        .unwrap_or_default();
     assert_eq!(storage_value, U256::from(1));
     assert!(receipts.last().unwrap().receipt.status());
 }
@@ -640,7 +647,7 @@ fn test_schnorr_verify() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -651,7 +658,7 @@ fn test_schnorr_verify() {
     // Deploy schnorr verify contract
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message =
             create_contract_message(&dev_signer, 0, SchnorrVerifyCallerContract::default());
@@ -675,12 +682,12 @@ fn test_schnorr_verify() {
             let l2_block_info = HookL2BlockInfo {
                 l2_height,
                 pre_state_root: [10u8; 32],
-                current_spec: SovSpecId::Tangerine,
+                current_spec: SovSpecId::latest(),
                 sequencer_pub_key: get_test_seq_pub_key(),
                 l1_fee_rate,
                 timestamp: 0,
             };
-            let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+            let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
             evm.begin_l2_block_hook(&l2_block_info, working_set);
             {
@@ -760,20 +767,22 @@ fn test_schnorr_verify() {
 }
 
 #[test]
+// this test was useful when offchain code was first implemented
+// now it shouldn't even be in this file
 fn test_offchain_contract_storage_evm() {
     let (config, dev_signer, contract_addr) =
         get_evm_config(U256::from_str("100000000000000000000").unwrap(), None);
 
     let (mut evm, mut working_set, _spec_id, ledger_db) =
-        get_evm_with_spec(&config, SovSpecId::Tangerine);
+        get_evm_with_spec(&config, SovSpecId::latest());
     let l1_fee_rate = 0;
     let mut l2_height = 2;
 
-    // Deployed a contract in Tangerine fork
+    // Deployed a contract in latest fork
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -782,7 +791,7 @@ fn test_offchain_contract_storage_evm() {
     let sender_address = generate_address::<C>("sender");
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message =
             create_contract_message(&dev_signer, 0, SimpleStorageContract::default());
@@ -801,9 +810,7 @@ fn test_offchain_contract_storage_evm() {
 
     l2_height += 1;
 
-    sleep(std::time::Duration::from_secs(2));
-
-    //try to get it from offchain storage and expect it to not exist
+    //try to get it from offchain storage
     let contract_info = evm.account_info(&contract_addr, &mut working_set);
     let code_hash = contract_info.unwrap().code_hash.unwrap();
 
@@ -812,17 +819,9 @@ fn test_offchain_contract_storage_evm() {
         .get(&code_hash, &mut working_set.offchain_state())
         .unwrap();
 
-    // Try to get the code from Tangerine fork and expect it to exist
-    let code = evm
-        .get_code(contract_addr, None, &mut working_set, &ledger_db)
-        .unwrap();
+    assert!(!cont_code.is_empty());
 
-    assert_eq!(*cont_code.original_byte_slice(), code);
-
-    let evm_code = evm
-        .offchain_code
-        .get(&code_hash, &mut working_set.offchain_state())
-        .unwrap();
+    // compare rpc
 
     let code = evm
         .get_code(
@@ -835,12 +834,12 @@ fn test_offchain_contract_storage_evm() {
         )
         .unwrap();
 
-    assert_eq!(code, *evm_code.original_byte_slice());
+    assert_eq!(code, *cont_code.original_byte_slice());
 
-    // Deploy contract in fork1
+    // Deploy contract in latest fork
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let deploy_message =
             create_contract_message(&dev_signer, 1, SelfDestructorContract::default());
@@ -856,55 +855,10 @@ fn test_offchain_contract_storage_evm() {
     }
     evm.end_l2_block_hook(&l2_block_info, &mut working_set);
     evm.finalize_hook(&[99u8; 32], &mut working_set.accessory_state());
-    l2_height += 1;
 
     let new_contract_address = address!("d26ff5586e488e65d86bcc3f0fe31551e381a596");
 
     let contract_info = evm.account_info(&new_contract_address, &mut working_set);
-    let code_hash = contract_info.unwrap().code_hash.unwrap();
-
-    let offchain_code = evm
-        .offchain_code
-        .get(&code_hash, &mut working_set.offchain_state());
-
-    assert!(offchain_code.is_some());
-
-    // make tx on the contract that was deployed before fork1 and see that you can read it from offchain storage afterwards
-    let l2_block_info = HookL2BlockInfo {
-        l2_height,
-        pre_state_root: [10u8; 32],
-        current_spec: SovSpecId::Tangerine,
-        sequencer_pub_key: get_test_seq_pub_key(),
-        l1_fee_rate,
-        timestamp: 0,
-    };
-
-    evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
-    {
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
-
-        let call_message = set_arg_message(contract_addr, &dev_signer, 2, 99);
-
-        evm.call(
-            CallMessage {
-                txs: vec![call_message],
-            },
-            &context,
-            &mut working_set,
-        )
-        .unwrap();
-    }
-    evm.end_l2_block_hook(&l2_block_info, &mut working_set);
-    evm.finalize_hook(&[99u8; 32], &mut working_set.accessory_state());
-
-    // Try to get the code from Tangerine fork and expect it to not exist because it is stored in offchain storage
-    let code = evm
-        .get_code(new_contract_address, None, &mut working_set, &ledger_db)
-        .unwrap();
-    assert_eq!(code, *offchain_code.unwrap().original_byte_slice());
-
-    // Now I should be able to read the contract from offchain storage
-    let contract_info = evm.account_info(&contract_addr, &mut working_set);
     let code_hash = contract_info.unwrap().code_hash.unwrap();
 
     let offchain_code = evm

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -340,9 +340,6 @@ fn finalize_hook_creates_final_block() {
 }
 
 #[test]
-// this test is run with Tangerine spec
-// because pre tangerine we were deleting block hashes and
-// we'd still like to test that
 fn begin_l2_block_hook_appends_last_block_hashes() {
     let (mut evm, mut working_set, _spec_id, _ledger_db) = get_evm(&get_evm_test_config());
 

--- a/crates/evm/src/tests/hooks_tests.rs
+++ b/crates/evm/src/tests/hooks_tests.rs
@@ -29,7 +29,7 @@ fn begin_l2_block_hook_creates_pending_block() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 54,
@@ -65,7 +65,7 @@ fn end_l2_block_hook_sets_head() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root,
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 54,
@@ -135,7 +135,7 @@ fn end_l2_block_hook_moves_transactions_and_receipts() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -250,7 +250,7 @@ fn finalize_hook_creates_final_block() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: root,
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 54,
@@ -275,7 +275,7 @@ fn finalize_hook_creates_final_block() {
         &HookL2BlockInfo {
             l2_height,
             pre_state_root: root_hash,
-            current_spec: SpecId::Tangerine,
+            current_spec: SpecId::latest(),
             sequencer_pub_key: get_test_seq_pub_key(),
             l1_fee_rate,
             timestamp: 54,
@@ -359,7 +359,7 @@ fn begin_l2_block_hook_appends_last_block_hashes() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: root,
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -393,7 +393,7 @@ fn begin_l2_block_hook_appends_last_block_hashes() {
         let l2_block_info = HookL2BlockInfo {
             l2_height,
             pre_state_root: random_32_bytes,
-            current_spec: SpecId::Tangerine,
+            current_spec: SpecId::latest(),
             sequencer_pub_key: get_test_seq_pub_key(),
             l1_fee_rate,
             timestamp: 0,
@@ -413,7 +413,7 @@ fn begin_l2_block_hook_appends_last_block_hashes() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: random_32_bytes,
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,

--- a/crates/evm/src/tests/queries/basic_queries.rs
+++ b/crates/evm/src/tests/queries/basic_queries.rs
@@ -20,7 +20,7 @@ use crate::EstimatedDiffSize;
 #[test]
 fn get_block_by_hash_test() {
     // make a block
-    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::Tangerine);
+    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::latest());
 
     let result = evm.get_block_by_hash([5u8; 32].into(), Some(false), &mut working_set, &ledger_db);
 
@@ -43,7 +43,7 @@ fn get_block_by_hash_test() {
 #[test]
 fn get_block_by_number_test() {
     // make a block
-    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::Tangerine);
+    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::latest());
 
     let result = evm.get_block_by_number(
         Some(BlockNumberOrTag::Number(1000)),
@@ -71,7 +71,7 @@ fn get_block_by_number_test() {
 #[test]
 fn get_block_receipts_test() {
     // make a block
-    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::Tangerine);
+    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::latest());
 
     let result = evm.get_block_receipts(
         BlockId::Number(BlockNumberOrTag::Number(1000)),
@@ -108,7 +108,7 @@ fn get_block_receipts_test() {
 
 #[test]
 fn get_transaction_by_block_hash_and_index_test() {
-    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::Tangerine);
+    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::latest());
 
     let result = evm.get_transaction_by_block_hash_and_index(
         [0u8; 32].into(),
@@ -152,7 +152,7 @@ fn get_transaction_by_block_hash_and_index_test() {
 
 #[test]
 fn get_transaction_by_block_number_and_index_test() {
-    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::Tangerine);
+    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::latest());
 
     let result = evm.get_transaction_by_block_number_and_index(
         BlockNumberOrTag::Number(100),
@@ -205,7 +205,7 @@ fn get_transaction_by_block_number_and_index_test() {
 
 #[test]
 fn get_block_transaction_count_by_hash_test() {
-    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::Tangerine);
+    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::latest());
 
     let result = evm.eth_get_block_transaction_count_by_hash(
         B256::from([0u8; 32]),
@@ -268,7 +268,7 @@ fn get_block_transaction_count_by_hash_test() {
 
 #[test]
 fn get_block_transaction_count_by_number_test() {
-    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::Tangerine);
+    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SovSpecId::latest());
 
     let result = evm.eth_get_block_transaction_count_by_number(
         BlockNumberOrTag::Number(5),
@@ -302,7 +302,7 @@ fn get_block_transaction_count_by_number_test() {
 
 #[test]
 fn call_test() {
-    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SovSpecId::Tangerine);
+    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SovSpecId::latest());
 
     let fail_result = evm.get_call_inner(
         TransactionRequest {
@@ -803,7 +803,7 @@ fn test_queries_with_forks() {
 
     let (evm, mut working_set, signer, _l2_height, ledger_db) = init_evm_with_caller_contract();
 
-    let fork_fn = |_: u64| Fork::new(SovSpecId::Tangerine, 3);
+    let fork_fn = |_: u64| Fork::new(SovSpecId::latest(), 3);
 
     let caller = CallerContract::default();
     let input_data = caller.call_set_call_data(

--- a/crates/evm/src/tests/queries/estimate_gas_tests.rs
+++ b/crates/evm/src/tests/queries/estimate_gas_tests.rs
@@ -23,7 +23,7 @@ type C = DefaultContext;
 #[test]
 fn test_payable_contract_value() {
     let (evm, mut working_set, signer, ledger_db) =
-        init_evm_single_block(sov_modules_api::SpecId::Tangerine);
+        init_evm_single_block(sov_modules_api::SpecId::latest());
 
     let tx_req = TransactionRequest {
         from: Some(signer.address()),
@@ -62,7 +62,7 @@ fn test_payable_contract_value() {
 #[test]
 fn test_tx_request_fields_gas_fork1() {
     let (evm, mut working_set, signer, ledger_db) =
-        init_evm_single_block(sov_modules_api::SpecId::Tangerine);
+        init_evm_single_block(sov_modules_api::SpecId::latest());
 
     let tx_req_contract_call = TransactionRequest {
         from: Some(signer.address()),
@@ -411,7 +411,7 @@ fn test_access_list() {
 #[test]
 fn estimate_gas_with_varied_inputs_test() {
     let (evm, mut working_set, _, signer, _, ledger_db) =
-        init_evm(sov_modules_api::SpecId::Tangerine);
+        init_evm(sov_modules_api::SpecId::latest());
 
     let simple_call_data = 0;
     let simple_result = test_estimate_gas_with_input(
@@ -453,7 +453,7 @@ fn estimate_gas_with_varied_inputs_test() {
 #[test]
 fn test_pending_env() {
     let (evm, mut working_set, signer, ledger_db) =
-        init_evm_single_block(sov_modules_api::SpecId::Tangerine);
+        init_evm_single_block(sov_modules_api::SpecId::latest());
 
     let tx_req = TransactionRequest {
         from: Some(signer.address()),

--- a/crates/evm/src/tests/queries/eth_call_tests.rs
+++ b/crates/evm/src/tests/queries/eth_call_tests.rs
@@ -27,7 +27,7 @@ type C = DefaultContext;
 
 #[test]
 fn call_contract_without_value() {
-    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::Tangerine);
+    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::latest());
 
     let contract = SimpleStorageContract::default();
     let contract_address = Address::from_str("0xeeb03d20dae810f52111b853b31c8be6f30f4cd3").unwrap();
@@ -79,7 +79,7 @@ fn call_contract_without_value() {
 
 #[test]
 fn test_state_change() {
-    let (mut evm, mut working_set, _, signer, l2_height, ledger_db) = init_evm(SpecId::Tangerine);
+    let (mut evm, mut working_set, _, signer, l2_height, ledger_db) = init_evm(SpecId::latest());
 
     let balance_1 = evm.get_balance(signer.address(), None, &mut working_set, &ledger_db);
 
@@ -88,7 +88,7 @@ fn test_state_change() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate: 1,
         timestamp: 0,
@@ -123,7 +123,7 @@ fn test_state_change() {
 
 #[test]
 fn call_contract_with_value_transfer() {
-    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::Tangerine);
+    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::latest());
 
     let contract = SimpleStorageContract::default();
     let contract_address = Address::from_str("0xeeb03d20dae810f52111b853b31c8be6f30f4cd3").unwrap();
@@ -151,7 +151,7 @@ fn call_contract_with_value_transfer() {
 
 #[test]
 fn call_contract_with_invalid_nonce() {
-    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::Tangerine);
+    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::latest());
 
     let contract = SimpleStorageContract::default();
     let contract_address = Address::from_str("0xeeb03d20dae810f52111b853b31c8be6f30f4cd3").unwrap();
@@ -205,7 +205,7 @@ fn call_contract_with_invalid_nonce() {
 
 #[test]
 fn call_to_nonexistent_contract() {
-    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::Tangerine);
+    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::latest());
 
     let nonexistent_contract_address =
         Address::from_str("0x000000000000000000000000000000000000dead").unwrap();
@@ -235,7 +235,7 @@ fn call_to_nonexistent_contract() {
 
 #[test]
 fn call_with_high_gas_price() {
-    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::Tangerine);
+    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::latest());
 
     let contract = SimpleStorageContract::default();
     let contract_address = Address::from_str("0xeeb03d20dae810f52111b853b31c8be6f30f4cd3").unwrap();
@@ -271,7 +271,7 @@ fn call_with_high_gas_price() {
 
 #[test]
 fn test_eip1559_fields_call() {
-    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::Tangerine);
+    let (evm, mut working_set, _, signer, _, ledger_db) = init_evm(SpecId::latest());
 
     let default_result = eth_call_eip1559(
         &evm,
@@ -395,7 +395,7 @@ fn eth_call_eip1559(
 
 #[test]
 fn gas_price_call_test() {
-    let (evm, mut working_set, signer, ledger_db) = init_evm_single_block(SpecId::Tangerine);
+    let (evm, mut working_set, signer, ledger_db) = init_evm_single_block(SpecId::latest());
 
     // Define a base transaction request for reuse
     let base_tx_req = || TransactionRequest {
@@ -580,7 +580,7 @@ fn gas_price_call_test() {
 
 #[test]
 fn test_call_with_state_overrides() {
-    let (evm, mut working_set, prover_storage, signer, _, ledger_db) = init_evm(SpecId::Tangerine);
+    let (evm, mut working_set, prover_storage, signer, _, ledger_db) = init_evm(SpecId::latest());
 
     let contract = SimpleStorageContract::default();
     let contract_address = Address::from_str("0xeeb03d20dae810f52111b853b31c8be6f30f4cd3").unwrap();
@@ -756,7 +756,7 @@ fn test_call_with_block_overrides() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -766,8 +766,7 @@ fn test_call_with_block_overrides() {
     let sender_address = generate_address::<C>("sender");
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context =
-            DefaultContext::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = DefaultContext::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         let deploy_message = create_contract_message(&dev_signer, 0, BlockHashContract::default());
 
@@ -790,7 +789,7 @@ fn test_call_with_block_overrides() {
         let l2_block_info = HookL2BlockInfo {
             l2_height,
             pre_state_root: [99u8; 32],
-            current_spec: SpecId::Tangerine,
+            current_spec: SpecId::latest(),
             sequencer_pub_key: get_test_seq_pub_key(),
             l1_fee_rate,
             timestamp: 0,

--- a/crates/evm/src/tests/queries/log_tests.rs
+++ b/crates/evm/src/tests/queries/log_tests.rs
@@ -24,7 +24,7 @@ type C = DefaultContext;
 
 #[test]
 fn logs_for_filter_test() {
-    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SpecId::Tangerine);
+    let (evm, mut working_set, _, _, _, ledger_db) = init_evm(SpecId::latest());
 
     let result = evm.eth_get_logs(
         Filter {
@@ -91,7 +91,7 @@ fn log_filter_test_at_block_hash() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -100,7 +100,7 @@ fn log_filter_test_at_block_hash() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         // deploy logs contract
         // call the contract function
@@ -302,7 +302,7 @@ fn log_filter_test_with_range() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -311,7 +311,7 @@ fn log_filter_test_with_range() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         // deploy selfdestruct contract
         // call the contract function
@@ -360,7 +360,7 @@ fn log_filter_test_with_range() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [99u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -369,7 +369,7 @@ fn log_filter_test_with_range() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
         // call the contract function
         evm.call(
             CallMessage {
@@ -420,7 +420,7 @@ fn test_log_limits() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -429,7 +429,7 @@ fn test_log_limits() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         // deploy logs contract
         let mut rlp_transactions = vec![create_contract_message(
@@ -524,7 +524,7 @@ fn test_log_limits() {
         let l2_block_info = HookL2BlockInfo {
             l2_height,
             pre_state_root: [99u8; 32],
-            current_spec: SpecId::Tangerine,
+            current_spec: SpecId::latest(),
             sequencer_pub_key: get_test_seq_pub_key(),
             l1_fee_rate,
             timestamp: 0,

--- a/crates/evm/src/tests/queries/mod.rs
+++ b/crates/evm/src/tests/queries/mod.rs
@@ -319,7 +319,7 @@ pub fn init_evm_with_caller_contract() -> (
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [0u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -329,7 +329,7 @@ pub fn init_evm_with_caller_contract() -> (
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let transactions: Vec<RlpEvmTransaction> = vec![
             create_contract_transaction(&dev_signer, 0, SimpleStorageContract::default()),
@@ -355,7 +355,7 @@ pub fn init_evm_with_caller_contract() -> (
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [2u8; 32],
-        current_spec: SovSpecId::Tangerine,
+        current_spec: SovSpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -365,7 +365,7 @@ pub fn init_evm_with_caller_contract() -> (
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SovSpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SovSpecId::latest(), l1_fee_rate);
 
         let transactions: Vec<RlpEvmTransaction> = vec![create_contract_transaction(
             &dev_signer,

--- a/crates/evm/src/tests/sys_tx_tests.rs
+++ b/crates/evm/src/tests/sys_tx_tests.rs
@@ -175,7 +175,7 @@ fn test_sys_bitcoin_light_client() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 42,
@@ -186,7 +186,7 @@ fn test_sys_bitcoin_light_client() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         let txs = initial_system_txs(1, [1; 32], [2; 32], 0, &evm, &mut working_set);
 
@@ -318,7 +318,7 @@ fn test_sys_bitcoin_light_client() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 42,
@@ -329,7 +329,7 @@ fn test_sys_bitcoin_light_client() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         let set_block_info_tx =
             set_block_info_system_tx([2; 32], [3; 32], 0, &evm, &mut working_set);
@@ -402,7 +402,7 @@ fn test_sys_bitcoin_light_client() {
     let base_fee_vault = evm.account_info(&BASE_FEE_VAULT, &mut working_set).unwrap();
     let l1_fee_vault = evm.account_info(&L1_FEE_VAULT, &mut working_set).unwrap();
 
-    assert_eq!(base_fee_vault.balance, U256::from(114235u64 * 10000000));
+    assert_eq!(base_fee_vault.balance, U256::from(114235u64 * 1000000));
     assert_eq!(l1_fee_vault.balance, U256::from(36 + L1_FEE_OVERHEAD));
 
     let block_hash = get_block_hash(&evm, &mut working_set, &ledger_db, 2).unwrap();
@@ -431,7 +431,7 @@ fn test_sys_bitcoin_light_client() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 42,
@@ -443,7 +443,7 @@ fn test_sys_bitcoin_light_client() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         let set_block_info_tx = set_block_info_system_tx(
             [3; 32],
@@ -493,12 +493,12 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
     let mut l2_height = 1;
 
     let sender_address = generate_address::<C>("sender");
-    let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+    let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate: 1,
         timestamp: 0,
@@ -525,7 +525,7 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -533,7 +533,7 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
 
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         let sys_tx = set_block_info_system_tx([2; 32], [3; 32], 0, &evm, &mut working_set);
 
@@ -604,7 +604,7 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -612,7 +612,7 @@ fn test_sys_tx_gas_usage_effect_on_block_gas_limit() {
 
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         let sys_tx = set_block_info_system_tx([2; 32], [3; 32], 0, &evm, &mut working_set);
 
@@ -708,12 +708,12 @@ fn test_bridge() {
     let l1_fee_rate = 1;
     let l2_height = 1;
     let sender_address = generate_address::<C>("sender");
-    let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+    let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
     let mut l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate: 1,
         timestamp: 0,
@@ -916,12 +916,12 @@ fn test_upgrade_light_client() {
     let l2_height = 2;
 
     let sender_address = generate_address::<C>("sender");
-    let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+    let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1026,12 +1026,12 @@ fn test_change_upgrade_owner() {
     let l1_fee_rate = 1;
     let mut l2_height = 2;
     let sender_address = generate_address::<C>("sender");
-    let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+    let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1061,12 +1061,12 @@ fn test_change_upgrade_owner() {
     evm.finalize_hook(&[99u8; 32], &mut working_set.accessory_state());
 
     l2_height += 1;
-    let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+    let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1147,12 +1147,12 @@ fn test_wcbtc() {
     let l1_fee_rate = 1;
     let mut l2_height = 2;
     let sender_address = generate_address::<C>("sender");
-    let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+    let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1219,11 +1219,11 @@ fn test_wcbtc() {
     assert!(signer_new_balance <= signer_old_balance - U256::from(deposit_amount));
 
     l2_height += 1;
-    let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+    let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1309,12 +1309,12 @@ fn test_system_tx_after_user_tx_should_error_out() {
     let mut l2_height = 1;
 
     let sender_address = generate_address::<C>("sender");
-    let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+    let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate: 1,
         timestamp: 0,
@@ -1341,7 +1341,7 @@ fn test_system_tx_after_user_tx_should_error_out() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 0,
@@ -1351,7 +1351,7 @@ fn test_system_tx_after_user_tx_should_error_out() {
 
     evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
     {
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
         let call_tx = dev_signer
             .sign_default_transaction(
                 TxKind::Call(contract_addr),
@@ -1427,7 +1427,7 @@ fn test_set_block_info_shp_not_found() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 42,
@@ -1438,7 +1438,7 @@ fn test_set_block_info_shp_not_found() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         let txs = initial_system_txs(1, [1; 32], [2; 32], 0, &evm, &mut working_set);
 
@@ -1463,7 +1463,7 @@ fn test_set_block_info_shp_not_found() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         let set_block_info_tx =
             set_block_info_system_tx([2; 32], [3; 32], 0, &evm, &mut working_set);
@@ -1539,7 +1539,7 @@ fn test_set_block_info_shp_verification_failed() {
     let l2_block_info = HookL2BlockInfo {
         l2_height,
         pre_state_root: [10u8; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: get_test_seq_pub_key(),
         l1_fee_rate,
         timestamp: 42,
@@ -1550,7 +1550,7 @@ fn test_set_block_info_shp_verification_failed() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         let txs = initial_system_txs(1, [1; 32], [2; 32], 0, &evm, &mut working_set);
 
@@ -1575,7 +1575,7 @@ fn test_set_block_info_shp_verification_failed() {
     {
         let sender_address = generate_address::<C>("sender");
 
-        let context = C::new(sender_address, l2_height, SpecId::Tangerine, l1_fee_rate);
+        let context = C::new(sender_address, l2_height, SpecId::latest(), l1_fee_rate);
 
         let set_block_info_tx =
             set_block_info_system_tx([2; 32], [3; 32], 0, &evm, &mut working_set);

--- a/crates/evm/src/tests/utils.rs
+++ b/crates/evm/src/tests/utils.rs
@@ -62,7 +62,7 @@ pub(crate) fn get_evm(
     SovSpecId,
     LedgerDB,
 ) {
-    get_evm_with_spec(config, SovSpecId::Tangerine)
+    get_evm_with_spec(config, SovSpecId::latest())
 }
 
 pub(crate) fn get_evm_with_spec(

--- a/crates/l2-block-rule-enforcer/src/tests/call_tests.rs
+++ b/crates/l2-block-rule-enforcer/src/tests/call_tests.rs
@@ -27,7 +27,7 @@ fn change_max_l2_blocks_per_l1_and_authority() {
     )
     .unwrap();
 
-    let context = C::new(sender_address, 1, SpecId::Tangerine, 0);
+    let context = C::new(sender_address, 1, SpecId::latest(), 0);
 
     let _ = l2_block_rule_enforcer
         .call(call_message, &context, &mut working_set)
@@ -94,7 +94,7 @@ fn change_max_l2_blocks_per_l1_and_authority() {
     );
 
     // create a new context with the new authority
-    let context = C::new(new_authority, 1, SpecId::Tangerine, 0);
+    let context = C::new(new_authority, 1, SpecId::latest(), 0);
     let _ = l2_block_rule_enforcer
         .call(
             modify_max_l2_blocks_per_l1_message,

--- a/crates/l2-block-rule-enforcer/src/tests/hooks_tests.rs
+++ b/crates/l2-block-rule-enforcer/src/tests/hooks_tests.rs
@@ -27,7 +27,7 @@ fn begin_l2_block_hook_checks_max_l2_blocks_per_l1() {
     )
     .unwrap();
 
-    let context = C::new(sender_address, 1, SpecId::Tangerine, 0);
+    let context = C::new(sender_address, 1, SpecId::latest(), 0);
 
     let _ = l2_block_rule_enforcer
         .call(call_message, &context, &mut working_set)

--- a/crates/l2-block-rule-enforcer/src/tests/mod.rs
+++ b/crates/l2-block-rule-enforcer/src/tests/mod.rs
@@ -19,7 +19,7 @@ fn sc_info_helper() -> HookL2BlockInfo {
     HookL2BlockInfo {
         l2_height: 1,
         pre_state_root: [0; 32],
-        current_spec: SpecId::Tangerine,
+        current_spec: SpecId::latest(),
         sequencer_pub_key: K256PublicKey::try_from_slice(
             &hex::decode("036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f7")
                 .unwrap(),

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/tests/rpc/expose_rpc_associated_type_not_static.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/tests/rpc/expose_rpc_associated_type_not_static.rs
@@ -3,8 +3,8 @@ use sov_modules_api::default_context::ZkDefaultContext;
 use sov_modules_api::macros::{expose_rpc, rpc_gen, DefaultRuntime};
 use sov_modules_api::prelude::*;
 use sov_modules_api::{
-    Address, CallResponse, Context, DispatchCall, EncodeCall, Genesis, MessageCodec, Module,
-    ModuleInfo, L2BlockModuleCallError, Spec, SpecId, StateValue, WorkingSet,
+    Address, CallResponse, Context, DispatchCall, EncodeCall, Genesis, L2BlockModuleCallError,
+    MessageCodec, Module, ModuleInfo, Spec, SpecId, StateValue, WorkingSet,
 };
 use sov_state::ZkStorage;
 
@@ -123,7 +123,7 @@ fn main() {
         <RT as EncodeCall<my_module::QueryModule<C, u32>>>::encode_call(message);
     let module = RT::decode_call(&serialized_message).unwrap();
     let sender = Address::try_from([11; 32].as_ref()).unwrap();
-    let context = C::new(sender, 1, SpecId::Tangerine, 0);
+    let context = C::new(sender, 1, SpecId::latest(), 0);
 
     let _ = runtime
         .dispatch_call(module, working_set, &context)

--- a/crates/sovereign-sdk/module-system/sov-modules-macros/tests/rpc/expose_rpc_first_generic_not_context.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-macros/tests/rpc/expose_rpc_first_generic_not_context.rs
@@ -2,8 +2,8 @@ use jsonrpsee::core::RpcResult;
 use sov_modules_api::default_context::ZkDefaultContext;
 use sov_modules_api::macros::{expose_rpc, rpc_gen, DefaultRuntime};
 use sov_modules_api::{
-    Address, CallResponse, Context, DispatchCall, EncodeCall, Genesis, MessageCodec, Module,
-    ModuleInfo, L2BlockModuleCallError, Spec, SpecId, StateValue, WorkingSet,
+    Address, CallResponse, Context, DispatchCall, EncodeCall, Genesis, L2BlockModuleCallError,
+    MessageCodec, Module, ModuleInfo, Spec, SpecId, StateValue, WorkingSet,
 };
 use sov_state::ZkStorage;
 
@@ -120,7 +120,7 @@ fn main() {
         <RT as EncodeCall<my_module::QueryModule<C, u32>>>::encode_call(message);
     let module = RT::decode_call(&serialized_message).unwrap();
     let sender = Address::try_from([11; 32].as_ref()).unwrap();
-    let context = C::new(sender, 1, SpecId::Tangerine, 0);
+    let context = C::new(sender, 1, SpecId::latest(), 0);
 
     let _ = runtime
         .dispatch_call(module, working_set, &context)


### PR DESCRIPTION
# Description
we forgot to update esp. the evm tests when we introduced the `latest` method. so fixing it now.


### for reviewers
make sure I only made changes to tests, there is a comment change on evm/lib.rs, which should be fine.