### PR TITLE
fix: debug_traceCall with pending block

### DIFF
--- a/bin/citrea/tests/mock/evm/tracing.rs
+++ b/bin/citrea/tests/mock/evm/tracing.rs
@@ -153,7 +153,11 @@ async fn test_call_tracer() -> Result<(), Box<dyn std::error::Error>> {
 
     let call_frame_call_trace = test_client
         // test tracing in pending block
-        .debug_trace_call(tx_request.clone(), Some(BlockId::Number(BlockNumberOrTag::Pending)), Some(opts))
+        .debug_trace_call(
+            tx_request.clone(),
+            Some(BlockId::Number(BlockNumberOrTag::Pending)),
+            Some(opts),
+        )
         .await;
 
     let json_value = serde_json::from_value::<CallFrame>(json! [{

--- a/bin/citrea/tests/mock/evm/tracing.rs
+++ b/bin/citrea/tests/mock/evm/tracing.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use alloy_primitives::ruint::aliases::U256;
 use alloy_primitives::{Address, Bytes};
-use alloy_rpc_types::{BlockNumberOrTag, TransactionInput, TransactionRequest};
+use alloy_rpc_types::{BlockId, BlockNumberOrTag, TransactionInput, TransactionRequest};
 use alloy_rpc_types_trace::geth::call::FlatCallFrame;
 use alloy_rpc_types_trace::geth::mux::{MuxConfig, MuxFrame};
 use alloy_rpc_types_trace::geth::GethTrace::{
@@ -152,7 +152,8 @@ async fn test_call_tracer() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let call_frame_call_trace = test_client
-        .debug_trace_call(tx_request.clone(), None, Some(opts))
+        // test tracing in pending block
+        .debug_trace_call(tx_request.clone(), Some(BlockId::Number(BlockNumberOrTag::Pending)), Some(opts))
         .await;
 
     let json_value = serde_json::from_value::<CallFrame>(json! [{

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1538,10 +1538,15 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         let cfg_env = get_cfg_env(cfg, evm_spec_id);
 
-        let sealed_block = self
-            .get_sealed_block_by_number(Some(block_number), working_set, ledger_db)?
+        let l1_fee_block_num = match block_number {
+            // use l1 fee rate of latest block for pending block
+            BlockNumberOrTag::Pending => BlockNumberOrTag::Latest,
+            _ => block_number,
+        };
+        let l1_fee_block = self
+            .get_sealed_block_by_number(Some(l1_fee_block_num), working_set, ledger_db)?
             .ok_or_else(|| EthApiError::HeaderNotFound(block_id.unwrap()))?;
-        let l1_fee_rate = sealed_block.l1_fee_rate;
+        let l1_fee_rate = l1_fee_block.l1_fee_rate;
 
         let account = self
             .account_info(&request.from.unwrap_or_default(), working_set)


### PR DESCRIPTION
# Description
`debug_traceCall` with pending block param was giving `"pending block not supported"`
Cause of the error was in `crates/evm/src/query.rs:1541`
```
 let sealed_block = self
    .get_sealed_block_by_number(Some(block_number), working_set, ledger_db)?
    .ok_or_else(|| EthApiError::HeaderNotFound(block_id.unwrap()))?;
 let l1_fee_rate = sealed_block.l1_fee_rate;
```
When `block_number == Pending`, `get_sealed_block_by_number` returns this error.

Fix: For pending blocks, use latest block for l1 fee rate.

## Testing
Added to call tracer test.