### PR TITLE
test: Fine tune lcp l1 start height

### DIFF
--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -1009,7 +1009,7 @@ impl TestCase for SubmitFakeProofRpcTest {
     }
 
     fn scan_l1_start_height() -> Option<u64> {
-        Some(170)
+        Some(195)
     }
 
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
@@ -1032,6 +1032,7 @@ impl TestCase for SubmitFakeProofRpcTest {
         da.generate(DEFAULT_FINALITY_DEPTH).await.unwrap();
 
         let finalized_height = da.get_finalized_height(None).await.unwrap();
+
         // ensure batch prover saw 1 commitment
         batch_prover
             .wait_for_l1_height(finalized_height, None)

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -1287,7 +1287,7 @@ impl TestCase for OutOfRangeProofTest {
     }
 
     fn scan_l1_start_height() -> Option<u64> {
-        Some(150)
+        Some(170)
     }
 
     fn light_client_prover_config() -> LightClientProverConfig {
@@ -2440,7 +2440,7 @@ impl TestCase for UnsyncedCommitmentL2RangeTest {
     }
 
     fn scan_l1_start_height() -> Option<u64> {
-        Some(170)
+        Some(195)
     }
 
     fn light_client_prover_config() -> LightClientProverConfig {
@@ -2879,7 +2879,7 @@ impl TestCase for FullNodeLcpChunkProofTest {
     }
 
     fn scan_l1_start_height() -> Option<u64> {
-        Some(170)
+        Some(204)
     }
 
     fn light_client_prover_config() -> LightClientProverConfig {
@@ -2935,13 +2935,6 @@ impl TestCase for FullNodeLcpChunkProofTest {
                 .await;
 
         da.generate(DEFAULT_FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height(None).await?;
-
-        // Wait for light client prover to create light client proof.
-        light_client_prover
-            .wait_for_l1_height(finalized_height, Some(TEN_MINS))
-            .await
-            .unwrap();
 
         let genesis_state_root = full_node
             .client

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -89,6 +89,10 @@ impl TestCase for LightClientProvingTest {
         }
     }
 
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(195)
+    }
+
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
         let da = f.bitcoin_nodes.get(0).unwrap();
         let sequencer = f.sequencer.as_ref().unwrap();
@@ -228,7 +232,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
     }
 
     fn scan_l1_start_height() -> Option<u64> {
-        Some(169)
+        Some(195)
     }
 
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
@@ -1210,6 +1214,10 @@ impl TestCase for LightClientUnverifiableBatchProofTest {
         }
     }
 
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(170)
+    }
+
     async fn cleanup(self) -> Result<()> {
         self.task_manager
             .graceful_shutdown_with_timeout(Duration::from_secs(1));
@@ -1471,6 +1479,10 @@ impl TestCase for VerifyChunkedTxsInLightClient {
             max_l2_blocks_per_commitment: 10000,
             ..Default::default()
         }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(170)
     }
 
     async fn cleanup(self) -> Result<()> {
@@ -2109,6 +2121,10 @@ impl TestCase for UnknownL1HashBatchProofTest {
         }
     }
 
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(170)
+    }
+
     async fn cleanup(self) -> Result<()> {
         self.task_manager
             .graceful_shutdown_with_timeout(Duration::from_secs(1));
@@ -2253,6 +2269,10 @@ impl TestCase for ChainProofByCommitmentIndex {
             max_l2_blocks_per_commitment: 10000,
             ..Default::default()
         }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(170)
     }
 
     async fn cleanup(self) -> Result<()> {
@@ -2467,6 +2487,10 @@ impl TestCase for ProofWithMissingCommitment {
         }
     }
 
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(170)
+    }
+
     async fn cleanup(self) -> Result<()> {
         self.task_manager
             .graceful_shutdown_with_timeout(Duration::from_secs(1));
@@ -2610,6 +2634,10 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
             max_l2_blocks_per_commitment: 10000,
             ..Default::default()
         }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(164)
     }
 
     async fn cleanup(self) -> Result<()> {
@@ -2925,6 +2953,10 @@ impl TestCase for ProofWithWrongPreviousCommitmentHash {
             max_l2_blocks_per_commitment: 10000,
             ..Default::default()
         }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(170)
     }
 
     async fn cleanup(self) -> Result<()> {

--- a/bin/citrea/tests/bitcoin/rollback.rs
+++ b/bin/citrea/tests/bitcoin/rollback.rs
@@ -123,7 +123,7 @@ impl TestCase for TestRollBackLightClientProverToInitialDaHeight {
     }
 
     fn scan_l1_start_height() -> Option<u64> {
-        Some(150)
+        Some(180)
     }
 
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {


### PR DESCRIPTION
This PR :

```
m test bitcoin::light_client_test
...
 Nextest run ID 0850459c-cf1f-4e56-8d78-79fe472aceb5 with nextest profile: default
    Starting 14 tests across 49 binaries (537 tests skipped)
        PASS [  10.173s] citrea::bitcoin_e2e bitcoin::light_client_test::proving_session_info_test
        PASS [  22.565s] citrea::bitcoin_e2e bitcoin::light_client_test::test_unknown_l1_hash_batch_proof_in_light_client
        PASS [  23.977s] citrea::bitcoin_e2e bitcoin::light_client_test::test_light_client_proving
        PASS [  26.343s] citrea::bitcoin_e2e bitcoin::light_client_test::test_proof_with_missing_commitment_is_discarded
        PASS [  27.029s] citrea::bitcoin_e2e bitcoin::light_client_test::test_chain_proof_by_commitment_index
        PASS [  28.351s] citrea::bitcoin_e2e bitcoin::light_client_test::test_light_client_unverifiable_batch_proof
        PASS [  30.393s] citrea::bitcoin_e2e bitcoin::light_client_test::test_unchained_batch_proofs_in_light_client
        PASS [  30.452s] citrea::bitcoin_e2e bitcoin::light_client_test::test_light_client_batch_proof_method_id_update
        PASS [  33.828s] citrea::bitcoin_e2e bitcoin::light_client_test::test_proof_with_wrong_previous_commitment_hash
        PASS [  40.532s] citrea::bitcoin_e2e bitcoin::light_client_test::test_verify_chunked_txs_in_light_client
        PASS [  41.962s] citrea::bitcoin_e2e bitcoin::light_client_test::test_undecompressable_blob
        PASS [  42.576s] citrea::bitcoin_e2e bitcoin::light_client_test::test_proof_and_commitment_with_wrong_da_pubkey
        PASS [  48.275s] citrea::bitcoin_e2e bitcoin::light_client_test::test_light_client_proving_multiple_proofs
        PASS [  48.590s] citrea::bitcoin_e2e bitcoin::light_client_test::test_light_client_batch_proof_method_id_update_security_council
────────────
     Summary [  48.608s] 14 tests run: 14 passed, 537 skipped
```

Nightly :

```
m test bitcoin::light_client_test
...
 Nextest run ID fb2e2dac-542f-4e4f-afc0-a814ee55205a with nextest profile: default
    Starting 14 tests across 49 binaries (537 tests skipped)
        PASS [  10.057s] citrea::bitcoin_e2e bitcoin::light_client_test::proving_session_info_test
        PASS [  43.465s] citrea::bitcoin_e2e bitcoin::light_client_test::test_light_client_batch_proof_method_id_update
        PASS [  46.497s] citrea::bitcoin_e2e bitcoin::light_client_test::test_unchained_batch_proofs_in_light_client
        PASS [  70.137s] citrea::bitcoin_e2e bitcoin::light_client_test::test_undecompressable_blob
        PASS [  75.755s] citrea::bitcoin_e2e bitcoin::light_client_test::test_light_client_batch_proof_method_id_update_security_council
        PASS [  80.423s] citrea::bitcoin_e2e bitcoin::light_client_test::test_light_client_proving_multiple_proofs
        PASS [ 143.572s] citrea::bitcoin_e2e bitcoin::light_client_test::test_unknown_l1_hash_batch_proof_in_light_client
        PASS [ 149.498s] citrea::bitcoin_e2e bitcoin::light_client_test::test_proof_with_missing_commitment_is_discarded
        PASS [ 150.219s] citrea::bitcoin_e2e bitcoin::light_client_test::test_chain_proof_by_commitment_index
        PASS [ 152.662s] citrea::bitcoin_e2e bitcoin::light_client_test::test_light_client_unverifiable_batch_proof
        PASS [ 154.976s] citrea::bitcoin_e2e bitcoin::light_client_test::test_light_client_proving
        PASS [ 156.525s] citrea::bitcoin_e2e bitcoin::light_client_test::test_proof_with_wrong_previous_commitment_hash
        PASS [ 162.538s] citrea::bitcoin_e2e bitcoin::light_client_test::test_verify_chunked_txs_in_light_client
        PASS [ 163.487s] citrea::bitcoin_e2e bitcoin::light_client_test::test_proof_and_commitment_with_wrong_da_pubkey
────────────
     Summary [ 163.503s] 14 tests run: 14 passed, 537 skipped
```
