### PR TITLE
Fix: Handle pruning task failures properly

### DIFF
--- a/bin/cli/src/commands/prune.rs
+++ b/bin/cli/src/commands/prune.rs
@@ -48,7 +48,7 @@ pub(crate) async fn prune(
         Arc::new(native_db),
     );
     if let Some(up_to_block) = pruner.should_prune(last_pruned_block_number, l2_block_number) {
-        pruner.prune(node_type.into(), up_to_block).await;
+        pruner.prune(node_type.into(), up_to_block).await?;
     }
     Ok(())
 }

--- a/crates/storage-ops/src/pruning/mod.rs
+++ b/crates/storage-ops/src/pruning/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Result;
 use citrea_common::config::PruningConfig;
 use citrea_common::NodeType;
 use futures::future;
@@ -62,7 +63,7 @@ impl Pruner {
     }
 
     /// Prune everything
-    pub async fn prune(&self, node_type: NodeType, up_to_block: u64) {
+    pub async fn prune(&self, node_type: NodeType, up_to_block: u64) -> Result<()> {
         info!("Pruning up to L2 block: {}", up_to_block);
         let ledger_db = self.ledger_db.clone();
 
@@ -70,8 +71,9 @@ impl Pruner {
 
         // let state_db = self.state_db.clone();
 
-        let ledger_pruning_handle =
-            tokio::task::spawn_blocking(move || prune_ledger(node_type, ledger_db, up_to_block));
+        let ledger_pruning_handle = tokio::task::spawn_blocking(move || {
+            prune_ledger(node_type, ledger_db, up_to_block)
+        });
 
         // TODO: Fix me
         // let state_db_pruning_handle =
@@ -80,11 +82,13 @@ impl Pruner {
         let native_db_pruning_handle =
             tokio::task::spawn_blocking(move || prune_native_db(native_db, up_to_block));
 
-        future::join_all([
+        future::try_join_all([
             ledger_pruning_handle,
             // state_db_pruning_handle,
             native_db_pruning_handle,
         ])
-        .await;
+        .await
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("Pruning task failed: {}", e))
     }
 }

--- a/crates/storage-ops/src/pruning/service.rs
+++ b/crates/storage-ops/src/pruning/service.rs
@@ -43,8 +43,14 @@ impl PrunerService {
                     if let Ok(current_l2_block) = current_l2_block {
                         debug!("Pruner received L2 {}, checking criteria", current_l2_block);
                         if let Some(up_to_block) = self.pruner.should_prune(self.last_pruned_block, current_l2_block) {
-                            self.pruner.prune(node_type, up_to_block).await;
-                            self.last_pruned_block = up_to_block;
+                            match self.pruner.prune(node_type, up_to_block).await {
+                                Ok(()) => {
+                                    self.last_pruned_block = up_to_block;
+                                }
+                                Err(e) => {
+                                    error!("Pruning failed at L2 {}: {:?}", up_to_block, e);
+                                }
+                            }
                         }
                     }
                 },


### PR DESCRIPTION


Previously, `Pruner::prune` ignored errors and panics from background pruning tasks, causing silent failures where pruning appeared successful even when it failed.

