### PR TITLE
fix: multiple tracing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   &nbsp;&nbsp;&nbsp;&nbsp; `BOUNDLESS_S3_USE_PRESIGNED` Use presigned URLs for S3 (default: false)
   &nbsp;\
   New configuration values can also be set inside `batch_prover_config.toml` files under `[risc0_host.prover.Boundless.storage]` with key `s3_use_presigned`.
+- fix: multiple tracing related issues fixed. ([#3064](https://github.com/chainwayxyz/citrea/pull/3064))
 
 ## v1.0.0 (2025-12-01)
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10627,8 +10627,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a32ec21c38a85f83773e6b3cdb7060aae8ac9edb291118fbfd4da7f2a50e620"
+source = "git+https://github.com/chainwayxyz/revm-inspectors?rev=574d614ce505d3c0c4534d8b8e62d8acb3fa9651#574d614ce505d3c0c4534d8b8e62d8acb3fa9651"
 dependencies = [
  "alloy-primitives 0.8.26",
  "alloy-rpc-types-eth 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,8 @@ citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "10ff3e2
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "a6e011a" }
+# Use our fork of revm-inspectors to apply fixes after v0.18.1
+# Cannot update to latest as it requires latest revm, which we cannot use yet
 revm-inspectors = { git = "https://github.com/chainwayxyz/revm-inspectors", rev = "574d614ce505d3c0c4534d8b8e62d8acb3fa9651" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,7 @@ citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "10ff3e2
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "a6e011a" }
+revm-inspectors = { git = "https://github.com/chainwayxyz/revm-inspectors", rev = "574d614ce505d3c0c4534d8b8e62d8acb3fa9651" }
 
 [profile.release]
 opt-level = 3

--- a/bin/citrea/tests/mock/evm/tracing.rs
+++ b/bin/citrea/tests/mock/evm/tracing.rs
@@ -11,8 +11,10 @@ use alloy_rpc_types_trace::geth::GethTrace::{
 };
 use alloy_rpc_types_trace::geth::{
     CallConfig, CallFrame, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
-    GethDebugTracingCallOptions, GethDebugTracingOptions, PreStateFrame, TraceResult,
+    GethDebugTracingCallOptions, GethDebugTracingOptions, PreStateConfig, PreStateFrame,
+    TraceResult,
 };
+use bincode::de;
 // use citrea::initialize_logging;
 use citrea_common::SequencerConfig;
 use citrea_evm::smart_contracts::{CallerContract, SimpleStorageContract};
@@ -1008,6 +1010,51 @@ async fn test_pre_state_tracer() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(json_res.len(), 1);
     assert_eq!(json_res[0], PreStateTracer(json_value));
+
+    // reproduce bug where a contract deployment on an address with balance doesn't show up on
+    // "pre" field of prestate tracer when diff mode is enabled
+    let cur_nonce = test_client
+        .eth_get_transaction_count(test_client.from_addr, None)
+        .await
+        .unwrap();
+
+    // +1 because we'll send funds to the contract address first, using cur_nonce
+    let contract_addr = test_client.from_addr.create(cur_nonce + 1);
+
+    let res = test_client
+        .send_eth(contract_addr, None, None, Some(cur_nonce), 1_000_000)
+        .await?;
+
+    test_client.send_publish_batch_request().await;
+
+    res.get_receipt().await?;
+
+    // any contract works as this is CREATE
+    let deploy_tx = test_client
+        .deploy_contract(CallerContract::default().byte_code(), Some(cur_nonce + 1))
+        .await?;
+
+    test_client.send_publish_batch_request().await;
+
+    let tx_hash = deploy_tx.get_receipt().await?.transaction_hash;
+
+    let trace_result = test_client
+        .debug_trace_transaction(
+            tx_hash,
+            Some(GethDebugTracingOptions::prestate_tracer(PreStateConfig {
+                diff_mode: Some(true),
+                ..Default::default()
+            })),
+        )
+        .await;
+
+    assert!(trace_result
+        .try_into_pre_state_frame()
+        .unwrap()
+        .as_diff()
+        .unwrap()
+        .pre
+        .contains_key(&contract_addr));
 
     task_manager.graceful_shutdown();
     Ok(())

--- a/bin/citrea/tests/mock/evm/tracing.rs
+++ b/bin/citrea/tests/mock/evm/tracing.rs
@@ -14,7 +14,6 @@ use alloy_rpc_types_trace::geth::{
     GethDebugTracingCallOptions, GethDebugTracingOptions, PreStateConfig, PreStateFrame,
     TraceResult,
 };
-use bincode::de;
 // use citrea::initialize_logging;
 use citrea_common::SequencerConfig;
 use citrea_evm::smart_contracts::{CallerContract, SimpleStorageContract};

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1453,8 +1453,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let cfg_env = get_cfg_env(cfg, evm_spec_id);
         let l1_fee_rate = sealed_block.l1_fee_rate;
 
-        // EvmDB is the replacement of revm::CacheDB because cachedb requires immutable state
-        // TODO: Move to CacheDB once immutable state is implemented
         let mut evm_db = self.get_db(working_set);
 
         // TODO: Convert below steps to blocking task like in reth after implementing the semaphores

--- a/crates/evm/src/rpc_helpers/tracing_utils.rs
+++ b/crates/evm/src/rpc_helpers/tracing_utils.rs
@@ -108,7 +108,7 @@ pub(crate) fn trace_call<C: sov_modules_api::Context>(
                         l1_fee_rate,
                         &mut inspector,
                     )?;
-                    let mut frame = inspector
+                    let frame = inspector
                         .with_transaction_gas_limit(tx_env.gas_limit())
                         .into_geth_builder()
                         .geth_prestate_traces(&res, &prestate_config, &db_ref)
@@ -292,7 +292,7 @@ pub(crate) fn trace_transaction<C: sov_modules_api::Context>(
                         l1_fee_rate,
                         &mut inspector,
                     )?;
-                    let mut frame = inspector
+                    let frame = inspector
                         .with_transaction_gas_limit(tx_env.gas_limit())
                         .into_geth_builder()
                         .geth_prestate_traces(&res, &prestate_config, db_ref)

--- a/crates/evm/src/rpc_helpers/tracing_utils.rs
+++ b/crates/evm/src/rpc_helpers/tracing_utils.rs
@@ -114,18 +114,6 @@ pub(crate) fn trace_call<C: sov_modules_api::Context>(
                         .geth_prestate_traces(&res, &prestate_config, &db_ref)
                         .map_err(EthApiError::from_eth_err)?;
 
-                    // Workaround for revm-inspectors v0.18.0 bug where disableCode doesn't filter post state
-                    // TODO: Remove this when upgrading revm-inspectors to a version with the fix
-                    if prestate_config.disable_code.unwrap_or(false) {
-                        if let alloy_rpc_types_trace::geth::PreStateFrame::Diff(ref mut diff_mode) =
-                            &mut frame
-                        {
-                            for (_, account_state) in diff_mode.post.iter_mut() {
-                                account_state.code = None;
-                            }
-                        }
-                    }
-
                     Ok(frame.into())
                 }
                 GethDebugBuiltInTracerType::FlatCallTracer => {
@@ -309,18 +297,6 @@ pub(crate) fn trace_transaction<C: sov_modules_api::Context>(
                         .into_geth_builder()
                         .geth_prestate_traces(&res, &prestate_config, db_ref)
                         .map_err(EthApiError::from_eth_err)?;
-
-                    // Workaround for revm-inspectors v0.18.0 bug where disableCode doesn't filter post state
-                    // TODO: Remove this when upgrading revm-inspectors to a version with the fix
-                    if prestate_config.disable_code.unwrap_or(false) {
-                        if let alloy_rpc_types_trace::geth::PreStateFrame::Diff(ref mut diff_mode) =
-                            &mut frame
-                        {
-                            for (_, account_state) in diff_mode.post.iter_mut() {
-                                account_state.code = None;
-                            }
-                        }
-                    }
 
                     Ok((frame.into(), res.state))
                 }


### PR DESCRIPTION
# Description
Updates revm-inspectors with fixes to multiple tracers, mainly the prestate tracer.

Since `revm-inspectors` couldn't be updated, we created a fork at https://github.com/chainwayxyz/revm-inspectors/ and applied all fix PRs after v0.18.1 on the v0.18.1 tag. The changes can be reviewed here: https://github.com/chainwayxyz/revm-inspectors/pull/1