### PR TITLE
test(bitcoin): enable mempool_accept regression coverage

### DIFF
--- a/bin/citrea/tests/bitcoin/mempool_accept.rs
+++ b/bin/citrea/tests/bitcoin/mempool_accept.rs
@@ -1,11 +1,28 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use bitcoincore_rpc::RpcApi;
-use citrea_e2e::bitcoin::DEFAULT_FINALITY_DEPTH;
+use citrea_e2e::bitcoin::{BitcoinNode, DEFAULT_FINALITY_DEPTH};
 use citrea_e2e::config::BitcoinConfig;
 use citrea_e2e::framework::TestFramework;
 use citrea_e2e::test_case::{TestCase, TestCaseRunner};
-use citrea_e2e::traits::L2Node;
 use citrea_e2e::Result;
+
+use super::get_citrea_path;
+
+const MEMPOOL_SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn observe_commit_reveal_mempool_len(da: &BitcoinNode) -> Result<usize> {
+    let _ = da.wait_mempool_len(2, Some(MEMPOOL_SETTLE_TIMEOUT)).await;
+    Ok(da.get_raw_mempool().await?.len())
+}
+
+fn assert_atomic_commit_reveal_result(mempool_len: usize, context: &str) {
+    assert!(
+        matches!(mempool_len, 0 | 2),
+        "{context}: expected the commit/reveal pair to be either fully queued or fully broadcast, found {mempool_len} txs in the mempool",
+    );
+}
 
 struct MempoolAcceptTest;
 
@@ -26,8 +43,7 @@ impl TestCase for MempoolAcceptTest {
         let sequencer = f.sequencer.as_ref().unwrap();
         let da = f.bitcoin_nodes.get(0).expect("DA not running.");
 
-        let min_l2_block_per_commitment =
-            sequencer.sequencer.config.node.max_l2_blocks_per_commitment;
+        let min_l2_block_per_commitment = sequencer.config.node.max_l2_blocks_per_commitment;
 
         // publish min_l2_block_per_commitment - 1 confirmations, no commitments should be sent
         for _ in 0..min_l2_block_per_commitment {
@@ -39,12 +55,20 @@ impl TestCase for MempoolAcceptTest {
 
         da.generate(DEFAULT_FINALITY_DEPTH).await?;
 
-        // TODO find the right assertions here
-        // Should be either 2 or 0
-        // Before this PR and the addition of testmempoolaccept, first tx would go in and second would be rejected due to mempool policy set above
+        // Under restrictive ancestor policy, the commit/reveal pair must never be partially
+        // broadcast. It can either stay queued (0 txs) or reach the mempool atomically (2 txs).
+        let mempool_len = observe_commit_reveal_mempool_len(da).await?;
+        assert_atomic_commit_reveal_result(mempool_len, "after triggering sequencer commitments");
 
-        // Wait for blob tx to hit the mempool
-        da.wait_mempool_len(2, None).await?;
+        if mempool_len == 0 {
+            da.generate(1).await?;
+
+            let retried_mempool_len = observe_commit_reveal_mempool_len(da).await?;
+            assert_atomic_commit_reveal_result(
+                retried_mempool_len,
+                "after retrying queued transactions on a new DA block",
+            );
+        }
 
         Ok(())
     }

--- a/bin/citrea/tests/bitcoin/mod.rs
+++ b/bin/citrea/tests/bitcoin/mod.rs
@@ -5,12 +5,8 @@ use bitcoin::Transaction;
 use bitcoin_da::helpers::parsers::{parse_relevant_transaction, ParsedTransaction, VerifyParsed};
 use bitcoin_da::spec::blob::BlobWithSender;
 
-pub mod batch_prover_test;
-pub mod light_client_test;
-pub mod rollback;
-mod utils;
-// pub mod mempool_accept;
 pub mod backup;
+pub mod batch_prover_test;
 pub mod bitcoin_service;
 pub mod bitcoin_test;
 pub mod bitcoin_verifier;
@@ -20,6 +16,9 @@ pub mod fork;
 #[cfg(feature = "testing")]
 pub mod full_node;
 pub mod guest_cycles;
+pub mod light_client_test;
+pub mod mempool_accept;
+pub mod rollback;
 pub mod sequencer_commitments;
 pub mod sequencer_test;
 pub mod syncing;
@@ -27,6 +26,7 @@ pub mod tangerine_related;
 pub mod taproot_key_spend;
 pub mod tx_chain;
 pub mod tx_propagation;
+mod utils;
 
 pub(super) fn get_citrea_path() -> PathBuf {
     std::env::var("CITREA_E2E_TEST_BINARY").map_or_else(


### PR DESCRIPTION
## Summary

- enable the dormant `mempool_accept` bitcoin e2e test
- replace the existing TODO with assertions around commit/reveal atomicity
- verify that restrictive ancestor policy never leaves the sequencer in a partial-broadcast state
- cover both immediate acceptance and retry-on-next-block behavior