### PR TITLE
fix: move START_WAIT sleep before process wait

### DIFF
--- a/devops/dockers/citrea/entrypoint.sh
+++ b/devops/dockers/citrea/entrypoint.sh
@@ -49,5 +49,5 @@ fi
 
 ./citrea --da-layer "$DA_LAYER" --genesis-paths "$GENESIS_PATH" "${SERVICE_FLAG[@]}" --network "$NETWORK" &
 MAIN_PROCESS_PID=$!
-wait "$MAIN_PROCESS_PID"
 sleep "$START_WAIT"
+wait "$MAIN_PROCESS_PID"


### PR DESCRIPTION
sleep $START_WAIT was executed after wait, meaning it only ran after the main process had already exited. Moved it immediately after launch so it correctly serves as a startup grace period.