### PR TITLE
fix: GPL-3.0 SPDX license identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 [workspace.package]
 version = "1.0.1"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 authors = ["Chainway Labs <info@chainway.xyz>"]
 homepage = "https://citrea.xyz"
 publish = false

--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,7 @@ allow = [
   "BSD-3-Clause",
   "BSL-1.0",
   "CC0-1.0",
-  "GPL-3.0",
+  "GPL-3.0-only",
   "ISC",
   # "LGPL-3.0",
   "MIT",


### PR DESCRIPTION
# Description
Fixes most of the warnings in deny workflow