### PR TITLE
refactor: Use StartVariant in L1 processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   **New hidden node args:**\
   `--stop-at-l1-height`: Stop the full node L1 sync after reaching this L1 height
   `--stop-at-l2-height`: Stop the full node L2 sync after reaching this L2 height
+- refactor: Use `StartVariant` in L1 processing ([#3185](https://github.com/chainwayxyz/citrea/pull/3185))
 
 ## [v2.2.0](2026-03-02)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
   **New hidden node args:**\
   `--stop-at-l1-height`: Stop the full node L1 sync after reaching this L1 height
   `--stop-at-l2-height`: Stop the full node L2 sync after reaching this L2 height
-- refactor: Use `StartVariant` in L1 processing ([#3185](https://github.com/chainwayxyz/citrea/pull/3185))
 
 ## [v2.2.0](2026-03-02)
 ### Added

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -315,9 +315,21 @@ where
 
             start_rpc_server(rollup_config.rpc.clone(), &task_executor, rpc_module, None);
 
+            let l1_start_variant = match ledger_db.get_last_scanned_l1_height()? {
+                Some(l1_height) => StartVariant::LastScanned(l1_height.0 + 1),
+                None => StartVariant::FromBlock(
+                    rollup_config
+                        .runner
+                        .context(
+                            "Failed to start prover L1 syncer: Runner config not present",
+                        )?
+                        .scan_l1_start_height
+                ),
+            };
+
             task_executor.spawn_critical_with_graceful_shutdown_signal(
                 "ProverL1Syncer",
-                |shutdown_signal| async move { l1_syncer.run(shutdown_signal).await },
+                |shutdown_signal| async move { l1_syncer.run(l1_start_variant, shutdown_signal).await },
             );
 
             task_executor.spawn_critical_with_graceful_shutdown_signal(

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -320,10 +320,8 @@ where
                 None => StartVariant::FromBlock(
                     rollup_config
                         .runner
-                        .context(
-                            "Failed to start prover L1 syncer: Runner config not present",
-                        )?
-                        .scan_l1_start_height
+                        .context("Failed to start prover L1 syncer: Runner config not present")?
+                        .scan_l1_start_height,
                 ),
             };
 
@@ -400,14 +398,16 @@ where
                         .context(
                             "Failed to start full node L1 block handler: Runner config not present",
                         )?
-                        .scan_l1_start_height
+                        .scan_l1_start_height,
                 ),
             };
 
             task_executor.spawn_critical_with_graceful_shutdown_signal(
                 "FullNodeL1BlockHandler",
                 |shutdown_signal| async move {
-                    l1_block_handler.run(l1_start_variant, shutdown_signal).await
+                    l1_block_handler
+                        .run(l1_start_variant, shutdown_signal)
+                        .await
                 },
             );
 

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -316,7 +316,7 @@ where
             start_rpc_server(rollup_config.rpc.clone(), &task_executor, rpc_module, None);
 
             let l1_start_variant = match ledger_db.get_last_scanned_l1_height()? {
-                Some(l1_height) => StartVariant::LastScanned(l1_height.0 + 1),
+                Some(l1_height) => StartVariant::LastScanned(l1_height.0),
                 None => StartVariant::FromBlock(
                     rollup_config
                         .runner
@@ -393,7 +393,7 @@ where
             start_rpc_server(rollup_config.rpc.clone(), &task_executor, rpc_module, None);
 
             let l1_start_variant = match ledger_db.get_last_scanned_l1_height()? {
-                Some(l1_height) => StartVariant::LastScanned(l1_height.0 + 1),
+                Some(l1_height) => StartVariant::LastScanned(l1_height.0),
                 None => StartVariant::FromBlock(
                     rollup_config
                         .runner

--- a/bin/citrea/src/main.rs
+++ b/bin/citrea/src/main.rs
@@ -13,9 +13,8 @@ use citrea_common::backup::BackupManager;
 use citrea_common::rpc::server::start_rpc_server;
 use citrea_common::rpc::{register_healthcheck_rpc, register_healthcheck_rpc_light_client_prover};
 use citrea_common::utils::is_dev_mode_enabled_via_environment;
-use citrea_common::{from_toml_path, FromEnv, FullNodeConfig, NodeType};
+use citrea_common::{from_toml_path, FromEnv, FullNodeConfig, NodeType, StartVariant};
 use citrea_light_client_prover::circuit::initial_values::InitialValueProvider;
-use citrea_light_client_prover::da_block_handler::StartVariant;
 use citrea_stf::genesis_config::GenesisPaths;
 use citrea_stf::runtime::{CitreaRuntime, DefaultContext};
 use clap::Parser;
@@ -381,21 +380,22 @@ where
 
             start_rpc_server(rollup_config.rpc.clone(), &task_executor, rpc_module, None);
 
-            let l1_start_height =
-                match ledger_db.get_last_scanned_l1_height()? {
-                    Some(l1_height) => l1_height.0 + 1,
-                    None => rollup_config
+            let l1_start_variant = match ledger_db.get_last_scanned_l1_height()? {
+                Some(l1_height) => StartVariant::LastScanned(l1_height.0 + 1),
+                None => StartVariant::FromBlock(
+                    rollup_config
                         .runner
                         .context(
                             "Failed to start full node L1 block handler: Runner config not present",
                         )?
-                        .scan_l1_start_height,
-                };
+                        .scan_l1_start_height
+                ),
+            };
 
             task_executor.spawn_critical_with_graceful_shutdown_signal(
                 "FullNodeL1BlockHandler",
                 |shutdown_signal| async move {
-                    l1_block_handler.run(l1_start_height, shutdown_signal).await
+                    l1_block_handler.run(l1_start_variant, shutdown_signal).await
                 },
             );
 

--- a/bin/citrea/tests/bitcoin/backup.rs
+++ b/bin/citrea/tests/bitcoin/backup.rs
@@ -817,7 +817,7 @@ impl TestCase for BackupBatchProverTest {
         let rollback_target_l1 = commitment_l1_height;
         let proof_output = first_proof.proof_output;
 
-        let rollback_target_commitment_index = 0;
+        let rollback_target_commitment_index = 1;
         let rollback_target_l2 = proof_output.last_l2_height.to::<u64>();
 
         citrea_cli

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -424,12 +424,23 @@ pub async fn start_rollup(
         );
 
         let handler_span = span.clone();
+        let l1_start_variant = match ledger_db
+            .get_last_scanned_l1_height()
+            .expect("Should be able to read DB")
+        {
+            Some(l1_height) => StartVariant::LastScanned(l1_height.0),
+            // first time starting the full node
+            // start from the block given in the config
+            None => StartVariant::FromBlock(
+                rollup_config
+                    .runner
+                    .map_or(1, |runner| runner.scan_l1_start_height),
+            ),
+        };
+        
         task_executor.spawn_with_graceful_shutdown_signal(|shutdown_signal| async move {
-            let start_l1_height = rollup_config
-                .runner
-                .map_or(1, |runner| runner.scan_l1_start_height);
             l1_block_handler
-                .run(StartVariant::FromBlock(start_l1_height), shutdown_signal)
+                .run(l1_start_variant, shutdown_signal)
                 .instrument(handler_span.clone())
                 .await
         });

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -10,7 +10,8 @@ use citrea_common::backup::BackupManager;
 use citrea_common::rpc::server::start_rpc_server;
 use citrea_common::rpc::{register_healthcheck_rpc, register_healthcheck_rpc_light_client_prover};
 use citrea_common::{
-    BatchProverConfig, FullNodeConfig, LightClientProverConfig, NodeType, PruningConfig, RollupPublicKeys, RpcConfig, RunnerConfig, SequencerConfig, StartVariant, StorageConfig
+    BatchProverConfig, FullNodeConfig, LightClientProverConfig, NodeType, PruningConfig,
+    RollupPublicKeys, RpcConfig, RunnerConfig, SequencerConfig, StartVariant, StorageConfig,
 };
 use citrea_primitives::TEST_PRIVATE_KEY;
 use citrea_stf::genesis_config::GenesisPaths;
@@ -325,7 +326,11 @@ pub async fn start_rollup(
             Some(l1_height) => StartVariant::LastScanned(l1_height.0),
             // first time starting the prover
             // start from the block given in the config
-            None => StartVariant::FromBlock(rollup_config.runner.map_or(1, |runner| runner.scan_l1_start_height)),
+            None => StartVariant::FromBlock(
+                rollup_config
+                    .runner
+                    .map_or(1, |runner| runner.scan_l1_start_height),
+            ),
         };
         task_executor.spawn_with_graceful_shutdown_signal(|shutdown_signal| async move {
             l1_syncer

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -437,7 +437,7 @@ pub async fn start_rollup(
                     .map_or(1, |runner| runner.scan_l1_start_height),
             ),
         };
-        
+
         task_executor.spawn_with_graceful_shutdown_signal(|shutdown_signal| async move {
             l1_block_handler
                 .run(l1_start_variant, shutdown_signal)

--- a/bin/citrea/tests/common/helpers.rs
+++ b/bin/citrea/tests/common/helpers.rs
@@ -10,10 +10,8 @@ use citrea_common::backup::BackupManager;
 use citrea_common::rpc::server::start_rpc_server;
 use citrea_common::rpc::{register_healthcheck_rpc, register_healthcheck_rpc_light_client_prover};
 use citrea_common::{
-    BatchProverConfig, FullNodeConfig, LightClientProverConfig, NodeType, PruningConfig,
-    RollupPublicKeys, RpcConfig, RunnerConfig, SequencerConfig, StorageConfig,
+    BatchProverConfig, FullNodeConfig, LightClientProverConfig, NodeType, PruningConfig, RollupPublicKeys, RpcConfig, RunnerConfig, SequencerConfig, StartVariant, StorageConfig
 };
-use citrea_light_client_prover::da_block_handler::StartVariant;
 use citrea_primitives::TEST_PRIVATE_KEY;
 use citrea_stf::genesis_config::GenesisPaths;
 use reth_tasks::TaskManager;
@@ -319,9 +317,19 @@ pub async fn start_rollup(
         );
 
         let handler_span = span.clone();
+
+        let l1_start_variant = match ledger_db
+            .get_last_scanned_l1_height()
+            .expect("Should be able to read DB")
+        {
+            Some(l1_height) => StartVariant::LastScanned(l1_height.0),
+            // first time starting the prover
+            // start from the block given in the config
+            None => StartVariant::FromBlock(rollup_config.runner.map_or(1, |runner| runner.scan_l1_start_height)),
+        };
         task_executor.spawn_with_graceful_shutdown_signal(|shutdown_signal| async move {
             l1_syncer
-                .run(shutdown_signal)
+                .run(l1_start_variant, shutdown_signal)
                 .instrument(handler_span)
                 .await
         });
@@ -416,7 +424,7 @@ pub async fn start_rollup(
                 .runner
                 .map_or(1, |runner| runner.scan_l1_start_height);
             l1_block_handler
-                .run(start_l1_height, shutdown_signal)
+                .run(StartVariant::FromBlock(start_l1_height), shutdown_signal)
                 .instrument(handler_span.clone())
                 .await
         });

--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -97,10 +97,7 @@ where
     /// 4. Maintains metrics about syncing progress
     #[instrument(name = "L1Syncer", skip_all)]
     pub async fn run(mut self, l1_start_variant: StartVariant, mut shutdown_signal: GracefulShutdown) {
-        let l1_start_height = match l1_start_variant {
-            StartVariant::LastScanned(height) => height + 1, // last scanned block + 1
-            StartVariant::FromBlock(height) => height,       // first block to scan
-        };
+        let l1_start_height = l1_start_variant.start_height();
 
         let notifier = Arc::new(Notify::new());
         let l1_sync_worker = sync_l1(

--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -65,7 +65,6 @@ where
     /// * `ledger_db` - The database instance to store L1 block data.
     /// * `da_service` - The DA service instance to fetch L1 blocks.
     /// * `public_keys` - The public keys used for distinguishing between different rollup participants.
-    /// * `scan_l1_start_height` - The height from which to start scanning L1 blocks.
     /// * `l1_block_cache` - A cache for L1 blocks to avoid redundant fetches.
     /// * `backup_manager` - Manager for backup operations.
     /// * `l1_signal_tx` - A channel sender to signal prover module when new L1 blocks are processed.

--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -11,7 +11,7 @@ use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::{extract_sequencer_commitments, sync_l1};
 use citrea_common::utils::shutdown_requested;
-use citrea_common::RollupPublicKeys;
+use citrea_common::{RollupPublicKeys, StartVariant};
 use reth_tasks::shutdown::GracefulShutdown;
 use sov_db::ledger_db::BatchProverLedgerOps;
 use sov_db::schema::types::SlotNumber;
@@ -44,8 +44,6 @@ where
     da_service: Arc<Da>,
     /// Sequencer's DA public key for verifying commitments
     sequencer_da_pub_key: Vec<u8>,
-    /// The height from which to start scanning L1 blocks
-    scan_l1_start_height: u64,
     /// Cache for L1 blocks to avoid redundant fetches
     l1_block_cache: Arc<Mutex<L1BlockCache<Da>>>,
     /// Queue of pending L1 blocks to be processed
@@ -76,7 +74,6 @@ where
         ledger_db: DB,
         da_service: Arc<Da>,
         public_keys: RollupPublicKeys,
-        scan_l1_start_height: u64,
         l1_block_cache: Arc<Mutex<L1BlockCache<Da>>>,
         backup_manager: Arc<BackupManager>,
         l1_signal_tx: mpsc::Sender<()>,
@@ -85,7 +82,6 @@ where
             ledger_db,
             da_service,
             sequencer_da_pub_key: public_keys.sequencer_da_pub_key,
-            scan_l1_start_height,
             l1_block_cache,
             pending_l1_blocks: Arc::new(Mutex::new(VecDeque::new())),
             backup_manager,
@@ -101,13 +97,11 @@ where
     /// 3. Handles any errors with exponential backoff
     /// 4. Maintains metrics about syncing progress
     #[instrument(name = "L1Syncer", skip_all)]
-    pub async fn run(mut self, mut shutdown_signal: GracefulShutdown) {
-        let l1_start_height = self
-            .ledger_db
-            .get_last_scanned_l1_height()
-            .expect("Failed to get last scanned l1 height when starting l1 syncer")
-            .map(|h| h.0)
-            .unwrap_or(self.scan_l1_start_height);
+    pub async fn run(mut self, l1_start_variant: StartVariant, mut shutdown_signal: GracefulShutdown) {
+        let l1_start_height = match l1_start_variant {
+            StartVariant::LastScanned(height) => height + 1, // last scanned block + 1
+            StartVariant::FromBlock(height) => height,       // first block to scan
+        };
 
         let notifier = Arc::new(Notify::new());
         let l1_sync_worker = sync_l1(

--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -96,7 +96,11 @@ where
     /// 3. Handles any errors with exponential backoff
     /// 4. Maintains metrics about syncing progress
     #[instrument(name = "L1Syncer", skip_all)]
-    pub async fn run(mut self, l1_start_variant: StartVariant, mut shutdown_signal: GracefulShutdown) {
+    pub async fn run(
+        mut self,
+        l1_start_variant: StartVariant,
+        mut shutdown_signal: GracefulShutdown,
+    ) {
         let l1_start_height = l1_start_variant.start_height();
 
         let notifier = Arc::new(Notify::new());

--- a/crates/batch-prover/src/lib.rs
+++ b/crates/batch-prover/src/lib.rs
@@ -168,7 +168,6 @@ where
         ledger_db.clone(),
         da_service,
         public_keys.clone(),
-        runner_config.scan_l1_start_height,
         l1_block_cache,
         backup_manager,
         l1_signal_tx,

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -31,6 +31,16 @@ pub enum StartVariant { // TODO: rename to L1StartVariant
     FromBlock(u64),
 }
 
+impl StartVariant {
+    /// Returns the actual L1 block height to start processing from based on the variant.
+    pub fn start_height(self) -> u64 {
+        match self {
+            StartVariant::LastScanned(h) => h + 1,
+            StartVariant::FromBlock(h) => h,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum NodeType {

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -24,7 +24,7 @@ pub struct InitParams {
 }
 
 /// Variant to specify how to start processing L1 blocks
-pub enum StartVariant { // TODO: rename to L1StartVariant
+pub enum StartVariant {
     /// Resume from the last scanned L1 block height, the following L1 block will be the next one to process.
     LastScanned(u64),
     /// Start processing from an initial L1 block height

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -23,6 +23,14 @@ pub struct InitParams {
     pub prev_l2_block_hash: L2BlockHash,
 }
 
+/// Variant to specify how to start processing L1 blocks
+pub enum StartVariant { // TODO: rename to L1StartVariant
+    /// Resume from the last scanned L1 block height, the following L1 block will be the next one to process.
+    LastScanned(u64),
+    /// Start processing from an initial L1 block height
+    FromBlock(u64),
+}
+
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum NodeType {

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -136,7 +136,7 @@ where
     /// 4. Updates the chain state accordingly
     ///
     /// # Arguments
-    /// * `start_l1_height` - Height to start syncing from
+    /// * `l1_start_variant` - Variant indicating where to start syncing L1 blocks from
     /// * `shutdown_signal` - Signal to gracefully shut down
     #[instrument(name = "L1BlockHandler", skip_all)]
     pub async fn run(mut self, l1_start_variant: StartVariant, mut shutdown_signal: GracefulShutdown) {

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -141,11 +141,7 @@ where
     #[instrument(name = "L1BlockHandler", skip_all)]
     pub async fn run(mut self, l1_start_variant: StartVariant, mut shutdown_signal: GracefulShutdown) {
         let notifier = Arc::new(Notify::new());
-
-        let start_l1_height = match l1_start_variant {
-            StartVariant::LastScanned(height) => height + 1, // last scanned block + 1
-            StartVariant::FromBlock(height) => height,       // first block to scan
-        };
+        let start_l1_height = l1_start_variant.start_height();
 
         let l1_sync_worker = sync_l1(
             start_l1_height,

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -15,6 +15,7 @@ use citrea_common::da::{extract_zk_proofs_and_sequencer_commitments, sync_l1, Pr
 use citrea_common::utils::{
     exceeded_stop_height, get_tangerine_activation_height_non_zero, shutdown_requested,
 };
+use citrea_common::StartVariant;
 use citrea_primitives::forks::fork_from_block_number;
 use citrea_primitives::network_to_dev_mode;
 use reth_tasks::shutdown::GracefulShutdown;
@@ -138,8 +139,13 @@ where
     /// * `start_l1_height` - Height to start syncing from
     /// * `shutdown_signal` - Signal to gracefully shut down
     #[instrument(name = "L1BlockHandler", skip_all)]
-    pub async fn run(mut self, start_l1_height: u64, mut shutdown_signal: GracefulShutdown) {
+    pub async fn run(mut self, l1_start_variant: StartVariant, mut shutdown_signal: GracefulShutdown) {
         let notifier = Arc::new(Notify::new());
+
+        let start_l1_height = match l1_start_variant {
+            StartVariant::LastScanned(height) => height + 1, // last scanned block + 1
+            StartVariant::FromBlock(height) => height,       // first block to scan
+        };
 
         let l1_sync_worker = sync_l1(
             start_l1_height,

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -139,7 +139,11 @@ where
     /// * `l1_start_variant` - Variant indicating where to start syncing L1 blocks from
     /// * `shutdown_signal` - Signal to gracefully shut down
     #[instrument(name = "L1BlockHandler", skip_all)]
-    pub async fn run(mut self, l1_start_variant: StartVariant, mut shutdown_signal: GracefulShutdown) {
+    pub async fn run(
+        mut self,
+        l1_start_variant: StartVariant,
+        mut shutdown_signal: GracefulShutdown,
+    ) {
         let notifier = Arc::new(Notify::new());
         let start_l1_height = l1_start_variant.start_height();
 

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -10,7 +10,7 @@ use citrea_common::backup::BackupManager;
 use citrea_common::cache::L1BlockCache;
 use citrea_common::da::sync_l1;
 use citrea_common::utils::shutdown_requested;
-use citrea_common::LightClientProverConfig;
+use citrea_common::{LightClientProverConfig, StartVariant};
 use citrea_primitives::forks::fork_from_block_number;
 use prover_services::{ParallelProverService, ProofData, ProofWithDuration};
 use reth_tasks::shutdown::GracefulShutdown;
@@ -33,14 +33,6 @@ use tracing::{error, info, instrument};
 use crate::circuit::initial_values::InitialValueProvider;
 use crate::circuit::LightClientProofCircuit;
 use crate::metrics::LIGHT_CLIENT_METRICS as LPM;
-
-/// Variant to specify how to start processing L1 blocks
-pub enum StartVariant {
-    /// Resume from the last scanned L1 block height, the following L1 block will be the next one to process.
-    LastScanned(u64),
-    /// Start processing from an initial L1 block height
-    FromBlock(u64),
-}
 
 /// Handler for processing L1 blocks and the relevant transactions within them.
 ///

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -142,11 +142,7 @@ where
         //         .clear_pending_proving_sessions()
         //         .expect("Failed to clear pending proving sessions");
         // }
-        let start_l1_height = match last_l1_height_scanned {
-            StartVariant::LastScanned(height) => height + 1, // last scanned block + 1
-            StartVariant::FromBlock(height) => height,       // first block to scan
-        };
-
+        let start_l1_height = last_l1_height_scanned.start_height();
         let notifier = Arc::new(Notify::new());
 
         let l1_sync_worker = sync_l1(


### PR DESCRIPTION
# Description
Also fixes the batch prover bug where it re-processes the last scanned L1 block on start.

## Linked Issues
- Fixes #3181 
