### PR TITLE
feat: Support eth_sendRawTransactionSync on websocket disabled nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [Unreleased]
 ### Added
+- feat: Support `eth_sendRawTransactionSync` on websocket disabled nodes. ([#3164](https://github.com/chainwayxyz/citrea/pull/3164))\
 
 ### Changed
 - refactor: Remove `dev_mode` field from local prover config to fix prover config confusion.(This change does not require no env var change because it was set with `RISC0_DEV_MODE` env var, right now dev mode is determined with `PROVING_MODE` in batch prover config) ([#3160](https://github.com/chainwayxyz/citrea/pull/3160))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## [Unreleased]
 ### Added
-- feat: Support `eth_sendRawTransactionSync` on websocket disabled nodes. ([#3164](https://github.com/chainwayxyz/citrea/pull/3164))\
+- feat: Support `eth_sendRawTransactionSync` on websocket disabled nodes. ([#3164](https://github.com/chainwayxyz/citrea/pull/3164))
 
 ### Changed
 - refactor: Remove `dev_mode` field from local prover config to fix prover config confusion.(This change does not require no env var change because it was set with `RISC0_DEV_MODE` env var, right now dev mode is determined with `PROVING_MODE` in batch prover config) ([#3160](https://github.com/chainwayxyz/citrea/pull/3160))

--- a/crates/common/src/rpc/eip_7966.rs
+++ b/crates/common/src/rpc/eip_7966.rs
@@ -20,6 +20,9 @@ const UNREADY_ERROR_CODE: i32 = 5;
 /// Default timeout in milliseconds. (5secs)
 const DEFAULT_TIMEOUT_MS: u64 = 5_000;
 
+/// Polling interval in milliseconds when subscriptions are not enabled. (1sec)
+pub const POLL_INTERVAL_NO_SUBSCRIPTION_MS: u64 = 1_000;
+
 /// Creates an EIP-7966 timeout error (code 4).
 ///
 /// Returned when the transaction was added to the mempool but wasn't

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -532,10 +532,7 @@ where
         data: Bytes,
         timeout_ms: Option<u64>,
     ) -> RpcResult<AnyTransactionReceipt> {
-        let block_rx = self
-            .l2_block_rx
-            .as_ref()
-            .map(|rx| rx.resubscribe());
+        let block_rx = self.l2_block_rx.as_ref().map(|rx| rx.resubscribe());
 
         let hash: B256 = self
             .ethereum
@@ -610,7 +607,8 @@ where
                 Some(block_rx) => wait_for_receipt(block_rx).await,
                 None => wait_for_receipt_without_subscription.await,
             }
-        }).await;
+        })
+        .await;
 
         match result {
             Ok(result) => result,

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -519,8 +519,8 @@ where
 
     /// eth_sendRawTransactionSync RPC call implementation (EIP-7966)
     /// - Send raw transaction to sequencer
-    /// - Subscribes to new block subscription
-    /// - Waits for transaction to be included in a block
+    /// - If subscriptions are enabled, subscribes to new block subscription and waits for transaction to be included in a block
+    /// - Otherwise, falls back to polling for transaction receipt until transaction is included in a block
     /// - Returns the transaction receipt
     /// - Timeout in milliseconds (default: 5_000ms, max: configurable via RpcConfig, default max: 30_000ms)
     ///

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -532,16 +532,10 @@ where
         data: Bytes,
         timeout_ms: Option<u64>,
     ) -> RpcResult<AnyTransactionReceipt> {
-        // eth_sendRawTransactionSync is not available if fullnode is running without `enable_subscriptions`
-        let mut block_rx = self
+        let block_rx = self
             .l2_block_rx
             .as_ref()
-            .ok_or_else(|| {
-                EthApiError::Unsupported(
-                    "Block subscriptions must be enabled for eth_sendRawTransactionSync",
-                )
-            })?
-            .resubscribe();
+            .map(|rx| rx.resubscribe());
 
         let hash: B256 = self
             .ethereum
@@ -572,7 +566,7 @@ where
             "Waiting for transaction inclusion"
         );
 
-        let wait_for_receipt = async {
+        let wait_for_receipt = async |mut block_rx: broadcast::Receiver<u64>| {
             loop {
                 match block_rx.recv().await {
                     Ok(_) => {
@@ -600,7 +594,25 @@ where
             }
         };
 
-        match tokio::time::timeout(timeout_duration, wait_for_receipt).await {
+        let wait_for_receipt_without_subscription = async {
+            loop {
+                let mut working_set = WorkingSet::new(self.ethereum.storage.clone());
+                if let Ok(Some(receipt)) = evm.get_transaction_receipt(hash, &mut working_set) {
+                    return Ok(receipt);
+                }
+                let duration_ms = eip_7966::POLL_INTERVAL_NO_SUBSCRIPTION_MS;
+                tokio::time::sleep(tokio::time::Duration::from_millis(duration_ms)).await;
+            }
+        };
+
+        let result = tokio::time::timeout(timeout_duration, async {
+            match block_rx {
+                Some(block_rx) => wait_for_receipt(block_rx).await,
+                None => wait_for_receipt_without_subscription.await,
+            }
+        }).await;
+
+        match result {
             Ok(result) => result,
             Err(_) => Err(eip_7966::timeout_error(hash, timeout)),
         }


### PR DESCRIPTION
# Description
Polls the state with constant intervals if subscriptions are disabled.

## Linked Issues
- Fixes #3158 
