### PR TITLE
ci: nextest timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,4 @@
 [profile.default]
-slow-timeout = "3m" # Mark slow tests after exceeding 3 minutes
+slow-timeout = { period = "3m", terminate-after = 2 } # Mark slow tests after exceeding 3 minutes and times out after 6 minutes
 retries = 2 # A flaky test is retried a total of 3 times.
+

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,3 @@
 [profile.default]
 slow-timeout = { period = "3m", terminate-after = 2 } # Mark slow tests after exceeding 3 minutes and times out after 6 minutes
 retries = 2 # A flaky test is retried a total of 3 times.
-


### PR DESCRIPTION
# Description

- Add a per-test timeout of 6min
- Fix the rare but costly issue where `test_sequencer_halt_resume_commitments` runs for 6hours until it hits ci default timeout.
Issue can be seen here https://github.com/chainwayxyz/citrea/actions/runs/20138320981/job/57798203209 and to lesser degree https://github.com/chainwayxyz/citrea/actions/runs/20226821410/job/58060162723

## Linked Issues
- Fixes #2721 