### PR TITLE
ci: Use ubicloud cache for build binaries

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -102,15 +102,14 @@ jobs:
           path: crates/evm/ethereum-tests
       - name: Build citrea
         run: make build
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Cache binaries
+        uses: actions/cache@v4
         with:
-          name: citrea-build
           path: |
             target/debug/citrea
             target/debug/citrea-cli
             target/debug/**/methods.rs
-          retention-days: 2
+          key: citrea-build-${{ github.sha }}
 
   check:
     name: check
@@ -252,11 +251,14 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 18
-      - name: Download artifact
-        uses: actions/download-artifact@v4
+      - name: Restore binaries
+        uses: actions/cache@v4
         with:
-          name: citrea-build
-          path: target/debug
+          path: |
+            target/debug/citrea
+            target/debug/citrea-cli
+            target/debug/**/methods.rs
+          key: citrea-build-${{ github.sha }}
       - name: Make citrea executable
         run: chmod +x target/debug/citrea
       - name: Install node dependencies
@@ -295,11 +297,14 @@ jobs:
         with:
           python-version: "3.x"
       - uses: dcarbone/install-jq-action@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v4
+      - name: Restore binaries
+        uses: actions/cache@v4
         with:
-          name: citrea-build
-          path: target/debug
+          path: |
+            target/debug/citrea
+            target/debug/citrea-cli
+            target/debug/**/methods.rs
+          key: citrea-build-${{ github.sha }}
       - name: Make citrea executable
         run: chmod +x target/debug/citrea
       - name: Install dependencies
@@ -323,11 +328,14 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 18
-      - name: Download artifact
-        uses: actions/download-artifact@v4
+      - name: Restore binaries
+        uses: actions/cache@v4
         with:
-          name: citrea-build
-          path: target/debug
+          path: |
+            target/debug/citrea
+            target/debug/citrea-cli
+            target/debug/**/methods.rs
+          key: citrea-build-${{ github.sha }}
       - name: Make citrea executable
         run: chmod +x target/debug/citrea
       - name: Install node dependencies
@@ -523,11 +531,14 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download artifact
-        uses: actions/download-artifact@v4
+      - name: Restore binaries
+        uses: actions/cache@v4
         with:
-          name: citrea-build
-          path: target/debug
+          path: |
+            target/debug/citrea
+            target/debug/citrea-cli
+            target/debug/**/methods.rs
+          key: citrea-build-${{ github.sha }}
       - name: Make citrea executable
         run: chmod +x target/debug/citrea
       - name: Install dependencies


### PR DESCRIPTION
# Description

- Speed up download artifact step for `uniswap`, `ether_js` and `web3_py`.
These were taking between 10min and 15min on artifact download as can be seen here https://github.com/chainwayxyz/citrea/actions/runs/20164249733/job/57884469294 due to ubicloud fetching artifact hosted by github.

- Switch to transparent ubicloud cache and sheds it down to a more reasonable 10s
