### PR TITLE
perf: Use mutex for write only locks

### DIFF
--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -299,7 +299,7 @@ impl FromEnv for MonitoringConfig {
 pub struct MonitoringService {
     client: Arc<Client>,
     monitored_txs: RwLock<HashMap<Txid, MonitoredTx>>,
-    chain_state: RwLock<ChainState>,
+    chain_state: Mutex<ChainState>,
     config: MonitoringConfig,
     // Last tx in queue
     last_tx: Mutex<Option<Txid>>,
@@ -323,7 +323,7 @@ impl MonitoringService {
             Self {
                 client,
                 monitored_txs: RwLock::new(HashMap::new()),
-                chain_state: RwLock::new(ChainState::default()),
+                chain_state: Mutex::new(ChainState::default()),
                 config: config.unwrap_or_default(),
                 last_tx: Mutex::new(None),
                 total_size: AtomicUsize::new(0),
@@ -352,7 +352,7 @@ impl MonitoringService {
             recent_blocks.push((current_hash, height));
         }
 
-        let mut chain_state = self.chain_state.write().await;
+        let mut chain_state = self.chain_state.lock().await;
         *chain_state = ChainState {
             current_height,
             current_tip,
@@ -579,7 +579,7 @@ impl MonitoringService {
         let new_height = self.client.get_block_count().await?;
         let new_tip = self.client.get_best_block_hash().await?;
 
-        let mut chain_state = self.chain_state.write().await;
+        let mut chain_state = self.chain_state.lock().await;
 
         if new_tip != chain_state.current_tip {
             // Send new tip notification

--- a/crates/evm/src/rpc_helpers/filter.rs
+++ b/crates/evm/src/rpc_helpers/filter.rs
@@ -14,7 +14,7 @@ use reth_rpc::eth::filter::EthFilterError;
 use reth_rpc_eth_types::{EthApiError, EthSubscriptionIdProvider};
 use reth_tasks::TaskExecutor;
 use sov_modules_api::{StateVecAccessor, WorkingSet};
-use tokio::sync::RwLock;
+use tokio::sync::Mutex;
 use tokio::time::MissedTickBehavior;
 
 use crate::{get_filter_block_range, Evm};
@@ -69,14 +69,14 @@ pub fn convert_block_number(
 /// All active filters
 #[derive(Debug, Clone, Default)]
 pub struct ActiveFilters {
-    inner: Arc<RwLock<HashMap<FilterId, ActiveFilter>>>,
+    inner: Arc<Mutex<HashMap<FilterId, ActiveFilter>>>,
 }
 
 impl ActiveFilters {
     /// Returns an empty instance.
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(RwLock::new(HashMap::default())),
+            inner: Arc::new(Mutex::new(HashMap::default())),
         }
     }
 }
@@ -173,7 +173,7 @@ impl CitreaFilter {
         let removed: Vec<(FilterId, ActiveFilter)> = self
             .active_filters()
             .inner
-            .write()
+            .lock()
             .await
             .extract_if(|_id, filter| (now - filter.last_poll_timestamp) >= self.stale_filter_ttl)
             .collect();
@@ -203,7 +203,7 @@ impl CitreaFilter {
             SubscriptionId::Num(n) => FilterId::Num(n),
             SubscriptionId::Str(s) => FilterId::Str(s.into_owned()),
         };
-        let mut filters = self.active_filters.inner.write().await;
+        let mut filters = self.active_filters.inner.lock().await;
         filters.insert(
             id.clone(),
             ActiveFilter {
@@ -218,7 +218,7 @@ impl CitreaFilter {
     /// Uninstalls a filter with the given id. Returns true if the filter was found and removed,
     /// false otherwise.
     pub async fn uninstall_filter(&self, id: FilterId) -> RpcResult<bool> {
-        let mut filters = self.active_filters.inner.write().await;
+        let mut filters = self.active_filters.inner.lock().await;
         if filters.remove(&id).is_some() {
             tracing::trace!(target: "uninstallFilter", ?id, "uninstalled filter");
             Ok(true)
@@ -244,7 +244,7 @@ impl CitreaFilter {
         // start_block is the block from which we should start fetching changes, the next block from
         // the last time changes were polled, in other words the best block at last poll + 1
         let (start_block, kind) = {
-            let mut filters = self.active_filters.inner.write().await;
+            let mut filters = self.active_filters.inner.lock().await;
             let filter = filters
                 .get_mut(&id)
                 .ok_or(EthFilterError::FilterNotFound(id.clone()))?;
@@ -331,7 +331,7 @@ impl CitreaFilter {
         id: FilterId,
     ) -> Result<Vec<Log>, EthFilterError> {
         let filter = {
-            let mut filters = self.active_filters.inner.write().await;
+            let mut filters = self.active_filters.inner.lock().await;
             let filter = filters
                 .get_mut(&id)
                 .ok_or_else(|| EthFilterError::FilterNotFound(id.clone()))?;


### PR DESCRIPTION
# Description
Noticed some RwLocks were only used for writes, updated them with mutex.
We gain slight performance, with more code clarity
