### PR TITLE
chore: Bump bitcoin version to v30

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,7 +62,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   FOUNDRY_PROFILE: ci
-  BITCOIN_DOCKER_IMAGE: "bitcoin/bitcoin:29.0"
+  BITCOIN_DOCKER_IMAGE: "bitcoin/bitcoin:30.0"
 
 # Automatically cancels a job if a new commit if pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,7 +62,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   FOUNDRY_PROFILE: ci
-  TEST_BITCOIN_DOCKER: "bitcoin/bitcoin:29.0"
+  BITCOIN_DOCKER_IMAGE: "bitcoin/bitcoin:29.0"
 
 # Automatically cancels a job if a new commit if pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   Usage: citrea-cli create-backup --node-type <NODE_TYPE> --db-path <DB_PATH> --backup-path <BACKUP_PATH>
 - feat: Store proving session info of LCP ([#3050](https://github.com/chainwayxyz/citrea/pull/3050))\
   `lightClientProver_getLightClientProofByL1Height` endpoint now returns information about the proving session, using the same structure as the batch prover responses.
+- ci: Run citrea-e2e tests against bitcoin v30
 
 ### Changed
 - chore: renamed `BOUNDLESS_S3_NO_PRESIGNED` to `BOUNDLESS_S3_USE_PRESIGNED`. ([#3046](https://github.com/chainwayxyz/citrea/pull/3046))\

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=a93a037#a93a03750618d037c63bee8edd9183da1a0c4141"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=10ff3e2#10ff3e2e8ca6cad1457ce5ae74602520da465c54"
 dependencies = [
  "alloy-primitives 0.8.26",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,7 +3756,6 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=5671cf8#5671cf81b13934508c55431d02958c59fcecada9"
 dependencies = [
  "alloy-primitives 0.8.26",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,6 +3756,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=a93a037#a93a03750618d037c63bee8edd9183da1a0c4141"
 dependencies = [
  "alloy-primitives 0.8.26",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ alloy-network = { version = "0.13", default-features = false }
 alloy-signer = { version = "0.13", default-features = false }
 alloy-signer-local = { version = "0.13.0", default-features = false }
 
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "a93a037" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "10ff3e2" }
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "a6e011a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ alloy-network = { version = "0.13", default-features = false }
 alloy-signer = { version = "0.13", default-features = false }
 alloy-signer-local = { version = "0.13.0", default-features = false }
 
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "5671cf8" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "a93a037" }
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "a6e011a" }

--- a/docker/docker-compose.regtest.yml
+++ b/docker/docker-compose.regtest.yml
@@ -1,6 +1,6 @@
 services:
   citrea-bitcoin-regtest:
-    image: bitcoin/bitcoin:28.0
+    image: bitcoin/bitcoin:30.0
     container_name: bitcoin-regtest
     environment:
       - BITCOIN_DATA=/var/lib/bitcoin

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
-services:  
+services:
   citrea-bitcoin-testnet4:
-    image: bitcoin/bitcoin:28.0
+    image: bitcoin/bitcoin:30.0
     container_name: bitcoin-testnet4
     ports:
       - "18443:18443"
@@ -21,7 +21,7 @@ services:
     networks:
       - citrea-testnet-network
 
-  
+
   citrea-full-node:
     depends_on:
       - citrea-bitcoin-testnet4

--- a/docs/run-testnet.md
+++ b/docs/run-testnet.md
@@ -34,16 +34,16 @@ Testnet4 is only enabled in versions bigger than 28.0.
 ```sh
 git clone https://github.com/bitcoin/bitcoin.git
 cd bitcoin
-git checkout v28.0
+git checkout v30.0
 ```
 
 #### Step 1.2: Build Bitcoin Core
 
 Then follow the instructions on the links below for the build. However, don't clone the repository since we already did.
 
-OSX: https://github.com/bitcoin/bitcoin/blob/v28.0/doc/build-osx.md
+OSX: https://github.com/bitcoin/bitcoin/blob/v30.0/doc/build-osx.md
 
-Linux: https://github.com/bitcoin/bitcoin/blob/v28.0/doc/build-unix.md
+Linux: https://github.com/bitcoin/bitcoin/blob/v30.0/doc/build-unix.md
 
 
 #### Step 1.3: Run testnet4 node:
@@ -66,7 +66,7 @@ Follow instructions to install Docker here: https://docs.docker.com/engine/insta
 
 #### Step 2.2: Run testnet4 node:
 
-After Docker is installed, run this command to pull Bitcoin v0.28.0 image and run it as a container:
+After Docker is installed, run this command to pull Bitcoin v0.30.0 image and run it as a container:
 
 ```sh
 docker run -d \
@@ -74,7 +74,7 @@ docker run -d \
   --name bitcoin-testnet4 \
   -p 18443:18443 \
   -p 18444:18444 \
-  bitcoin/bitcoin:28.0 \
+  bitcoin/bitcoin:30.0 \
   -printtoconsole \
   -testnet4=1 \
   -rest \

--- a/proving-stats/docker-compose.regtest.yml
+++ b/proving-stats/docker-compose.regtest.yml
@@ -1,6 +1,6 @@
 services:
   citrea-bitcoin-regtest:
-    image: bitcoin/bitcoin:29.0
+    image: bitcoin/bitcoin:30.0
     container_name: bitcoin-regtest
     environment:
       - BITCOIN_DATA=/var/lib/bitcoin


### PR DESCRIPTION
# Description

- Bump CI bitcon version to v30 when running citrea-e2e

Requires https://github.com/chainwayxyz/citrea-e2e/pull/151

## Linked Issues
- Fixes #3052 