### PR TITLE
fix: Prover dev mode config confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Changed
 - refactor: Remove `dev_mode` field from local prover config to fix prover config confusion.(This change does not require no env var change because it was set with `RISC0_DEV_MODE` env var, right now dev mode is determined with `PROVING_MODE` in batch prover config) ([#3160](https://github.com/chainwayxyz/citrea/pull/3160))
-
 - refactor: Use reth task manager instead of tokio spawn in sequencer services ([#3145](https://github.com/chainwayxyz/citrea/pull/3145))
 - perf: Skip re-execution of proof request in boundless([#3144](https://github.com/chainwayxyz/citrea/pull/3144))
 - fix: Check for shutdown signal when processing blocks in L1/L2 syncers loops ([#3152](https://github.com/chainwayxyz/citrea/pull/3152))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Added
 
 ### Changed
+- refactor: Remove `dev_mode` field from local prover config to fix prover config confusion.(This change does not require no env var change because it was set with `RISC0_DEV_MODE` env var, right now dev mode is determined with `PROVING_MODE` in batch prover config) ([#3160](https://github.com/chainwayxyz/citrea/pull/3160))
+
 - refactor: Use reth task manager instead of tokio spawn in sequencer services ([#3145](https://github.com/chainwayxyz/citrea/pull/3145))
 - perf: Skip re-execution of proof request in boundless([#3144](https://github.com/chainwayxyz/citrea/pull/3144))
 - fix: Check for shutdown signal when processing blocks in L1/L2 syncers loops ([#3152](https://github.com/chainwayxyz/citrea/pull/3152))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3760,7 +3760,7 @@ dependencies = [
 [[package]]
 name = "citrea-e2e"
 version = "0.1.0"
-source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=10ff3e2#10ff3e2e8ca6cad1457ce5ae74602520da465c54"
+source = "git+https://github.com/chainwayxyz/citrea-e2e?rev=143d76086591006d2424bda027512bd03565229a#143d76086591006d2424bda027512bd03565229a"
 dependencies = [
  "alloy-primitives 0.8.26",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ alloy-network = { version = "0.13", default-features = false }
 alloy-signer = { version = "0.13", default-features = false }
 alloy-signer-local = { version = "0.13.0", default-features = false }
 
-citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "10ff3e2" }
+citrea-e2e = { git = "https://github.com/chainwayxyz/citrea-e2e", rev = "143d76086591006d2424bda027512bd03565229a" }
 
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "a6e011a" }

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -887,7 +887,6 @@ mod tests {
 
             [risc0_host.prover.Local]
             r0vm_path = "path/to/vm"
-            dev_mode = false
         "#;
 
         let config_file = create_config_from(config);
@@ -901,7 +900,6 @@ mod tests {
             risc0_host: Risc0HostConfig {
                 prover: Risc0ProverConfig::Local(LocalProverConfig {
                     r0vm_path: Some("path/to/vm".into()),
-                    dev_mode: false,
                 }),
                 tx_backup_dir: Some("/tmp/backup".into()),
             },

--- a/crates/common/src/config/risc0.rs
+++ b/crates/common/src/config/risc0.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use crate::utils::{is_dev_mode_enabled_via_environment, read_env};
+use crate::utils::read_env;
 use crate::FromEnv;
 
 /// Boundless storage configuration for S3
@@ -170,20 +170,13 @@ impl FromEnv for PricingServiceConfig {
 pub struct LocalProverConfig {
     /// Optional path to the r0vm binary
     pub r0vm_path: Option<PathBuf>,
-    /// Enable dev mode
-    #[serde(default)]
-    pub dev_mode: bool,
 }
 
 impl FromEnv for LocalProverConfig {
     fn from_env() -> anyhow::Result<Self> {
         let r0vm_path = read_env("RISC0_SERVER_PATH").ok().map(PathBuf::from);
-        let dev_mode = is_dev_mode_enabled_via_environment();
 
-        Ok(Self {
-            r0vm_path,
-            dev_mode,
-        })
+        Ok(Self { r0vm_path })
     }
 }
 

--- a/crates/risc0/src/host/local.rs
+++ b/crates/risc0/src/host/local.rs
@@ -60,6 +60,8 @@ impl LocalProver {
                 !with_prove,
                 "Prove should not be called with prove in dev mode"
             );
+            // Set risc0 dev mode so in prover opts dev mode is enabled
+            env::set_var("RISC0_DEV_MODE", "1");
         } else if with_prove {
             env::remove_var("RISC0_DEV_MODE");
         } else {

--- a/crates/risc0/src/host/local.rs
+++ b/crates/risc0/src/host/local.rs
@@ -18,7 +18,6 @@ use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct LocalProver {
-    dev_mode: bool,
     r0vm_path: PathBuf,
     #[cfg_attr(not(feature = "testing"), allow(unused))]
     network: Network,
@@ -26,7 +25,6 @@ pub struct LocalProver {
 
 impl LocalProver {
     pub fn new(network: Network, config: LocalProverConfig) -> Self {
-        let dev_mode = config.dev_mode;
         let r0vm_path = config
             .r0vm_path
             .unwrap_or_else(|| get_r0vm_path().expect("Could not get r0vm path"));
@@ -39,11 +37,7 @@ impl LocalProver {
         // so we need to check if the version is correct
         compare_risc0_versions(&r0vm_path).expect("Something is wrong with system r0vm");
 
-        Self {
-            dev_mode,
-            r0vm_path,
-            network,
-        }
+        Self { r0vm_path, network }
     }
 
     pub fn prove(
@@ -55,25 +49,14 @@ impl LocalProver {
         receipt_type: ReceiptType,
         with_prove: bool,
     ) -> anyhow::Result<oneshot::Receiver<ProofWithJob>> {
-        if self.dev_mode {
-            assert!(
-                !with_prove,
-                "Prove should not be called with prove in dev mode"
-            );
-            // Set risc0 dev mode so in prover opts dev mode is enabled
-            env::set_var("RISC0_DEV_MODE", "1");
-        } else if with_prove {
-            env::remove_var("RISC0_DEV_MODE");
-        } else {
-            env::set_var("RISC0_DEV_MODE", "1");
-        }
-
         // std::fs::write("kumquat-input.bin", &input).unwrap();
 
         let prover_opts = match receipt_type {
             ReceiptType::Groth16 => ProverOpts::groth16(),
             ReceiptType::Succinct => ProverOpts::succinct(),
         };
+
+        let prover_opts = prover_opts.with_dev_mode(!with_prove); // pass dev mode here
 
         tracing::info!("Starting local risc0 proving, job_id={}", job_id);
 


### PR DESCRIPTION
# Description
Currently if the config is read from env var there is no problem because
```rust
impl FromEnv for LocalProverConfig {
    fn from_env() -> anyhow::Result<Self> {
        let r0vm_path = read_env("RISC0_SERVER_PATH").ok().map(PathBuf::from);
        let dev_mode = is_dev_mode_enabled_via_environment();

        Ok(Self {
            r0vm_path,
            dev_mode,
        })
    }
}
```
The problem arises when the following conditions occur at the same time:
- The batch prover config is read from toml
- The `RISC0_DEV_MODE` env var is not set or set to false.
- `dev_mode` in prover config is set to true even though the  `RISC0_DEV_MODE` is not set or set to false
- and proving mode is execute which causes `with_prove` variable to be set to false.

In the current implementation with the above conditions, the first if will be entered and assertion will pass, after that 
`ProverOpts::groth16()` or `ProverOpts::succinct()` calls will call `is_dev_mode_enabled_via_environment()` which will return false even though `dev_mode` is set to false in our batch prover config toml file
```rust
if self.dev_mode {
            assert!(
                !with_prove,
                "Prove should not be called with prove in dev mode"
            );
        } else if with_prove {
            env::remove_var("RISC0_DEV_MODE");
        } else {
            env::set_var("RISC0_DEV_MODE", "1");
        }

        // std::fs::write("kumquat-input.bin", &input).unwrap();

        let prover_opts = match receipt_type {
            ReceiptType::Groth16 => ProverOpts::groth16(),
            ReceiptType::Succinct => ProverOpts::succinct(),
        };
```

by adding 
```rust
env::set_var("RISC0_DEV_MODE", "1");
```
to the end of the first if branch we can fix this

but per @exeokan suggestion we can also remove dev mode and get rid of setting risc0_dev_mode at all

```rust
// and just update prover opts
let prover_opts = prover_opts.with_dev_mode(!with_prove); // pass dev mode here
```
## Linked Issues
- Fixes #3009  
