### PR TITLE
feat: citrea-cli validate-backup command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - perf: Remove validation from backup creation. Backup validation should now be handled by `backup_validate` RPC method. ([#3045](https://github.com/chainwayxyz/citrea/pull/3045))
 - feat: Add create backup `citrea-cli` command([#3047](https://github.com/chainwayxyz/citrea/pull/3047))\
   Usage: citrea-cli create-backup --node-type <NODE_TYPE> --db-path <DB_PATH> --backup-path <BACKUP_PATH>
+- feat: Add `validate-backup` `citrea-cli` command([#3068](https://github.com/chainwayxyz/citrea/pull/3068))\
+  Usage: citrea-cli validate-backup --backup-path <BACKUP_PATH>
 - feat: Store proving session info of LCP ([#3050](https://github.com/chainwayxyz/citrea/pull/3050))\
   `lightClientProver_getLightClientProofByL1Height` endpoint now returns information about the proving session, using the same structure as the batch prover responses.
 - ci: Run citrea-e2e tests against bitcoin v30

--- a/bin/cli/src/commands/backup.rs
+++ b/bin/cli/src/commands/backup.rs
@@ -41,6 +41,20 @@ pub(crate) async fn create_backup(
         .await
 }
 
+pub(crate) async fn validate_backup(backup_path: PathBuf) -> anyhow::Result<()> {
+    let kind = backup_kind_from_metadata(&backup_path).await?;
+
+    info!(
+        "Validating backup at {} for {}.",
+        backup_path.display(),
+        kind,
+    );
+
+    let backup_manager = BackupManager::new(kind, None, None);
+
+    backup_manager.validate_backup(&backup_path)
+}
+
 pub(crate) async fn restore_backup(
     node_type: NodeType,
     db_path: PathBuf,

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -58,6 +58,12 @@ enum Commands {
         #[arg(long)]
         backup_path: PathBuf,
     },
+    /// Validate DBs backup
+    ValidateBackup {
+        /// The path of backup to validate
+        #[arg(long)]
+        backup_path: PathBuf,
+    },
     /// Restore DBs from backup
     RestoreBackup {
         /// The node kind
@@ -152,6 +158,9 @@ async fn main() -> anyhow::Result<()> {
             node_type,
         } => {
             commands::create_backup(node_type, db_path, backup_path).await?;
+        }
+        Commands::ValidateBackup { backup_path } => {
+            commands::validate_backup(backup_path).await?;
         }
         Commands::RestoreBackup {
             db_path,

--- a/crates/common/src/backup/manager.rs
+++ b/crates/common/src/backup/manager.rs
@@ -326,7 +326,7 @@ impl BackupManager {
     ///
     /// # Arguments
     /// * `backup_path` - Path to the backup directory to validate
-    pub(super) fn validate_backup<P: AsRef<Path>>(&self, backup_path: P) -> anyhow::Result<()> {
+    pub fn validate_backup<P: AsRef<Path>>(&self, backup_path: P) -> anyhow::Result<()> {
         let backup_path = backup_path.as_ref();
 
         if !backup_path.exists() {


### PR DESCRIPTION
# Description

- Add `citrea-cli` `validate-backup` for completeness sake
```
Usage: citrea-cli validate-backup --backup-path <BACKUP_PATH>
```


## Linked Issues
- Testnet first backup issue and https://github.com/chainwayxyz/citrea/pull/3045