### PR TITLE
feat: forced transaction inclusion via Bitcoin inscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,6 +3699,10 @@ name = "citrea-cli"
 version = "1.2.2"
 dependencies = [
  "anyhow",
+ "bitcoin",
+ "bitcoin-da",
+ "bitcoincore-rpc",
+ "borsh",
  "citrea-batch-prover",
  "citrea-common",
  "citrea-fullnode",
@@ -3707,7 +3711,9 @@ dependencies = [
  "citrea-storage-ops",
  "clap",
  "derive_more 1.0.0",
+ "hex",
  "sov-db",
+ "sov-rollup-interface",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.20",

--- a/bin/cli/Cargo.toml
+++ b/bin/cli/Cargo.toml
@@ -12,6 +12,7 @@ resolver = "2"
 
 [dependencies]
 # Citrea deps
+bitcoin-da = { path = "../../crates/bitcoin-da" }
 citrea-batch-prover = { path = "../../crates/batch-prover" }
 citrea-common = { path = "../../crates/common" }
 citrea-fullnode = { path = "../../crates/fullnode" }
@@ -21,11 +22,16 @@ citrea-storage-ops = { path = "../../crates/storage-ops" }
 
 # Sovereign-SDK deps
 sov-db = { path = "../../crates/sovereign-sdk/full-node/db/sov-db" }
+sov-rollup-interface = { path = "../../crates/sovereign-sdk/rollup-interface" }
 
 # 3rd-party deps
 anyhow = { workspace = true }
+bitcoin = { workspace = true }
+bitcoincore-rpc = { workspace = true }
+borsh = { workspace = true }
 clap = { workspace = true }
 derive_more = { workspace = true }
+hex = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/bin/cli/src/commands/force_include.rs
+++ b/bin/cli/src/commands/force_include.rs
@@ -1,0 +1,147 @@
+use anyhow::{anyhow, Context};
+use bitcoin_da::helpers::builders::body_builders::{create_inscription_type_5, DaTxs};
+use bitcoin_da::spec::utxo::UTXO;
+use bitcoin_da::utxo_manager::UtxoContext;
+use sov_rollup_interface::da::{DataOnDa, ForcedTransaction};
+use tracing::info;
+
+/// Execute the force-include command: creates and broadcasts a Bitcoin inscription
+/// containing a forced EVM transaction.
+pub(crate) async fn force_include(
+    rlp_tx_hex: String,
+    da_private_key: String,
+    fee_rate: f64,
+    network: String,
+    reveal_tx_prefix: Vec<u8>,
+    bitcoin_url: String,
+    bitcoin_user: String,
+    bitcoin_password: String,
+) -> anyhow::Result<()> {
+    // 1. Decode the hex RLP transaction
+    let rlp_tx = hex::decode(rlp_tx_hex.trim_start_matches("0x"))
+        .context("Failed to decode hex RLP transaction")?;
+
+    if rlp_tx.is_empty() {
+        return Err(anyhow!("RLP transaction is empty"));
+    }
+
+    info!("Preparing forced transaction inscription ({} bytes)", rlp_tx.len());
+
+    // 2. Build ForcedTransaction and serialize as DataOnDa
+    let forced_tx = ForcedTransaction {
+        rlp_tx,
+        l1_block_height: 0, // Will be set by the sequencer upon extraction
+    };
+    let data_on_da = DataOnDa::ForcedTransaction(forced_tx);
+    let body = borsh::to_vec(&data_on_da).context("Failed to serialize DataOnDa")?;
+
+    // 3. Parse the DA private key
+    let da_key_bytes =
+        hex::decode(da_private_key.trim_start_matches("0x")).context("Failed to decode DA private key")?;
+    let da_secret_key = bitcoin::secp256k1::SecretKey::from_slice(&da_key_bytes)
+        .context("Invalid DA private key")?;
+
+    // 4. Determine bitcoin network
+    let btc_network = match network.as_str() {
+        "mainnet" => bitcoin::Network::Bitcoin,
+        "testnet" | "testnet3" => bitcoin::Network::Testnet,
+        "signet" => bitcoin::Network::Signet,
+        "regtest" => bitcoin::Network::Regtest,
+        _ => return Err(anyhow!("Unknown network: {}", network)),
+    };
+
+    // 5. Connect to Bitcoin RPC and get UTXOs
+    let client = bitcoincore_rpc::Client::new(
+        &bitcoin_url,
+        bitcoincore_rpc::Auth::UserPass(bitcoin_user, bitcoin_password),
+    )
+    .context("Failed to connect to Bitcoin RPC")?;
+
+    // Get wallet UTXOs
+    let unspent = client
+        .list_unspent(Some(1), None, None, None, None)
+        .context("Failed to list unspent UTXOs")?;
+
+    if unspent.is_empty() {
+        return Err(anyhow!("No UTXOs available in wallet"));
+    }
+
+    let utxos: Vec<UTXO> = unspent
+        .into_iter()
+        .filter(|u| u.spendable)
+        .map(|u| UTXO {
+            tx_id: u.txid,
+            vout: u.vout,
+            address: u.address.map(|a| a.as_unchecked().clone()),
+            script_pubkey: u.script_pub_key.to_hex_string(),
+            amount: u.amount.to_sat(),
+            confirmations: u.confirmations,
+            spendable: true,
+            solvable: u.solvable.unwrap_or(false),
+        })
+        .collect();
+
+    info!("Found {} spendable UTXOs", utxos.len());
+
+    // Get change address from wallet
+    let change_address = client
+        .get_new_address(None, Some(bitcoincore_rpc::json::AddressType::Bech32m))
+        .context("Failed to get new change address")?
+        .require_network(btc_network)
+        .context("Change address network mismatch")?;
+
+    // 6. Build the inscription transactions
+    let utxo_context = UtxoContext {
+        available_utxos: utxos,
+        prev_utxo: None,
+    };
+
+    let da_txs = create_inscription_type_5(
+        body,
+        &da_secret_key,
+        utxo_context,
+        change_address,
+        fee_rate,
+        fee_rate,
+        btc_network,
+        &reveal_tx_prefix,
+    )
+    .context("Failed to create inscription transactions")?;
+
+    let (commit_tx, reveal_tx) = match da_txs {
+        DaTxs::ForcedTransaction { commit, reveal } => (commit, reveal),
+        _ => return Err(anyhow!("Unexpected DaTxs variant")),
+    };
+
+    // 7. Sign and broadcast commit transaction
+    let signed_commit = client
+        .sign_raw_transaction_with_wallet(&commit_tx, None, None)
+        .context("Failed to sign commit transaction")?;
+
+    if !signed_commit.complete {
+        return Err(anyhow!("Commit transaction signing incomplete"));
+    }
+
+    let signed_commit_tx = signed_commit
+        .transaction()
+        .ok_or_else(|| anyhow!("No transaction in signing result"))?;
+
+    let commit_txid = client
+        .send_raw_transaction(&signed_commit_tx)
+        .context("Failed to broadcast commit transaction")?;
+
+    info!("Commit transaction broadcast: {}", commit_txid);
+
+    // 8. Broadcast reveal transaction (already signed via taproot script)
+    let reveal_txid = client
+        .send_raw_transaction(&reveal_tx.tx)
+        .context("Failed to broadcast reveal transaction")?;
+
+    info!("Reveal transaction broadcast: {}", reveal_txid);
+
+    println!("Forced transaction inscription created successfully!");
+    println!("  Commit TXID: {}", commit_txid);
+    println!("  Reveal TXID: {}", reveal_txid);
+
+    Ok(())
+}

--- a/bin/cli/src/commands/mod.rs
+++ b/bin/cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ use citrea_common::NodeType;
 use clap::ValueEnum;
 pub(crate) use db_migrate::*;
 use derive_more::Display;
+pub(crate) use force_include::*;
 pub(crate) use prune::*;
 pub(crate) use rollback::*;
 use sov_db::schema::tables::{
@@ -12,6 +13,7 @@ use sov_db::schema::tables::{
 
 mod backup;
 mod db_migrate;
+pub(crate) mod force_include;
 mod prune;
 mod rollback;
 

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -112,6 +112,33 @@ enum Commands {
         #[arg(long)]
         db_max_open_files: Option<i32>,
     },
+    /// Create a forced transaction inscription on Bitcoin
+    ForceInclude {
+        /// Hex-encoded signed EVM transaction (RLP)
+        #[arg(long)]
+        rlp_tx: String,
+        /// Bitcoin RPC URL
+        #[arg(long)]
+        bitcoin_url: String,
+        /// Bitcoin RPC username
+        #[arg(long)]
+        bitcoin_user: String,
+        /// Bitcoin RPC password
+        #[arg(long)]
+        bitcoin_password: String,
+        /// Hex-encoded private key for the DA inscription
+        #[arg(long)]
+        da_private_key: String,
+        /// Fee rate in sat/vByte
+        #[arg(long, default_value = "10")]
+        fee_rate: f64,
+        /// Bitcoin network (mainnet, testnet, signet, regtest)
+        #[arg(long, default_value = "regtest")]
+        network: String,
+        /// Hex-encoded reveal TX prefix for wtxid matching
+        #[arg(long, default_value = "0202")]
+        reveal_tx_prefix: String,
+    },
 }
 
 #[tokio::main]
@@ -183,6 +210,30 @@ async fn main() -> anyhow::Result<()> {
             db_max_open_files,
         } => {
             commands::db_migrate(node_type, db_path, db_max_open_files).await?;
+        }
+        Commands::ForceInclude {
+            rlp_tx,
+            bitcoin_url,
+            bitcoin_user,
+            bitcoin_password,
+            da_private_key,
+            fee_rate,
+            network,
+            reveal_tx_prefix,
+        } => {
+            let prefix = hex::decode(reveal_tx_prefix.trim_start_matches("0x"))
+                .expect("Invalid hex for reveal_tx_prefix");
+            commands::force_include(
+                rlp_tx,
+                da_private_key,
+                fee_rate,
+                network,
+                prefix,
+                bitcoin_url,
+                bitcoin_user,
+                bitcoin_password,
+            )
+            .await?;
         }
     }
 

--- a/crates/bitcoin-da/src/helpers/backup.rs
+++ b/crates/bitcoin-da/src/helpers/backup.rs
@@ -15,6 +15,7 @@ fn transaction_kind_to_backup_name(kind: &TransactionKind) -> &str {
         TransactionKind::Complete => "complete_zk_proof",
         TransactionKind::SequencerCommitment => "sequencer_commitment",
         TransactionKind::BatchProofMethodId => "method_id_update",
+        TransactionKind::ForcedTransaction => "forced_transaction",
         TransactionKind::Chunks => "chunks",
         TransactionKind::Aggregate => "aggregate",
         TransactionKind::Unknown(_) => "unknown",
@@ -30,7 +31,8 @@ pub(crate) fn backup_txs_to_file(
         match &tx.kind {
             TransactionKind::Complete
             | TransactionKind::BatchProofMethodId
-            | TransactionKind::SequencerCommitment => {
+            | TransactionKind::SequencerCommitment
+            | TransactionKind::ForcedTransaction => {
                 if txs.len() != 1 {
                     return Err(BitcoinServiceError::TransactionBackupError(format!(
                         "Expected exactly 2 transactions for {:?}, got {}",

--- a/crates/bitcoin-da/src/helpers/builders/body_builders.rs
+++ b/crates/bitcoin-da/src/helpers/builders/body_builders.rs
@@ -38,6 +38,8 @@ pub(crate) enum RawTxData {
     BatchProofMethodId(Vec<u8>),
     /// borsh(DataOnDa::SequencerCommitment(SequencerCommitment))
     SequencerCommitment(Vec<u8>),
+    /// borsh(DataOnDa::ForcedTransaction(ForcedTransaction))
+    ForcedTransaction(Vec<u8>),
 }
 
 /// This is a list of txs we need to send to DA
@@ -70,6 +72,13 @@ pub enum DaTxs {
     },
     /// Sequencer commitment.
     SequencerCommitment {
+        /// Unsigned
+        commit: Transaction,
+        /// Signed
+        reveal: TxWithId,
+    },
+    /// Forced transaction.
+    ForcedTransaction {
         /// Unsigned
         commit: Transaction,
         /// Signed
@@ -125,6 +134,16 @@ pub fn create_inscription_transactions(
             &reveal_tx_prefix,
         ),
         RawTxData::SequencerCommitment(body) => create_inscription_type_4(
+            body,
+            &da_private_key,
+            utxo_context,
+            change_address,
+            commit_fee_rate,
+            reveal_fee_rate,
+            network,
+            &reveal_tx_prefix,
+        ),
+        RawTxData::ForcedTransaction(body) => create_inscription_type_5(
             body,
             &da_private_key,
             utxo_context,
@@ -1010,6 +1029,180 @@ pub fn create_inscription_type_4(
                     info!("Taproot merkle root for inscription - Commitment: {}", root);
                 }
                 return Ok(DaTxs::SequencerCommitment {
+                    commit: unsigned_commit_tx,
+                    reveal: TxWithId {
+                        id: reveal_tx.compute_txid(),
+                        tx: reveal_tx,
+                    },
+                });
+            } else {
+                unsigned_commit_tx.output[0].value -= Amount::ONE_SAT;
+                unsigned_commit_tx.output[1].value += Amount::ONE_SAT;
+                reveal_tx.output[0].value -= Amount::ONE_SAT;
+                reveal_tx.input[0].previous_output.txid = unsigned_commit_tx.compute_txid();
+                update_witness(
+                    &unsigned_commit_tx,
+                    &mut reveal_tx,
+                    tapscript_hash,
+                    &key_pair,
+                    SECP256K1,
+                );
+            }
+        }
+
+        nonce += 1;
+    }
+}
+
+/// Creates the inscription transactions Type 5 - ForcedTransaction
+#[allow(clippy::too_many_arguments)]
+#[instrument(level = "trace", skip_all, err)]
+pub fn create_inscription_type_5(
+    body: Vec<u8>,
+    da_private_key: &SecretKey,
+    utxo_context: UtxoContext,
+    change_address: Address,
+    commit_fee_rate: f64,
+    reveal_fee_rate: f64,
+    network: Network,
+    reveal_tx_prefix: &[u8],
+) -> Result<DaTxs, anyhow::Error> {
+    let UtxoContext {
+        available_utxos: utxos,
+        prev_utxo,
+    } = utxo_context;
+
+    // Create reveal key
+    let key_pair = UntweakedKeypair::from_secret_key(SECP256K1, da_private_key);
+    let (public_key, _parity) = XOnlyPublicKey::from_keypair(&key_pair);
+
+    let kind = TransactionKind::ForcedTransaction;
+    let kind_bytes = kind.to_bytes();
+
+    // sign the body for integrity verification
+    let (signature, signer_public_key) = sign_blob_with_private_key(&body, da_private_key);
+
+    let start = Instant::now();
+
+    // start creating inscription content
+    let mut reveal_script_builder = script::Builder::new()
+        .push_x_only_key(&public_key)
+        .push_opcode(OP_CHECKSIGVERIFY)
+        .push_slice(PushBytesBuf::from(kind_bytes))
+        .push_opcode(OP_FALSE)
+        .push_opcode(OP_IF)
+        .push_slice(PushBytesBuf::try_from(signature).expect("Cannot push signature"))
+        .push_slice(
+            PushBytesBuf::try_from(signer_public_key).expect("Cannot push public key"),
+        );
+    // push body in chunks of 520 bytes
+    for chunk in body.chunks(520) {
+        reveal_script_builder = reveal_script_builder
+            .push_slice(PushBytesBuf::try_from(chunk.to_vec()).expect("Cannot push body chunk"));
+    }
+    // push end if
+    reveal_script_builder = reveal_script_builder.push_opcode(OP_ENDIF);
+
+    // Start loop to find a 'nonce' i.e. random number that makes the reveal tx hash starting with zeros given length
+    let mut nonce: i64 = 16; // skip the first digits to avoid OP_PUSHNUM_X
+    loop {
+        if nonce % 1000 == 0 {
+            trace!(nonce, "Trying to find commit & reveal nonce");
+            if nonce > 16384 {
+                warn!("Too many iterations finding nonce");
+            }
+        }
+        let utxos = utxos.clone();
+        let change_address = change_address.clone();
+        let mut reveal_script_builder = reveal_script_builder.clone();
+
+        // push nonce
+        reveal_script_builder = reveal_script_builder
+            .push_slice(nonce.to_le_bytes())
+            .push_opcode(OP_NIP);
+
+        // finalize reveal script
+        let reveal_script = reveal_script_builder.into_script();
+
+        let (control_block, merkle_root, tapscript_hash) =
+            build_control_block(&reveal_script, public_key, SECP256K1);
+
+        // create commit tx address
+        let commit_tx_address = Address::p2tr(SECP256K1, public_key, merkle_root, network);
+
+        let reveal_value = REVEAL_OUTPUT_AMOUNT;
+        let fee = (get_size_reveal(
+            change_address.script_pubkey(),
+            reveal_value,
+            &reveal_script,
+            &control_block,
+        ) as f64
+            * reveal_fee_rate)
+            .ceil() as u64;
+        let reveal_input_value = fee + reveal_value + REVEAL_OUTPUT_THRESHOLD;
+
+        let (mut unsigned_commit_tx, _leftover_utxos) = build_commit_transaction(
+            prev_utxo.clone(),
+            utxos,
+            commit_tx_address.clone(),
+            change_address.clone(),
+            reveal_input_value,
+            commit_fee_rate,
+        )?;
+
+        let output_to_reveal = unsigned_commit_tx.output[0].clone();
+
+        let mut reveal_tx = build_reveal_transaction(
+            output_to_reveal.clone(),
+            unsigned_commit_tx.compute_txid(),
+            0,
+            change_address,
+            reveal_value + REVEAL_OUTPUT_THRESHOLD,
+            reveal_fee_rate,
+            &reveal_script,
+            &control_block,
+        )?;
+
+        build_witness(
+            &unsigned_commit_tx,
+            &mut reveal_tx,
+            tapscript_hash,
+            reveal_script,
+            control_block,
+            &key_pair,
+            SECP256K1,
+        );
+
+        let min_commit_value = Amount::from_sat(fee + reveal_value);
+        while unsigned_commit_tx.output[0].value >= min_commit_value
+            && reveal_tx.output[0].value > Amount::from_sat(REVEAL_OUTPUT_AMOUNT)
+        {
+            let reveal_wtxid = reveal_tx.compute_wtxid();
+            let reveal_hash = reveal_wtxid.as_raw_hash().to_byte_array();
+            if reveal_hash.starts_with(reveal_tx_prefix) {
+                let recovery_key_pair = key_pair.tap_tweak(SECP256K1, merkle_root);
+                let (x_only_pub_key, _parity) = recovery_key_pair.to_inner().x_only_public_key();
+                assert_eq!(
+                    Address::p2tr_tweaked(
+                        TweakedPublicKey::dangerous_assume_tweaked(x_only_pub_key),
+                        network,
+                    ),
+                    commit_tx_address
+                );
+
+                histogram!("forced_transaction_mine_da_transaction").record(
+                    Instant::now()
+                        .saturating_duration_since(start)
+                        .as_secs_f64(),
+                );
+
+                if let Some(root) = merkle_root {
+                    info!(
+                        "Taproot merkle root for inscription - ForcedTransaction: {}",
+                        root
+                    );
+                }
+                return Ok(DaTxs::ForcedTransaction {
                     commit: unsigned_commit_tx,
                     reveal: TxWithId {
                         id: reveal_tx.compute_txid(),

--- a/crates/bitcoin-da/src/helpers/mod.rs
+++ b/crates/bitcoin-da/src/helpers/mod.rs
@@ -29,8 +29,8 @@ pub(crate) enum TransactionKind {
     BatchProofMethodId = 3,
     /// SequencerCommitment
     SequencerCommitment = 4,
-    // /// ForcedTransaction
-    // ForcedTransaction, // = ?,
+    /// ForcedTransaction
+    ForcedTransaction = 5,
     /// An unknown type of transaction
     Unknown(NonZero<u16>),
 }
@@ -45,6 +45,7 @@ impl TransactionKind {
             TransactionKind::Chunks => 2u16.to_le_bytes(),
             TransactionKind::BatchProofMethodId => 3u16.to_le_bytes(),
             TransactionKind::SequencerCommitment => 4u16.to_le_bytes(),
+            TransactionKind::ForcedTransaction => 5u16.to_le_bytes(),
             TransactionKind::Unknown(n) => n.get().to_le_bytes(),
         }
     }
@@ -61,6 +62,7 @@ impl TransactionKind {
             2 => Some(TransactionKind::Chunks),
             3 => Some(TransactionKind::BatchProofMethodId),
             4 => Some(TransactionKind::SequencerCommitment),
+            5 => Some(TransactionKind::ForcedTransaction),
             n => Some(TransactionKind::Unknown(
                 NonZero::new(n).expect("Is not zero"),
             )),

--- a/crates/bitcoin-da/src/helpers/parsers.rs
+++ b/crates/bitcoin-da/src/helpers/parsers.rs
@@ -24,8 +24,8 @@ pub enum ParsedTransaction {
     BatchProofMethodId(ParsedBatchProofMethodId),
     /// Kind 4
     SequencerCommitment(ParsedSequencerCommitment),
-    // /// Kind ?
-    // ForcedTransaction(ForcedTransaction),
+    /// Kind 5
+    ForcedTransaction(ParsedForcedTransaction),
 }
 
 /// ParsedComplete is a transaction that contains the full body of a proof.
@@ -55,6 +55,14 @@ pub struct ParsedChunk {
 /// ParsedSequencerCommitment is a transaction that contains the sequencer commitment.
 #[derive(Debug, Clone)]
 pub struct ParsedSequencerCommitment {
+    pub(crate) body: Vec<u8>,
+    pub(crate) signature: Vec<u8>,
+    pub(crate) public_key: Vec<u8>,
+}
+
+/// ParsedForcedTransaction is a transaction that contains a forced transaction inscription.
+#[derive(Debug, Clone)]
+pub struct ParsedForcedTransaction {
     pub(crate) body: Vec<u8>,
     pub(crate) signature: Vec<u8>,
     pub(crate) public_key: Vec<u8>,
@@ -128,6 +136,18 @@ impl VerifyParsed for ParsedAggregate {
 }
 
 impl VerifyParsed for ParsedSequencerCommitment {
+    fn public_key(&self) -> &[u8] {
+        &self.public_key
+    }
+    fn signature(&self) -> &[u8] {
+        &self.signature
+    }
+    fn body(&self) -> &[u8] {
+        &self.body
+    }
+}
+
+impl VerifyParsed for ParsedForcedTransaction {
     fn public_key(&self) -> &[u8] {
         &self.public_key
     }
@@ -222,6 +242,8 @@ fn parse_transaction(
         }
         TransactionKind::SequencerCommitment => body_parsers::parse_type_4_body(instructions)
             .map(ParsedTransaction::SequencerCommitment),
+        TransactionKind::ForcedTransaction => body_parsers::parse_type_5_body(instructions)
+            .map(ParsedTransaction::ForcedTransaction),
         TransactionKind::Unknown(n) => Err(ParserError::InvalidHeaderType(n)),
     }
 }
@@ -266,7 +288,7 @@ mod body_parsers {
 
     use super::{
         read_instr, read_opcode, read_push_bytes, ParsedAggregate, ParsedChunk, ParsedComplete,
-        ParsedSequencerCommitment, ParserError,
+        ParsedForcedTransaction, ParsedSequencerCommitment, ParserError,
     };
     use crate::helpers::parsers::ParsedBatchProofMethodId;
 
@@ -507,6 +529,65 @@ mod body_parsers {
         let body = body.as_bytes().to_vec();
 
         Ok(ParsedSequencerCommitment {
+            body,
+            signature,
+            public_key,
+        })
+    }
+
+    /// Parse transaction body of Type5 Forced Transaction
+    pub(super) fn parse_type_5_body(
+        instructions: &mut dyn Iterator<Item = Result<Instruction<'_>, ParserError>>,
+    ) -> Result<ParsedForcedTransaction, ParserError> {
+        let op_false = read_push_bytes(instructions)?;
+        if !op_false.is_empty() {
+            // OP_FALSE = OP_PUSHBYTES_0
+            return Err(ParserError::UnexpectedOpcode);
+        }
+
+        if OP_IF != read_opcode(instructions)? {
+            return Err(ParserError::UnexpectedOpcode);
+        }
+
+        let signature = read_push_bytes(instructions)?;
+        let public_key = read_push_bytes(instructions)?;
+
+        let mut chunks = vec![];
+
+        loop {
+            let instr = read_instr(instructions)?;
+            match instr {
+                PushBytes(chunk) => {
+                    if chunk.is_empty() {
+                        return Err(ParserError::UnexpectedOpcode);
+                    }
+                    chunks.push(chunk)
+                }
+                Op(OP_ENDIF) => break,
+                Op(_) => return Err(ParserError::UnexpectedOpcode),
+            }
+        }
+
+        // Nonce
+        let _nonce = read_push_bytes(instructions)?;
+        if OP_NIP != read_opcode(instructions)? {
+            return Err(ParserError::UnexpectedOpcode);
+        }
+        // END of transaction
+        if instructions.next().is_some() {
+            return Err(ParserError::UnexpectedOpcode);
+        }
+
+        let body_size: usize = chunks.iter().map(|c| c.len()).sum();
+        let mut body = Vec::with_capacity(body_size);
+        for chunk in chunks {
+            body.extend_from_slice(chunk.as_bytes());
+        }
+
+        let signature = signature.as_bytes().to_vec();
+        let public_key = public_key.as_bytes().to_vec();
+
+        Ok(ParsedForcedTransaction {
             body,
             signature,
             public_key,

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -29,7 +29,7 @@ use citrea_primitives::{MAX_COMPRESSED_BLOB_SIZE, MAX_TX_BODY_SIZE};
 use lru::LruCache;
 use reth_tasks::shutdown::GracefulShutdown;
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::da::{DaSpec, DaTxRequest, DataOnDa, SequencerCommitment};
+use sov_rollup_interface::da::{DaSpec, DaTxRequest, DataOnDa, ForcedTransaction, SequencerCommitment};
 use sov_rollup_interface::services::da::{DaService, TxRequestWithNotifier};
 use sov_rollup_interface::zk::Proof;
 use sov_rollup_interface::Network;
@@ -412,6 +412,11 @@ impl BitcoinService {
                 let blob = borsh::to_vec(&data).expect("DataOnDa serialize must not fail");
                 RawTxData::BatchProofMethodId(blob)
             }
+            DaTxRequest::ForcedTransaction(ft) => {
+                let data = DataOnDa::ForcedTransaction(ft);
+                let blob = borsh::to_vec(&data).expect("DataOnDa serialize must not fail");
+                RawTxData::ForcedTransaction(blob)
+            }
         };
 
         let network = self.network;
@@ -541,7 +546,8 @@ impl BitcoinService {
         match &tx.kind {
             TransactionKind::Complete
             | TransactionKind::BatchProofMethodId
-            | TransactionKind::SequencerCommitment => {
+            | TransactionKind::SequencerCommitment
+            | TransactionKind::ForcedTransaction => {
                 info!("Blob inscribe tx sent. Hash: {}", tx.reveal_txid())
             }
             TransactionKind::Chunks => {
@@ -683,6 +689,40 @@ impl BitcoinService {
         };
 
         Ok(new_txid)
+    }
+
+    /// Extract forced transactions from a block.
+    /// Any public key is accepted — the inscription signature only proves integrity.
+    pub fn extract_forced_transactions(
+        &self,
+        block: &BitcoinBlock,
+        l1_block_height: u64,
+    ) -> Vec<(usize, ForcedTransaction)> {
+        let mut forced_txs = Vec::new();
+
+        for (idx, tx) in block.txdata.iter().enumerate() {
+            if !tx
+                .compute_wtxid()
+                .to_byte_array()
+                .as_slice()
+                .starts_with(&self.reveal_tx_prefix)
+            {
+                continue;
+            }
+
+            if let Ok(ParsedTransaction::ForcedTransaction(ft)) = parse_relevant_transaction(tx) {
+                // Accept ANY public key — inscription signature only proves integrity
+                if ft.get_sig_verified_hash().is_some() {
+                    let data = DataOnDa::try_from_slice(&ft.body);
+                    if let Ok(DataOnDa::ForcedTransaction(mut forced_tx)) = data {
+                        // Set the L1 block height where it was observed
+                        forced_tx.l1_block_height = l1_block_height;
+                        forced_txs.push((idx, forced_tx));
+                    }
+                }
+            }
+        }
+        forced_txs
     }
 
     /// A Chunk is valid if:
@@ -920,6 +960,9 @@ impl DaService for BitcoinService {
                     ParsedTransaction::SequencerCommitment(_) => {
                         // ignore
                     }
+                    ParsedTransaction::ForcedTransaction(_) => {
+                        // ignore because these are not proofs
+                    }
                 }
             }
         }
@@ -1016,7 +1059,8 @@ impl DaService for BitcoinService {
                     ParsedTransaction::Complete(_)
                     | ParsedTransaction::Aggregate(_)
                     | ParsedTransaction::BatchProofMethodId(_)
-                    | ParsedTransaction::SequencerCommitment(_) => {
+                    | ParsedTransaction::SequencerCommitment(_)
+                    | ParsedTransaction::ForcedTransaction(_) => {
                         error!("{}:{}: Expected chunk, got other tx kind", tx_id, chunk_id);
                         continue 'aggregate;
                     }
@@ -1071,6 +1115,13 @@ impl DaService for BitcoinService {
             }
         }
         sequencer_commitments
+    }
+
+    fn extract_relevant_forced_transactions(
+        &self,
+        block: &Self::FilteredBlock,
+    ) -> Vec<(usize, ForcedTransaction)> {
+        self.extract_forced_transactions(block, block.header.height)
     }
 
     /// Extract the relevant transactions from a block, along with a proof that the extraction has been done correctly.
@@ -1191,6 +1242,17 @@ impl DaService for BitcoinService {
                                 wtxid.to_byte_array(),
                             );
 
+                            relevant_txs.push(relevant_tx);
+                        }
+                    }
+                    ParsedTransaction::ForcedTransaction(ft) => {
+                        if let Some(hash) = ft.get_sig_verified_hash() {
+                            let relevant_tx = BlobWithSender::new(
+                                ft.body,
+                                ft.public_key,
+                                hash,
+                                wtxid.to_byte_array(),
+                            );
                             relevant_txs.push(relevant_tx);
                         }
                     }

--- a/crates/bitcoin-da/src/tx_signer.rs
+++ b/crates/bitcoin-da/src/tx_signer.rs
@@ -98,6 +98,16 @@ impl TxSigner {
                     .await?,
                 ]
             }
+            DaTxs::ForcedTransaction { commit, reveal } => {
+                vec![
+                    self.sign_complete_transaction(
+                        commit,
+                        reveal,
+                        TransactionKind::ForcedTransaction,
+                    )
+                    .await?,
+                ]
+            }
             DaTxs::Chunked {
                 commit_chunks,
                 reveal_chunks,

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -176,6 +176,16 @@ impl DaVerifier for BitcoinVerifier {
                             ));
                         }
                     }
+                    ParsedTransaction::ForcedTransaction(forced_tx) => {
+                        if let Some(hash) = forced_tx.get_sig_verified_hash() {
+                            blobs.push(BlobWithSender::new(
+                                forced_tx.body,
+                                forced_tx.public_key,
+                                hash,
+                                *wtxid,
+                            ));
+                        }
+                    }
                 }
             }
         }

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -262,6 +262,16 @@ const fn default_max_l1_fee_rate_sat_vb() -> u64 {
     15 // sat/vbyte
 }
 
+#[inline]
+const fn default_forced_tx_fetch_limit() -> usize {
+    10
+}
+
+#[inline]
+const fn default_forced_tx_deadline_l1_blocks() -> u64 {
+    10
+}
+
 /// Rollup Configuration
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SequencerConfig {
@@ -288,6 +298,12 @@ pub struct SequencerConfig {
     /// Maximum L1 fee rate in sat/vbyte
     #[serde(default = "default_max_l1_fee_rate_sat_vb")]
     pub max_l1_fee_rate_sat_vb: u64,
+    /// Limit for the number of forced transactions to include per block
+    #[serde(default = "default_forced_tx_fetch_limit")]
+    pub forced_tx_fetch_limit: usize,
+    /// Number of L1 blocks after which a forced transaction deadline expires
+    #[serde(default = "default_forced_tx_deadline_l1_blocks")]
+    pub forced_tx_deadline_l1_blocks: u64,
 }
 
 impl Default for SequencerConfig {
@@ -304,6 +320,8 @@ impl Default for SequencerConfig {
             mempool_conf: Default::default(),
             l1_fee_rate_multiplier: 1.0,
             max_l1_fee_rate_sat_vb: 1, // doesn't matter since mock da returns 10 wei/byte
+            forced_tx_fetch_limit: default_forced_tx_fetch_limit(),
+            forced_tx_deadline_l1_blocks: default_forced_tx_deadline_l1_blocks(),
         }
     }
 }
@@ -327,6 +345,14 @@ impl FromEnv for SequencerConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or_else(default_max_l1_fee_rate_sat_vb),
+            forced_tx_fetch_limit: read_env("FORCED_TX_FETCH_LIMIT")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or_else(default_forced_tx_fetch_limit),
+            forced_tx_deadline_l1_blocks: read_env("FORCED_TX_DEADLINE_L1_BLOCKS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or_else(default_forced_tx_deadline_l1_blocks),
         })
     }
 }
@@ -677,6 +703,8 @@ mod tests {
             bridge_initialize_params: PRE_TANGERINE_BRIDGE_INITIALIZE_PARAMS.to_vec(),
             l1_fee_rate_multiplier: 0.75,
             max_l1_fee_rate_sat_vb: 15,
+            forced_tx_fetch_limit: 10,
+            forced_tx_deadline_l1_blocks: 10,
         };
         assert_eq!(config, expected);
     }
@@ -742,6 +770,8 @@ mod tests {
             bridge_initialize_params: PRE_TANGERINE_BRIDGE_INITIALIZE_PARAMS.to_vec(),
             l1_fee_rate_multiplier: 1.0,
             max_l1_fee_rate_sat_vb: 40,
+            forced_tx_fetch_limit: 10,
+            forced_tx_deadline_l1_blocks: 10,
         };
         assert_eq!(sequencer_config, expected);
     }

--- a/crates/common/src/da.rs
+++ b/crates/common/src/da.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::anyhow;
 use backoff::future::retry as retry_backoff;
 use backoff::ExponentialBackoffBuilder;
-use sov_rollup_interface::da::{BlockHeaderTrait, SequencerCommitment};
+use sov_rollup_interface::da::{BlockHeaderTrait, ForcedTransaction, SequencerCommitment};
 use sov_rollup_interface::services::da::{DaService, SlotData};
 use sov_rollup_interface::zk::Proof;
 use tokio::sync::{Mutex, Notify};
@@ -125,6 +125,24 @@ where
     sequencer_commitments.sort();
 
     sequencer_commitments
+}
+
+/// Extract ForcedTransactions from an L1 block, ordered by their position in the block.
+pub fn extract_forced_transactions<Da>(
+    da_service: Arc<Da>,
+    l1_block: &Da::FilteredBlock,
+) -> Vec<ForcedTransaction>
+where
+    Da: DaService,
+{
+    let mut indexed: Vec<_> = da_service
+        .as_ref()
+        .extract_relevant_forced_transactions(l1_block);
+
+    // Sort by transaction index to maintain ordering within the L1 block.
+    indexed.sort_by_key(|(idx, _)| *idx);
+
+    indexed.into_iter().map(|(_, ft)| ft).collect()
 }
 
 /// Extract proofs and commitments and return them sorted by tx index

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -11,7 +11,10 @@ use std::time::{Duration, Instant};
 use anyhow::anyhow;
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;
-use citrea_common::da::{extract_zk_proofs_and_sequencer_commitments, sync_l1, ProofOrCommitment};
+use citrea_common::da::{
+    extract_forced_transactions, extract_zk_proofs_and_sequencer_commitments, sync_l1,
+    ProofOrCommitment,
+};
 use citrea_common::utils::get_tangerine_activation_height_non_zero;
 use citrea_primitives::forks::fork_from_block_number;
 use citrea_primitives::network_to_dev_mode;
@@ -201,6 +204,16 @@ where
         // Set the l1 height of the l1 hash
         self.ledger_db
             .set_l1_height_of_l1_hash(l1_block.header().hash().into(), l1_height)?;
+
+        // Extract and log forced transactions from L1 block
+        let forced_tx_count =
+            extract_forced_transactions(self.da_service.clone(), &l1_block).len();
+        if forced_tx_count > 0 {
+            info!(
+                "Found {} forced transaction(s) in L1 block {}",
+                forced_tx_count, l1_height
+            );
+        }
 
         let commitments_and_proofs = extract_zk_proofs_and_sequencer_commitments(
             self.da_service.clone(),

--- a/crates/light-client-prover/src/circuit/mod.rs
+++ b/crates/light-client-prover/src/circuit/mod.rs
@@ -583,6 +583,11 @@ impl<S: Storage, DS: DaSpec, Z: Zkvm> LightClientProofCircuit<S, DS, Z> {
                         )
                     }
                 }
+                DataOnDa::ForcedTransaction(_) => {
+                    // Forced transactions are handled by the sequencer/fullnode,
+                    // not relevant for the light client prover circuit.
+                    log!("Found forced transaction, skipping in circuit");
+                }
             }
         }
 

--- a/crates/sequencer/src/forced_tx_mempool.rs
+++ b/crates/sequencer/src/forced_tx_mempool.rs
@@ -1,0 +1,148 @@
+use std::collections::{HashSet, VecDeque};
+
+use alloy_primitives::keccak256;
+use sov_rollup_interface::da::ForcedTransaction;
+use tracing::debug;
+
+use crate::metrics::SEQUENCER_METRICS as SM;
+
+/// A mempool for forced transactions extracted from L1 blocks.
+/// Forced transactions are user-submitted EVM transactions inscribed on Bitcoin
+/// that the sequencer MUST include within a deadline.
+#[derive(Clone, Debug, Default)]
+pub struct ForcedTxMempool {
+    /// Queue of pending forced transactions (FIFO order)
+    pending_txs: VecDeque<ForcedTransaction>,
+    /// Set of seen tx hashes (keccak256 of rlp_tx) for deduplication
+    seen_tx_hashes: HashSet<[u8; 32]>,
+}
+
+impl ForcedTxMempool {
+    /// Creates a new empty forced transaction mempool
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a forced transaction to the mempool.
+    /// Returns true if the transaction was added, false if it was already seen.
+    pub fn add(&mut self, ft: ForcedTransaction) -> bool {
+        let tx_hash: [u8; 32] = keccak256(&ft.rlp_tx).into();
+
+        if !self.seen_tx_hashes.insert(tx_hash) {
+            debug!("Forced transaction already in mempool: {}", hex::encode(tx_hash));
+            return false;
+        }
+
+        self.pending_txs.push_back(ft);
+        SM.forced_tx_mempool_txs.set(self.pending_txs.len() as f64);
+        true
+    }
+
+    /// Fetches up to `limit` forced transactions from the front of the queue
+    /// without removing them.
+    pub fn fetch(&self, limit: usize) -> Vec<ForcedTransaction> {
+        self.pending_txs
+            .iter()
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
+    /// Removes the given forced transactions from the mempool after successful inclusion.
+    pub fn remove(&mut self, txs: &[ForcedTransaction]) {
+        let hashes_to_remove: HashSet<[u8; 32]> = txs
+            .iter()
+            .map(|ft| keccak256(&ft.rlp_tx).into())
+            .collect();
+
+        self.pending_txs.retain(|ft| {
+            let hash: [u8; 32] = keccak256(&ft.rlp_tx).into();
+            !hashes_to_remove.contains(&hash)
+        });
+
+        SM.forced_tx_mempool_txs.set(self.pending_txs.len() as f64);
+    }
+
+    /// Returns the number of pending forced transactions.
+    pub fn len(&self) -> usize {
+        self.pending_txs.len()
+    }
+
+    /// Returns true if the mempool has no pending forced transactions.
+    pub fn is_empty(&self) -> bool {
+        self.pending_txs.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ft(rlp: &[u8], height: u64) -> ForcedTransaction {
+        ForcedTransaction {
+            rlp_tx: rlp.to_vec(),
+            l1_block_height: height,
+        }
+    }
+
+    #[test]
+    fn test_add_and_fetch() {
+        let mut mempool = ForcedTxMempool::new();
+        let ft1 = make_ft(b"tx1", 100);
+        let ft2 = make_ft(b"tx2", 101);
+
+        assert!(mempool.add(ft1.clone()));
+        assert!(mempool.add(ft2.clone()));
+        assert_eq!(mempool.len(), 2);
+
+        let fetched = mempool.fetch(1);
+        assert_eq!(fetched.len(), 1);
+        assert_eq!(fetched[0].rlp_tx, b"tx1");
+
+        let fetched_all = mempool.fetch(10);
+        assert_eq!(fetched_all.len(), 2);
+    }
+
+    #[test]
+    fn test_dedup() {
+        let mut mempool = ForcedTxMempool::new();
+        let ft = make_ft(b"tx1", 100);
+
+        assert!(mempool.add(ft.clone()));
+        assert!(!mempool.add(ft.clone()));
+        assert_eq!(mempool.len(), 1);
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut mempool = ForcedTxMempool::new();
+        let ft1 = make_ft(b"tx1", 100);
+        let ft2 = make_ft(b"tx2", 101);
+        let ft3 = make_ft(b"tx3", 102);
+
+        mempool.add(ft1.clone());
+        mempool.add(ft2.clone());
+        mempool.add(ft3.clone());
+
+        mempool.remove(&[ft1, ft2]);
+        assert_eq!(mempool.len(), 1);
+        assert_eq!(mempool.fetch(10)[0].rlp_tx, b"tx3");
+    }
+
+    #[test]
+    fn test_fifo_order() {
+        let mut mempool = ForcedTxMempool::new();
+        let ft1 = make_ft(b"first", 100);
+        let ft2 = make_ft(b"second", 101);
+        let ft3 = make_ft(b"third", 102);
+
+        mempool.add(ft1);
+        mempool.add(ft2);
+        mempool.add(ft3);
+
+        let fetched = mempool.fetch(3);
+        assert_eq!(fetched[0].rlp_tx, b"first");
+        assert_eq!(fetched[1].rlp_tx, b"second");
+        assert_eq!(fetched[2].rlp_tx, b"third");
+    }
+}

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -71,6 +71,8 @@ pub mod db_migrations;
 mod db_provider;
 /// Separate mempool implementation only for handling deposit data in FIFO (First-In-First-Out) order
 mod deposit_data_mempool;
+/// Mempool for forced transactions from L1 inscriptions
+pub mod forced_tx_mempool;
 /// Module containing mempool functionality for transaction management
 mod mempool;
 /// Module containing metrics collection and reporting functionality

--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -146,6 +146,9 @@ pub struct SequencerMetrics {
     /// The l2 end height of the latest sequencer commitment
     #[metric(describe = "The l2 end height of the latest sequencer commitment")]
     pub latest_sequencer_commitment_l2_end_height: Gauge,
+    /// Current number of forced transactions in the mempool
+    #[metric(describe = "How many forced transactions are currently in the forced tx mempool")]
+    pub forced_tx_mempool_txs: Gauge,
 }
 
 /// Sequencer metrics

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -65,6 +65,7 @@ use crate::commitment::service::CommitmentService;
 use crate::da::{da_block_monitor, get_da_block_data};
 use crate::db_provider::DbProvider;
 use crate::deposit_data_mempool::{Deposit, DepositDataMempool};
+use crate::forced_tx_mempool::ForcedTxMempool;
 use crate::mempool::CitreaMempool;
 use crate::metrics::SEQUENCER_METRICS as SM;
 use crate::types::SequencerRpcMessage;
@@ -103,6 +104,8 @@ where
     pub(crate) stf: StfBlueprint<DefaultContext, Da::Spec, CitreaRuntime<DefaultContext, Da::Spec>>,
     /// Mempool for deposit transactions
     pub(crate) deposit_mempool: Arc<Mutex<DepositDataMempool>>,
+    /// Mempool for forced transactions from L1 inscriptions
+    pub(crate) forced_tx_mempool: Arc<Mutex<ForcedTxMempool>>,
     /// Manager for prover storage
     pub(crate) storage_manager: ProverStorageManager,
     /// Current state root hash
@@ -173,6 +176,7 @@ where
             config,
             stf,
             deposit_mempool,
+            forced_tx_mempool: Arc::new(Mutex::new(ForcedTxMempool::new())),
             storage_manager,
             state_root: init_params.prev_state_root,
             l2_block_hash: init_params.prev_l2_block_hash,
@@ -192,6 +196,7 @@ where
     /// * `l2_block_info` - Block information for hooks
     /// * `deposit_data` - Deposit transaction data
     /// * `da_blocks` - Data availability blocks
+    /// * `forced_txs` - Forced transactions from L1 inscriptions to include before mempool txs
     ///
     /// # Returns
     /// A tuple containing the validated transactions and their hashes
@@ -205,6 +210,7 @@ where
         l2_block_info: HookL2BlockInfo,
         deposit_data: &[Deposit],
         da_blocks: Vec<Da::FilteredBlock>,
+        forced_txs: &[sov_rollup_interface::da::ForcedTransaction],
     ) -> anyhow::Result<(
         Vec<RlpEvmTransaction>,
         Vec<TxHash>,
@@ -254,6 +260,51 @@ where
             let mut l1_fee_failed_txs = vec![];
             // Track senders for successfully validated transactions
             let mut senders = vec![];
+
+            // Process forced transactions from L1 inscriptions before mempool txs
+            for ft in forced_txs {
+                let start_tx = Instant::now();
+                let rlp_tx = RlpEvmTransaction { rlp: ft.rlp_tx.clone() };
+                let call_txs = CallMessage {
+                    txs: vec![rlp_tx.clone()],
+                };
+                let raw_message = <CitreaRuntime<DefaultContext, Da::Spec> as EncodeCall<
+                    citrea_evm::Evm<DefaultContext>,
+                >>::encode_call(call_txs);
+
+                let signed_tx = self.sign_tx(l2_block_info.current_spec, raw_message, nonce)?;
+                nonce += 1;
+
+                let txs = vec![signed_tx];
+                let mut working_set = working_set_to_discard.checkpoint().to_revertable();
+
+                match self.stf.apply_l2_block_txs(&l2_block_info, &txs, &mut working_set) {
+                    Ok(()) => {
+                        // Forced tx included successfully (even if EVM-reverted, it counts)
+                        working_set_to_discard = working_set.checkpoint().to_revertable();
+                        // Recover sender from RLP for mempool maintenance
+                        let sender = match recover_raw_transaction(rlp_tx.rlp.clone().into()) {
+                            Ok(recovered) => recovered.signer(),
+                            Err(e) => {
+                                warn!("Failed to recover sender from forced tx RLP: {:?}", e);
+                                Address::ZERO
+                            }
+                        };
+                        senders.push(sender);
+                        all_txs.push(rlp_tx);
+                        SM.dry_run_single_tx_time.record(
+                            Instant::now()
+                                .saturating_duration_since(start_tx)
+                                .as_secs_f64(),
+                        );
+                    }
+                    Err(e) => {
+                        nonce = nonce.saturating_sub(1);
+                        warn!("Forced transaction dry-run failed, skipping: {:?}", e);
+                        working_set_to_discard = working_set.revert().to_revertable();
+                    }
+                }
+            }
 
             // using .next() instead of a for loop because its the intended
             // behaviour for the BestTransactions implementations
@@ -498,6 +549,12 @@ where
             .lock()
             .fetch_deposits(self.config.deposit_mempool_fetch_limit);
 
+        // Get pending forced transactions from L1 inscriptions
+        let forced_txs = self
+            .forced_tx_mempool
+            .lock()
+            .fetch(self.config.forced_tx_fetch_limit);
+
         let pub_key = self.sov_tx_signer_priv_key.pub_key();
 
         let l2_block_info = HookL2BlockInfo {
@@ -532,6 +589,7 @@ where
                 l2_block_info.clone(),
                 &deposit_data,
                 da_blocks,
+                &forced_txs,
             )
             .await?;
 
@@ -618,6 +676,15 @@ where
             debug!(
                 "Removed {} deposits from mempool after successful block production",
                 removed_count
+            );
+        }
+
+        // Remove successfully included forced transactions from the mempool
+        if !forced_txs.is_empty() {
+            self.forced_tx_mempool.lock().remove(&forced_txs);
+            debug!(
+                "Removed {} forced txs from mempool after successful block production",
+                forced_txs.len()
             );
         }
 
@@ -1172,6 +1239,18 @@ where
                         last_finalized_l1_height = new_finalized_l1_height;
 
                         info!("New finalized L1 block at height {}", last_finalized_l1_height);
+
+                        // Extract forced transactions from the new L1 block
+                        let forced_txs = self.da_service.extract_relevant_forced_transactions(&last_finalized_block);
+                        if !forced_txs.is_empty() {
+                            let mut ftm = self.forced_tx_mempool.lock();
+                            for (_idx, ft) in forced_txs {
+                                if ftm.add(ft) {
+                                    debug!("Added forced transaction from L1 block {}", last_finalized_l1_height);
+                                }
+                            }
+                            info!("Forced tx mempool size: {}", ftm.len());
+                        }
 
                         missed_da_blocks_count = self.da_blocks_missed(last_finalized_l1_height, last_used_l1_height);
                     }

--- a/crates/sovereign-sdk/adapters/mock-da/src/service.rs
+++ b/crates/sovereign-sdk/adapters/mock-da/src/service.rs
@@ -447,6 +447,11 @@ impl DaService for MockDaService {
                 let req = DataOnDa::BatchProofMethodId(method_id);
                 borsh::to_vec(&req).unwrap()
             }
+            DaTxRequest::ForcedTransaction(forced_tx) => {
+                tracing::debug!("Adding a forced transaction");
+                let req = DataOnDa::ForcedTransaction(forced_tx);
+                borsh::to_vec(&req).unwrap()
+            }
         };
         let blocks = self.blocks.lock().await;
         let _ = self.add_blob(&blocks, blob, Default::default())?;

--- a/crates/sovereign-sdk/rollup-interface/src/node/services/da.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/node/services/da.rs
@@ -9,7 +9,7 @@ use tokio::sync::oneshot::Sender as OneshotSender;
 
 use crate::da::BlockHeaderTrait;
 #[cfg(feature = "native")]
-use crate::da::{DaSpec, DaTxRequest, DaVerifier, SequencerCommitment};
+use crate::da::{DaSpec, DaTxRequest, DaVerifier, ForcedTransaction, SequencerCommitment};
 #[cfg(feature = "native")]
 use crate::zk::Proof;
 
@@ -124,6 +124,15 @@ pub trait DaService: Send + Sync + 'static {
         &self,
         sequencer_da_pub_key: &[u8],
     ) -> Vec<SequencerCommitment>;
+
+    /// Extract forced transactions from a block.
+    /// Returns a list of (tx_index, ForcedTransaction) pairs.
+    fn extract_relevant_forced_transactions(
+        &self,
+        _block: &Self::FilteredBlock,
+    ) -> Vec<(usize, ForcedTransaction)> {
+        vec![]
+    }
 
     /// Convert a DA layer block to short form header proof.
     fn block_to_short_header_proof(

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
@@ -15,6 +15,16 @@ pub const SECURITY_COUNCIL_SIGNATURE_THRESHOLD: usize = 3;
 /// Size of a signature in bytes.
 pub const SECURITY_COUNCIL_SIGNATURE_SIZE: usize = 64;
 
+/// A forced transaction published as a Bitcoin inscription.
+/// Contains an RLP-encoded signed EVM transaction that the sequencer MUST include.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, BorshDeserialize, BorshSerialize)]
+pub struct ForcedTransaction {
+    /// RLP-encoded signed EVM transaction
+    pub rlp_tx: Vec<u8>,
+    /// L1 block height where the forced transaction was observed
+    pub l1_block_height: u64,
+}
+
 /// Commitments made to the DA layer from the sequencer.
 /// Has merkle root of l2 block hashes from L1 start block to L1 end block (inclusive)
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, BorshDeserialize, BorshSerialize)]
@@ -111,6 +121,8 @@ pub enum DaTxRequest {
     ZKProof(Proof),
     /// Batch proof method id update for light client
     BatchProofMethodId(BatchProofMethodId),
+    /// A forced transaction inscription
+    ForcedTransaction(ForcedTransaction),
 }
 
 /// Data written to DA and read from DA must be the borsh serialization of this enum
@@ -127,6 +139,8 @@ pub enum DataOnDa {
     BatchProofMethodId(BatchProofMethodId),
     /// Sequencer commitment
     SequencerCommitment(SequencerCommitment),
+    /// A forced transaction
+    ForcedTransaction(ForcedTransaction),
 }
 
 /// A specification for the types used by a DA layer.

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
@@ -98,6 +98,8 @@ pub enum L2BlockHookError {
     TooManyL2BlocksOnDaSlot,
     /// The timestamp of the l2 block is incorrect
     TimestampShouldBeGreater,
+    /// A forced transaction deadline was missed
+    ForcedTxDeadlineMissed,
 }
 
 #[derive(Debug, PartialEq)]
@@ -200,6 +202,9 @@ impl std::fmt::Display for L2BlockHookError {
             }
             L2BlockHookError::TimestampShouldBeGreater => {
                 write!(f, "Timestamp should be greater")
+            }
+            L2BlockHookError::ForcedTxDeadlineMissed => {
+                write!(f, "Forced transaction inclusion deadline missed")
             }
         }
     }


### PR DESCRIPTION
## Summary

- Allow users to publish signed EVM transactions as Bitcoin inscriptions (kind byte 5) that the sequencer must include in L2 blocks, enabling censorship resistance
- Add full inscription type 5 pipeline: parser, builder, signer, verifier, backup, and extraction across bitcoin-da
- Add `ForcedTxMempool` in sequencer with FIFO ordering and keccak256-based deduplication
- Integrate forced TX extraction from L1 blocks and injection into L2 block production (priority over mempool TXs)
- Add `force-include` CLI command for broadcasting forced transaction inscriptions

## Design Decisions

- Forced TXs are **not** system transactions — they go through normal EVM execution (gas, nonce, balance checks)
- Anyone can publish — no public key whitelist, inscription signature only proves integrity
- EVM reverts count as "included" — the sequencer must execute them, not succeed
- FIFO ordering by position in Bitcoin block
- Deadline enforcement config exists (`forced_tx_deadline_l1_blocks`) but rule enforcer logic is not yet active (future PR)

## Changed Files (24 files, +915/-12)

| Area | Files |
|------|-------|
| Rollup Interface | `da.rs` (types), `stf.rs` (error variant), `services/da.rs` (trait method) |
| Bitcoin DA | `mod.rs`, `parsers.rs`, `body_builders.rs`, `tx_signer.rs`, `service.rs`, `verifier.rs`, `backup.rs` |
| Sequencer | `forced_tx_mempool.rs` (new), `runner.rs`, `metrics.rs`, `lib.rs` |
| Common | `config/mod.rs`, `da.rs` |
| Fullnode | `da_block_handler.rs` |
| Light Client | `circuit/mod.rs` |
| Mock DA | `service.rs` |
| CLI | `main.rs`, `force_include.rs` (new), `commands/mod.rs`, `Cargo.toml` |

## Test plan

- [ ] `cargo check` passes for all crates (verified locally, excluding pre-existing risc0 toolchain issue)
- [ ] Unit tests for `ForcedTxMempool` (add/fetch/remove/dedup)
- [ ] Unit tests for inscription type 5 round-trip (build → parse → verify)
- [ ] Integration test: CLI → Bitcoin regtest → sequencer extraction
- [ ] Verify all enum match arms are exhaustive across the codebase