### PR TITLE
perf: Remove validation from backup creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - feat(prover): Store proving info by job id ([#3011](https://github.com/chainwayxyz/citrea/pull/3011))\
   `batchProver_getProvingJob*` endpoints now return information about the proving session, including cycle counts and request IDs (bonsai and boundless proofs).
-- perf: Remove validation from backup creation. Backup validation should now be handle by `backup_validate` RPC method. ([#3045](https://github.com/chainwayxyz/citrea/pull/3045))
+- perf: Remove validation from backup creation. Backup validation should now be handled by `backup_validate` RPC method. ([#3045](https://github.com/chainwayxyz/citrea/pull/3045))
 
 ## v0.9.0 (2025-11-12)
 - feat: Implement eth filter rpc endpoints. ([#2956](https://github.com/chainwayxyz/citrea/pull/2956))\

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - feat(prover): Store proving info by job id ([#3011](https://github.com/chainwayxyz/citrea/pull/3011))\
   `batchProver_getProvingJob*` endpoints now return information about the proving session, including cycle counts and request IDs (bonsai and boundless proofs).
+- perf: Remove validation from backup creation. Backup validation should now be handle by `backup_validate` RPC method.
 
 ## v0.9.0 (2025-11-12)
 - feat: Implement eth filter rpc endpoints. ([#2956](https://github.com/chainwayxyz/citrea/pull/2956))\
@@ -60,7 +61,7 @@ Node operators need to rescan L1:
 # use citrea-cli v0.7.2
 citrea-cli --rollback --node-type fullnode --db-path path/to/db --l2-target 9999999999 --l1-target 74247 --sequencer-commitment-index 0
 
-citrea-cli clear-pending --db-path path/to/dbs 
+citrea-cli clear-pending --db-path path/to/dbs
 ```
 
 
@@ -73,7 +74,7 @@ Node operators need to rescan L1:
 # use citrea-cli v0.7.1
 citrea-cli --rollback --node-type fullnode --db-path path/to/db --l2-target 9999999999 --l1-target 74247 --sequencer-commitment-index 0
 
-citrea-cli clear-pending --db-path path/to/dbs 
+citrea-cli clear-pending --db-path path/to/dbs
 ```
 
 ## v0.7.0 (2025-04-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - feat(prover): Store proving info by job id ([#3011](https://github.com/chainwayxyz/citrea/pull/3011))\
   `batchProver_getProvingJob*` endpoints now return information about the proving session, including cycle counts and request IDs (bonsai and boundless proofs).
-- perf: Remove validation from backup creation. Backup validation should now be handle by `backup_validate` RPC method.
+- perf: Remove validation from backup creation. Backup validation should now be handle by `backup_validate` RPC method. ([#3045](https://github.com/chainwayxyz/citrea/pull/3045))
 
 ## v0.9.0 (2025-11-12)
 - feat: Implement eth filter rpc endpoints. ([#2956](https://github.com/chainwayxyz/citrea/pull/2956))\

--- a/crates/common/src/backup/manager.rs
+++ b/crates/common/src/backup/manager.rs
@@ -183,7 +183,6 @@ impl BackupManager {
         );
 
         let mut handles = Vec::new();
-
         {
             let dbs = self.databases.read().unwrap();
             for dir in &self.config.backup_dirs {
@@ -198,23 +197,21 @@ impl BackupManager {
         drop(l2_lock);
         drop(l1_lock);
 
+        let mut backup_id = None;
         for handle in handles {
-            handle.await??;
+            let result = handle.await??;
+
+            // Get backup_id from last `BackupEngineInfo` returned from `create_backup`
+            // Any database can be used as the three of them should always match on `backup_id`
+            let current_id = result.last().map(|v| v.backup_id);
+            if backup_id.is_none() {
+                backup_id = current_id;
+            } else {
+                anyhow::ensure!(backup_id == current_id, "Backup id mismatch");
+            }
         }
 
-        if let Err(e) = self.validate_backup(backup_path) {
-            warn!("Error validating backup: {e}");
-            bail!("Error creating valid backup: {e}");
-        }
-
-        let backup_info = self.get_backup_info(backup_path)?;
-        let backup_id = backup_info
-            .get("ledger")
-            .expect("Would fail on validate_backup")
-            .last()
-            .expect("Would fail on validate_backup")
-            .backup_id;
-
+        let backup_id = backup_id.ok_or(anyhow::anyhow!("Failed to get backup_id"))?;
         let info = CreateBackupInfo {
             node_type: self.node_type.to_string(),
             l2_block_height,

--- a/crates/sovereign-sdk/full-node/db/sov-schema-db/src/lib.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-schema-db/src/lib.rs
@@ -29,6 +29,7 @@ use ::metrics::{gauge, histogram};
 use anyhow::format_err;
 pub use iterator::{RawDbReverseIterator, ScanDirection, SchemaIterator, SeekKeyEncoder};
 pub use rocksdb;
+use rocksdb::backup::BackupEngineInfo;
 pub use rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
 use rocksdb::{DBIterator, ReadOptions, WriteBatch};
 use thiserror::Error;
@@ -428,7 +429,10 @@ impl DB {
     }
 
     /// Create backup at directory specified by `backup_path`
-    pub fn create_backup(&self, backup_path: impl AsRef<Path>) -> anyhow::Result<()> {
+    pub fn create_backup(
+        &self,
+        backup_path: impl AsRef<Path>,
+    ) -> anyhow::Result<Vec<BackupEngineInfo>> {
         std::fs::create_dir_all(&backup_path)?;
 
         let backup_opts = rocksdb::backup::BackupEngineOptions::new(backup_path.as_ref())?;
@@ -443,7 +447,7 @@ impl DB {
             "Created database backup"
         );
 
-        Ok(())
+        Ok(backup_engine.get_backup_info())
     }
 }
 


### PR DESCRIPTION
# Description

- Remove validation step from backup creation. Validation should now be handled by calling `backup_validate` RPC after creation.
- Fix potential testnet issue where first backup creation times out on internal validation.

## Linked Issues
- Fixes #3041 