### PR TITLE
chore: Simplify tx prefix mining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Unreleased]
 
+### Changed
+- perf: Mine reveal prefix relying on `sign_schnorr` internal randomness.([#3192](https://github.com/chainwayxyz/citrea/pull/3192))
+
 ## [v2.3.1](2026-03-31)
 
 Fix version. Only provers must update.
@@ -17,7 +20,7 @@ Fix version. Only provers must update.
 
 ### Changed
 - fix(fullnode): avoid rewriting pending proofs on retry (reduces PendingProof retry-path rewrite amplification). ([#3176](https://github.com/chainwayxyz/citrea/pull/3176))
-- fix: set L1 fee rate to zero in `eth_estimateGas` if sender has no balance ([#3169](https://github.com/chainwayxyz/citrea/pull/3169)) 
+- fix: set L1 fee rate to zero in `eth_estimateGas` if sender has no balance ([#3169](https://github.com/chainwayxyz/citrea/pull/3169))
 
 ## [v2.2.0](2026-03-02)
 ### Added

--- a/crates/bitcoin-da/src/helpers/builders/body_builders.rs
+++ b/crates/bitcoin-da/src/helpers/builders/body_builders.rs
@@ -3,7 +3,6 @@
 use core::result::Result::Ok;
 use std::time::Instant;
 
-use bitcoin::absolute::{LockTime, Time, LOCK_TIME_THRESHOLD};
 use bitcoin::blockdata::opcodes::all::{OP_ENDIF, OP_IF};
 use bitcoin::blockdata::opcodes::OP_FALSE;
 use bitcoin::blockdata::script;
@@ -78,10 +77,61 @@ pub enum DaTxs {
     },
 }
 
+/// Mine the reveal transaction's prefix
+fn mine_reveal_prefix(
+    commit_tx: &Transaction,
+    reveal_tx: &mut Transaction,
+    tapscript_hash: bitcoin::TapLeafHash,
+    key_pair: &bitcoin::key::Keypair,
+    secp: &secp256k1::Secp256k1<secp256k1::All>,
+    prefix: &[u8],
+    label: &str,
+) {
+    let mut iterations = 0u32;
+    loop {
+        let reveal_wtxid = reveal_tx.compute_wtxid();
+        if reveal_wtxid
+            .as_raw_hash()
+            .to_byte_array()
+            .starts_with(prefix)
+        {
+            return;
+        }
+
+        iterations += 1;
+        if iterations % 1000 == 0 {
+            trace!(iterations, "Mining for {label} reveal tx prefix");
+            if iterations > 16384 {
+                warn!("Too many iterations mining for {label} reveal tx prefix");
+            }
+        }
+
+        update_witness(commit_tx, reveal_tx, tapscript_hash, key_pair, secp);
+    }
+}
+
+/// Assert that inscription locked to the correct address
+fn verify_commit_address(
+    key_pair: &UntweakedKeypair,
+    merkle_root: Option<bitcoin::TapNodeHash>,
+    network: Network,
+    expected_address: &Address,
+) {
+    let recovery_key_pair = key_pair.tap_tweak(SECP256K1, merkle_root);
+    let (x_only_pub_key, _parity) = recovery_key_pair.to_inner().x_only_public_key();
+    assert_eq!(
+        Address::p2tr_tweaked(
+            TweakedPublicKey::dangerous_assume_tweaked(x_only_pub_key),
+            network,
+        ),
+        *expected_address
+    );
+}
+
 /// Creates the light client transactions (commit and reveal).
 /// Based on data type, the number of transactions may vary.
-/// In the end, reveal txs will be mined with a nonce to have
-/// wtxid start from the `reveal_tx_prefix`.
+/// In the end, reveal txs will be mined to have wtxid start
+/// from the `reveal_tx_prefix`.
 #[allow(clippy::too_many_arguments)]
 #[instrument(level = "trace", skip_all, err)]
 pub fn create_inscription_transactions(
@@ -188,7 +238,6 @@ pub fn create_inscription_type_0(
     reveal_script_builder = reveal_script_builder.push_opcode(OP_ENDIF);
 
     // Nonce is kept for legacy reasons but is now fixed at 16.
-    // Prefix mining is now done by iterating over lock_time instead.
     let nonce: i64 = 16; // >= 16 to avoid OP_PUSHNUM_X interpretation
 
     // push nonce
@@ -252,64 +301,35 @@ pub fn create_inscription_type_0(
         SECP256K1,
     );
 
-    // Mine for the reveal tx prefix by iterating over lock_time values.
-    // Starting from LOCK_TIME_THRESHOLD (500_000_000) is safe because it represents
-    // a Unix timestamp from 1985, and with a two-byte prefix requiring on average 2^16
-    // iterations, the resulting timestamp (~500_065_536) is still in 1985, making the
-    // transaction spendable immediately (equivalent to nLockTime == 0).
-    let mut lock_time = LOCK_TIME_THRESHOLD;
-    loop {
-        let iterations = lock_time - LOCK_TIME_THRESHOLD;
-        if iterations > 0 && iterations % 1000 == 0 {
-            trace!(iterations, "Mining for complete reveal tx prefix");
-            if iterations > 16384 {
-                warn!("Too many iterations mining for complete reveal tx prefix");
-            }
-        }
+    mine_reveal_prefix(
+        &unsigned_commit_tx,
+        &mut reveal_tx,
+        tapscript_hash,
+        &key_pair,
+        SECP256K1,
+        reveal_tx_prefix,
+        "complete",
+    );
 
-        let reveal_wtxid = reveal_tx.compute_wtxid();
-        let reveal_hash = reveal_wtxid.as_raw_hash().to_byte_array();
-        // check if first N bytes equal to the given prefix
-        if reveal_hash.starts_with(reveal_tx_prefix) {
-            // check if inscription locked to the correct address
-            let recovery_key_pair = key_pair.tap_tweak(SECP256K1, merkle_root);
-            let (x_only_pub_key, _parity) = recovery_key_pair.to_inner().x_only_public_key();
-            assert_eq!(
-                Address::p2tr_tweaked(
-                    TweakedPublicKey::dangerous_assume_tweaked(x_only_pub_key),
-                    network,
-                ),
-                commit_tx_address
-            );
+    verify_commit_address(&key_pair, merkle_root, network, &commit_tx_address);
 
-            histogram!("complete_mine_da_transaction").record(
-                Instant::now()
-                    .saturating_duration_since(start)
-                    .as_secs_f64(),
-            );
+    histogram!("complete_mine_da_transaction").record(
+        Instant::now()
+            .saturating_duration_since(start)
+            .as_secs_f64(),
+    );
 
-            if let Some(root) = merkle_root {
-                info!("Taproot merkle root for inscription - Complete: {}", root);
-            }
-            return Ok(DaTxs::Complete {
-                commit: unsigned_commit_tx,
-                reveal: TxWithId {
-                    id: reveal_tx.compute_txid(),
-                    tx: reveal_tx,
-                },
-            });
-        } else {
-            reveal_tx.lock_time = LockTime::Seconds(Time::from_consensus(lock_time).unwrap());
-            update_witness(
-                &unsigned_commit_tx,
-                &mut reveal_tx,
-                tapscript_hash,
-                &key_pair,
-                SECP256K1,
-            );
-            lock_time += 1;
-        }
+    if let Some(root) = merkle_root {
+        info!("Taproot merkle root for inscription - Complete: {}", root);
     }
+
+    Ok(DaTxs::Complete {
+        commit: unsigned_commit_tx,
+        reveal: TxWithId {
+            id: reveal_tx.compute_txid(),
+            tx: reveal_tx,
+        },
+    })
 }
 
 /// Creates the inscription transactions Type 1 - Chunked
@@ -360,7 +380,6 @@ pub fn create_inscription_type_1(
         reveal_script_builder = reveal_script_builder.push_opcode(OP_ENDIF);
 
         // Nonce is kept for legacy reasons but is now fixed at 16.
-        // Prefix mining is now done by iterating over lock_time instead.
         let nonce: i64 = 16; // >= 16 to avoid OP_PUSHNUM_X interpretation
 
         // push nonce
@@ -423,84 +442,51 @@ pub fn create_inscription_type_1(
             SECP256K1,
         );
 
-        // Mine for the reveal tx prefix by iterating over lock_time values.
-        // Starting from LOCK_TIME_THRESHOLD (500_000_000) is safe because it represents
-        // a Unix timestamp from 1985, and with a two-byte prefix requiring on average 2^16
-        // iterations, the resulting timestamp (~500_065_536) is still in 1985, making the
-        // transaction spendable immediately (equivalent to nLockTime == 0).
-        let mut lock_time = LOCK_TIME_THRESHOLD;
-        loop {
-            let iterations = lock_time - LOCK_TIME_THRESHOLD;
-            if iterations > 0 && iterations % 1000 == 0 {
-                trace!(iterations, "Mining for chunk reveal tx prefix");
-                if iterations > 16384 {
-                    warn!("Too many iterations mining for chunk reveal tx prefix");
-                }
-            }
+        mine_reveal_prefix(
+            &unsigned_commit_tx,
+            &mut reveal_tx,
+            tapscript_hash,
+            &key_pair,
+            SECP256K1,
+            reveal_tx_prefix,
+            "chunk",
+        );
 
-            let reveal_wtxid = reveal_tx.compute_wtxid();
-            let reveal_hash = reveal_wtxid.as_raw_hash().to_byte_array();
+        verify_commit_address(&key_pair, merkle_root, network, &commit_tx_address);
 
-            // check if first N bytes equal to the given prefix
-            if reveal_hash.starts_with(reveal_tx_prefix) {
-                // check if inscription locked to the correct address
-                let recovery_key_pair = key_pair.tap_tweak(SECP256K1, merkle_root);
-                let (x_only_pub_key, _parity) = recovery_key_pair.to_inner().x_only_public_key();
-                assert_eq!(
-                    Address::p2tr_tweaked(
-                        TweakedPublicKey::dangerous_assume_tweaked(x_only_pub_key),
-                        network,
-                    ),
-                    commit_tx_address
-                );
+        // set prev utxo to last reveal tx[0] to chain txs in order
+        prev_utxo = Some(UTXO {
+            tx_id: reveal_tx.compute_txid(),
+            vout: 0,
+            script_pubkey: reveal_tx.output[0].script_pubkey.to_hex_string(),
+            address: None,
+            amount: reveal_tx.output[0].value.to_sat(),
+            confirmations: 0,
+            spendable: true,
+            solvable: true,
+        });
 
-                // set prev utxo to last reveal tx[0] to chain txs in order
-                prev_utxo = Some(UTXO {
-                    tx_id: reveal_tx.compute_txid(),
-                    vout: 0,
-                    script_pubkey: reveal_tx.output[0].script_pubkey.to_hex_string(),
-                    address: None,
-                    amount: reveal_tx.output[0].value.to_sat(),
-                    confirmations: 0,
-                    spendable: true,
-                    solvable: true,
-                });
+        // Replace utxos with leftovers so we don't use prev utxos in next chunks
+        utxos = leftover_utxos;
 
-                // Replace utxos with leftovers so we don't use prev utxos in next chunks
-                utxos = leftover_utxos;
+        if unsigned_commit_tx.output.len() > 1 {
+            utxos.push(UTXO {
+                tx_id: unsigned_commit_tx.compute_txid(),
+                vout: 1,
+                address: None,
+                script_pubkey: unsigned_commit_tx.output[1].script_pubkey.to_hex_string(),
+                amount: unsigned_commit_tx.output[1].value.to_sat(),
+                confirmations: 0,
+                spendable: true,
+                solvable: true,
+            })
+        }
 
-                if unsigned_commit_tx.output.len() > 1 {
-                    utxos.push(UTXO {
-                        tx_id: unsigned_commit_tx.compute_txid(),
-                        vout: 1,
-                        address: None,
-                        script_pubkey: unsigned_commit_tx.output[1].script_pubkey.to_hex_string(),
-                        amount: unsigned_commit_tx.output[1].value.to_sat(),
-                        confirmations: 0,
-                        spendable: true,
-                        solvable: true,
-                    })
-                }
+        commit_chunks.push(unsigned_commit_tx);
+        reveal_chunks.push(reveal_tx);
 
-                commit_chunks.push(unsigned_commit_tx);
-                reveal_chunks.push(reveal_tx);
-
-                if let Some(root) = merkle_root {
-                    info!("Taproot merkle root for inscription - Chunked: {}", root);
-                }
-
-                break;
-            } else {
-                reveal_tx.lock_time = LockTime::Seconds(Time::from_consensus(lock_time).unwrap());
-                update_witness(
-                    &unsigned_commit_tx,
-                    &mut reveal_tx,
-                    tapscript_hash,
-                    &key_pair,
-                    SECP256K1,
-                );
-                lock_time += 1;
-            }
+        if let Some(root) = merkle_root {
+            info!("Taproot merkle root for inscription - Chunked: {}", root);
         }
     }
 
@@ -545,7 +531,6 @@ pub fn create_inscription_type_1(
     reveal_script_builder = reveal_script_builder.push_opcode(OP_ENDIF);
 
     // Nonce is kept for legacy reasons but is now fixed at 16.
-    // Prefix mining is now done by iterating over lock_time instead.
     let nonce: i64 = 16; // >= 16 to avoid OP_PUSHNUM_X interpretation
 
     // push nonce
@@ -608,67 +593,37 @@ pub fn create_inscription_type_1(
         SECP256K1,
     );
 
-    // Mine for the reveal tx prefix by iterating over lock_time values.
-    // Starting from LOCK_TIME_THRESHOLD (500_000_000) is safe because it represents
-    // a Unix timestamp from 1985, and with a two-byte prefix requiring on average 2^16
-    // iterations, the resulting timestamp (~500_065_536) is still in 1985, making the
-    // transaction spendable immediately (equivalent to nLockTime == 0).
-    let mut lock_time = LOCK_TIME_THRESHOLD;
-    loop {
-        let iterations = lock_time - LOCK_TIME_THRESHOLD;
-        if iterations > 0 && iterations % 1000 == 0 {
-            trace!(iterations, "Mining for aggregate reveal tx prefix");
-            if iterations > 16384 {
-                warn!("Too many iterations mining for aggregate reveal tx prefix");
-            }
-        }
+    mine_reveal_prefix(
+        &unsigned_commit_tx,
+        &mut reveal_tx,
+        tapscript_hash,
+        &key_pair,
+        SECP256K1,
+        reveal_tx_prefix,
+        "aggregate",
+    );
 
-        let reveal_wtxid = reveal_tx.compute_wtxid();
-        let reveal_hash = reveal_wtxid.as_raw_hash().to_byte_array();
+    verify_commit_address(&key_pair, merkle_root, network, &commit_tx_address);
 
-        // check if first N bytes equal to the given prefix
-        if reveal_hash.starts_with(reveal_tx_prefix) {
-            // check if inscription locked to the correct address
-            let recovery_key_pair = key_pair.tap_tweak(SECP256K1, merkle_root);
-            let (x_only_pub_key, _parity) = recovery_key_pair.to_inner().x_only_public_key();
-            assert_eq!(
-                Address::p2tr_tweaked(
-                    TweakedPublicKey::dangerous_assume_tweaked(x_only_pub_key),
-                    network,
-                ),
-                commit_tx_address
-            );
+    histogram!("chunked_mine_da_transaction").record(
+        Instant::now()
+            .saturating_duration_since(start)
+            .as_secs_f64(),
+    );
 
-            histogram!("chunked_mine_da_transaction").record(
-                Instant::now()
-                    .saturating_duration_since(start)
-                    .as_secs_f64(),
-            );
-
-            if let Some(root) = merkle_root {
-                info!("Taproot merkle root for inscription - Aggregate: {}", root);
-            }
-            return Ok(DaTxs::Chunked {
-                commit_chunks,
-                reveal_chunks,
-                commit: unsigned_commit_tx,
-                reveal: TxWithId {
-                    id: reveal_tx.compute_txid(),
-                    tx: reveal_tx,
-                },
-            });
-        } else {
-            reveal_tx.lock_time = LockTime::Seconds(Time::from_consensus(lock_time).unwrap());
-            update_witness(
-                &unsigned_commit_tx,
-                &mut reveal_tx,
-                tapscript_hash,
-                &key_pair,
-                SECP256K1,
-            );
-            lock_time += 1;
-        }
+    if let Some(root) = merkle_root {
+        info!("Taproot merkle root for inscription - Aggregate: {}", root);
     }
+
+    Ok(DaTxs::Chunked {
+        commit_chunks,
+        reveal_chunks,
+        commit: unsigned_commit_tx,
+        reveal: TxWithId {
+            id: reveal_tx.compute_txid(),
+            tx: reveal_tx,
+        },
+    })
 }
 
 /// Creates the inscription transactions Type 3 - BatchProofMethodId
@@ -705,7 +660,6 @@ pub fn create_inscription_type_3(
         .push_slice(PushBytesBuf::from(kind_bytes))
         .push_opcode(OP_FALSE)
         .push_opcode(OP_IF);
-
     // push body in chunks of 520 bytes
     // Body includes security council signatures and public keys
     for chunk in body.chunks(520) {
@@ -716,7 +670,6 @@ pub fn create_inscription_type_3(
     reveal_script_builder = reveal_script_builder.push_opcode(OP_ENDIF);
 
     // Nonce is kept for legacy reasons but is now fixed at 16.
-    // Prefix mining is now done by iterating over lock_time instead.
     let nonce: i64 = 16; // >= 16 to avoid OP_PUSHNUM_X interpretation
 
     // push nonce
@@ -780,70 +733,38 @@ pub fn create_inscription_type_3(
         SECP256K1,
     );
 
-    // Mine for the reveal tx prefix by iterating over lock_time values.
-    // Starting from LOCK_TIME_THRESHOLD (500_000_000) is safe because it represents
-    // a Unix timestamp from 1985, and with a two-byte prefix requiring on average 2^16
-    // iterations, the resulting timestamp (~500_065_536) is still in 1985, making the
-    // transaction spendable immediately (equivalent to nLockTime == 0).
-    let mut lock_time = LOCK_TIME_THRESHOLD;
-    loop {
-        let iterations = lock_time - LOCK_TIME_THRESHOLD;
-        if iterations > 0 && iterations % 1000 == 0 {
-            trace!(
-                iterations,
-                "Mining for batch proof method id reveal tx prefix"
-            );
-            if iterations > 16384 {
-                warn!("Too many iterations mining for batch proof method id reveal tx prefix");
-            }
-        }
+    mine_reveal_prefix(
+        &unsigned_commit_tx,
+        &mut reveal_tx,
+        tapscript_hash,
+        &key_pair,
+        SECP256K1,
+        reveal_tx_prefix,
+        "batch proof method id",
+    );
 
-        let reveal_wtxid = reveal_tx.compute_wtxid();
-        let reveal_hash = reveal_wtxid.as_raw_hash().to_byte_array();
-        // check if first N bytes equal to the given prefix
-        if reveal_hash.starts_with(reveal_tx_prefix) {
-            // check if inscription locked to the correct address
-            let recovery_key_pair = key_pair.tap_tweak(SECP256K1, merkle_root);
-            let (x_only_pub_key, _parity) = recovery_key_pair.to_inner().x_only_public_key();
-            assert_eq!(
-                Address::p2tr_tweaked(
-                    TweakedPublicKey::dangerous_assume_tweaked(x_only_pub_key),
-                    network,
-                ),
-                commit_tx_address
-            );
+    verify_commit_address(&key_pair, merkle_root, network, &commit_tx_address);
 
-            histogram!("batch_proof_method_id_mine_da_transaction").record(
-                Instant::now()
-                    .saturating_duration_since(start)
-                    .as_secs_f64(),
-            );
+    histogram!("batch_proof_method_id_mine_da_transaction").record(
+        Instant::now()
+            .saturating_duration_since(start)
+            .as_secs_f64(),
+    );
 
-            if let Some(root) = merkle_root {
-                info!(
-                    "Taproot merkle root for inscription - BatchProofMethodId: {}",
-                    root
-                );
-            }
-            return Ok(DaTxs::BatchProofMethodId {
-                commit: unsigned_commit_tx,
-                reveal: TxWithId {
-                    id: reveal_tx.compute_txid(),
-                    tx: reveal_tx,
-                },
-            });
-        } else {
-            reveal_tx.lock_time = LockTime::Seconds(Time::from_consensus(lock_time).unwrap());
-            update_witness(
-                &unsigned_commit_tx,
-                &mut reveal_tx,
-                tapscript_hash,
-                &key_pair,
-                SECP256K1,
-            );
-            lock_time += 1;
-        }
+    if let Some(root) = merkle_root {
+        info!(
+            "Taproot merkle root for inscription - BatchProofMethodId: {}",
+            root
+        );
     }
+
+    Ok(DaTxs::BatchProofMethodId {
+        commit: unsigned_commit_tx,
+        reveal: TxWithId {
+            id: reveal_tx.compute_txid(),
+            tx: reveal_tx,
+        },
+    })
 }
 
 /// Creates the batch proof transactions Type 4 - SequencerCommitment
@@ -896,7 +817,6 @@ pub fn create_inscription_type_4(
         .push_opcode(OP_ENDIF);
 
     // Nonce is kept for legacy reasons but is now fixed at 16.
-    // Prefix mining is now done by iterating over lock_time instead.
     let nonce: i64 = 16; // >= 16 to avoid OP_PUSHNUM_X interpretation
 
     // push nonce
@@ -960,65 +880,33 @@ pub fn create_inscription_type_4(
         SECP256K1,
     );
 
-    // Mine for the reveal tx prefix by iterating over lock_time values.
-    // Starting from LOCK_TIME_THRESHOLD (500_000_000) is safe because it represents
-    // a Unix timestamp from 1985, and with a two-byte prefix requiring on average 2^16
-    // iterations, the resulting timestamp (~500_065_536) is still in 1985, making the
-    // transaction spendable immediately (equivalent to nLockTime == 0).
-    let mut lock_time = LOCK_TIME_THRESHOLD;
-    loop {
-        let iterations = lock_time - LOCK_TIME_THRESHOLD;
-        if iterations > 0 && iterations % 1000 == 0 {
-            trace!(
-                iterations,
-                "Mining for sequencer commitment reveal tx prefix"
-            );
-            if iterations > 16384 {
-                warn!("Too many iterations mining for sequencer commitment reveal tx prefix");
-            }
-        }
+    mine_reveal_prefix(
+        &unsigned_commit_tx,
+        &mut reveal_tx,
+        tapscript_hash,
+        &key_pair,
+        SECP256K1,
+        reveal_tx_prefix,
+        "sequencer commitment",
+    );
 
-        let reveal_wtxid = reveal_tx.compute_wtxid();
-        let reveal_hash = reveal_wtxid.as_raw_hash().to_byte_array();
-        // check if first N bytes equal to the given prefix
-        if reveal_hash.starts_with(reveal_tx_prefix) {
-            // check if inscription locked to the correct address
-            let recovery_key_pair = key_pair.tap_tweak(SECP256K1, merkle_root);
-            let (x_only_pub_key, _parity) = recovery_key_pair.to_inner().x_only_public_key();
-            assert_eq!(
-                Address::p2tr_tweaked(
-                    TweakedPublicKey::dangerous_assume_tweaked(x_only_pub_key),
-                    network,
-                ),
-                commit_tx_address
-            );
+    verify_commit_address(&key_pair, merkle_root, network, &commit_tx_address);
 
-            histogram!("sequencer_commitment_mine_da_transaction").record(
-                Instant::now()
-                    .saturating_duration_since(start)
-                    .as_secs_f64(),
-            );
+    histogram!("sequencer_commitment_mine_da_transaction").record(
+        Instant::now()
+            .saturating_duration_since(start)
+            .as_secs_f64(),
+    );
 
-            if let Some(root) = merkle_root {
-                info!("Taproot merkle root for inscription - Commitment: {}", root);
-            }
-            return Ok(DaTxs::SequencerCommitment {
-                commit: unsigned_commit_tx,
-                reveal: TxWithId {
-                    id: reveal_tx.compute_txid(),
-                    tx: reveal_tx,
-                },
-            });
-        } else {
-            reveal_tx.lock_time = LockTime::Seconds(Time::from_consensus(lock_time).unwrap());
-            update_witness(
-                &unsigned_commit_tx,
-                &mut reveal_tx,
-                tapscript_hash,
-                &key_pair,
-                SECP256K1,
-            );
-            lock_time += 1;
-        }
+    if let Some(root) = merkle_root {
+        info!("Taproot merkle root for inscription - Commitment: {}", root);
     }
+
+    Ok(DaTxs::SequencerCommitment {
+        commit: unsigned_commit_tx,
+        reveal: TxWithId {
+            id: reveal_tx.compute_txid(),
+            tx: reveal_tx,
+        },
+    })
 }

--- a/crates/bitcoin-da/src/helpers/builders/body_builders.rs
+++ b/crates/bitcoin-da/src/helpers/builders/body_builders.rs
@@ -77,7 +77,7 @@ pub enum DaTxs {
     },
 }
 
-/// Mine the reveal transaction's prefix
+/// Mine the reveal transaction's prefix using `sign_schnorr` internal randomness
 fn mine_reveal_prefix(
     commit_tx: &Transaction,
     reveal_tx: &mut Transaction,


### PR DESCRIPTION
# Description

- Rely on randomized Schnorr signing from `sign_schnorr` in `update_witness` to mine tx prefix instead of tweaking `lock_time`
