### PR TITLE
chore: Upgrade debian

### DIFF
--- a/docker/build-push/nightly/Dockerfile
+++ b/docker/build-push/nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \

--- a/docker/build-push/testnet/Dockerfile
+++ b/docker/build-push/testnet/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
+
 RUN \
   apt-get update \
   && apt-get -y install gettext-base \


### PR DESCRIPTION
# Description

Github CI update their CI base which means that when we build citrea binaries in CI, our binaries are build using a newer version of glibc. When those binaries are copied into `debian:bookworm-slim`, the image doesn't have the newer glibc version and therefore it results in the following error:
```
./citrea: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./citrea)
./citrea: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./citrea)
```

This PR upgrades the docker debian base we use for our docker images which has the newer glibc version.