### PR TITLE
ci: Fix Validate PR Title job for external forks (#3178)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,7 +11,9 @@ jobs:
     name: Validate PR Title
     permissions:
       contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Check PR Title
         uses: amannn/action-semantic-pull-request@v5
@@ -48,14 +50,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   check-changelog:
-    needs: validate
     permissions:
       contents: read
       pull-requests: write
       issues: write
     name: Check Changelog Entry
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Problem:
The Validate PR Title job was failing on external forks because the GITHUB_TOKEN doesn't have the necessary permissions to post status checks on PRs from forks.

Solution:
- Added explicit condition to validate job: only run for PRs from the main repository
- Updated check-changelog job to also only run for PRs from the main repository
- Removed 'needs: validate' dependency since validate might be skipped on forks
- Added pull-requests: read permission to validate job for clarity

This allows the workflow to gracefully handle PRs from external forks while still validating PR titles for commits to the main repository.

Fixes #3178

# Description


## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
