### PR TITLE
fix(rpc): Disable base fee/eip-3607 on debug_traceCall

### DIFF
--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1534,10 +1534,10 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .expect("EVM chain config should be set");
 
         let mut cfg_env = get_cfg_env(cfg, evm_spec_id);
-
-        // Ignore the base fee check for trace calls
-        // This allows requests with a gas price lower than block base fee to succeed,
-        // Reference: <https://github.com/paradigmxyz/reth/blob/ed7da87da4de340a437bf46f39a7e1397ac82065/crates/rpc/rpc-eth-api/src/helpers/call.rs#L734>
+        // Match the CfgEnv of eth_call here
+        // Also see: <https://github.com/paradigmxyz/reth/blob/564ffa586845fa4a8bb066f0c7b015ff36b26c08/crates/rpc/rpc-eth-api/src/helpers/call.rs#L855>
+        cfg_env.disable_block_gas_limit = true;
+        cfg_env.disable_eip3607 = true;
         cfg_env.disable_base_fee = true;
 
         let l1_fee_block_num = match block_number {

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1533,7 +1533,10 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .get(working_set)
             .expect("EVM chain config should be set");
 
-        let cfg_env = get_cfg_env(cfg, evm_spec_id);
+        let mut cfg_env = get_cfg_env(cfg, evm_spec_id);
+        // See:
+        // <https://github.com/paradigmxyz/reth/blob/ed7da87da4de340a437bf46f39a7e1397ac82065/crates/rpc/rpc-eth-api/src/helpers/call.rs#L734>
+        cfg_env.disable_base_fee = true;
 
         let l1_fee_block_num = match block_number {
             // use l1 fee rate of latest block for pending block

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1534,8 +1534,10 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .expect("EVM chain config should be set");
 
         let mut cfg_env = get_cfg_env(cfg, evm_spec_id);
-        // See:
-        // <https://github.com/paradigmxyz/reth/blob/ed7da87da4de340a437bf46f39a7e1397ac82065/crates/rpc/rpc-eth-api/src/helpers/call.rs#L734>
+
+        // Ignore the base fee check for trace calls
+        // This allows requests with a gas price lower than block base fee to succeed,
+        // Reference: <https://github.com/paradigmxyz/reth/blob/ed7da87da4de340a437bf46f39a7e1397ac82065/crates/rpc/rpc-eth-api/src/helpers/call.rs#L734>
         cfg_env.disable_base_fee = true;
 
         let l1_fee_block_num = match block_number {

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1534,11 +1534,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .expect("EVM chain config should be set");
 
         let mut cfg_env = get_cfg_env(cfg, evm_spec_id);
-        // Match the CfgEnv of eth_call here
-        // Also see: <https://github.com/paradigmxyz/reth/blob/564ffa586845fa4a8bb066f0c7b015ff36b26c08/crates/rpc/rpc-eth-api/src/helpers/call.rs#L855>
-        cfg_env.disable_block_gas_limit = true;
-        cfg_env.disable_eip3607 = true;
-        cfg_env.disable_base_fee = true;
 
         let l1_fee_block_num = match block_number {
             // use l1 fee rate of latest block for pending block
@@ -1578,10 +1573,11 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let chain_id = cfg_env.chain_id();
 
         // create tx env
-        let tx_env = create_txn_env(
+        let tx_env = prepare_call_env(
             &block_env,
-            request.clone(),
-            Some(account.balance),
+            &mut cfg_env,
+            request,
+            account.balance,
             nonce,
             chain_id,
         )?;

--- a/crates/evm/src/tests/queries/trace_call_tests.rs
+++ b/crates/evm/src/tests/queries/trace_call_tests.rs
@@ -91,7 +91,7 @@ fn test_debug_trace_call_disables_base_fee() {
             Address::from_str("0x1111111111111111111111111111111111111111").unwrap(),
         )),
         value: Some(U256::from(1000)),
-        gas_price: Some(1), // 1 wei, much lower than the 1 gwei base fee
+        gas_price: Some(1), // 1 wei, much lower than the block's base fee
         ..Default::default()
     };
     let result = evm.debug_trace_call(

--- a/crates/evm/src/tests/queries/trace_call_tests.rs
+++ b/crates/evm/src/tests/queries/trace_call_tests.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::map::AddressMap;
-use alloy_primitives::{Address, TxKind, U256};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_rpc_types::state::AccountOverride;
 use alloy_rpc_types::TransactionRequest;
 use alloy_rpc_types_trace::geth::GethDebugTracingCallOptions;
@@ -75,5 +75,108 @@ fn test_debug_trace_call_with_balance_override_no_gas_limit() {
         result_with_override.is_ok(),
         "Balance override should make debug_traceCall succeed without explicit gas, but got error: {:?}",
         result_with_override.unwrap_err()
+    );
+}
+
+/// Test that debug_traceCall disables base fee validation.
+/// A transaction with gas_price below the base fee should still succeed
+#[test]
+fn test_debug_trace_call_disables_base_fee() {
+    let (evm, mut working_set, signer, ledger_db) =
+        init_evm_single_block(sov_modules_api::SpecId::latest());
+
+    let tx_req = TransactionRequest {
+        from: Some(signer.address()),
+        to: Some(TxKind::Call(
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap(),
+        )),
+        value: Some(U256::from(1000)),
+        gas_price: Some(1), // 1 wei, much lower than the 1 gwei base fee
+        ..Default::default()
+    };
+    let result = evm.debug_trace_call(
+        tx_req,
+        Some(BlockNumberOrTag::Latest.into()),
+        None,
+        &mut working_set,
+        &ledger_db,
+    );
+
+    assert!(
+        result.is_ok(),
+        "debug_traceCall should succeed with gas_price below base fee, but got error: {:?}",
+        result.unwrap_err()
+    );
+
+    // A second call with gas price omitted request
+    let tx_req_no_gas_price = TransactionRequest {
+        from: Some(signer.address()),
+        to: Some(TxKind::Call(
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap(),
+        )),
+        value: Some(U256::from(1000)),
+        // gas_price is intentionally omitted to test default handling
+        ..Default::default()
+    };
+    let result_no_gas_price = evm.debug_trace_call(
+        tx_req_no_gas_price,
+        Some(BlockNumberOrTag::Latest.into()),
+        None,
+        &mut working_set,
+        &ledger_db,
+    );
+
+    assert!(
+        result_no_gas_price.is_ok(),
+        "debug_traceCall should succeed with gas_price omitted, but got error: {:?}",
+        result_no_gas_price.unwrap_err()
+    );
+}
+
+/// Test that debug_traceCall disables EIP-3607 validation.
+/// EIP-3607 rejects transactions from senders that have deployed contract code.
+#[test]
+fn test_debug_trace_call_disables_eip3607() {
+    let (evm, mut working_set, signer, ledger_db) =
+        init_evm_single_block(sov_modules_api::SpecId::latest());
+
+    // Use a state override to give the sender account some contract code
+    // This would normally trigger EIP-3607 rejection
+    let mut state_override = AddressMap::default();
+    state_override.insert(
+        signer.address(),
+        AccountOverride {
+            // Add some dummy contract code to the sender's account
+            code: Some(Bytes::from_static(&[0x60, 0x00, 0x60, 0x00, 0xf3])), // PUSH 0, PUSH 0, RETURN
+            ..Default::default()
+        },
+    );
+
+    let tx_req = TransactionRequest {
+        from: Some(signer.address()),
+        to: Some(TxKind::Call(
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap(),
+        )),
+        value: Some(U256::from(1000)),
+        ..Default::default()
+    };
+
+    let opts = GethDebugTracingCallOptions {
+        state_overrides: Some(state_override),
+        ..Default::default()
+    };
+
+    let result = evm.debug_trace_call(
+        tx_req,
+        Some(BlockNumberOrTag::Latest.into()),
+        Some(opts),
+        &mut working_set,
+        &ledger_db,
+    );
+
+    assert!(
+        result.is_ok(),
+        "debug_traceCall should succeed when sender has contract code, but got error: {:?}",
+        result.unwrap_err()
     );
 }


### PR DESCRIPTION
# Description
When no gas price/ base fee is provided in `debug_traceCall` transaction params, gas price is set to 0, and the trace fails because gas price < block base fee.

With this PR, we mirror reth behaviour and disable the base fee check on `debug_traceCall`.
Also disabled to eip-3607 and block gas limit to match our `eth_call` impl.

Example call:
```
{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "debug_traceCall",
    "params": [
        {
            "from": "0x0f820f428ae436c1000b27577bf5bbf09bfec8f2",
            "value": "0x0"
        }
    ]
}
```
Nightly:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32003,
        "message": "max fee per gas less than block base fee"
    }
}

```
Head:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "failed": false,
        "gas": 53000,
        "returnValue": "",
        "structLogs": [
            {
                "pc": 0,
                "op": "STOP",
                "gas": 29947000,
                "gasCost": 0,
                "depth": 1,
                "stack": []
            }
        ]
    }
}
```