### PR TITLE
test: Use NIGHTLY_INITIAL_BATCH_PROOF_METHOD_IDS constant

### DIFF
--- a/bin/citrea/tests/bitcoin/da_queue.rs
+++ b/bin/citrea/tests/bitcoin/da_queue.rs
@@ -7,15 +7,13 @@ use bitcoin_da::error::BitcoinServiceError;
 use bitcoin_da::service::{BitcoinService, UtxoSelectionMode};
 use bitcoincore_rpc::RpcApi;
 use citrea_e2e::bitcoin::{BitcoinNode, DEFAULT_FINALITY_DEPTH};
-use citrea_e2e::config::{BitcoinConfig, LightClientProverConfig, TestCaseConfig};
+use citrea_e2e::config::{BitcoinConfig, TestCaseConfig};
 use citrea_e2e::framework::TestFramework;
 use citrea_e2e::test_case::{TestCase, TestCaseRunner};
 use citrea_e2e::Result;
-use citrea_light_client_prover::rpc::LightClientProverRpcClient;
 use reth_tasks::TaskManager;
 use sov_ledger_rpc::LedgerRpcClient;
 use sov_rollup_interface::da::{DaTxRequest, SequencerCommitment};
-use sov_rollup_interface::rpc::BatchProofMethodIdRpcResponse;
 use sov_rollup_interface::services::da::DaService;
 
 use super::light_client_test::create_random_state_diff;
@@ -39,7 +37,6 @@ impl DaTransactionQueueingTest {
         da_service: &BitcoinService,
         finalized_height: u64,
         genesis_state_root: [u8; 32],
-        batch_proof_method_ids: &[BatchProofMethodIdRpcResponse],
         commitment_1: &SequencerCommitment,
         commitment_1_state_root: [u8; 32],
     ) -> Result<()> {
@@ -51,7 +48,6 @@ impl DaTransactionQueueingTest {
             create_serialized_fake_receipt_batch_proof_with_state_roots(
                 genesis_state_root,
                 20,
-                batch_proof_method_ids[0].method_id.into(),
                 Some(state_diff_100kb.clone()),
                 false,
                 l1_hash.as_raw_hash().to_byte_array(),
@@ -146,7 +142,6 @@ impl DaTransactionQueueingTest {
         da_service: &BitcoinService,
         finalized_height: u64,
         genesis_state_root: [u8; 32],
-        batch_proof_method_ids: &[BatchProofMethodIdRpcResponse],
         commitment_1: &SequencerCommitment,
         commitment_1_state_root: [u8; 32],
     ) -> Result<()> {
@@ -159,7 +154,6 @@ impl DaTransactionQueueingTest {
             create_serialized_fake_receipt_batch_proof_with_state_roots(
                 genesis_state_root,
                 20,
-                batch_proof_method_ids[0].method_id.into(),
                 Some(state_diff_400kb.clone()),
                 false,
                 l1_hash.as_raw_hash().to_byte_array(),
@@ -247,7 +241,6 @@ impl TestCase for DaTransactionQueueingTest {
         TestCaseConfig {
             with_full_node: true,
             with_sequencer: true,
-            with_light_client_prover: true,
             ..Default::default()
         }
     }
@@ -266,14 +259,7 @@ impl TestCase for DaTransactionQueueingTest {
     }
 
     fn scan_l1_start_height() -> Option<u64> {
-        Some(170)
-    }
-
-    fn light_client_prover_config() -> LightClientProverConfig {
-        LightClientProverConfig {
-            initial_da_height: 171,
-            ..Default::default()
-        }
+        Some(145)
     }
 
     async fn cleanup(self) -> Result<()> {
@@ -288,7 +274,6 @@ impl TestCase for DaTransactionQueueingTest {
         let da = f.bitcoin_nodes.get_mut(0).unwrap();
         let sequencer = f.sequencer.as_mut().unwrap();
         let full_node = f.full_node.as_mut().unwrap();
-        let light_client_prover = f.light_client_prover.as_mut().unwrap();
 
         let da_service =
             spawn_bitcoin_da_prover_service(&task_executor, &da.config, Self::test_config().dir)
@@ -296,29 +281,16 @@ impl TestCase for DaTransactionQueueingTest {
         let max_l2_blocks_per_commitment = sequencer.max_l2_blocks_per_commitment();
 
         da.generate(DEFAULT_FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height(None).await?;
 
-        // Wait for light client prover to create light client proof.
-        light_client_prover
-            .wait_for_l1_height(finalized_height, None)
-            .await
+        let genesis_state_root = full_node
+            .client
+            .http_client()
+            .get_l2_genesis_state_root()
+            .await?
+            .unwrap()
+            .0
+            .try_into()
             .unwrap();
-
-        // Expect light client prover to have generated light client proof
-        let lcp = light_client_prover
-            .client
-            .http_client()
-            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
-            .await?;
-        let lcp_output = lcp.unwrap().light_client_proof_output;
-
-        // Get initial method ids and genesis state root
-        let batch_proof_method_ids = light_client_prover
-            .client
-            .http_client()
-            .get_batch_proof_method_ids()
-            .await?;
-        let genesis_state_root = lcp_output.l2_state_root;
 
         let sequencer_client = sequencer.client.clone();
 
@@ -360,7 +332,6 @@ impl TestCase for DaTransactionQueueingTest {
             &da_service,
             finalized_height,
             genesis_state_root,
-            &batch_proof_method_ids,
             &commitment_1,
             commitment_1_state_root,
         )
@@ -371,7 +342,6 @@ impl TestCase for DaTransactionQueueingTest {
             &da_service,
             finalized_height,
             genesis_state_root,
-            &batch_proof_method_ids,
             &commitment_1,
             commitment_1_state_root,
         )
@@ -405,7 +375,6 @@ impl DaTransactionQueueingUtxoSelectionModeOldestTest {
         da_service: &BitcoinService,
         finalized_height: u64,
         genesis_state_root: [u8; 32],
-        batch_proof_method_ids: &[BatchProofMethodIdRpcResponse],
         commitment_1: &SequencerCommitment,
         commitment_1_state_root: [u8; 32],
     ) -> Result<()> {
@@ -417,7 +386,6 @@ impl DaTransactionQueueingUtxoSelectionModeOldestTest {
             create_serialized_fake_receipt_batch_proof_with_state_roots(
                 genesis_state_root,
                 20,
-                batch_proof_method_ids[0].method_id.into(),
                 Some(state_diff_100kb.clone()),
                 false,
                 l1_hash.as_raw_hash().to_byte_array(),
@@ -509,7 +477,6 @@ impl DaTransactionQueueingUtxoSelectionModeOldestTest {
         da_service: &BitcoinService,
         finalized_height: u64,
         genesis_state_root: [u8; 32],
-        batch_proof_method_ids: &[BatchProofMethodIdRpcResponse],
         commitment_1: &SequencerCommitment,
         commitment_1_state_root: [u8; 32],
     ) -> Result<()> {
@@ -522,7 +489,6 @@ impl DaTransactionQueueingUtxoSelectionModeOldestTest {
             create_serialized_fake_receipt_batch_proof_with_state_roots(
                 genesis_state_root,
                 20,
-                batch_proof_method_ids[0].method_id.into(),
                 Some(state_diff_400kb.clone()),
                 false,
                 l1_hash.as_raw_hash().to_byte_array(),
@@ -612,7 +578,6 @@ impl TestCase for DaTransactionQueueingUtxoSelectionModeOldestTest {
         TestCaseConfig {
             with_full_node: true,
             with_sequencer: true,
-            with_light_client_prover: true,
             ..Default::default()
         }
     }
@@ -631,14 +596,7 @@ impl TestCase for DaTransactionQueueingUtxoSelectionModeOldestTest {
     }
 
     fn scan_l1_start_height() -> Option<u64> {
-        Some(170)
-    }
-
-    fn light_client_prover_config() -> LightClientProverConfig {
-        LightClientProverConfig {
-            initial_da_height: 171,
-            ..Default::default()
-        }
+        Some(145)
     }
 
     async fn cleanup(self) -> Result<()> {
@@ -653,7 +611,6 @@ impl TestCase for DaTransactionQueueingUtxoSelectionModeOldestTest {
         let da = f.bitcoin_nodes.get_mut(0).unwrap();
         let sequencer = f.sequencer.as_mut().unwrap();
         let full_node = f.full_node.as_mut().unwrap();
-        let light_client_prover = f.light_client_prover.as_mut().unwrap();
 
         let da_service = spawn_bitcoin_da_prover_service_with_utxo_selection_mode(
             &task_executor,
@@ -665,29 +622,16 @@ impl TestCase for DaTransactionQueueingUtxoSelectionModeOldestTest {
         let max_l2_blocks_per_commitment = sequencer.max_l2_blocks_per_commitment();
 
         da.generate(DEFAULT_FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height(None).await?;
 
-        // Wait for light client prover to create light client proof.
-        light_client_prover
-            .wait_for_l1_height(finalized_height, None)
-            .await
+        let genesis_state_root = full_node
+            .client
+            .http_client()
+            .get_l2_genesis_state_root()
+            .await?
+            .unwrap()
+            .0
+            .try_into()
             .unwrap();
-
-        // Expect light client prover to have generated light client proof
-        let lcp = light_client_prover
-            .client
-            .http_client()
-            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
-            .await?;
-        let lcp_output = lcp.unwrap().light_client_proof_output;
-
-        // Get initial method ids and genesis state root
-        let batch_proof_method_ids = light_client_prover
-            .client
-            .http_client()
-            .get_batch_proof_method_ids()
-            .await?;
-        let genesis_state_root = lcp_output.l2_state_root;
 
         let sequencer_client = sequencer.client.clone();
 
@@ -729,7 +673,6 @@ impl TestCase for DaTransactionQueueingUtxoSelectionModeOldestTest {
             &da_service,
             finalized_height,
             genesis_state_root,
-            &batch_proof_method_ids,
             &commitment_1,
             commitment_1_state_root,
         )
@@ -740,7 +683,6 @@ impl TestCase for DaTransactionQueueingUtxoSelectionModeOldestTest {
             &da_service,
             finalized_height,
             genesis_state_root,
-            &batch_proof_method_ids,
             &commitment_1,
             commitment_1_state_root,
         )

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -15,6 +15,7 @@ use citrea_e2e::test_case::{TestCase, TestCaseRunner};
 use citrea_e2e::traits::Restart;
 use citrea_e2e::Result;
 use citrea_fullnode::rpc::FullNodeRpcClient;
+use citrea_light_client_prover::circuit::initial_values::bitcoinda::NIGHTLY_INITIAL_BATCH_PROOF_METHOD_IDS;
 use citrea_light_client_prover::rpc::LightClientProverRpcClient;
 use reth_tasks::TaskManager;
 use risc0_zkvm::{FakeReceipt, InnerReceipt, MaybePruned, ReceiptClaim};
@@ -53,28 +54,13 @@ impl TestCase for PreStateRootMismatchTest {
     fn test_config() -> TestCaseConfig {
         TestCaseConfig {
             with_full_node: true,
-            with_light_client_prover: true,
             with_sequencer: true,
             ..Default::default()
         }
     }
 
-    fn bitcoin_config() -> BitcoinConfig {
-        BitcoinConfig {
-            extra_args: vec!["-persistmempool=0", "-walletbroadcast=0"],
-            ..Default::default()
-        }
-    }
-
     fn scan_l1_start_height() -> Option<u64> {
-        Some(175)
-    }
-
-    fn light_client_prover_config() -> LightClientProverConfig {
-        LightClientProverConfig {
-            initial_da_height: 175,
-            ..Default::default()
-        }
+        Some(150)
     }
 
     async fn cleanup(self) -> Result<()> {
@@ -88,7 +74,6 @@ impl TestCase for PreStateRootMismatchTest {
 
         let da = f.bitcoin_nodes.get_mut(0).unwrap();
         let sequencer = f.sequencer.as_ref().unwrap();
-        let light_client_prover = f.light_client_prover.as_ref().unwrap();
         let full_node = f.full_node.as_ref().unwrap();
 
         let prover_da_service =
@@ -121,16 +106,6 @@ impl TestCase for PreStateRootMismatchTest {
             l2_end_block_number: commitment_response.l2_end_block_number.to::<u64>(),
         };
 
-        light_client_prover
-            .wait_for_l1_height(commitment1_l1_height, None)
-            .await?;
-
-        let batch_proof_method_ids = light_client_prover
-            .client
-            .http_client()
-            .get_batch_proof_method_ids()
-            .await?;
-
         let l1_hash = da.get_block_hash(commitment1_l1_height).await?;
 
         let genesis_state_root = full_node
@@ -145,7 +120,6 @@ impl TestCase for PreStateRootMismatchTest {
         let proof = create_serialized_fake_receipt_batch_proof_with_state_roots(
             genesis_state_root.try_into().unwrap(),
             max_l2_blocks_per_commitment,
-            batch_proof_method_ids[0].method_id.into(),
             None,
             false,
             l1_hash.as_raw_hash().to_byte_array(),
@@ -191,17 +165,6 @@ impl TestCase for PreStateRootMismatchTest {
             l2_end_block_number: commitment_response2.l2_end_block_number.to::<u64>(),
         };
 
-        light_client_prover
-            .wait_for_l1_height(commitment2_l1_height, None)
-            .await?;
-
-        // Get batch proof method IDs and L1 hash
-        let batch_proof_method_ids = light_client_prover
-            .client
-            .http_client()
-            .get_batch_proof_method_ids()
-            .await?;
-
         let l1_hash = da.get_block_hash(commitment2_l1_height).await?;
 
         let commitment_2_state_root = sequencer
@@ -217,7 +180,6 @@ impl TestCase for PreStateRootMismatchTest {
         let invalid_proof = create_serialized_fake_receipt_batch_proof_with_state_roots(
             [1; 32], // Invalid state root
             max_l2_blocks_per_commitment * 2,
-            batch_proof_method_ids[0].method_id.into(),
             None,
             false,
             l1_hash.as_raw_hash().to_byte_array(),
@@ -297,7 +259,6 @@ impl TestCase for SequencerCommitmentHashMismatchTest {
     fn test_config() -> TestCaseConfig {
         TestCaseConfig {
             with_full_node: true,
-            with_light_client_prover: true, // Used for getting batch_proof_method_ids
             ..Default::default()
         }
     }
@@ -310,14 +271,7 @@ impl TestCase for SequencerCommitmentHashMismatchTest {
     }
 
     fn scan_l1_start_height() -> Option<u64> {
-        Some(170)
-    }
-
-    fn light_client_prover_config() -> LightClientProverConfig {
-        LightClientProverConfig {
-            initial_da_height: 171,
-            ..Default::default()
-        }
+        Some(145)
     }
 
     async fn cleanup(self) -> Result<()> {
@@ -332,7 +286,6 @@ impl TestCase for SequencerCommitmentHashMismatchTest {
         let da = f.bitcoin_nodes.get_mut(0).unwrap();
         let sequencer = f.sequencer.as_ref().unwrap();
         let full_node = f.full_node.as_ref().unwrap();
-        let light_client_prover = f.light_client_prover.as_ref().unwrap();
 
         let prover_da_service =
             spawn_bitcoin_da_prover_service(&task_executor, &da.config, Self::test_config().dir)
@@ -389,10 +342,6 @@ impl TestCase for SequencerCommitmentHashMismatchTest {
         full_node
             .wait_for_l1_height(commitment_l1_height, None)
             .await?;
-        light_client_prover
-            .wait_for_l1_height(commitment_l1_height, None)
-            .await
-            .unwrap();
 
         // Verify the correct commitment is stored and has the expected merkle_root
         let stored_commitment = full_node
@@ -413,11 +362,6 @@ impl TestCase for SequencerCommitmentHashMismatchTest {
             .await?
             .unwrap()
             .0;
-        let batch_proof_method_ids = light_client_prover
-            .client
-            .http_client()
-            .get_batch_proof_method_ids()
-            .await?;
 
         let wrong_commitment_state_root = sequencer
             .client
@@ -432,7 +376,6 @@ impl TestCase for SequencerCommitmentHashMismatchTest {
         let fake_proof = create_serialized_fake_receipt_batch_proof_with_state_roots(
             genesis_state_root.try_into().unwrap(),
             max_l2_blocks_per_commitment,
-            batch_proof_method_ids[0].method_id.into(),
             None,
             false,
             l1_hash.as_raw_hash().to_byte_array(),
@@ -494,13 +437,6 @@ impl TestCase for PendingCommitmentHaltingErrorTest {
     fn test_config() -> TestCaseConfig {
         TestCaseConfig {
             with_full_node: true,
-            ..Default::default()
-        }
-    }
-
-    fn bitcoin_config() -> BitcoinConfig {
-        BitcoinConfig {
-            extra_args: vec!["-persistmempool=0", "-walletbroadcast=0"],
             ..Default::default()
         }
     }
@@ -1376,6 +1312,9 @@ impl TestCase for OutOfRangeProofTest {
         let full_node = f.full_node.as_mut().unwrap();
         let citrea_cli = f.citrea_cli.as_ref().unwrap();
 
+        // Stopping lcp so it doesn't sync over the rolled back state
+        light_client_prover.wait_until_stopped().await?;
+
         let max_l2_blocks_per_commitment = sequencer.max_l2_blocks_per_commitment();
 
         let prover_da_service =
@@ -1386,35 +1325,15 @@ impl TestCase for OutOfRangeProofTest {
             spawn_bitcoin_da_sequencer_service(&task_executor, &da.config, Self::test_config().dir)
                 .await;
 
-        let finalized_height = da.get_finalized_height(None).await?;
-
-        // Wait for light client prover to create light client proof.
-        light_client_prover
-            .wait_for_l1_height(finalized_height, None)
-            .await
+        let genesis_state_root = full_node
+            .client
+            .http_client()
+            .get_l2_genesis_state_root()
+            .await?
+            .unwrap()
+            .0
+            .try_into()
             .unwrap();
-
-        // Expect light client prover to have generated light client proof
-        let lcp = light_client_prover
-            .client
-            .http_client()
-            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
-            .await?;
-        let lcp_output = lcp.unwrap().light_client_proof_output;
-
-        // Get initial method ids and genesis state root
-        let method_id = light_client_prover
-            .client
-            .http_client()
-            .get_batch_proof_method_ids()
-            .await?[0]
-            .method_id
-            .into();
-
-        // Stopping lcp so it doesn't sync over the rolled back state
-        light_client_prover.wait_until_stopped().await?;
-
-        let genesis_state_root = lcp_output.l2_state_root;
 
         // Generate two commitments to test pending proof over commitment ranges
         for _ in 0..max_l2_blocks_per_commitment * 2 {
@@ -1573,7 +1492,6 @@ impl TestCase for OutOfRangeProofTest {
         let proof1 = create_serialized_fake_receipt_batch_proof_with_state_roots(
             genesis_state_root,
             max_l2_blocks_per_commitment * 2,
-            method_id,
             None,
             false,
             current_l1_hash.as_raw_hash().to_byte_array(),
@@ -1823,7 +1741,6 @@ impl TestCase for OutOfRangeProofTest {
         let proof3 = create_serialized_fake_receipt_batch_proof_with_state_roots(
             commitment3_state_root,
             max_l2_blocks_per_commitment * 4,
-            method_id,
             None,
             false,
             current_l1_hash.as_raw_hash().to_byte_array(),
@@ -1881,7 +1798,6 @@ impl TestCase for OutOfRangeProofTest {
         let proof2 = create_serialized_fake_receipt_batch_proof_with_state_roots(
             commitment2_state_root,
             max_l2_blocks_per_commitment * 3,
-            method_id,
             None,
             false,
             current_l1_hash.as_raw_hash().to_byte_array(),
@@ -2018,15 +1934,6 @@ impl TestCase for OverlappingProofRangesTest {
             .get_light_client_proof_by_l1_height(U64::from(finalized_height))
             .await?;
         let lcp_output = lcp.unwrap().light_client_proof_output;
-
-        // Get initial method ids and genesis state root
-        let method_id = light_client_prover
-            .client
-            .http_client()
-            .get_batch_proof_method_ids()
-            .await?[0]
-            .method_id
-            .into();
 
         // Stopping lcp so it doesn't sync over the rolled back state
         light_client_prover.wait_until_stopped().await?;
@@ -2330,7 +2237,6 @@ impl TestCase for OverlappingProofRangesTest {
         let proof_a = create_serialized_fake_receipt_batch_proof_with_state_roots(
             genesis_state_root,
             max_l2_blocks_per_commitment * 3,
-            method_id,
             None,
             false,
             current_l1_hash.as_raw_hash().to_byte_array(),
@@ -2417,7 +2323,6 @@ impl TestCase for OverlappingProofRangesTest {
         let proof_b = create_serialized_fake_receipt_batch_proof_with_state_roots(
             commitment1_state_root,
             max_l2_blocks_per_commitment * 4,
-            method_id,
             None,
             false,
             current_l1_hash.as_raw_hash().to_byte_array(),
@@ -2529,20 +2434,20 @@ impl TestCase for UnsyncedCommitmentL2RangeTest {
 
     fn sequencer_config() -> SequencerConfig {
         SequencerConfig {
-            max_l2_blocks_per_commitment: 10000,
-            ..Default::default()
-        }
-    }
-
-    fn bitcoin_config() -> BitcoinConfig {
-        BitcoinConfig {
-            extra_args: vec!["-persistmempool=0", "-walletbroadcast=0"],
+            max_l2_blocks_per_commitment: 10_000,
             ..Default::default()
         }
     }
 
     fn scan_l1_start_height() -> Option<u64> {
         Some(170)
+    }
+
+    fn light_client_prover_config() -> LightClientProverConfig {
+        LightClientProverConfig {
+            initial_da_height: 171,
+            ..Default::default()
+        }
     }
 
     async fn cleanup(self) -> Result<()> {
@@ -3038,21 +2943,15 @@ impl TestCase for FullNodeLcpChunkProofTest {
             .await
             .unwrap();
 
-        // Expect light client prover to have generated light client proof
-        let lcp = light_client_prover
+        let genesis_state_root = full_node
             .client
             .http_client()
-            .get_light_client_proof_by_l1_height(U64::from(finalized_height))
-            .await?;
-        let lcp_output = lcp.unwrap().light_client_proof_output;
-
-        // Get initial method ids and genesis state root
-        let batch_proof_method_ids = light_client_prover
-            .client
-            .http_client()
-            .get_batch_proof_method_ids()
-            .await?;
-        let genesis_state_root = lcp_output.l2_state_root;
+            .get_l2_genesis_state_root()
+            .await?
+            .unwrap()
+            .0
+            .try_into()
+            .unwrap();
 
         let sequencer_client = sequencer.client.clone();
 
@@ -3188,7 +3087,6 @@ impl TestCase for FullNodeLcpChunkProofTest {
             create_serialized_fake_receipt_batch_proof_with_state_roots(
                 genesis_state_root,
                 20,
-                batch_proof_method_ids[0].method_id.into(),
                 Some(state_diff_60kb.clone()),
                 false,
                 l1_hash.as_raw_hash().to_byte_array(),
@@ -3300,7 +3198,6 @@ impl TestCase for FullNodeLcpChunkProofTest {
             create_serialized_fake_receipt_batch_proof_with_state_roots(
                 last_state_root,
                 40,
-                batch_proof_method_ids[0].method_id.into(),
                 Some(state_diff_60kb.clone()),
                 false,
                 l1_hash.as_raw_hash().to_byte_array(),
@@ -3425,7 +3322,6 @@ impl TestCase for FullNodeLcpChunkProofTest {
             create_serialized_fake_receipt_batch_proof_with_state_roots(
                 block_20_sr,
                 40,
-                batch_proof_method_ids[0].method_id.into(),
                 Some(state_diff_60kb.clone()),
                 false,
                 l1_hash.as_raw_hash().to_byte_array(),
@@ -3544,7 +3440,6 @@ impl TestCase for FullNodeLcpChunkProofTest {
             create_serialized_fake_receipt_batch_proof_with_state_roots(
                 last_state_root,
                 60,
-                batch_proof_method_ids[0].method_id.into(),
                 Some(state_diff_60kb.clone()),
                 false,
                 l1_hash.as_raw_hash().to_byte_array(),
@@ -3957,7 +3852,6 @@ async fn test_unsynced_first_commitment() -> Result<()> {
 pub fn create_serialized_fake_receipt_batch_proof_with_state_roots(
     initial_state_root: [u8; 32],
     last_l2_height: u64,
-    method_id: [u32; 8],
     state_diff: Option<CumulativeStateDiff>,
     malformed_journal: bool,
     last_l1_hash_on_bitcoin_light_client_contract: [u8; 32],
@@ -3965,6 +3859,8 @@ pub fn create_serialized_fake_receipt_batch_proof_with_state_roots(
     state_roots_of_seq_comms: Vec<[u8; 32]>,
     prev_sequencer_commitment_hash: Option<[u8; 32]>,
 ) -> Vec<u8> {
+    let method_id = NIGHTLY_INITIAL_BATCH_PROOF_METHOD_IDS.inner()[0].1;
+
     let sequencer_commitment_hashes = sequencer_commitments
         .iter()
         .map(|c| c.serialize_and_calculate_sha_256())


### PR DESCRIPTION
# Description

- Remove the need of light client prover to retrieve batch proof method ids