### PR TITLE
fix: subscription server unordered log delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 ### Changed
+- fix: Subscription server unordered log delivery ([#3156](https://github.com/chainwayxyz/citrea/pull/3156))
 - refactor: Use reth task manager instead of tokio spawn in sequencer services ([#3145](https://github.com/chainwayxyz/citrea/pull/3145))
 - perf: Skip re-execution of proof request in boundless([#3144](https://github.com/chainwayxyz/citrea/pull/3144))
 - fix: Check for shutdown signal when processing blocks in L1/L2 syncers loops ([#3152](https://github.com/chainwayxyz/citrea/pull/3152))

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -786,8 +786,7 @@ where
                     .subscription_manager
                     .as_ref()
                     .unwrap()
-                    .register_new_heads_subscription(subscription)
-                    .await;
+                    .register_new_heads_subscription(subscription);
             }
             "logs" => {
                 let subscription = pending.accept().await?;
@@ -795,8 +794,7 @@ where
                     .subscription_manager
                     .as_ref()
                     .unwrap()
-                    .register_new_logs_subscription(filter.unwrap_or_default(), subscription)
-                    .await;
+                    .register_new_logs_subscription(filter.unwrap_or_default(), subscription);
             }
             _ => {
                 pending

--- a/crates/ethereum-rpc/src/subscription.rs
+++ b/crates/ethereum-rpc/src/subscription.rs
@@ -27,8 +27,8 @@ impl SubscriptionManager {
         ledger_db: LedgerDB,
         l2_block_rx: broadcast::Receiver<u64>,
     ) -> Self {
-        let (heads_tx, _) = broadcast::channel(16);
-        let (logs_tx, _) = broadcast::channel(16);
+        let (heads_tx, _) = broadcast::channel(256);
+        let (logs_tx, _) = broadcast::channel(256);
 
         let l2_block_handle = tokio::spawn(l2_block_event_handler::<C>(
             storage,

--- a/crates/ethereum-rpc/src/subscription.rs
+++ b/crates/ethereum-rpc/src/subscription.rs
@@ -8,26 +8,17 @@ use jsonrpsee::{SubscriptionMessage, SubscriptionSink};
 use reth_rpc_eth_types::logs_utils::log_matches_filter;
 use sov_db::ledger_db::LedgerDB;
 use sov_modules_api::WorkingSet;
+use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::RecvError;
-use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
-const GC_TICK: Duration = Duration::from_secs(1);
 const SUBSCRIPTION_TIMEOUT: Duration = Duration::from_secs(1);
-
-// We need a reference counted SubscriptionSink
-//  because they remove uniq_sub on drop, so a simple clone would not work
-//  to keep the subscription alive.
-type SubSinkRc = Arc<SubscriptionSink>;
 
 pub(crate) struct SubscriptionManager {
     l2_block_handle: JoinHandle<()>,
-    logs_notifier_handle: JoinHandle<()>,
-    heads_notifier_handle: JoinHandle<()>,
-    gc_handle: JoinHandle<()>,
-    head_subscriptions: Arc<RwLock<Vec<SubSinkRc>>>,
-    logs_subscriptions: Arc<RwLock<Vec<(Filter, SubSinkRc)>>>,
+    heads_tx: broadcast::Sender<Arc<WithOtherFields<Block>>>,
+    logs_tx: broadcast::Sender<Arc<Vec<Log>>>,
 }
 
 impl SubscriptionManager {
@@ -36,150 +27,122 @@ impl SubscriptionManager {
         ledger_db: LedgerDB,
         l2_block_rx: broadcast::Receiver<u64>,
     ) -> Self {
-        let (new_heads_tx, new_heads_rx) = mpsc::channel(16);
-        let (logs_tx, logs_rx) = mpsc::channel(16);
+        let (heads_tx, _) = broadcast::channel(16);
+        let (logs_tx, _) = broadcast::channel(16);
 
-        let head_subscriptions = Arc::new(RwLock::new(vec![]));
-        let logs_subscriptions = Arc::new(RwLock::new(vec![]));
-
-        let l2_block_rx = l2_block_rx;
-        // Spawn the task that will listen for new l2 block heights
-        // and send the corresponding ethereum block to subscribers
         let l2_block_handle = tokio::spawn(l2_block_event_handler::<C>(
             storage,
             ledger_db,
             l2_block_rx,
-            new_heads_tx.clone(),
+            heads_tx.clone(),
             logs_tx.clone(),
-        ));
-
-        let logs_notifier_handle = tokio::spawn(logs_notifier(logs_rx, logs_subscriptions.clone()));
-        let heads_notifier_handle =
-            tokio::spawn(new_heads_notifier(new_heads_rx, head_subscriptions.clone()));
-        let gc_handle = tokio::spawn(collect_gc(
-            head_subscriptions.clone(),
-            logs_subscriptions.clone(),
         ));
 
         Self {
             l2_block_handle,
-            logs_notifier_handle,
-            heads_notifier_handle,
-            gc_handle,
-            head_subscriptions,
-            logs_subscriptions,
+            heads_tx,
+            logs_tx,
         }
     }
 
-    pub async fn register_new_heads_subscription(&self, subscription: SubscriptionSink) {
-        let mut head_subscriptions = self.head_subscriptions.write().await;
-        head_subscriptions.push(Arc::new(subscription));
+    pub fn register_new_heads_subscription(&self, subscription: SubscriptionSink) {
+        let rx = self.heads_tx.subscribe();
+        tokio::spawn(head_subscriber_task(rx, Arc::new(subscription)));
     }
 
-    pub async fn register_new_logs_subscription(
+    pub fn register_new_logs_subscription(
         &self,
         filter: Filter,
         subscription: SubscriptionSink,
     ) {
-        let mut logs_subscriptions = self.logs_subscriptions.write().await;
-        logs_subscriptions.push((filter, Arc::new(subscription)));
+        let rx = self.logs_tx.subscribe();
+        tokio::spawn(log_subscriber_task(rx, filter, Arc::new(subscription)));
     }
 }
 
 impl Drop for SubscriptionManager {
     fn drop(&mut self) {
-        self.gc_handle.abort();
         self.l2_block_handle.abort();
-        self.logs_notifier_handle.abort();
-        self.heads_notifier_handle.abort();
     }
 }
 
-async fn collect_gc(
-    head_subscriptions: Arc<RwLock<Vec<SubSinkRc>>>,
-    logs_subscriptions: Arc<RwLock<Vec<(Filter, SubSinkRc)>>>,
+async fn head_subscriber_task(
+    mut rx: broadcast::Receiver<Arc<WithOtherFields<Block>>>,
+    sink: Arc<SubscriptionSink>,
 ) {
     loop {
-        tokio::time::sleep(GC_TICK).await;
-
-        let mut head_subscriptions = head_subscriptions.write().await;
-        head_subscriptions.retain(|s| !s.is_closed());
-        drop(head_subscriptions);
-
-        let mut logs_subscriptions = logs_subscriptions.write().await;
-        logs_subscriptions.retain(|(_, s)| !s.is_closed());
-        drop(logs_subscriptions);
-    }
-}
-
-pub async fn new_heads_notifier(
-    mut rx: mpsc::Receiver<WithOtherFields<Block>>,
-    head_subscriptions: Arc<RwLock<Vec<SubSinkRc>>>,
-) {
-    while let Some(block) = rx.recv().await {
-        debug!(target: "subscriptions", "Received new block: {}", block.header.number);
-        // Acquire the read lock here to prevent starving the writes.
-        let subscriptions = head_subscriptions.read().await;
-        for subscription in subscriptions.iter() {
-            let subscription = subscription.clone();
-            let msg = SubscriptionMessage::new(
-                subscription.method_name(),
-                subscription.subscription_id(),
-                &block,
-            )
-            .unwrap();
-            tokio::spawn(async move {
-                let _ = subscription.send_timeout(msg, SUBSCRIPTION_TIMEOUT).await;
-            });
-        }
-        // Drop lock to release the read lock.
-        drop(subscriptions);
-    }
-}
-
-pub async fn logs_notifier(
-    mut rx: mpsc::Receiver<Vec<Log>>,
-    logs_subscriptions: Arc<RwLock<Vec<(Filter, SubSinkRc)>>>,
-) {
-    while let Some(logs) = rx.recv().await {
-        // Acquire the read lock here to prevent starving the writes.
-        let subscriptions = logs_subscriptions.read().await;
-        for log in logs {
-            for (filter, subscription) in subscriptions.iter().cloned() {
-                let num_hash =
-                    BlockNumHash::new(log.block_number.unwrap(), log.block_hash.unwrap());
-
-                if log_matches_filter(num_hash, &log.inner, &FilteredParams::new(Some(filter))) {
-                    let msg = SubscriptionMessage::new(
-                        subscription.method_name(),
-                        subscription.subscription_id(),
-                        &log,
-                    )
-                    .unwrap();
-                    tokio::spawn(async move {
-                        let _ = subscription.send_timeout(msg, SUBSCRIPTION_TIMEOUT).await;
-                    });
+        match rx.recv().await {
+            Ok(block) => {
+                let msg = SubscriptionMessage::new(
+                    sink.method_name(),
+                    sink.subscription_id(),
+                    block.as_ref(),
+                )
+                .unwrap();
+                if sink.send_timeout(msg, SUBSCRIPTION_TIMEOUT).await.is_err() {
+                    break;
                 }
             }
+            Err(RecvError::Lagged(n)) => {
+                warn!(target: "subscriptions", "head subscriber lagged by {} messages", n);
+                if sink.is_closed() {
+                    break;
+                }
+            }
+            Err(RecvError::Closed) => break,
         }
-        // Drop lock to release the read lock.
-        drop(subscriptions);
     }
 }
 
-pub async fn l2_block_event_handler<C: sov_modules_api::Context>(
+async fn log_subscriber_task(
+    mut rx: broadcast::Receiver<Arc<Vec<Log>>>,
+    filter: Filter,
+    sink: Arc<SubscriptionSink>,
+) {
+    let filtered_params = FilteredParams::new(Some(filter));
+    loop {
+        match rx.recv().await {
+            Ok(logs) => {
+                for log in logs.iter() {
+                    let num_hash =
+                        BlockNumHash::new(log.block_number.unwrap(), log.block_hash.unwrap());
+
+                    if log_matches_filter(num_hash, &log.inner, &filtered_params) {
+                        let msg = SubscriptionMessage::new(
+                            sink.method_name(),
+                            sink.subscription_id(),
+                            log,
+                        )
+                        .unwrap();
+                        if sink.send_timeout(msg, SUBSCRIPTION_TIMEOUT).await.is_err() {
+                            return;
+                        }
+                    }
+                }
+            }
+            Err(RecvError::Lagged(n)) => {
+                warn!(target: "subscriptions", "log subscriber lagged by {} messages", n);
+                if sink.is_closed() {
+                    return;
+                }
+            }
+            Err(RecvError::Closed) => return,
+        }
+    }
+}
+
+async fn l2_block_event_handler<C: sov_modules_api::Context>(
     storage: C::Storage,
     ledger_db: LedgerDB,
     mut l2_block_rx: broadcast::Receiver<u64>,
-    new_heads_tx: mpsc::Sender<WithOtherFields<Block>>,
-    logs_tx: mpsc::Sender<Vec<Log>>,
+    heads_tx: broadcast::Sender<Arc<WithOtherFields<Block>>>,
+    logs_tx: broadcast::Sender<Arc<Vec<Log>>>,
 ) {
     let evm = Evm::<C>::default();
     loop {
         let height = match l2_block_rx.recv().await {
             Err(RecvError::Lagged(n)) => {
                 warn!(target: "subscriptions", "Lagged messages: {}", n);
-                // Do not exit on lag
                 continue;
             }
             Err(RecvError::Closed) => {
@@ -188,9 +151,6 @@ pub async fn l2_block_event_handler<C: sov_modules_api::Context>(
             }
             Ok(height) => height,
         };
-
-        let new_heads_tx = new_heads_tx.clone();
-        let logs_tx = logs_tx.clone();
 
         let mut working_set = WorkingSet::new(storage.clone());
         let block = evm
@@ -203,12 +163,8 @@ pub async fn l2_block_event_handler<C: sov_modules_api::Context>(
             .expect("Error querying block from evm")
             .expect("Received signal but evm block is not found");
 
-        tokio::spawn(async move {
-            if let Err(_closed) = new_heads_tx.send(block).await {
-                // Only possible error is no receiver
-                warn!(target: "subscriptions", "new_heads_tx is closed");
-            }
-        });
+        // Ignore send errors — just means no subscribers currently
+        let _ = heads_tx.send(Arc::new(block));
 
         let mut working_set = WorkingSet::new(storage.clone());
 
@@ -222,11 +178,6 @@ pub async fn l2_block_event_handler<C: sov_modules_api::Context>(
             )
             .expect("Error getting logs in block range");
 
-        tokio::spawn(async move {
-            if let Err(_closed) = logs_tx.send(logs).await {
-                // Only possible error is no receiver
-                warn!(target: "subscriptions", "logs_tx is closed");
-            }
-        });
+        let _ = logs_tx.send(Arc::new(logs));
     }
 }

--- a/crates/ethereum-rpc/src/subscription.rs
+++ b/crates/ethereum-rpc/src/subscription.rs
@@ -67,25 +67,33 @@ async fn head_subscriber_task(
     sink: Arc<SubscriptionSink>,
 ) {
     loop {
-        match rx.recv().await {
-            Ok(block) => {
-                let msg = SubscriptionMessage::new(
-                    sink.method_name(),
-                    sink.subscription_id(),
-                    block.as_ref(),
-                )
-                .unwrap();
-                if sink.send_timeout(msg, SUBSCRIPTION_TIMEOUT).await.is_err() {
-                    break;
+        tokio::select! {
+            biased;
+            _ = sink.closed() => {
+                break;
+            }
+            maybe_block = rx.recv() => {
+                match maybe_block {
+                    Ok(block) => {
+                        let msg = SubscriptionMessage::new(
+                            sink.method_name(),
+                            sink.subscription_id(),
+                            block.as_ref(),
+                        )
+                        .unwrap();
+                        if sink.send_timeout(msg, SUBSCRIPTION_TIMEOUT).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(RecvError::Lagged(n)) => {
+                        warn!(target: "subscriptions", "head subscriber lagged by {} messages", n);
+                        if sink.is_closed() {
+                            break;
+                        }
+                    }
+                    Err(RecvError::Closed) => break,
                 }
             }
-            Err(RecvError::Lagged(n)) => {
-                warn!(target: "subscriptions", "head subscriber lagged by {} messages", n);
-                if sink.is_closed() {
-                    break;
-                }
-            }
-            Err(RecvError::Closed) => break,
         }
     }
 }
@@ -97,32 +105,40 @@ async fn log_subscriber_task(
 ) {
     let filtered_params = FilteredParams::new(Some(filter));
     loop {
-        match rx.recv().await {
-            Ok(logs) => {
-                for log in logs.iter() {
-                    let num_hash =
-                        BlockNumHash::new(log.block_number.unwrap(), log.block_hash.unwrap());
+        tokio::select! {
+            biased;
+            _ = sink.closed() => {
+                break;
+            }
+            maybe_logs = rx.recv() => {
+                match maybe_logs {
+                    Ok(logs) => {
+                        for log in logs.iter() {
+                            let num_hash =
+                                BlockNumHash::new(log.block_number.unwrap(), log.block_hash.unwrap());
 
-                    if log_matches_filter(num_hash, &log.inner, &filtered_params) {
-                        let msg = SubscriptionMessage::new(
-                            sink.method_name(),
-                            sink.subscription_id(),
-                            log,
-                        )
-                        .unwrap();
-                        if sink.send_timeout(msg, SUBSCRIPTION_TIMEOUT).await.is_err() {
-                            return;
+                            if log_matches_filter(num_hash, &log.inner, &filtered_params) {
+                                let msg = SubscriptionMessage::new(
+                                    sink.method_name(),
+                                    sink.subscription_id(),
+                                    log,
+                                )
+                                .unwrap();
+                                if sink.send_timeout(msg, SUBSCRIPTION_TIMEOUT).await.is_err() {
+                                    break;
+                                }
+                            }
                         }
                     }
+                    Err(RecvError::Lagged(n)) => {
+                        warn!(target: "subscriptions", "log subscriber lagged by {} messages", n);
+                        if sink.is_closed() {
+                            break;
+                        }
+                    }
+                    Err(RecvError::Closed) => break,
                 }
             }
-            Err(RecvError::Lagged(n)) => {
-                warn!(target: "subscriptions", "log subscriber lagged by {} messages", n);
-                if sink.is_closed() {
-                    return;
-                }
-            }
-            Err(RecvError::Closed) => return,
         }
     }
 }

--- a/crates/ethereum-rpc/src/subscription.rs
+++ b/crates/ethereum-rpc/src/subscription.rs
@@ -11,7 +11,7 @@ use sov_modules_api::WorkingSet;
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
-use tracing::{debug, warn};
+use tracing::warn;
 
 const SUBSCRIPTION_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -50,11 +50,7 @@ impl SubscriptionManager {
         tokio::spawn(head_subscriber_task(rx, Arc::new(subscription)));
     }
 
-    pub fn register_new_logs_subscription(
-        &self,
-        filter: Filter,
-        subscription: SubscriptionSink,
-    ) {
+    pub fn register_new_logs_subscription(&self, filter: Filter, subscription: SubscriptionSink) {
         let rx = self.logs_tx.subscribe();
         tokio::spawn(log_subscriber_task(rx, filter, Arc::new(subscription)));
     }


### PR DESCRIPTION
# Description
Because the messages are sent concurrently, this was the main reason behind flaky #3153  

## Linked Issues
- Fixes #3155 #3153 