### PR TITLE
fix: use mock hash for inspector for trace_call

### DIFF
--- a/crates/evm/src/rpc_helpers/tracing_utils.rs
+++ b/crates/evm/src/rpc_helpers/tracing_utils.rs
@@ -453,9 +453,10 @@ where
     I: for<'c> Inspector<CitreaContext<'c, DB>>,
 {
     let mut ext = CitreaChain::new(l1_fee_rate);
-    if let Some(tx_hash) = tx_hash {
-        ext.set_current_tx_hash(tx_hash);
-    }
+
+    let tx_hash = tx_hash.unwrap_or_else(|| b"hash_of_an_ephemeral_transaction".into());
+
+    ext.set_current_tx_hash(tx_hash);
 
     let mut journal = Journal::new(db);
     journal.set_spec_id(config_env.spec());


### PR DESCRIPTION
# Description
it's logging an ERROR because we don't set hash for the executor for the specific inspector runs 