### PR TITLE
fix: Check for shutdown in syncers' loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - refactor: Use reth task manager instead of tokio spawn in sequencer services ([#3145](https://github.com/chainwayxyz/citrea/pull/3145))
 - perf: Skip re-execution of proof request in boundless([#3144](https://github.com/chainwayxyz/citrea/pull/3144))
+- fix: Check for shutdown signal when processing blocks in L1/L2 syncers loops ([#3152](https://github.com/chainwayxyz/citrea/pull/3152))
 
 ## [v2.1.0](2026-02-17)
 ### Added

--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -10,6 +10,7 @@ use std::time::Instant;
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::{extract_sequencer_commitments, sync_l1};
+use citrea_common::utils::shutdown_requested;
 use citrea_common::RollupPublicKeys;
 use reth_tasks::shutdown::GracefulShutdown;
 use sov_db::ledger_db::BatchProverLedgerOps;
@@ -128,7 +129,7 @@ where
                 }
                 _ = notifier.notified() => {
                     let _l1_guard = backup_manager.start_l1_processing().await;
-                    if let Err(e) = self.process_l1_blocks().await {
+                    if let Err(e) = self.process_l1_blocks(&shutdown_signal).await {
                         error!("Could not process L1 blocks: {:?}", e);
                     }
                 },
@@ -145,13 +146,21 @@ where
     /// 3. Extracts sequencer commitments and stores them by index
     /// 4. Updates the last scanned L1 height in the database after each successfully processed block
     /// 5. If queue is not empty, After processing each block in the queue , pings the L1 signal channel.
-    async fn process_l1_blocks(&mut self) -> Result<(), anyhow::Error> {
+    async fn process_l1_blocks(
+        &mut self,
+        shutdown_signal: &GracefulShutdown,
+    ) -> Result<(), anyhow::Error> {
         let mut pending_l1_blocks = self.pending_l1_blocks.lock().await;
         // don't ping if no new l1 blocks
         let should_ping = !pending_l1_blocks.is_empty();
 
         // process all the pending l1 blocks
         while !pending_l1_blocks.is_empty() {
+            if shutdown_requested(shutdown_signal) {
+                info!("Shutting down L1 syncer");
+                return Ok(());
+            }
+
             let l1_block = pending_l1_blocks
                 .front()
                 .expect("Pending l1 blocks cannot be empty");

--- a/crates/batch-prover/src/l2_syncer.rs
+++ b/crates/batch-prover/src/l2_syncer.rs
@@ -183,14 +183,7 @@ where
                                     if let Some(duration) = backoff.next_backoff() {
                                         last_backoff_duration = duration;
                                     }
-                                    select! {
-                                        biased;
-                                        _ = &mut shutdown_signal => {
-                                            info!("Shutting down L2Syncer");
-                                            return;
-                                        }
-                                        _ = tokio::time::sleep(last_backoff_duration) => {}
-                                    }
+                                    tokio::time::sleep(last_backoff_duration).await;
                                 }
                             }
                         }

--- a/crates/batch-prover/src/l2_syncer.rs
+++ b/crates/batch-prover/src/l2_syncer.rs
@@ -12,6 +12,7 @@ use borsh::BorshDeserialize;
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;
 use citrea_common::l2::{apply_l2_block, commit_l2_block, sync_l2};
+use citrea_common::utils::shutdown_requested;
 use citrea_primitives::types::L2BlockHash;
 use citrea_stf::runtime::CitreaRuntime;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
@@ -159,7 +160,7 @@ where
             select! {
                 biased;
                 _ = &mut shutdown_signal => {
-                    info!("Shutting down L2 syncer");
+                    info!("Shutting down L2Syncer");
                     return;
                 },
                 Some(l2_blocks) = l2_rx.recv() => {
@@ -168,22 +169,37 @@ where
                         let mut backoff = ExponentialBackoff::default();
                         let mut last_backoff_duration = backoff.current_interval;
                         loop {
+                            if shutdown_requested(&shutdown_signal) {
+                                info!("Shutting down L2Syncer");
+                                return;
+                            }
+
                             let _l2_lock = backup_manager.start_l2_processing().await;
                             match self.process_l2_block(&l2_block).await {
                                 Ok(_) => break,
                                 Err(e) => {
-                                    error!("Failed to process L2 block {}: {}", l2_block.header.height, e);
+                                    error!("Failed to process L2 block {}: {e}", l2_block.header.height);
 
                                     if let Some(duration) = backoff.next_backoff() {
                                         last_backoff_duration = duration;
                                     }
-                                    tokio::time::sleep(last_backoff_duration).await;
+                                    select! {
+                                        biased;
+                                        _ = &mut shutdown_signal => {
+                                            info!("Shutting down L2Syncer");
+                                            return;
+                                        }
+                                        _ = tokio::time::sleep(last_backoff_duration) => {}
+                                    }
                                 }
                             }
                         }
                     }
                 },
-                _ = &mut l2_sync_worker => {},
+                _ = &mut l2_sync_worker => {
+                    info!("Shutting down L2Syncer");
+                    return;
+                },
             }
         }
     }

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -9,7 +9,9 @@ use borsh::BorshDeserialize;
 use citrea_evm::system_contracts::{BitcoinLightClientContract, BridgeContract};
 use citrea_evm::{CallMessage as EvmCallMessage, SYSTEM_SIGNER};
 use citrea_primitives::forks::get_forks;
+use futures::FutureExt;
 use reth_primitives::{Recovered, TransactionSigned};
+use reth_tasks::shutdown::GracefulShutdown;
 use sov_db::ledger_db::SharedLedgerOps;
 use sov_modules_api::DaSpec;
 use sov_rollup_interface::rpc::block::L2BlockResponse;
@@ -138,6 +140,15 @@ pub async fn decode_sov_tx_and_update_short_header_proofs<Da: DaService, DB: Sha
 
 pub fn read_env(key: &str) -> anyhow::Result<String> {
     env::var(key).map_err(|_| anyhow::anyhow!("Env {} missing or invalid UTF-8", key))
+}
+
+/// Non-blocking shutdown probe.
+pub fn shutdown_requested(shutdown_signal: &GracefulShutdown) -> bool {
+    shutdown_signal
+        .clone()
+        .ignore_guard()
+        .now_or_never()
+        .is_some()
 }
 
 // If tangerine activation height is 0, return 1

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -12,7 +12,7 @@ use anyhow::anyhow;
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::{extract_zk_proofs_and_sequencer_commitments, sync_l1, ProofOrCommitment};
-use citrea_common::utils::get_tangerine_activation_height_non_zero;
+use citrea_common::utils::{get_tangerine_activation_height_non_zero, shutdown_requested};
 use citrea_primitives::forks::fork_from_block_number;
 use citrea_primitives::network_to_dev_mode;
 use reth_tasks::shutdown::GracefulShutdown;
@@ -153,7 +153,7 @@ where
                 }
                 _ = &mut l1_sync_worker => {},
                 _ = notifier.notified() => {
-                    if let Err(e) = self.process_queued_l1_blocks().await {
+                    if let Err(e) = self.process_queued_l1_blocks(&shutdown_signal).await {
                         error!("{e}");
                         return;
                     }
@@ -163,8 +163,16 @@ where
     }
 
     /// Processes L1 blocks waiting in the queue
-    async fn process_queued_l1_blocks(&mut self) -> Result<(), anyhow::Error> {
+    async fn process_queued_l1_blocks(
+        &mut self,
+        shutdown_signal: &GracefulShutdown,
+    ) -> Result<(), anyhow::Error> {
         loop {
+            if shutdown_requested(shutdown_signal) {
+                info!("Shutting down L1BlockHandler");
+                return Ok(());
+            }
+
             let Some(l1_block) = self.queued_l1_blocks.lock().await.front().cloned() else {
                 break;
             };

--- a/crates/fullnode/src/l2_syncer.rs
+++ b/crates/fullnode/src/l2_syncer.rs
@@ -180,15 +180,7 @@ where
                                 Err(e) => {
                                     error!("Failed to process L2 block {}: {e}", l2_block.header.height);
                                     let backoff_duration = backoff.next_backoff().expect("Failed to process L2 block multiple times. Killing L2Syncer...");
-                                    select! {
-                                        biased;
-                                        _ = &mut shutdown_signal => {
-                                            info!("Shutting down L2Syncer");
-                                            l2_rx.close();
-                                            return;
-                                        }
-                                        _ = tokio::time::sleep(backoff_duration) => {}
-                                    }
+                                    tokio::time::sleep(backoff_duration).await;
                                 }
                             }
                         }

--- a/crates/fullnode/src/l2_syncer.rs
+++ b/crates/fullnode/src/l2_syncer.rs
@@ -11,6 +11,7 @@ use borsh::BorshDeserialize;
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;
 use citrea_common::l2::{apply_l2_block, commit_l2_block, sync_l2};
+use citrea_common::utils::shutdown_requested;
 use citrea_primitives::types::L2BlockHash;
 use citrea_stf::runtime::CitreaRuntime;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
@@ -153,28 +154,45 @@ where
         let backup_manager = self.backup_manager.clone();
         loop {
             select! {
-                _ = &mut l2_sync_worker => {},
+                _ = &mut shutdown_signal => {
+                    info!("Shutting down L2Syncer");
+                    l2_rx.close();
+                    return;
+                },
+                _ = &mut l2_sync_worker => {
+                    info!("Shutting down L2Syncer");
+                    return;
+                },
                 Some(l2_blocks) = l2_rx.recv() => {
                     // While syncing, we'd like to process L2 blocks as they come without any delays.
                     for l2_block in l2_blocks {
                         let mut backoff = ExponentialBackoff::default();
                         loop {
+                            if shutdown_requested(&shutdown_signal) {
+                                info!("Shutting down L2Syncer");
+                                l2_rx.close();
+                                return;
+                            }
+
                             let _l2_lock = backup_manager.start_l2_processing().await;
                             match self.process_l2_block(&l2_block).await {
                                 Ok(_) => break,
                                 Err(e) => {
-                                    error!("Failed to process L2 block {}: {}", l2_block.header.height, e);
+                                    error!("Failed to process L2 block {}: {e}", l2_block.header.height);
                                     let backoff_duration = backoff.next_backoff().expect("Failed to process L2 block multiple times. Killing L2Syncer...");
-                                    tokio::time::sleep(backoff_duration).await;
+                                    select! {
+                                        biased;
+                                        _ = &mut shutdown_signal => {
+                                            info!("Shutting down L2Syncer");
+                                            l2_rx.close();
+                                            return;
+                                        }
+                                        _ = tokio::time::sleep(backoff_duration) => {}
+                                    }
                                 }
                             }
                         }
                     }
-                },
-                _ = &mut shutdown_signal => {
-                    info!("Shutting down L2 sync worker");
-                    l2_rx.close();
-                    return;
                 },
             }
         }

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::sync_l1;
+use citrea_common::utils::shutdown_requested;
 use citrea_common::LightClientProverConfig;
 use citrea_primitives::forks::fork_from_block_number;
 use prover_services::{ParallelProverService, ProofData, ProofWithDuration};
@@ -27,7 +28,7 @@ use sov_rollup_interface::zk::{ReceiptType, ZkvmHost};
 use sov_rollup_interface::Network;
 use tokio::select;
 use tokio::sync::{Mutex, Notify};
-use tracing::{error, instrument};
+use tracing::{error, info, instrument};
 
 use crate::circuit::initial_values::InitialValueProvider;
 use crate::circuit::LightClientProofCircuit;
@@ -171,12 +172,13 @@ where
             select! {
                 biased;
                 _ = &mut shutdown_signal => {
+                    info!("Shutting down L1BlockHandler");
                     return;
                 }
                 _ = &mut l1_sync_worker => {},
                 _ = notifier.notified() => {
                     let _l1_guard = backup_manager.start_l1_processing().await;
-                    if let Err(e) = self.process_queued_l1_blocks().await {
+                    if let Err(e) = self.process_queued_l1_blocks(&shutdown_signal).await {
                         error!("Could not process queued L1 blocks and generate proof: {:?}", e);
                     }
                 },
@@ -185,8 +187,16 @@ where
     }
 
     /// Processes L1 blocks waiting in the queue.
-    async fn process_queued_l1_blocks(&mut self) -> Result<(), anyhow::Error> {
+    async fn process_queued_l1_blocks(
+        &mut self,
+        shutdown_signal: &GracefulShutdown,
+    ) -> Result<(), anyhow::Error> {
         loop {
+            if shutdown_requested(shutdown_signal) {
+                info!("Shutting down L1BlockHandler");
+                return Ok(());
+            }
+
             let Some(l1_block) = self.queued_l1_blocks.lock().await.front().cloned() else {
                 break;
             };


### PR DESCRIPTION
# Description

- Stop looping over L1/L2 block processing if shutdown is already requested.
- Prevent processing blocks after shutdown completion
- Fix panic after shutdown completion
- Prevent state corruption on graceful shutdown

## Linked Issues
- Fixes #3150 