### PR TITLE
perf: Skip re-execution in preflight layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   `RPC_MAX_SYNC_SEND_TIMEOUT_MS`: Maximum timeout in milliseconds for `eth_sendRawTransactionSync` (EIP-7966) (default: 20 seconds).\
 
 ### Changed
+- perf: Skip re-execution of proof request in boundless
 - feat: Separate l1 fee rate from block update
 **New env var:**\
   `L1_FEE_RATE_UPDATE_INTERVAL_MS`: L1 fee rate update interval in milliseconds (default: 30 seconds)\

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Changelog
 ## [Unreleased]
 ### Added
-- Add `linux/arm64` release binary and support for multi-arch (arm64/amd64) docker image.
-- feat: implement `eth_sendRawTransactionSync` RPC as per EIP-7966. ([#3095](https://github.com/chainwayxyz/citrea/pull/3095))
+- Add `linux/arm64` release binary and support for multi-arch (arm64/amd64) docker image. ([#3130](https://github.com/chainwayxyz/citrea/pull/3130))
+- feat: implement `eth_sendRawTransactionSync` RPC as per EIP-7966. ([#3095](https://github.com/chainwayxyz/citrea/pull/3095))\
 **New env var:**\
-  `RPC_MAX_SYNC_SEND_TIMEOUT_MS`: Maximum timeout in milliseconds for `eth_sendRawTransactionSync` (EIP-7966) (default: 20 seconds).\
+  `RPC_MAX_SYNC_SEND_TIMEOUT_MS`: Maximum timeout in milliseconds for `eth_sendRawTransactionSync` (EIP-7966) (default: 20 seconds).
 
 ### Changed
-- perf: Skip re-execution of proof request in boundless
-- feat: Separate l1 fee rate from block update
+- perf: Skip re-execution of proof request in boundless([#3144](https://github.com/chainwayxyz/citrea/pull/3144))
+- feat: Separate l1 fee rate from block update ([#3131](https://github.com/chainwayxyz/citrea/pull/3131))\
 **New env var:**\
-  `L1_FEE_RATE_UPDATE_INTERVAL_MS`: L1 fee rate update interval in milliseconds (default: 30 seconds)\
+  `L1_FEE_RATE_UPDATE_INTERVAL_MS`: L1 fee rate update interval in milliseconds (default: 30 seconds)
 
 
 ## [v2.0.0] (2026-02-05)
@@ -27,10 +27,10 @@
 
 ## [v1.2.1] (2026-01-27)
 ### Added
-- docs: Add mainnet run guide at `docs/run-mainnet.md`.
+- docs: Add mainnet run guide at `docs/run-mainnet.md` ([#3119](https://github.com/chainwayxyz/citrea/pull/3119)).
 
 ### Changed
-- feat: unify fullnode docker image to be usable on mainnet.
+- feat: unify fullnode docker image to be usable on mainnet ([#3119](https://github.com/chainwayxyz/citrea/pull/3119)).
 
 ## [v1.2.0] (2026-01-07)
 ### Added

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -276,6 +276,7 @@ impl BoundlessProver {
                 lock_stake,
                 bidding_start_delay,
                 total_cycles_approx,
+                journal.clone(),
             )
             .await;
 
@@ -320,6 +321,7 @@ impl BoundlessProver {
         lock_stake: u64,
         bidding_start_delay: u64,
         total_cycles_approx: u64,
+        journal: Journal,
     ) -> RequestParams {
         // Note that offer ramp up period must be less than or equal to the lock timeout)
 
@@ -408,6 +410,7 @@ impl BoundlessProver {
                     .with_ramp_up_start(bidding_start),
             )
             .with_cycles(total_cycles_approx)
+            .with_journal(journal)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -713,6 +716,7 @@ impl BoundlessProver {
                 price_response.bidding_start_delay,
                 // TODO: https://github.com/chainwayxyz/citrea/issues/2820
                 total_cycles_approx,
+                journal.clone(),
             )
             .await;
 


### PR DESCRIPTION
# Description
This enables us to skip preflight layer in boundless request builder where, if the journal is not provided the image and input is fetched from remote and re executed for journal to be re-attached to the request.
I've checked if this results in putting the journal to the fulfillment data that is written on the contract and realized that this is function `with_journal` is called eventually in preflight layer anyways. So we do not need to worry about that. The fulfillment data is determined in broker.rs

```rust
let (claim_digest, fulfillment_data, fulfillment_data_type) = match predicate_type {
      PredicateType::ClaimDigestMatch => (
          order_request.requirements.predicate.data.0.as_ref().try_into().unwrap(),
          vec![],
          FulfillmentDataType::None,
      ),
      PredicateType::PrefixMatch | PredicateType::DigestMatch => (
          order_claim_digest,
          FulfillmentDataImageIdAndJournal {
              imageId: <[u8; 32]>::from(order_img_id).into(),
              journal: order_journal.into(),
          }
          .abi_encode(),
          FulfillmentDataType::ImageIdAndJournal,
      ),
      _ => {
          return Err(anyhow!("Invalid predicate type: {predicate_type:?}"));
      }
  };
```

Since we use ClaimDigestMatch we're good on that front as well.

## Linked Issues
- Fixes #3122 
