### PR TITLE
ci(changelog): Split check and comment dismissal into separate jobs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -55,12 +55,99 @@ jobs:
       issues: write
     name: Check Changelog Entry
     runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if CHANGELOG.md was modified
+        id: changelog-check
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^CHANGELOG.md$"; then
+            echo "modified=true" >> $GITHUB_OUTPUT
+          else
+            echo "modified=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment if changelog is missing
+        if: steps.changelog-check.outputs.modified == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prTitle = context.payload.pull_request.title;
+
+            // Check if bot already commented
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Changelog entry missing')
+            );
+
+            // Only comment if we haven't already
+            if (!botComment) {
+              const commentBody = `## ⚠️ Changelog entry missing
+
+            No changes detected in \`CHANGELOG.md\`.
+
+            **Recommendation:**
+            \`\`\`
+            ${prTitle}
+            \`\`\`
+
+            Please add an entry to the CHANGELOG.md or dismiss this if the change doesn't require documentation.
+
+            **To dismiss:** Reply with \`/skip-changelog\` in any comment.`;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: commentBody
+              });
+            }
+
+      - name: Remove comment if changelog was added
+        if: steps.changelog-check.outputs.modified == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Changelog entry missing')
+            );
+
+            if (botComment) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id
+              });
+            }
+
+  handle-changelog-dismissal:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    name: Handle Changelog Dismissal
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request
     steps:
       - name: Handle dismissal comment
-        if: github.event_name == 'issue_comment'
         uses: actions/github-script@v7
         with:
           script: |
@@ -104,91 +191,4 @@ jobs:
                   content: '+1'
                 });
               }
-            }
-
-      - name: Checkout code
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check if CHANGELOG.md was modified
-        if: github.event_name == 'pull_request'
-        id: changelog-check
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^CHANGELOG.md$"; then
-            echo "modified=true" >> $GITHUB_OUTPUT
-          else
-            echo "modified=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Comment if changelog is missing
-        if: |
-          github.event_name == 'pull_request' &&
-          steps.changelog-check.outputs.modified == 'false'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prTitle = context.payload.pull_request.title;
-
-            // Check if bot already commented
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('Changelog entry missing')
-            );
-
-            // Only comment if we haven't already
-            if (!botComment) {
-              const commentBody = `## ⚠️ Changelog entry missing
-
-            No changes detected in \`CHANGELOG.md\`.
-
-            **Recommendation:**
-            \`\`\`
-            ${prTitle}
-            \`\`\`
-
-            Please add an entry to the CHANGELOG.md or dismiss this if the change doesn't require documentation.
-
-            **To dismiss:** Reply with \`/skip-changelog\` in any comment.`;
-
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: commentBody
-              });
-            }
-
-      - name: Remove comment if changelog was added
-        if: |
-          github.event_name == 'pull_request' &&
-          steps.changelog-check.outputs.modified == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('Changelog entry missing')
-            );
-
-            if (botComment) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id
-              });
             }


### PR DESCRIPTION
- Simplify logic and split in two jobs for bot comment and comment dismissal
- Remove `needs: Validate` for comment dismissal which led to comment not working properly