### PR TITLE
ci: Remove build guests step

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -133,8 +133,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check TOML
         uses: dprint/check@v2.2
-      - name: Build guests
-        run: make build-risc0
       - name: Run lint
         run: |
           if ! make lint ; then
@@ -166,8 +164,6 @@ jobs:
         uses: ./.github/actions/install-risc0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build guests
-        run: make build-risc0
       - name: Run cargo-udeps
         env:
           RUSTFLAGS: -A warnings


### PR DESCRIPTION
# Description

- Noop as `build-risc0` target doesn't exist
