### PR TITLE
fix(batch-prover): L2Syncer saturates backoff at max value instead of panicking

### DIFF
--- a/crates/batch-prover/src/l2_syncer.rs
+++ b/crates/batch-prover/src/l2_syncer.rs
@@ -166,14 +166,18 @@ where
                     // While syncing, we'd like to process L2 blocks as they come without any delays.
                     for l2_block in l2_blocks {
                         let mut backoff = ExponentialBackoff::default();
+                        let mut last_backoff_duration = backoff.current_interval;
                         loop {
                             let _l2_lock = backup_manager.start_l2_processing().await;
                             match self.process_l2_block(&l2_block).await {
                                 Ok(_) => break,
                                 Err(e) => {
                                     error!("Failed to process L2 block {}: {}", l2_block.header.height, e);
-                                    let backoff_duration = backoff.next_backoff().expect("Failed to process L2 block multiple times. Killing L2Syncer...");
-                                    tokio::time::sleep(backoff_duration).await;
+
+                                    if let Some(duration) = backoff.next_backoff() {
+                                        last_backoff_duration = duration;
+                                    }
+                                    tokio::time::sleep(last_backoff_duration).await;
                                 }
                             }
                         }


### PR DESCRIPTION
# Description

- Keep using max expontential backoff value instead of panicking 

## Linked Issues
- Fixes #3012 