### PR TITLE
chore: Bump boundless-market to v1.0.1 and unpin ubuntu ci

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,7 +63,7 @@ env:
   RUSTFLAGS: -D warnings
   FOUNDRY_PROFILE: ci
   BITCOIN_DOCKER_IMAGE: "bitcoin/bitcoin:30.0"
-  RUST_CACHE_PREFIX: v1-rust-ubuntu-2204
+  RUST_CACHE_PREFIX: v2-rust
 
 # Automatically cancels a job if a new commit if pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>
@@ -76,7 +76,7 @@ concurrency:
 jobs:
   build:
     name: build
-    runs-on: ubicloud-standard-30-ubuntu-2204
+    runs-on: ubicloud-standard-30
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
@@ -101,9 +101,9 @@ jobs:
       - name: Cache riscv-guest
         uses: ubicloud/cache@v4
         with:
-          key: build-guests-v1-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          key: build-guests-v2-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           path: ${{ github.workspace }}/target/riscv-guest
-          restore-keys: build-guests-v1-${{ runner.os }}-
+          restore-keys: build-guests-v2-${{ runner.os }}-
 
       - name: Build citrea
         run: make build
@@ -118,7 +118,7 @@ jobs:
 
   check:
     name: check
-    runs-on: ubicloud-standard-4-ubuntu-2204
+    runs-on: ubicloud-standard-4
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
@@ -144,7 +144,7 @@ jobs:
 
   udeps:
     name: udeps
-    runs-on: ubicloud-standard-8-ubuntu-2204
+    runs-on: ubicloud-standard-8
     timeout-minutes: 60
     if: github.event.pull_request.draft == false
     steps:
@@ -202,7 +202,7 @@ jobs:
   coverage:
     needs:
       - docker-setup
-    runs-on: ubicloud-standard-30-ubuntu-2204
+    runs-on: ubicloud-standard-30
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.88.0
@@ -240,9 +240,9 @@ jobs:
       - name: Cache riscv-guest
         uses: ubicloud/cache@v4
         with:
-          key: coverage-guests-v1-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          key: coverage-guests-v2-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           path: ${{ github.workspace }}/target/llvm-cov-target/riscv-guest
-          restore-keys: coverage-guests-v1-${{ runner.os }}-
+          restore-keys: coverage-guests-v2-${{ runner.os }}-
 
       - name: Run coverage
         run: make coverage
@@ -380,7 +380,7 @@ jobs:
     needs:
       - docker-setup
     name: nextest
-    runs-on: ubicloud-standard-30-ubuntu-2204
+    runs-on: ubicloud-standard-30
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
@@ -417,9 +417,9 @@ jobs:
       - name: Cache riscv-guest
         uses: ubicloud/cache@v4
         with:
-          key: build-guests-v1-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          key: build-guests-v2-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           path: ${{ github.workspace }}/target/riscv-guest
-          restore-keys: build-guests-v1-${{ runner.os }}-
+          restore-keys: build-guests-v2-${{ runner.os }}-
 
       - name: Run nextest
         run: make test
@@ -548,7 +548,7 @@ jobs:
 
   proving-stats:
     name: Proving stats
-    runs-on: ubicloud-standard-2-ubuntu-2204
+    runs-on: ubicloud-standard-2
     needs: [build, docker-setup]
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'guest-code')
     steps:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -9,7 +9,7 @@ env:
   TARGET_PCT: 3
   COMPARISON_FILE: comparison_results.log
   USE_DOCKER: "true"
-  RUST_CACHE_PREFIX: v1-rust-ubuntu-2204
+  RUST_CACHE_PREFIX: v2-rust
 
 jobs:
   performance-comparison:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   linux_amd64_binary_extraction:
-    runs-on: ubicloud-standard-30-ubuntu-2204
+    runs-on: ubicloud-standard-30
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -42,7 +42,7 @@ jobs:
           path: target/release/citrea-cli
 
   linux_arm64_binary_extraction:
-    runs-on: ubicloud-standard-30-arm-ubuntu-2204
+    runs-on: ubicloud-standard-30-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - perf: Mine reveal prefix relying on `sign_schnorr` internal randomness.([#3192](https://github.com/chainwayxyz/citrea/pull/3192))
+- fix: use deterministic boundless patch and unpin ubuntu ci.([#3216](https://github.com/chainwayxyz/citrea/pull/3216))
 
 ## [v2.3.1](2026-03-31)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "boundless-market"
 version = "1.0.0"
-source = "git+https://github.com/chainwayxyz/boundless?branch=v1.0.0-deterministic-build#005352d0afd8db93f6b674175fdd678ae7d887a5"
+source = "git+https://github.com/chainwayxyz/boundless?rev=005352d#005352d0afd8db93f6b674175fdd678ae7d887a5"
 dependencies = [
  "alloy 1.0.9",
  "alloy-chains 0.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,8 +3140,7 @@ dependencies = [
 [[package]]
 name = "boundless-market"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e939949e2749b619d344203780648f4d85433a623199adc314807ad11bb6338a"
+source = "git+https://github.com/jfldde/boundless?branch=v1.0.0-deterministic-build#4ab00226ffd2325a86a194b61ac6634ad58889cb"
 dependencies = [
  "alloy 1.0.9",
  "alloy-chains 0.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,8 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.0.0"
-source = "git+https://github.com/chainwayxyz/boundless?rev=005352d#005352d0afd8db93f6b674175fdd678ae7d887a5"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae22e74e7982fccb92f96068ac984d88d1d3a5e2b32429212457c2d6dab2e85"
 dependencies = [
  "alloy 1.0.9",
  "alloy-chains 0.2.1",
@@ -4440,7 +4441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "boundless-market"
 version = "1.0.0"
-source = "git+https://github.com/jfldde/boundless?branch=v1.0.0-deterministic-build#4ab00226ffd2325a86a194b61ac6634ad58889cb"
+source = "git+https://github.com/chainwayxyz/boundless?branch=v1.0.0-deterministic-build#005352d0afd8db93f6b674175fdd678ae7d887a5"
 dependencies = [
  "alloy 1.0.9",
  "alloy-chains 0.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ url = { version = "2.5.4" }
 
 # Risc0 dependencies
 bonsai-sdk = { version = "1.4.1" }
-boundless-market = { version = "1.0.0", default-features = false }
+boundless-market = { version = "=1.0.1", default-features = false }
 risc0-ethereum-contracts = { version = "3.0.1" }
 risc0-binfmt = "3.0.2"
 risc0-zkvm = { version = "3.0.3", default-features = false }
@@ -178,8 +178,6 @@ bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/ru
 # Use our fork of revm-inspectors to apply fixes after v0.18.1
 # Cannot update to latest as it requires latest revm, which we cannot use yet
 revm-inspectors = { git = "https://github.com/chainwayxyz/revm-inspectors", rev = "574d614ce505d3c0c4534d8b8e62d8acb3fa9651" }
-# Fix build non-determinism in boundless-market
-boundless-market = { git = "https://github.com/chainwayxyz/boundless", rev = "005352d" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/ru
 # Cannot update to latest as it requires latest revm, which we cannot use yet
 revm-inspectors = { git = "https://github.com/chainwayxyz/revm-inspectors", rev = "574d614ce505d3c0c4534d8b8e62d8acb3fa9651" }
 # Fix build non-determinism in boundless-market
-boundless-market = { git = "https://github.com/jfldde/boundless", branch = "v1.0.0-deterministic-build" }
+boundless-market = { git = "https://github.com/chainwayxyz/boundless", branch = "v1.0.0-deterministic-build" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/ru
 # Cannot update to latest as it requires latest revm, which we cannot use yet
 revm-inspectors = { git = "https://github.com/chainwayxyz/revm-inspectors", rev = "574d614ce505d3c0c4534d8b8e62d8acb3fa9651" }
 # Fix build non-determinism in boundless-market
-boundless-market = { git = "https://github.com/chainwayxyz/boundless", branch = "v1.0.0-deterministic-build" }
+boundless-market = { git = "https://github.com/chainwayxyz/boundless", rev = "005352d" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,8 @@ bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/ru
 # Use our fork of revm-inspectors to apply fixes after v0.18.1
 # Cannot update to latest as it requires latest revm, which we cannot use yet
 revm-inspectors = { git = "https://github.com/chainwayxyz/revm-inspectors", rev = "574d614ce505d3c0c4534d8b8e62d8acb3fa9651" }
+# Fix build non-determinism in boundless-market
+boundless-market = { git = "https://github.com/jfldde/boundless", branch = "v1.0.0-deterministic-build" }
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
# Description

- Use boundless-market v1.0.1 for deterministic build
- Removes the need for ubuntu pinning
- Fix boundless-market v1.0.0 build on latest ubuntu version

Boundless PR: https://github.com/boundless-xyz/boundless/pull/1943
Needed by #3214 
Fixes #3211 