### PR TITLE
ci(proving-stats): simplify cycle reading 

### DIFF
--- a/.github/scripts/run-proving-test.sh
+++ b/.github/scripts/run-proving-test.sh
@@ -12,11 +12,11 @@ docker exec bitcoin-regtest bitcoin-cli -regtest -rpcuser=citrea -rpcpassword=ci
 
 RUST_LOG=off target/debug/citrea --dev --da-layer bitcoin --rollup-config-path $TEST_DIR/configs/sequencer_rollup_config.toml --sequencer $TEST_DIR/configs/sequencer_config.toml --genesis-paths bin/citrea/tests/bitcoin/test-data/gen-proof-input-genesis &
 PID_SEQUENCER=$!
-PARALLEL_PROOF_LIMIT=2 target/debug/citrea --dev --da-layer bitcoin --rollup-config-path $TEST_DIR/configs/batch_prover_rollup_config.toml --batch-prover $TEST_DIR/configs/batch_prover_config.toml --genesis-paths bin/citrea/tests/bitcoin/test-data/gen-proof-input-genesis >> batch-prover.log &
+PARALLEL_PROOF_LIMIT=2 target/debug/citrea --dev --da-layer bitcoin --rollup-config-path $TEST_DIR/configs/batch_prover_rollup_config.toml --batch-prover $TEST_DIR/configs/batch_prover_config.toml --genesis-paths bin/citrea/tests/bitcoin/test-data/gen-proof-input-genesis &
 PID_BATCH_PROVER=$!
 
 mkdir -p $TEST_DIR/results
-python3 $TEST_DIR/get-proving-stats.py batch-prover.log $TEST_DIR/results/$OUT_FILE_NAME
+python3 $TEST_DIR/get-proving-stats.py $TEST_DIR/results/$OUT_FILE_NAME
 
 kill -9 $PID_SEQUENCER $PID_BATCH_PROVER
 docker compose -f $TEST_DIR/docker-compose.regtest.yml down
@@ -27,4 +27,3 @@ sudo chown -R $USER:$USER $TEST_DIR/bitcoin
 # we must clean batch prover db but we also clean
 # the sequencer db as there may be corruption due to the kill -9
 rm -rf $TEST_DIR/dbs/
-rm batch-prover.log

--- a/proving-stats/get-proving-stats.py
+++ b/proving-stats/get-proving-stats.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python3
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-import subprocess
 import time
-import uuid
-import os
-import re
 import json
-import signal
 import requests
 from pathlib import Path
 import sys
@@ -28,7 +23,7 @@ def wait_for_proofs()->dict:
             res = requests.post(PROVER_RPC_URL, json=payload, timeout=5)
             res.raise_for_status()
             result = res.json().get("result")
-            return result.get("proof")
+            return result
         except Exception as e:
             print(f"RPC error for commitment {commitment_id}: {e}")
             return None
@@ -36,38 +31,33 @@ def wait_for_proofs()->dict:
     def query_until_proven(commitment_id):
         start_time = time.time()
         while True:
-            proof = query(commitment_id)
-            if proof:
-                return proof
+            job_response = query(commitment_id)
+            if job_response and job_response.get("proof"):
+                return job_response.get("proof")
             elif (time.time() - start_time) > 600: # 10 minutes in seconds
                 raise TimeoutError(f"Timeout: Commitment {commitment_id} not proven within 10 minutes.")
-                return None
             time.sleep(5)
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         futures = {executor.submit(query_until_proven, commitment_id): commitment_id for commitment_id in COMMITMENTS}
         results = []
         for future in as_completed(futures):
-            proof = future.result()
-            results.append(proof)
+            job_response = future.result()
+            results.append(job_response)
         return results
 
-# --- Parse log lines ---
-def extract_cycles(log_lines):
-    pattern = re.compile(r"SessionStats\s*{[^}]*?total_cycles:\s*(\d+),\s*user_cycles:\s*(\d+),\s*paging_cycles:\s*(\d+),\s*reserved_cycles:\s*(\d+)")
+def extract_cycles_from_job_responses(proof_responses):
+    """Extract cycles from the proving session info in proof responses (Local prover format)"""
     total = user = paging = reserved = 0
-    matched = 0
-    for line in log_lines:
-        match = pattern.search(line)
-        if match:
-            matched += 1
+    
+    for proof in proof_responses:
+        info = proof["info"]
+        local_info = info["Local"]
 
-            total += int(match.group(1))
-            user += int(match.group(2))
-            paging += int(match.group(3))
-            reserved += int(match.group(4))
-
-    assert matched == 2, f"Expected exactly two lines with cycle counts, found {matched}."
+        total += local_info["total_cycles"]
+        user += local_info["user_cycles"]
+        paging += local_info["paging_cycles"]
+        reserved += local_info["reserved_cycles"]
     return {
         "Total Cycles": total,
         "User Cycles": user,
@@ -85,26 +75,24 @@ def state_diff_size(state_diff):
 
 
 def main():
-    if len(sys.argv) < 3:
-        print("Usage: python get_proof_data.py <batch_prover_stdout_file> <output_file>")
+    if len(sys.argv) < 2:
+        print("Usage: python get_proof_data.py <output_file>")
         sys.exit(1)
-    batch_prover_stdout_file = sys.argv[1]
-    output_file = sys.argv[2]
+    output_file = sys.argv[1]
 
     # Wait for proofs to be ready
-    proofs = wait_for_proofs()
+    proof_responses = wait_for_proofs()
 
-    state_diffs = map(lambda proof: proof["proofOutput"]["stateDiff"], proofs)
+    # Extract cycles from RPC responses
+    cycles = extract_cycles_from_job_responses(proof_responses)
+    print(f"Extracted cycles: {cycles}")
+
+    # Extract state diffs
+    state_diffs = map(lambda proof: proof["proofOutput"]["stateDiff"], proof_responses)
     total_diff_size = sum(
         map(state_diff_size, state_diffs)
     )
     print(f"Total state diff size: {total_diff_size} bytes")
-
-    # Read log lines from the batch prover stdout file
-    with open(batch_prover_stdout_file, 'r') as log_f:
-        log_lines = log_f.readlines()
-    cycles = extract_cycles(log_lines)
-    print(f"Extracted cycles: {cycles}")
 
     with open(output_file, 'w') as out_f:
         output_data = {**cycles, "State Diff Size (bytes)": total_diff_size}

--- a/proving-stats/get-proving-stats.py
+++ b/proving-stats/get-proving-stats.py
@@ -42,7 +42,7 @@ def wait_for_proofs()->dict:
         results.append(query_until_proven(commitment_id))
     return results
 
-def extract_cycles_from_job_responses(proof_responses):
+def extract_cycles_from_proof_responses(proof_responses):
     """Extract cycles from the proving session info in proof responses (Local prover format)"""
     total = user = paging = reserved = 0
     
@@ -72,7 +72,7 @@ def state_diff_size(state_diff):
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python get_proof_data.py <output_file>")
+        print("Usage: python get-proving-stats.py <output_file>")
         sys.exit(1)
     output_file = sys.argv[1]
 
@@ -80,7 +80,7 @@ def main():
     proof_responses = wait_for_proofs()
 
     # Extract cycles from RPC responses
-    cycles = extract_cycles_from_job_responses(proof_responses)
+    cycles = extract_cycles_from_proof_responses(proof_responses)
     print(f"Extracted cycles: {cycles}")
 
     # Extract state diffs

--- a/proving-stats/get-proving-stats.py
+++ b/proving-stats/get-proving-stats.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
 import json
 import requests
-from pathlib import Path
 import sys
 
 COMMITMENTS = [1, 2]
@@ -38,13 +36,11 @@ def wait_for_proofs()->dict:
                 raise TimeoutError(f"Timeout: Commitment {commitment_id} not proven within 10 minutes.")
             time.sleep(5)
 
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        futures = {executor.submit(query_until_proven, commitment_id): commitment_id for commitment_id in COMMITMENTS}
-        results = []
-        for future in as_completed(futures):
-            job_response = future.result()
-            results.append(job_response)
-        return results
+    results = []
+    for commitment_id in COMMITMENTS:
+        print(f"Waiting for proof of commitment {commitment_id}...")
+        results.append(query_until_proven(commitment_id))
+    return results
 
 def extract_cycles_from_job_responses(proof_responses):
     """Extract cycles from the proving session info in proof responses (Local prover format)"""


### PR DESCRIPTION
# Description
Uses the new batch prover API that allows reading the proving session info(including cycles) in `getProvingJob*` RPCs.

Fixes #3022 
