### PR TITLE
fix: Remove biased from monitoring select loop

### DIFF
--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -424,7 +424,6 @@ impl MonitoringService {
         let mut rebroadcast_interval = interval(Duration::from_secs(self.config.rebroadcast_delay));
         loop {
             select! {
-                biased;
                 _ = &mut shutdown_signal => {
                     info!("Shutting down monitoring service");
                     return;


### PR DESCRIPTION
# Description

- Fix `test_queue_da_transactions_oldest_mode` flakiness.
- `biased;` made `check_interval.tick()` starve the `rebroadcast_interval.tick()`.

## Linked Issues
- Fixes #2930 
- Fixes #2744 