### PR TITLE
Add GPG signing and verification for release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - "v*.*.*"
 
-permissions:
-  contents: write
-
 jobs:
   linux_amd64_binary_extraction:
     runs-on: ubicloud-standard-30-ubuntu-2204
@@ -113,9 +110,13 @@ jobs:
   create-draft-release:
     needs: [ linux_amd64_binary_extraction, linux_arm64_binary_extraction, osx_arm64_binary_extraction ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       release_id: ${{ steps.create_release.outputs.id }}
       sha256sums_hash: ${{ steps.hash_sums.outputs.sha256sums_hash }}
+      amd64_hash: ${{ steps.binary_hashes.outputs.amd64 }}
+      arm64_hash: ${{ steps.binary_hashes.outputs.arm64 }}
     steps:
       - name: Download linux-amd64 Binary
         uses: actions/download-artifact@v4
@@ -184,6 +185,15 @@ jobs:
           sha256sum * > SHA256SUMS
           echo "Hash file created."
 
+      - name: Calculate Binary Hashes for Docker Job
+        id: binary_hashes
+        run: |
+          AMD64=$(sha256sum release/citrea-${{ github.ref_name }}-linux-amd64 | awk '{print $1}')
+          ARM64=$(sha256sum release/citrea-${{ github.ref_name }}-linux-arm64 | awk '{print $1}')
+          echo "amd64=$AMD64" >> "$GITHUB_OUTPUT"
+          echo "arm64=$ARM64" >> "$GITHUB_OUTPUT"
+          echo "Calculated output hashes for Docker job."
+
       - name: Hash the SHA256SUMS file for cross-job integrity
         id: hash_sums
         run: |
@@ -219,6 +229,8 @@ jobs:
   verify-and-publish:
     needs: [ create-draft-release ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     environment: 'protected-release'
     steps:
       - uses: actions/checkout@v5
@@ -336,12 +348,15 @@ jobs:
 
   update-dockerhub:
     runs-on: ubuntu-latest
-    needs: [ verify-and-publish ]
+    needs: [ create-draft-release, verify-and-publish ]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
       - name: Download binaries and verify integrity
+        env:
+          EXPECTED_AMD: ${{ needs.create-draft-release.outputs.amd64_hash }}
+          EXPECTED_ARM: ${{ needs.create-draft-release.outputs.arm64_hash }}
         run: |
           sudo apt update && sudo apt -y install wget
           RELEASE="${{ github.ref_name }}"
@@ -349,10 +364,8 @@ jobs:
 
           wget -O docker/full-node/citrea-amd64 "${BASE_URL}/citrea-${RELEASE}-linux-amd64"
           wget -O docker/full-node/citrea-arm64 "${BASE_URL}/citrea-${RELEASE}-linux-arm64"
-          wget -O SHA256SUMS "${BASE_URL}/SHA256SUMS"
 
-          # Verify the AMD64 binary
-          EXPECTED_AMD=$(grep "citrea-${RELEASE}-linux-amd64" SHA256SUMS | awk '{print $1}')
+          # Verify AMD64
           ACTUAL_AMD=$(sha256sum docker/full-node/citrea-amd64 | awk '{print $1}')
           if [[ "$ACTUAL_AMD" != "$EXPECTED_AMD" ]]; then
             echo "CRITICAL: AMD64 Binary hash mismatch!"
@@ -361,8 +374,7 @@ jobs:
             exit 1
           fi
 
-          # Verify the ARM64 binary
-          EXPECTED_ARM=$(grep "citrea-${RELEASE}-linux-arm64" SHA256SUMS | awk '{print $1}')
+          # Verify ARM64
           ACTUAL_ARM=$(sha256sum docker/full-node/citrea-arm64 | awk '{print $1}')
           if [[ "$ACTUAL_ARM" != "$EXPECTED_ARM" ]]; then
             echo "CRITICAL: ARM64 Binary hash mismatch!"
@@ -371,7 +383,7 @@ jobs:
             exit 1
           fi
 
-          echo "Binaries integrity verified."
+          echo "Binaries integrity verified securely via internal outputs."
 
           mkdir -p docker/full-node/genesis
           cp -r resources/genesis/mainnet docker/full-node/genesis/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,6 @@ jobs:
     permissions:
       contents: write
     outputs:
-      release_id: ${{ steps.create_release.outputs.id }}
       sha256sums_hash: ${{ steps.hash_sums.outputs.sha256sums_hash }}
       amd64_hash: ${{ steps.binary_hashes.outputs.amd64 }}
       arm64_hash: ${{ steps.binary_hashes.outputs.arm64 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,5 @@
 name: Release
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
-
 on:
   push:
     tags:
@@ -180,10 +175,10 @@ jobs:
             accept-flake-config = true
 
       - name: Build
-        run: nix build ./nix#citrea
+        run: nix build ./nix
 
       - name: Rebuild to verify reproducibility
-        run: nix build ./nix#citrea --rebuild
+        run: nix build ./nix
 
       - name: Collect artifacts
         shell: bash
@@ -214,11 +209,14 @@ jobs:
           name: release-build-${{ matrix.platform }}-${{ steps.vars.outputs.release_tag }}
           path: artifacts/
 
-
   verify-against-manifest:
     needs: [verify-manifest, build]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     outputs:
       sha256sums_hash: ${{ steps.expose.outputs.sha256sums_hash }}
     steps:
@@ -274,9 +272,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Normalize both files (sort, strip trailing whitespace) and diff.
-          # If maintainers and CI built the same source with the same Nix flake,
-          # every hash must match.
           sort artifacts/SHA256SUMS.txt > /tmp/ci.txt
           sort "manifest/${GITHUB_REF_NAME}.txt" > /tmp/signed.txt
 
@@ -315,11 +310,13 @@ jobs:
             artifacts/citrea-cli-${{ github.ref_name }}-linux-arm64
             artifacts/citrea-cli-${{ github.ref_name }}-osx-arm64
 
-
   package:
     needs: verify-against-manifest
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Download verified bundle
         uses: actions/download-artifact@v4
@@ -341,7 +338,7 @@ jobs:
           (cd artifacts && shasum -a 256 -c SHA256SUMS.txt)
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22
 
       - name: Sign SHA256SUMS.txt
         shell: bash
@@ -394,11 +391,13 @@ jobs:
             artifacts/citrea-cli-${{ github.ref_name }}-linux-arm64
             artifacts/citrea-cli-${{ github.ref_name }}-osx-arm64
 
-
   update-dockerhub:
     needs: package
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -456,7 +455,7 @@ jobs:
             ${{ vars.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPOSITORY }}:${{ github.ref_name }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22
 
       - name: Sign Docker image
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: write
+
 jobs:
   linux_amd64_binary_extraction:
     runs-on: ubicloud-standard-30-ubuntu-2204
@@ -107,9 +110,12 @@ jobs:
           name: citrea-cli-${{ github.ref_name }}-osx-arm64
           path: target/release/citrea-cli
 
-  release:
+  create-draft-release:
     needs: [ linux_amd64_binary_extraction, linux_arm64_binary_extraction, osx_arm64_binary_extraction ]
     runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create_release.outputs.id }}
+      sha256sums_hash: ${{ steps.hash_sums.outputs.sha256sums_hash }}
     steps:
       - name: Download linux-amd64 Binary
         uses: actions/download-artifact@v4
@@ -172,19 +178,35 @@ jobs:
         run: |
           mv release/citrea-cli release/citrea-cli-${{ github.ref_name }}-osx-arm64
 
-      - name: Release
+      - name: Prepare Release Assets & Checksums
+        run: |
+          cd release
+          sha256sum * > SHA256SUMS
+          echo "Hash file created."
+
+      - name: Hash the SHA256SUMS file for cross-job integrity
+        id: hash_sums
+        run: |
+          HASH=$(sha256sum release/SHA256SUMS | awk '{print $1}')
+          echo "sha256sums_hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "SHA256SUMS integrity hash: $HASH"
+
+      - name: Create Draft Release
+        id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            release/citrea-${{ github.ref_name }}-linux-amd64
-            release/citrea-${{ github.ref_name }}-linux-arm64
-            release/citrea-${{ github.ref_name }}-osx-arm64
-            release/citrea-cli-${{ github.ref_name }}-linux-amd64
-            release/citrea-cli-${{ github.ref_name }}-linux-arm64
-            release/citrea-cli-${{ github.ref_name }}-osx-arm64
+          draft: true
+          files: release/*
           name: Release ${{ github.ref_name }}
           body: |
-            This is the release for version ${{ github.ref_name }}.
+            ## GPG Verification Required
+            This release is in DRAFT mode. Signatures are required for `SHA256SUMS`.
+            
+            **Action required:**
+            1. Download `SHA256SUMS`
+            2. Sign it: `gpg --armor --detach-sign SHA256SUMS`
+            3. Rename to `SHA256SUMS.<your-name>.sig`
+            4. Upload to this release.
 
             It includes:
             - citrea-${{ github.ref_name }}-linux-amd64
@@ -194,21 +216,162 @@ jobs:
             - citrea-cli-${{ github.ref_name }}-linux-arm64
             - citrea-cli-${{ github.ref_name }}-osx-arm64
 
+  verify-and-publish:
+    needs: [ create-draft-release ]
+    runs-on: ubuntu-latest
+    environment: 'protected-release'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download and verify SHA256SUMS integrity
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          EXPECTED_HASH: ${{ needs.create-draft-release.outputs.sha256sums_hash }}
+        run: |
+          gh release download "$TAG" -p "SHA256SUMS*"
+
+          ACTUAL_HASH=$(sha256sum SHA256SUMS | awk '{print $1}')
+          if [[ "$ACTUAL_HASH" != "$EXPECTED_HASH" ]]; then
+            echo "CRITICAL: SHA256SUMS was tampered with between jobs!"
+            echo "Expected: $EXPECTED_HASH"
+            echo "Got:      $ACTUAL_HASH"
+            exit 1
+          fi
+          echo "SHA256SUMS integrity verified."
+
+      - name: Check Authorized Signatures
+        env:
+          REQUIRED_SIGS: 2
+          AUTHORIZED_KEYS: >-
+            7F52EC9A995025E87F3AF1200C17966C01E52A9A
+            CFF759A7C0EF99813BD1E6EE85CCAD8803F887A0
+
+        run: |
+          if [ -z "$AUTHORIZED_KEYS" ]; then
+            echo "CRITICAL: No authorized keys configured."
+            exit 1
+          fi
+
+          KEY_COUNT=$(echo $AUTHORIZED_KEYS | wc -w)
+          echo "Loaded $KEY_COUNT authorized key(s)."
+
+          if [ "$KEY_COUNT" -lt "$REQUIRED_SIGS" ]; then
+            echo "CRITICAL: Only $KEY_COUNT key(s) configured but $REQUIRED_SIGS signature(s) required."
+            exit 1
+          fi
+
+          MAX_RETRIES=3
+          for i in $(seq 1 $MAX_RETRIES); do
+            if gpg --keyserver keyserver.ubuntu.com --recv-keys $AUTHORIZED_KEYS; then
+              echo "Keys imported successfully."
+              break
+            fi
+            echo "Keyserver attempt $i/$MAX_RETRIES failed."
+            if [ "$i" -eq "$MAX_RETRIES" ]; then
+              echo "CRITICAL: Could not import GPG keys after $MAX_RETRIES attempts."
+              exit 1
+            fi
+            sleep 5
+          done
+
+          VALID_AUTH_COUNT=0
+          declare -A SEEN_KEYS
+          
+          for sig in *.sig; do
+            [ -e "$sig" ] || continue
+            echo "--- Analyzing: $sig ---"
+            
+            SIG_STATUS=$(gpg --status-fd 1 --verify "$sig" SHA256SUMS 2>/dev/null)
+            
+            if echo "$SIG_STATUS" | grep -q "VALIDSIG"; then
+              CURRENT_SIG_FPR=$(echo "$SIG_STATUS" | grep "VALIDSIG" | awk '{print $3}')
+              PRIMARY_FPR=$(gpg --with-colons --list-keys "$CURRENT_SIG_FPR" | awk -F: '$1=="fpr"{print $10; exit}')
+              
+              echo "Signature by subkey: $CURRENT_SIG_FPR"
+              echo "Belongs to primary: $PRIMARY_FPR"
+
+              AUTHORIZED=false
+              for AUTH_FPR in $AUTHORIZED_KEYS; do
+                if [[ "$PRIMARY_FPR" == "$AUTH_FPR" ]]; then
+                  AUTHORIZED=true
+                  break
+                fi
+              done
+
+              if $AUTHORIZED; then
+                if [[ -z "${SEEN_KEYS[$PRIMARY_FPR]}" ]]; then
+                  echo "Verified: $PRIMARY_FPR"
+                  VALID_AUTH_COUNT=$((VALID_AUTH_COUNT + 1))
+                  SEEN_KEYS[$PRIMARY_FPR]=1
+                else
+                  echo "Duplicate from $PRIMARY_FPR ignored."
+                fi
+              else
+                echo "Unauthorized key: $PRIMARY_FPR"
+              fi
+            else
+              echo "Invalid signature: $sig"
+            fi
+          done
+          
+          echo "---------------------------------------"
+          echo "Total authorized signers confirmed: $VALID_AUTH_COUNT"
+          
+          if [ "$VALID_AUTH_COUNT" -lt "$REQUIRED_SIGS" ]; then
+            echo "Security failure: Need $REQUIRED_SIGS signatures, found $VALID_AUTH_COUNT."
+            exit 1
+          fi
+
+          echo "VALID_AUTH_COUNT=$VALID_AUTH_COUNT" >> "$GITHUB_ENV"
+
+      - name: Publish Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit ${{ github.ref_name }} \
+            --draft=false \
+            --title "Release ${{ github.ref_name }} - Verified" \
+            --notes "This release has been cryptographically verified by ${{ env.VALID_AUTH_COUNT }} authorized maintainer(s)."
+
   update-dockerhub:
     runs-on: ubuntu-latest
-    needs: [ release ]
+    needs: [ verify-and-publish ]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Download binaries and prepare Docker context
+      - name: Download binaries and verify integrity
         run: |
           sudo apt update && sudo apt -y install wget
           RELEASE="${{ github.ref_name }}"
+          BASE_URL="https://github.com/chainwayxyz/citrea/releases/download/${RELEASE}"
 
-          # Download both arch
-          wget -O docker/full-node/citrea-amd64 "https://github.com/chainwayxyz/citrea/releases/download/${RELEASE}/citrea-${RELEASE}-linux-amd64"
-          wget -O docker/full-node/citrea-arm64 "https://github.com/chainwayxyz/citrea/releases/download/${RELEASE}/citrea-${RELEASE}-linux-arm64"
+          wget -O docker/full-node/citrea-amd64 "${BASE_URL}/citrea-${RELEASE}-linux-amd64"
+          wget -O docker/full-node/citrea-arm64 "${BASE_URL}/citrea-${RELEASE}-linux-arm64"
+          wget -O SHA256SUMS "${BASE_URL}/SHA256SUMS"
+
+          # Verify the AMD64 binary
+          EXPECTED_AMD=$(grep "citrea-${RELEASE}-linux-amd64" SHA256SUMS | awk '{print $1}')
+          ACTUAL_AMD=$(sha256sum docker/full-node/citrea-amd64 | awk '{print $1}')
+          if [[ "$ACTUAL_AMD" != "$EXPECTED_AMD" ]]; then
+            echo "CRITICAL: AMD64 Binary hash mismatch!"
+            echo "Expected: $EXPECTED_AMD"
+            echo "Got:      $ACTUAL_AMD"
+            exit 1
+          fi
+
+          # Verify the ARM64 binary
+          EXPECTED_ARM=$(grep "citrea-${RELEASE}-linux-arm64" SHA256SUMS | awk '{print $1}')
+          ACTUAL_ARM=$(sha256sum docker/full-node/citrea-arm64 | awk '{print $1}')
+          if [[ "$ACTUAL_ARM" != "$EXPECTED_ARM" ]]; then
+            echo "CRITICAL: ARM64 Binary hash mismatch!"
+            echo "Expected: $EXPECTED_ARM"
+            echo "Got:      $ACTUAL_ARM"
+            exit 1
+          fi
+
+          echo "Binaries integrity verified."
 
           mkdir -p docker/full-node/genesis
           cp -r resources/genesis/mainnet docker/full-node/genesis/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   verify-manifest:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     if: startsWith(github.ref, 'refs/tags/')
     outputs:
       manifest_sha256: ${{ steps.hash.outputs.manifest_sha256 }}
@@ -212,7 +212,7 @@ jobs:
   verify-against-manifest:
     needs: [verify-manifest, build]
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     permissions:
       contents: read
       id-token: write
@@ -313,7 +313,7 @@ jobs:
   package:
     needs: verify-against-manifest
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     permissions:
       contents: write
       id-token: write
@@ -394,7 +394,7 @@ jobs:
   update-dockerhub:
     needs: package
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,406 +1,447 @@
-name: release
+name: Release
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
 
 on:
   push:
     tags:
       - "v*.*.*"
+    branches:
+      - feat/repr-build
 
 jobs:
-  linux_amd64_binary_extraction:
-    runs-on: ubicloud-standard-30-ubuntu-2204
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Install Dependencies
-        run: |
-          sudo apt update && sudo apt -y install curl gcc cpp cmake clang llvm
-          sudo apt -y autoremove && sudo apt clean && sudo rm -rf /var/lib/apt/lists/*
-
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          rustup install 1.88.0
-          rustup default 1.88.0
-
-      - name: Build Project
-        env:
-          SKIP_GUEST_BUILD: 1
-        run: |
-          cargo build --release
-
-      - name: Upload citrea linux-amd64 Binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: citrea-${{ github.ref_name }}-linux-amd64
-          path: target/release/citrea
-
-      - name: Upload citrea-cli linux-amd64 Binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: citrea-cli-${{ github.ref_name }}-linux-amd64
-          path: target/release/citrea-cli
-
-  linux_arm64_binary_extraction:
-    runs-on: ubicloud-standard-30-arm-ubuntu-2204
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Install Dependencies
-        run: |
-          sudo apt update && sudo apt -y install curl gcc cpp cmake clang llvm
-          sudo apt -y autoremove && sudo apt clean && sudo rm -rf /var/lib/apt/lists/*
-
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          rustup install 1.88.0
-          rustup default 1.88.0
-
-      - name: Build Project
-        env:
-          SKIP_GUEST_BUILD: 1
-        run: |
-          cargo build --release
-
-      - name: Upload citrea linux-arm64 Binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: citrea-${{ github.ref_name }}-linux-arm64
-          path: target/release/citrea
-
-      - name: Upload citrea-cli linux-arm64 Binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: citrea-cli-${{ github.ref_name }}-linux-arm64
-          path: target/release/citrea-cli
-
-  osx_arm64_binary_extraction:
-    runs-on: self-hosted-citrea-osx-arm64
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          rustup install 1.88.0
-          rustup default 1.88.0
-
-      - name: Build Project
-        env:
-          SKIP_GUEST_BUILD: 1
-        run: |
-          source $HOME/.cargo/env
-          cargo build --release
-
-      - name: Upload citrea osx-arm64 Binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: citrea-${{ github.ref_name }}-osx-arm64
-          path: target/release/citrea
-
-      - name: Upload citrea-cli osx-arm64 Binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: citrea-cli-${{ github.ref_name }}-osx-arm64
-          path: target/release/citrea-cli
-
-  create-draft-release:
-    needs: [ linux_amd64_binary_extraction, linux_arm64_binary_extraction, osx_arm64_binary_extraction ]
+  verify-manifest:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    if: startsWith(github.ref, 'refs/tags/')
     outputs:
-      sha256sums_hash: ${{ steps.hash_sums.outputs.sha256sums_hash }}
-      amd64_hash: ${{ steps.binary_hashes.outputs.amd64 }}
-      arm64_hash: ${{ steps.binary_hashes.outputs.arm64 }}
+      manifest_sha256: ${{ steps.hash.outputs.manifest_sha256 }}
+    env:
+      REQUIRED_SIGS: 3
+      AUTHORIZED_KEYS: >-
+        7F52EC9A995025E87F3AF1200C17966C01E52A9A
+        CFF759A7C0EF99813BD1E6EE85CCAD8803F887A0
+        350B725CBA2D7EC3A1AD048C00980777D2839E81
     steps:
-      - name: Download linux-amd64 Binary
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Locate manifest and signatures
+        id: locate
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          MANIFEST="release-manifests/${TAG}.txt"
+
+          if [[ ! -f "$MANIFEST" ]]; then
+            echo "CRITICAL: manifest $MANIFEST not found at this tag."
+            echo "Maintainers must commit release-manifests/${TAG}.txt"
+            echo "and at least ${REQUIRED_SIGS} detached signatures before tagging."
+            exit 1
+          fi
+
+          SIG_COUNT=$(find release-manifests -maxdepth 1 -type f \
+            -name "${TAG}.txt.*.sig" | wc -l)
+          if [[ "$SIG_COUNT" -lt "$REQUIRED_SIGS" ]]; then
+            echo "CRITICAL: found only $SIG_COUNT signature(s), need $REQUIRED_SIGS."
+            exit 1
+          fi
+
+          echo "manifest=$MANIFEST" >> "$GITHUB_OUTPUT"
+          echo "Found manifest with $SIG_COUNT signature file(s)."
+          cat "$MANIFEST"
+
+      - name: Import authorized GPG keys
+        shell: bash
+        run: |
+          set -euo pipefail
+          MAX_RETRIES=3
+          for i in $(seq 1 $MAX_RETRIES); do
+            if gpg --keyserver keyserver.ubuntu.com --recv-keys $AUTHORIZED_KEYS; then
+              echo "Keys imported."
+              break
+            fi
+            echo "Keyserver attempt $i/$MAX_RETRIES failed."
+            if [[ "$i" -eq "$MAX_RETRIES" ]]; then
+              echo "CRITICAL: could not import GPG keys."
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: Verify signatures
+        shell: bash
+        env:
+          MANIFEST: ${{ steps.locate.outputs.manifest }}
+        run: |
+          set -euo pipefail
+
+          VALID_AUTH_COUNT=0
+          declare -A SEEN_KEYS
+
+          for sig in release-manifests/${GITHUB_REF_NAME}.txt.*.sig; do
+            [[ -e "$sig" ]] || continue
+            echo "--- Verifying: $sig ---"
+
+            SIG_STATUS=$(gpg --status-fd 1 --verify "$sig" "$MANIFEST" 2>/dev/null || true)
+
+            if ! echo "$SIG_STATUS" | grep -q "VALIDSIG"; then
+              echo "Invalid signature: $sig"
+              continue
+            fi
+
+            CURRENT_FPR=$(echo "$SIG_STATUS" | grep "VALIDSIG" | awk '{print $3}')
+            PRIMARY_FPR=$(gpg --with-colons --list-keys "$CURRENT_FPR" \
+              | awk -F: '$1=="fpr"{print $10; exit}')
+
+            echo "  signed by subkey:  $CURRENT_FPR"
+            echo "  primary key:       $PRIMARY_FPR"
+
+            AUTHORIZED=false
+            for AUTH_FPR in $AUTHORIZED_KEYS; do
+              if [[ "$PRIMARY_FPR" == "$AUTH_FPR" ]]; then
+                AUTHORIZED=true
+                break
+              fi
+            done
+
+            if ! $AUTHORIZED; then
+              echo "  unauthorized key, skipping."
+              continue
+            fi
+
+            if [[ -n "${SEEN_KEYS[$PRIMARY_FPR]:-}" ]]; then
+              echo "  duplicate signer, skipping."
+              continue
+            fi
+
+            SEEN_KEYS[$PRIMARY_FPR]=1
+            VALID_AUTH_COUNT=$((VALID_AUTH_COUNT + 1))
+            echo "  accepted."
+          done
+
+          echo "---"
+          echo "Distinct authorized signers: $VALID_AUTH_COUNT (need $REQUIRED_SIGS)"
+          if [[ "$VALID_AUTH_COUNT" -lt "$REQUIRED_SIGS" ]]; then
+            echo "CRITICAL: insufficient authorized signatures."
+            exit 1
+          fi
+
+      - name: Hash manifest for downstream integrity
+        id: hash
+        shell: bash
+        env:
+          MANIFEST: ${{ steps.locate.outputs.manifest }}
+        run: |
+          set -euo pipefail
+          H=$(sha256sum "$MANIFEST" | awk '{print $1}')
+          echo "manifest_sha256=$H" >> "$GITHUB_OUTPUT"
+          echo "Manifest SHA-256: $H"
+
+      - name: Upload manifest as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: signed-manifest-${{ github.ref_name }}
+          path: release-manifests/${{ github.ref_name }}.txt
+
+  build:
+    needs: verify-manifest
+    if: startsWith(github.ref, 'refs/tags/')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-amd64
+            runner: ubicloud-standard-30
+          - platform: linux-arm64
+            runner: ubicloud-standard-30-arm
+          - platform: osx-arm64
+            runner: macos-latest
+
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Compute release tag
+        id: vars
+        shell: bash
+        run: echo "release_tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.34.6/install
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Build
+        run: nix build ./nix#citrea
+
+      - name: Rebuild to verify reproducibility
+        run: nix build ./nix#citrea --rebuild
+
+      - name: Collect artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          cp ./result/bin/citrea     "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-${{ matrix.platform }}"
+          cp ./result/bin/citrea-cli "artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-${{ matrix.platform }}"
+
+      - name: Hash binaries (job summary)
+        shell: bash
+        run: |
+          set -euo pipefail
+          CITREA_HASH=$(shasum -a 256 "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-${{ matrix.platform }}" | awk '{print $1}')
+          CLI_HASH=$(shasum -a 256 "artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-${{ matrix.platform }}" | awk '{print $1}')
+          {
+            echo "## ${{ matrix.platform }}"
+            echo ""
+            echo "| Binary | SHA-256 |"
+            echo "|--------|---------|"
+            echo "| citrea | \`$CITREA_HASH\` |"
+            echo "| citrea-cli | \`$CLI_HASH\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-build-${{ matrix.platform }}-${{ steps.vars.outputs.release_tag }}
+          path: artifacts/
+
+
+  verify-against-manifest:
+    needs: [verify-manifest, build]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    outputs:
+      sha256sums_hash: ${{ steps.expose.outputs.sha256sums_hash }}
+    steps:
+      - name: Download all build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: citrea-${{ github.ref_name }}-linux-amd64
-          path: release
+          pattern: release-build-*-${{ github.ref_name }}
+          path: artifacts
+          merge-multiple: true
 
-      - name: rename file
-        run: |
-          mv release/citrea release/citrea-${{ github.ref_name }}-linux-amd64
-
-      - name: Download linux-arm64 Binary
+      - name: Download signed manifest
         uses: actions/download-artifact@v4
         with:
-          name: citrea-${{ github.ref_name }}-linux-arm64
-          path: release
+          name: signed-manifest-${{ github.ref_name }}
+          path: manifest
 
-      - name: rename linux-arm64 file
+      - name: Re-verify manifest integrity
+        env:
+          EXPECTED: ${{ needs.verify-manifest.outputs.manifest_sha256 }}
+        shell: bash
         run: |
-          mv release/citrea release/citrea-${{ github.ref_name }}-linux-arm64
+          set -euo pipefail
+          ACTUAL=$(sha256sum "manifest/${GITHUB_REF_NAME}.txt" | awk '{print $1}')
+          if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+            echo "CRITICAL: manifest tampered between jobs."
+            echo "Expected: $EXPECTED"
+            echo "Got:      $ACTUAL"
+            exit 1
+          fi
+          echo "Manifest integrity OK."
 
-      - name: Download OSX ARM64 Binary
+      - name: Generate SHA256SUMS.txt from CI build
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE="${GITHUB_REF_NAME}"
+          (cd artifacts && shasum -a 256 \
+            "citrea-${RELEASE}-linux-amd64" \
+            "citrea-${RELEASE}-linux-arm64" \
+            "citrea-${RELEASE}-osx-arm64" \
+            "citrea-cli-${RELEASE}-linux-amd64" \
+            "citrea-cli-${RELEASE}-linux-arm64" \
+            "citrea-cli-${RELEASE}-osx-arm64" \
+            > SHA256SUMS.txt)
+
+          echo "--- CI-generated SHA256SUMS.txt ---"
+          cat artifacts/SHA256SUMS.txt
+          echo "--- Signed manifest ---"
+          cat "manifest/${GITHUB_REF_NAME}.txt"
+
+      - name: Compare CI hashes against signed manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Normalize both files (sort, strip trailing whitespace) and diff.
+          # If maintainers and CI built the same source with the same Nix flake,
+          # every hash must match.
+          sort artifacts/SHA256SUMS.txt > /tmp/ci.txt
+          sort "manifest/${GITHUB_REF_NAME}.txt" > /tmp/signed.txt
+
+          if ! diff -u /tmp/signed.txt /tmp/ci.txt; then
+            echo ""
+            echo "CRITICAL: CI build does not match pre-signed manifest."
+            echo "Either the source diverged, the build is non-reproducible,"
+            echo "or someone tampered with the signing or build step."
+            exit 1
+          fi
+
+          echo "All six binaries match the pre-signed manifest."
+
+      - name: Expose SHA256SUMS hash for downstream jobs
+        id: expose
+        shell: bash
+        run: |
+          set -euo pipefail
+          H=$(sha256sum artifacts/SHA256SUMS.txt | awk '{print $1}')
+          echo "sha256sums_hash=$H" >> "$GITHUB_OUTPUT"
+
+      - name: Upload verified bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: verified-bundle-${{ github.ref_name }}
+          path: artifacts/
+
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            artifacts/citrea-${{ github.ref_name }}-linux-amd64
+            artifacts/citrea-${{ github.ref_name }}-linux-arm64
+            artifacts/citrea-${{ github.ref_name }}-osx-arm64
+            artifacts/citrea-cli-${{ github.ref_name }}-linux-amd64
+            artifacts/citrea-cli-${{ github.ref_name }}-linux-arm64
+            artifacts/citrea-cli-${{ github.ref_name }}-osx-arm64
+
+
+  package:
+    needs: verify-against-manifest
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download verified bundle
         uses: actions/download-artifact@v4
         with:
-          name: citrea-${{ github.ref_name }}-osx-arm64
-          path: release
+          name: verified-bundle-${{ github.ref_name }}
+          path: artifacts
 
-      - name: rename file
+      - name: Re-verify SHA256SUMS integrity
+        env:
+          EXPECTED: ${{ needs.verify-against-manifest.outputs.sha256sums_hash }}
+        shell: bash
         run: |
-          mv release/citrea release/citrea-${{ github.ref_name }}-osx-arm64
+          set -euo pipefail
+          ACTUAL=$(sha256sum artifacts/SHA256SUMS.txt | awk '{print $1}')
+          if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+            echo "CRITICAL: SHA256SUMS.txt tampered between jobs."
+            exit 1
+          fi
+          (cd artifacts && shasum -a 256 -c SHA256SUMS.txt)
 
-      - name: Download citrea-cli linux-amd64 Binary
-        uses: actions/download-artifact@v4
-        with:
-          name: citrea-cli-${{ github.ref_name }}-linux-amd64
-          path: release
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
 
-
-      - name: rename file
+      - name: Sign SHA256SUMS.txt
+        shell: bash
         run: |
-          mv release/citrea-cli release/citrea-cli-${{ github.ref_name }}-linux-amd64
+          set -euo pipefail
+          cosign sign-blob --yes \
+            --bundle artifacts/SHA256SUMS.txt.sigstore.json \
+            artifacts/SHA256SUMS.txt
 
-      - name: Download citrea-cli linux-arm64 Binary
-        uses: actions/download-artifact@v4
-        with:
-          name: citrea-cli-${{ github.ref_name }}-linux-arm64
-          path: release
-
-      - name: rename citrea-cli linux-arm64 file
+      - name: Verify cosign signature
+        shell: bash
+        env:
+          CERTIFICATE_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
         run: |
-          mv release/citrea-cli release/citrea-cli-${{ github.ref_name }}-linux-arm64
+          set -euo pipefail
+          cosign verify-blob artifacts/SHA256SUMS.txt \
+            --bundle artifacts/SHA256SUMS.txt.sigstore.json \
+            --certificate-identity "$CERTIFICATE_IDENTITY" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            --certificate-github-workflow-repository "${{ github.repository }}" \
+            --certificate-github-workflow-ref "${{ github.ref }}" \
+            --certificate-github-workflow-sha "${{ github.sha }}"
 
-      - name: Download citrea-cli osx-arm64 Binary
-        uses: actions/download-artifact@v4
-        with:
-          name: citrea-cli-${{ github.ref_name }}-osx-arm64
-          path: release
-
-      - name: rename file
-        run: |
-          mv release/citrea-cli release/citrea-cli-${{ github.ref_name }}-osx-arm64
-
-      - name: Prepare Release Assets & Checksums
-        run: |
-          cd release
-          sha256sum * > SHA256SUMS
-          echo "Hash file created."
-
-      - name: Calculate Binary Hashes for Docker Job
-        id: binary_hashes
-        run: |
-          AMD64=$(sha256sum release/citrea-${{ github.ref_name }}-linux-amd64 | awk '{print $1}')
-          ARM64=$(sha256sum release/citrea-${{ github.ref_name }}-linux-arm64 | awk '{print $1}')
-          echo "amd64=$AMD64" >> "$GITHUB_OUTPUT"
-          echo "arm64=$ARM64" >> "$GITHUB_OUTPUT"
-          echo "Calculated output hashes for Docker job."
-
-      - name: Hash the SHA256SUMS file for cross-job integrity
-        id: hash_sums
-        run: |
-          HASH=$(sha256sum release/SHA256SUMS | awk '{print $1}')
-          echo "sha256sums_hash=$HASH" >> "$GITHUB_OUTPUT"
-          echo "SHA256SUMS integrity hash: $HASH"
-
-      - name: Create Draft Release
-        id: create_release
+      - name: Attach to release
         uses: softprops/action-gh-release@v2
         with:
-          draft: true
-          files: release/*
           name: Release ${{ github.ref_name }}
           body: |
-            ## GPG Verification Required
-            This release is in DRAFT mode. Signatures are required for `SHA256SUMS`.
-            
-            **Action required:**
-            1. Download `SHA256SUMS`
-            2. Sign it: `gpg --armor --detach-sign SHA256SUMS`
-            3. Rename to `SHA256SUMS.<your-name>.sig`
-            4. Upload to this release.
+            Release ${{ github.ref_name }}.
 
-            It includes:
+            Verified pre-signed manifest from authorized maintainers (≥2 GPG signatures),
+            built reproducibly with Nix, and signed with cosign.
+
+            Binaries:
             - citrea-${{ github.ref_name }}-linux-amd64
             - citrea-${{ github.ref_name }}-linux-arm64
             - citrea-${{ github.ref_name }}-osx-arm64
             - citrea-cli-${{ github.ref_name }}-linux-amd64
             - citrea-cli-${{ github.ref_name }}-linux-arm64
             - citrea-cli-${{ github.ref_name }}-osx-arm64
+            - SHA256SUMS.txt
+            - SHA256SUMS.txt.sigstore.json
+          files: |
+            artifacts/SHA256SUMS.txt
+            artifacts/SHA256SUMS.txt.sigstore.json
+            artifacts/citrea-${{ github.ref_name }}-linux-amd64
+            artifacts/citrea-${{ github.ref_name }}-linux-arm64
+            artifacts/citrea-${{ github.ref_name }}-osx-arm64
+            artifacts/citrea-cli-${{ github.ref_name }}-linux-amd64
+            artifacts/citrea-cli-${{ github.ref_name }}-linux-arm64
+            artifacts/citrea-cli-${{ github.ref_name }}-osx-arm64
 
-  verify-and-publish:
-    needs: [ create-draft-release ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    environment: 'protected-release'
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Download and verify SHA256SUMS integrity
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          EXPECTED_HASH: ${{ needs.create-draft-release.outputs.sha256sums_hash }}
-        run: |
-          gh release download "$TAG" -p "SHA256SUMS*"
-
-          ACTUAL_HASH=$(sha256sum SHA256SUMS | awk '{print $1}')
-          if [[ "$ACTUAL_HASH" != "$EXPECTED_HASH" ]]; then
-            echo "CRITICAL: SHA256SUMS was tampered with between jobs!"
-            echo "Expected: $EXPECTED_HASH"
-            echo "Got:      $ACTUAL_HASH"
-            exit 1
-          fi
-          echo "SHA256SUMS integrity verified."
-
-      - name: Check Authorized Signatures
-        env:
-          REQUIRED_SIGS: 2
-          AUTHORIZED_KEYS: >-
-            7F52EC9A995025E87F3AF1200C17966C01E52A9A
-            CFF759A7C0EF99813BD1E6EE85CCAD8803F887A0
-
-        run: |
-          if [ -z "$AUTHORIZED_KEYS" ]; then
-            echo "CRITICAL: No authorized keys configured."
-            exit 1
-          fi
-
-          KEY_COUNT=$(echo $AUTHORIZED_KEYS | wc -w)
-          echo "Loaded $KEY_COUNT authorized key(s)."
-
-          if [ "$KEY_COUNT" -lt "$REQUIRED_SIGS" ]; then
-            echo "CRITICAL: Only $KEY_COUNT key(s) configured but $REQUIRED_SIGS signature(s) required."
-            exit 1
-          fi
-
-          MAX_RETRIES=3
-          for i in $(seq 1 $MAX_RETRIES); do
-            if gpg --keyserver keyserver.ubuntu.com --recv-keys $AUTHORIZED_KEYS; then
-              echo "Keys imported successfully."
-              break
-            fi
-            echo "Keyserver attempt $i/$MAX_RETRIES failed."
-            if [ "$i" -eq "$MAX_RETRIES" ]; then
-              echo "CRITICAL: Could not import GPG keys after $MAX_RETRIES attempts."
-              exit 1
-            fi
-            sleep 5
-          done
-
-          VALID_AUTH_COUNT=0
-          declare -A SEEN_KEYS
-          
-          for sig in *.sig; do
-            [ -e "$sig" ] || continue
-            echo "--- Analyzing: $sig ---"
-            
-            SIG_STATUS=$(gpg --status-fd 1 --verify "$sig" SHA256SUMS 2>/dev/null)
-            
-            if echo "$SIG_STATUS" | grep -q "VALIDSIG"; then
-              CURRENT_SIG_FPR=$(echo "$SIG_STATUS" | grep "VALIDSIG" | awk '{print $3}')
-              PRIMARY_FPR=$(gpg --with-colons --list-keys "$CURRENT_SIG_FPR" | awk -F: '$1=="fpr"{print $10; exit}')
-              
-              echo "Signature by subkey: $CURRENT_SIG_FPR"
-              echo "Belongs to primary: $PRIMARY_FPR"
-
-              AUTHORIZED=false
-              for AUTH_FPR in $AUTHORIZED_KEYS; do
-                if [[ "$PRIMARY_FPR" == "$AUTH_FPR" ]]; then
-                  AUTHORIZED=true
-                  break
-                fi
-              done
-
-              if $AUTHORIZED; then
-                if [[ -z "${SEEN_KEYS[$PRIMARY_FPR]}" ]]; then
-                  echo "Verified: $PRIMARY_FPR"
-                  VALID_AUTH_COUNT=$((VALID_AUTH_COUNT + 1))
-                  SEEN_KEYS[$PRIMARY_FPR]=1
-                else
-                  echo "Duplicate from $PRIMARY_FPR ignored."
-                fi
-              else
-                echo "Unauthorized key: $PRIMARY_FPR"
-              fi
-            else
-              echo "Invalid signature: $sig"
-            fi
-          done
-          
-          echo "---------------------------------------"
-          echo "Total authorized signers confirmed: $VALID_AUTH_COUNT"
-          
-          if [ "$VALID_AUTH_COUNT" -lt "$REQUIRED_SIGS" ]; then
-            echo "Security failure: Need $REQUIRED_SIGS signatures, found $VALID_AUTH_COUNT."
-            exit 1
-          fi
-
-          echo "VALID_AUTH_COUNT=$VALID_AUTH_COUNT" >> "$GITHUB_ENV"
-
-      - name: Publish Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release edit ${{ github.ref_name }} \
-            --draft=false \
-            --title "Release ${{ github.ref_name }} - Verified" \
-            --notes "This release has been cryptographically verified by ${{ env.VALID_AUTH_COUNT }} authorized maintainer(s)."
 
   update-dockerhub:
+    needs: package
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    needs: [ create-draft-release, verify-and-publish ]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Download binaries and verify integrity
-        env:
-          EXPECTED_AMD: ${{ needs.create-draft-release.outputs.amd64_hash }}
-          EXPECTED_ARM: ${{ needs.create-draft-release.outputs.arm64_hash }}
+      - name: Download verified bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: verified-bundle-${{ github.ref_name }}
+          path: artifacts
+
+      - name: Verify binaries against signed SHA256SUMS
+        shell: bash
         run: |
-          sudo apt update && sudo apt -y install wget
+          set -euo pipefail
+          (cd artifacts && shasum -a 256 -c SHA256SUMS.txt)
+
+      - name: Prepare Docker context
+        shell: bash
+        run: |
+          set -euo pipefail
           RELEASE="${{ github.ref_name }}"
-          BASE_URL="https://github.com/chainwayxyz/citrea/releases/download/${RELEASE}"
-
-          wget -O docker/full-node/citrea-amd64 "${BASE_URL}/citrea-${RELEASE}-linux-amd64"
-          wget -O docker/full-node/citrea-arm64 "${BASE_URL}/citrea-${RELEASE}-linux-arm64"
-
-          # Verify AMD64
-          ACTUAL_AMD=$(sha256sum docker/full-node/citrea-amd64 | awk '{print $1}')
-          if [[ "$ACTUAL_AMD" != "$EXPECTED_AMD" ]]; then
-            echo "CRITICAL: AMD64 Binary hash mismatch!"
-            echo "Expected: $EXPECTED_AMD"
-            echo "Got:      $ACTUAL_AMD"
-            exit 1
-          fi
-
-          # Verify ARM64
-          ACTUAL_ARM=$(sha256sum docker/full-node/citrea-arm64 | awk '{print $1}')
-          if [[ "$ACTUAL_ARM" != "$EXPECTED_ARM" ]]; then
-            echo "CRITICAL: ARM64 Binary hash mismatch!"
-            echo "Expected: $EXPECTED_ARM"
-            echo "Got:      $ACTUAL_ARM"
-            exit 1
-          fi
-
-          echo "Binaries integrity verified securely via internal outputs."
+          cp "artifacts/citrea-${RELEASE}-linux-amd64" docker/full-node/citrea-amd64
+          cp "artifacts/citrea-${RELEASE}-linux-arm64" docker/full-node/citrea-arm64
+          chmod +x docker/full-node/citrea-amd64 docker/full-node/citrea-arm64
 
           mkdir -p docker/full-node/genesis
           cp -r resources/genesis/mainnet docker/full-node/genesis/
           cp -r resources/genesis/testnet docker/full-node/genesis/
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push multi-arch image
+        id: build
         uses: docker/build-push-action@v5
         env:
           DOCKERHUB_REPOSITORY: citrea-full-node
@@ -413,6 +454,31 @@ jobs:
           tags: |
             ${{ vars.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPOSITORY }}:latest
             ${{ vars.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPOSITORY }}:${{ github.ref_name }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+
+      - name: Sign Docker image
+        shell: bash
+        env:
+          IMAGE_REF: ${{ vars.DOCKERHUB_USERNAME }}/citrea-full-node@${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${IMAGE_REF}"
+
+      - name: Verify signed Docker image
+        shell: bash
+        env:
+          IMAGE_REF: ${{ vars.DOCKERHUB_USERNAME }}/citrea-full-node@${{ steps.build.outputs.digest }}
+          CERTIFICATE_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
+        run: |
+          set -euo pipefail
+          cosign verify "${IMAGE_REF}" \
+            --certificate-identity "$CERTIFICATE_IDENTITY" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            --certificate-github-workflow-repository "${{ github.repository }}" \
+            --certificate-github-workflow-ref "${{ github.ref }}" \
+            --certificate-github-workflow-sha "${{ github.sha }}"
 
       - name: Verify pushed manifest
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,150 +1,30 @@
 name: Release
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:
       - "v*.*.*"
-    branches:
-      - feat/repr-build
 
 jobs:
-  verify-manifest:
+  create-draft-release:
     runs-on: ubicloud-standard-2
-    if: startsWith(github.ref, 'refs/tags/')
-    outputs:
-      manifest_sha256: ${{ steps.hash.outputs.manifest_sha256 }}
-    env:
-      REQUIRED_SIGS: 3
-      AUTHORIZED_KEYS: >-
-        7F52EC9A995025E87F3AF1200C17966C01E52A9A
-        CFF759A7C0EF99813BD1E6EE85CCAD8803F887A0
-        350B725CBA2D7EC3A1AD048C00980777D2839E81
+    environment: release-signing
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Locate manifest and signatures
-        id: locate
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
-          MANIFEST="release-manifests/${TAG}.txt"
-
-          if [[ ! -f "$MANIFEST" ]]; then
-            echo "CRITICAL: manifest $MANIFEST not found at this tag."
-            echo "Maintainers must commit release-manifests/${TAG}.txt"
-            echo "and at least ${REQUIRED_SIGS} detached signatures before tagging."
-            exit 1
-          fi
-
-          SIG_COUNT=$(find release-manifests -maxdepth 1 -type f \
-            -name "${TAG}.txt.*.sig" | wc -l)
-          if [[ "$SIG_COUNT" -lt "$REQUIRED_SIGS" ]]; then
-            echo "CRITICAL: found only $SIG_COUNT signature(s), need $REQUIRED_SIGS."
-            exit 1
-          fi
-
-          echo "manifest=$MANIFEST" >> "$GITHUB_OUTPUT"
-          echo "Found manifest with $SIG_COUNT signature file(s)."
-          cat "$MANIFEST"
-
-      - name: Import authorized GPG keys
-        shell: bash
-        run: |
-          set -euo pipefail
-          MAX_RETRIES=3
-          for i in $(seq 1 $MAX_RETRIES); do
-            if gpg --keyserver keyserver.ubuntu.com --recv-keys $AUTHORIZED_KEYS; then
-              echo "Keys imported."
-              break
-            fi
-            echo "Keyserver attempt $i/$MAX_RETRIES failed."
-            if [[ "$i" -eq "$MAX_RETRIES" ]]; then
-              echo "CRITICAL: could not import GPG keys."
-              exit 1
-            fi
-            sleep 5
-          done
-
-      - name: Verify signatures
-        shell: bash
-        env:
-          MANIFEST: ${{ steps.locate.outputs.manifest }}
-        run: |
-          set -euo pipefail
-
-          VALID_AUTH_COUNT=0
-          declare -A SEEN_KEYS
-
-          for sig in release-manifests/${GITHUB_REF_NAME}.txt.*.sig; do
-            [[ -e "$sig" ]] || continue
-            echo "--- Verifying: $sig ---"
-
-            SIG_STATUS=$(gpg --status-fd 1 --verify "$sig" "$MANIFEST" 2>/dev/null || true)
-
-            if ! echo "$SIG_STATUS" | grep -q "VALIDSIG"; then
-              echo "Invalid signature: $sig"
-              continue
-            fi
-
-            CURRENT_FPR=$(echo "$SIG_STATUS" | grep "VALIDSIG" | awk '{print $3}')
-            PRIMARY_FPR=$(gpg --with-colons --list-keys "$CURRENT_FPR" \
-              | awk -F: '$1=="fpr"{print $10; exit}')
-
-            echo "  signed by subkey:  $CURRENT_FPR"
-            echo "  primary key:       $PRIMARY_FPR"
-
-            AUTHORIZED=false
-            for AUTH_FPR in $AUTHORIZED_KEYS; do
-              if [[ "$PRIMARY_FPR" == "$AUTH_FPR" ]]; then
-                AUTHORIZED=true
-                break
-              fi
-            done
-
-            if ! $AUTHORIZED; then
-              echo "  unauthorized key, skipping."
-              continue
-            fi
-
-            if [[ -n "${SEEN_KEYS[$PRIMARY_FPR]:-}" ]]; then
-              echo "  duplicate signer, skipping."
-              continue
-            fi
-
-            SEEN_KEYS[$PRIMARY_FPR]=1
-            VALID_AUTH_COUNT=$((VALID_AUTH_COUNT + 1))
-            echo "  accepted."
-          done
-
-          echo "---"
-          echo "Distinct authorized signers: $VALID_AUTH_COUNT (need $REQUIRED_SIGS)"
-          if [[ "$VALID_AUTH_COUNT" -lt "$REQUIRED_SIGS" ]]; then
-            echo "CRITICAL: insufficient authorized signatures."
-            exit 1
-          fi
-
-      - name: Hash manifest for downstream integrity
-        id: hash
-        shell: bash
-        env:
-          MANIFEST: ${{ steps.locate.outputs.manifest }}
-        run: |
-          set -euo pipefail
-          H=$(sha256sum "$MANIFEST" | awk '{print $1}')
-          echo "manifest_sha256=$H" >> "$GITHUB_OUTPUT"
-          echo "Manifest SHA-256: $H"
-
-      - name: Upload manifest as artifact
-        uses: actions/upload-artifact@v4
+      - name: Create Draft Release
+        uses: softprops/action-gh-release@v2
         with:
-          name: signed-manifest-${{ github.ref_name }}
-          path: release-manifests/${{ github.ref_name }}.txt
+          draft: true
+          name: Release ${{ github.ref_name }}
 
-  build:
-    needs: verify-manifest
-    if: startsWith(github.ref, 'refs/tags/')
+  build-and-publish:
+    needs: create-draft-release
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -155,16 +35,9 @@ jobs:
             runner: ubicloud-standard-30-arm
           - platform: osx-arm64
             runner: macos-latest
-
-    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
-      - name: Compute release tag
-        id: vars
-        shell: bash
-        run: echo "release_tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -174,248 +47,216 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
+      - name: Download signatures from draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          mkdir -p sigs
+          gh release download "$TAG" \
+            -p "citrea-${TAG}-${PLATFORM}.ekrem.asc" \
+            -p "citrea-${TAG}-${PLATFORM}.esad.asc" \
+            -p "citrea-${TAG}-${PLATFORM}.emre.asc" \
+            -D sigs/
+
+          COUNT=$(ls sigs/*.asc 2>/dev/null | wc -l)
+          if [[ "$COUNT" -ne 3 ]]; then
+            echo "FAIL: Expected 3 signatures for ${PLATFORM}, found ${COUNT}."
+            exit 1
+          fi
+
+      - name: Merge signatures
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          cat sigs/citrea-${TAG}-${PLATFORM}.ekrem.asc \
+              sigs/citrea-${TAG}-${PLATFORM}.esad.asc \
+              sigs/citrea-${TAG}-${PLATFORM}.emre.asc \
+              > "citrea-${TAG}-${PLATFORM}.signatures.asc"
+
       - name: Build
-        run: nix build ./nix
+        run: nix build ./nix#citrea
 
       - name: Rebuild to verify reproducibility
-        run: nix build ./nix
+        run: nix build ./nix#citrea --rebuild
+
+      - name: Import authorized GPG keys
+        run: |
+          set -euo pipefail
+          AUTHORIZED_KEYS=(
+            "7F52EC9A995025E87F3AF1200C17966C01E52A9A"
+            "CFF759A7C0EF99813BD1E6EE85CCAD8803F887A0"
+            "350B725CBA2D7EC3A1AD048C00980777D2839E81"
+          )
+          MAX_RETRIES=3
+          for KEY in "${AUTHORIZED_KEYS[@]}"; do
+            for i in $(seq 1 $MAX_RETRIES); do
+              if gpg --keyserver keyserver.ubuntu.com --recv-keys "$KEY"; then
+                break
+              fi
+              if [[ "$i" -eq "$MAX_RETRIES" ]]; then
+                echo "FAIL: Could not import key $KEY"
+                exit 1
+              fi
+              sleep 5
+            done
+          done
+
+      - name: Verify merged signatures against binary
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          AUTHORIZED_KEYS=(
+            "7F52EC9A995025E87F3AF1200C17966C01E52A9A"
+            "CFF759A7C0EF99813BD1E6EE85CCAD8803F887A0"
+            "350B725CBA2D7EC3A1AD048C00980777D2839E81"
+          )
+
+          MERGED="citrea-${TAG}-${PLATFORM}.signatures.asc"
+          BINARY="./result/bin/citrea"
+
+          SIG_STATUS=$(gpg --status-fd 1 --verify "$MERGED" "$BINARY" 2>/dev/null)
+          echo "$SIG_STATUS"
+
+          if echo "$SIG_STATUS" | grep -q "BADSIG"; then
+            echo "FAIL: BAD signature detected — binary mismatch or tampering."
+            exit 1
+          fi
+
+          VALID_COUNT=0
+          declare -A SEEN_KEYS
+
+          while IFS= read -r line; do
+            if echo "$line" | grep -q "VALIDSIG"; then
+              SUBKEY_FPR=$(echo "$line" | awk '{print $3}')
+              PRIMARY_FPR=$(gpg --with-colons --list-keys "$SUBKEY_FPR" 2>/dev/null | awk -F: '$1=="fpr"{print $10; exit}')
+
+              AUTHORIZED=false
+              for AUTH_FPR in "${AUTHORIZED_KEYS[@]}"; do
+                if [[ "$PRIMARY_FPR" == "$AUTH_FPR" ]]; then
+                  AUTHORIZED=true
+                  break
+                fi
+              done
+
+              if ! $AUTHORIZED; then
+                echo "FAIL: Unauthorized key signed the binary: $PRIMARY_FPR"
+                exit 1
+              fi
+
+              if [[ -z "${SEEN_KEYS[$PRIMARY_FPR]+x}" ]]; then
+                VALID_COUNT=$((VALID_COUNT + 1))
+                SEEN_KEYS[$PRIMARY_FPR]=1
+                echo "✓ $PRIMARY_FPR"
+              else
+                echo "Duplicate from $PRIMARY_FPR — ignored."
+              fi
+            fi
+          done <<< "$SIG_STATUS"
+
+          echo "-----------------------------------"
+          echo "Authorized signatures verified: $VALID_COUNT / 3"
+
+          if [[ "$VALID_COUNT" -ne 3 ]]; then
+            echo "FAIL: All 3 authorized signers required. Got $VALID_COUNT."
+            exit 1
+          fi
+
+          echo "All signatures verified for ${PLATFORM}."
 
       - name: Collect artifacts
-        shell: bash
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          cp ./result/bin/citrea     "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-${{ matrix.platform }}"
-          cp ./result/bin/citrea-cli "artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-${{ matrix.platform }}"
-
-      - name: Hash binaries (job summary)
-        shell: bash
-        run: |
-          set -euo pipefail
-          CITREA_HASH=$(shasum -a 256 "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-${{ matrix.platform }}" | awk '{print $1}')
-          CLI_HASH=$(shasum -a 256 "artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-${{ matrix.platform }}" | awk '{print $1}')
-          {
-            echo "## ${{ matrix.platform }}"
-            echo ""
-            echo "| Binary | SHA-256 |"
-            echo "|--------|---------|"
-            echo "| citrea | \`$CITREA_HASH\` |"
-            echo "| citrea-cli | \`$CLI_HASH\` |"
-          } >> "$GITHUB_STEP_SUMMARY"
+          cp ./result/bin/citrea     "artifacts/citrea-${TAG}-${PLATFORM}"
+          cp ./result/bin/citrea-cli "artifacts/citrea-cli-${TAG}-${PLATFORM}"
+          cp "citrea-${TAG}-${PLATFORM}.signatures.asc" artifacts/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-build-${{ matrix.platform }}-${{ steps.vars.outputs.release_tag }}
+          name: release-build-${{ matrix.platform }}-${{ github.ref_name }}
           path: artifacts/
 
-  verify-against-manifest:
-    needs: [verify-manifest, build]
-    if: startsWith(github.ref, 'refs/tags/')
+  package-and-publish:
+    needs: build-and-publish
     runs-on: ubicloud-standard-2
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-    outputs:
-      sha256sums_hash: ${{ steps.expose.outputs.sha256sums_hash }}
     steps:
-      - name: Download all build artifacts
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: release-build-*-${{ github.ref_name }}
           path: artifacts
           merge-multiple: true
 
-      - name: Download signed manifest
-        uses: actions/download-artifact@v4
-        with:
-          name: signed-manifest-${{ github.ref_name }}
-          path: manifest
-
-      - name: Re-verify manifest integrity
-        env:
-          EXPECTED: ${{ needs.verify-manifest.outputs.manifest_sha256 }}
-        shell: bash
+      - name: Generate SHA256SUMS
         run: |
           set -euo pipefail
-          ACTUAL=$(sha256sum "manifest/${GITHUB_REF_NAME}.txt" | awk '{print $1}')
-          if [[ "$ACTUAL" != "$EXPECTED" ]]; then
-            echo "CRITICAL: manifest tampered between jobs."
-            echo "Expected: $EXPECTED"
-            echo "Got:      $ACTUAL"
-            exit 1
-          fi
-          echo "Manifest integrity OK."
-
-      - name: Generate SHA256SUMS.txt from CI build
-        shell: bash
-        run: |
-          set -euo pipefail
-          RELEASE="${GITHUB_REF_NAME}"
-          (cd artifacts && shasum -a 256 \
-            "citrea-${RELEASE}-linux-amd64" \
-            "citrea-${RELEASE}-linux-arm64" \
-            "citrea-${RELEASE}-osx-arm64" \
-            "citrea-cli-${RELEASE}-linux-amd64" \
-            "citrea-cli-${RELEASE}-linux-arm64" \
-            "citrea-cli-${RELEASE}-osx-arm64" \
+          TAG="${{ github.ref_name }}"
+          (cd artifacts && sha256sum \
+            "citrea-${TAG}-linux-amd64" \
+            "citrea-${TAG}-linux-arm64" \
+            "citrea-${TAG}-osx-arm64" \
+            "citrea-cli-${TAG}-linux-amd64" \
+            "citrea-cli-${TAG}-linux-arm64" \
+            "citrea-cli-${TAG}-osx-arm64" \
             > SHA256SUMS.txt)
 
-          echo "--- CI-generated SHA256SUMS.txt ---"
-          cat artifacts/SHA256SUMS.txt
-          echo "--- Signed manifest ---"
-          cat "manifest/${GITHUB_REF_NAME}.txt"
-
-      - name: Compare CI hashes against signed manifest
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          sort artifacts/SHA256SUMS.txt > /tmp/ci.txt
-          sort "manifest/${GITHUB_REF_NAME}.txt" > /tmp/signed.txt
-
-          if ! diff -u /tmp/signed.txt /tmp/ci.txt; then
-            echo ""
-            echo "CRITICAL: CI build does not match pre-signed manifest."
-            echo "Either the source diverged, the build is non-reproducible,"
-            echo "or someone tampered with the signing or build step."
-            exit 1
-          fi
-
-          echo "All six binaries match the pre-signed manifest."
-
-      - name: Expose SHA256SUMS hash for downstream jobs
-        id: expose
-        shell: bash
-        run: |
-          set -euo pipefail
-          H=$(sha256sum artifacts/SHA256SUMS.txt | awk '{print $1}')
-          echo "sha256sums_hash=$H" >> "$GITHUB_OUTPUT"
-
-      - name: Upload verified bundle
-        uses: actions/upload-artifact@v4
-        with:
-          name: verified-bundle-${{ github.ref_name }}
-          path: artifacts/
-
-      - name: Attest build provenance
-        uses: actions/attest@v4
-        with:
-          subject-path: |
-            artifacts/citrea-${{ github.ref_name }}-linux-amd64
-            artifacts/citrea-${{ github.ref_name }}-linux-arm64
-            artifacts/citrea-${{ github.ref_name }}-osx-arm64
-            artifacts/citrea-cli-${{ github.ref_name }}-linux-amd64
-            artifacts/citrea-cli-${{ github.ref_name }}-linux-arm64
-            artifacts/citrea-cli-${{ github.ref_name }}-osx-arm64
-
-  package:
-    needs: verify-against-manifest
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubicloud-standard-2
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - name: Download verified bundle
-        uses: actions/download-artifact@v4
-        with:
-          name: verified-bundle-${{ github.ref_name }}
-          path: artifacts
-
-      - name: Re-verify SHA256SUMS integrity
-        env:
-          EXPECTED: ${{ needs.verify-against-manifest.outputs.sha256sums_hash }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          ACTUAL=$(sha256sum artifacts/SHA256SUMS.txt | awk '{print $1}')
-          if [[ "$ACTUAL" != "$EXPECTED" ]]; then
-            echo "CRITICAL: SHA256SUMS.txt tampered between jobs."
-            exit 1
-          fi
-          (cd artifacts && shasum -a 256 -c SHA256SUMS.txt)
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22
-
-      - name: Sign SHA256SUMS.txt
-        shell: bash
-        run: |
-          set -euo pipefail
-          cosign sign-blob --yes \
-            --bundle artifacts/SHA256SUMS.txt.sigstore.json \
-            artifacts/SHA256SUMS.txt
-
-      - name: Verify cosign signature
-        shell: bash
-        env:
-          CERTIFICATE_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
-        run: |
-          set -euo pipefail
-          cosign verify-blob artifacts/SHA256SUMS.txt \
-            --bundle artifacts/SHA256SUMS.txt.sigstore.json \
-            --certificate-identity "$CERTIFICATE_IDENTITY" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            --certificate-github-workflow-repository "${{ github.repository }}" \
-            --certificate-github-workflow-ref "${{ github.ref }}" \
-            --certificate-github-workflow-sha "${{ github.sha }}"
-
-      - name: Attach to release
+      - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          name: Release ${{ github.ref_name }}
+          draft: false
+          name: Release ${{ github.ref_name }} — Verified
           body: |
-            Release ${{ github.ref_name }}.
+            This release has been cryptographically verified.
+            All 3 authorized maintainers independently built and signed each binary via reproducible builds.
 
-            Verified pre-signed manifest from authorized maintainers (≥2 GPG signatures),
-            built reproducibly with Nix, and signed with cosign.
-
-            Binaries:
+            Includes:
             - citrea-${{ github.ref_name }}-linux-amd64
             - citrea-${{ github.ref_name }}-linux-arm64
             - citrea-${{ github.ref_name }}-osx-arm64
             - citrea-cli-${{ github.ref_name }}-linux-amd64
             - citrea-cli-${{ github.ref_name }}-linux-arm64
             - citrea-cli-${{ github.ref_name }}-osx-arm64
+            - Per-platform merged `.signatures.asc` files
             - SHA256SUMS.txt
-            - SHA256SUMS.txt.sigstore.json
           files: |
-            artifacts/SHA256SUMS.txt
-            artifacts/SHA256SUMS.txt.sigstore.json
             artifacts/citrea-${{ github.ref_name }}-linux-amd64
             artifacts/citrea-${{ github.ref_name }}-linux-arm64
             artifacts/citrea-${{ github.ref_name }}-osx-arm64
             artifacts/citrea-cli-${{ github.ref_name }}-linux-amd64
             artifacts/citrea-cli-${{ github.ref_name }}-linux-arm64
             artifacts/citrea-cli-${{ github.ref_name }}-osx-arm64
+            artifacts/citrea-${{ github.ref_name }}-linux-amd64.signatures.asc
+            artifacts/citrea-${{ github.ref_name }}-linux-arm64.signatures.asc
+            artifacts/citrea-${{ github.ref_name }}-osx-arm64.signatures.asc
+            artifacts/SHA256SUMS.txt
 
   update-dockerhub:
-    needs: package
-    if: startsWith(github.ref, 'refs/tags/')
+    needs: package-and-publish
     runs-on: ubicloud-standard-2
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Download verified bundle
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: verified-bundle-${{ github.ref_name }}
+          pattern: release-build-*-${{ github.ref_name }}
           path: artifacts
-
-      - name: Verify binaries against signed SHA256SUMS
-        shell: bash
-        run: |
-          set -euo pipefail
-          (cd artifacts && shasum -a 256 -c SHA256SUMS.txt)
+          merge-multiple: true
 
       - name: Prepare Docker context
-        shell: bash
         run: |
           set -euo pipefail
           RELEASE="${{ github.ref_name }}"
@@ -453,31 +294,6 @@ jobs:
           tags: |
             ${{ vars.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPOSITORY }}:latest
             ${{ vars.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPOSITORY }}:${{ github.ref_name }}
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22
-
-      - name: Sign Docker image
-        shell: bash
-        env:
-          IMAGE_REF: ${{ vars.DOCKERHUB_USERNAME }}/citrea-full-node@${{ steps.build.outputs.digest }}
-        run: |
-          set -euo pipefail
-          cosign sign --yes "${IMAGE_REF}"
-
-      - name: Verify signed Docker image
-        shell: bash
-        env:
-          IMAGE_REF: ${{ vars.DOCKERHUB_USERNAME }}/citrea-full-node@${{ steps.build.outputs.digest }}
-          CERTIFICATE_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
-        run: |
-          set -euo pipefail
-          cosign verify "${IMAGE_REF}" \
-            --certificate-identity "$CERTIFICATE_IDENTITY" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            --certificate-github-workflow-repository "${{ github.repository }}" \
-            --certificate-github-workflow-ref "${{ github.ref }}" \
-            --certificate-github-workflow-sha "${{ github.sha }}"
 
       - name: Verify pushed manifest
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
 
-permissions:
-  contents: write
-
 on:
   push:
     tags:
@@ -12,6 +9,8 @@ jobs:
   create-draft-release:
     runs-on: ubicloud-standard-2
     environment: release-signing
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -191,6 +190,8 @@ jobs:
   package-and-publish:
     needs: build-and-publish
     runs-on: ubicloud-standard-2
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
# Description
This PR introduces a GPG signature verification feature to our release workflow (`release.yaml`) to enhance supply chain security. 

Key changes:
- Splits the original release process into `create-draft-release` and `verify-and-publish` jobs.
- Automatically generates a `SHA256SUMS` file and creates a draft release, waiting for maintainers to upload a GPG `.sig` file.
- Added @eyusufatik  and @ekrembal  GPG fingerprints hardcoded into the workflow as the authorized keys.
- Cryptographically verifies the uploaded signatures against these authorized keys before publishing the final release.
- Adds a strict integrity check to the `update-dockerhub` job to verify downloaded binaries against the signed `SHA256SUMS` file before building the multi-arch Docker images.

## Testing
- Triggered the modified GitHub Actions workflow to ensure the initial build jobs succeed.
- Verified that the workflow correctly stops at the draft release stage.
- Manually signed the `SHA256SUMS` file, uploaded the `.sig` artifact, and confirmed that the `verify-and-publish` job validates the signature and successfully publishes the release.
- Confirmed the Docker build job correctly verifies the binary hashes against the signed checksums before pushing the image.