### PR TITLE
feat(citrea-cli): create backup command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 
 - feat: Risc0 host configs can now be passed from `prover_config.toml` files. ([#2994](https://github.com/chainwayxyz/citrea/pull/2994))
 
+- feat: Add create backup `citrea-cli` command([#3047](https://github.com/chainwayxyz/citrea/pull/3047))\
+  Usage: citrea-cli create-backup --node-type <NODE_TYPE> --db-path <DB_PATH> --backup-path <BACKUP_PATH>
+
 ## v0.8.1 (2025-10-25)
 Fixes Testnet guest list for Light Client Prover.
 
@@ -60,7 +63,7 @@ Node operators need to rescan L1:
 # use citrea-cli v0.7.2
 citrea-cli --rollback --node-type fullnode --db-path path/to/db --l2-target 9999999999 --l1-target 74247 --sequencer-commitment-index 0
 
-citrea-cli clear-pending --db-path path/to/dbs 
+citrea-cli clear-pending --db-path path/to/dbs
 ```
 
 
@@ -73,7 +76,7 @@ Node operators need to rescan L1:
 # use citrea-cli v0.7.1
 citrea-cli --rollback --node-type fullnode --db-path path/to/db --l2-target 9999999999 --l1-target 74247 --sequencer-commitment-index 0
 
-citrea-cli clear-pending --db-path path/to/dbs 
+citrea-cli clear-pending --db-path path/to/dbs
 ```
 
 ## v0.7.0 (2025-04-18)

--- a/bin/cli/src/commands/backup.rs
+++ b/bin/cli/src/commands/backup.rs
@@ -1,9 +1,45 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use citrea_common::backup::metadata::backup_kind_from_metadata;
-use citrea_common::backup::BackupManager;
+use citrea_common::backup::{BackupManager, CreateBackupInfo};
 use citrea_common::NodeType;
+use sov_db::ledger_db::LedgerDB;
+use sov_db::native_db::NativeDB;
+use sov_db::rocks_db_config::RocksdbConfig;
+use sov_db::state_db::StateDB;
 use tracing::info;
+
+use crate::commands::{cfs_from_node_type, NodeTypeArg};
+
+pub(crate) async fn create_backup(
+    node_type: NodeTypeArg,
+    db_path: PathBuf,
+    backup_path: PathBuf,
+) -> anyhow::Result<CreateBackupInfo> {
+    info!(
+        "Create backup {} at {} for {}.",
+        backup_path.display(),
+        db_path.display(),
+        node_type,
+    );
+
+    let column_families = cfs_from_node_type(node_type);
+    let rocksdb_config = RocksdbConfig::new(&db_path, None, Some(column_families));
+    let ledger_db = LedgerDB::with_config(&rocksdb_config)?;
+    let state_db = Arc::new(StateDB::setup_schema_db(&rocksdb_config)?);
+    let native_db = Arc::new(NativeDB::setup_schema_db(&rocksdb_config)?);
+
+    let backup_manager = BackupManager::new(node_type.into(), None, None);
+    backup_manager
+        .register_database(LedgerDB::DB_PATH_SUFFIX.to_string(), ledger_db.db_handle())?;
+    backup_manager.register_database(StateDB::DB_PATH_SUFFIX.to_string(), state_db)?;
+    backup_manager.register_database(NativeDB::DB_PATH_SUFFIX.to_string(), native_db)?;
+
+    backup_manager
+        .create_backup(Some(backup_path), &ledger_db)
+        .await
+}
 
 pub(crate) async fn restore_backup(
     node_type: NodeType,

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -46,6 +46,18 @@ enum Commands {
         #[arg(long)]
         sequencer_commitment_index: Option<u32>,
     },
+    /// Create DBs backup
+    CreateBackup {
+        /// The node kind
+        #[arg(long)]
+        node_type: NodeTypeArg,
+        /// The path of the databases to backup
+        #[arg(long)]
+        db_path: PathBuf,
+        /// The backup path
+        #[arg(long)]
+        backup_path: PathBuf,
+    },
     /// Restore DBs from backup
     RestoreBackup {
         /// The node kind
@@ -121,6 +133,13 @@ async fn main() -> anyhow::Result<()> {
                 sequencer_commitment_index,
             )
             .await?;
+        }
+        Commands::CreateBackup {
+            db_path,
+            backup_path,
+            node_type,
+        } => {
+            commands::create_backup(node_type, db_path, backup_path).await?;
         }
         Commands::RestoreBackup {
             db_path,

--- a/crates/common/src/backup/manager.rs
+++ b/crates/common/src/backup/manager.rs
@@ -144,7 +144,7 @@ impl BackupManager {
     ///
     /// # Returns
     /// Information about the created backup including block height, path and timestamp
-    pub(super) async fn create_backup(
+    pub async fn create_backup(
         &self,
         path: Option<PathBuf>,
         ledger_db: &LedgerDB,


### PR DESCRIPTION
# Description

- Add `create-backup` command to `citrea-cli`

Usage:
```
citrea-cli create-backup                                        
error: the following required arguments were not provided:
  --node-type <NODE_TYPE>
  --db-path <DB_PATH>
  --backup-path <BACKUP_PATH>

Usage: citrea-cli create-backup --node-type <NODE_TYPE> --db-path <DB_PATH> --backup-path <BACKUP_PATH>

For more information, try '--help'.
```

## Linked Issues
- Fixes #3042 