### PR TITLE
fix: Fix check genesis CI failure

### DIFF
--- a/crates/evm/src/evm/system_contracts/foundry.toml
+++ b/crates/evm/src/evm/system_contracts/foundry.toml
@@ -10,6 +10,6 @@ bytecode_hash = "none"
 cbor_metadata = false
 additional_compiler_profiles = [ { name = "via-ir", via_ir = true } ]
 compilation_restrictions = [
-    { paths = "src/Bridge.sol", via_ir = true },
+    { paths = "src/Bridge.sol", via_ir = true, version = "=0.8.30" },
 ]
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options


### PR DESCRIPTION
# Description
Foundry 1.5.1 introduces solc 0.8.33 as the default compiler which changes the bytecode of Bridge.sol possibly due to a change in IR compilation steps. This PR fixes the Solidity version to 0.8.30 for Bridge.sol.