### PR TITLE
fix: set timeout on boundless requests

### DIFF
--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -283,6 +283,14 @@ impl BoundlessProver {
 
         let lock_timeout = cmp::max(lock_timeout, MIN_LOCK_TIMEOUT); // at least 200 seconds
 
+        tracing::info!(
+            "Got pricing response, building proof request for job_id={} image_id={} lock_timeout={}s timeout={}s",
+            job_id,
+            image_id,
+            lock_timeout,
+            timeout
+        );
+
         let request = self
             .build_proof_request(
                 receipt_claim.digest(),
@@ -306,6 +314,12 @@ impl BoundlessProver {
                 journal.clone(),
             )
             .await;
+
+        tracing::info!(
+            "Built proof request for job_id={} image_id={}, handing off to send_request",
+            job_id,
+            image_id
+        );
 
         // Start boundless proving session
         let (req_id, request_expiry) = self
@@ -353,7 +367,15 @@ impl BoundlessProver {
     ) -> RequestParams {
         // Note that offer ramp up period must be less than or equal to the lock timeout)
 
+        tracing::info!(
+            "build_proof_request: entered, image_id={} total_cycles_approx={}",
+            image_id,
+            total_cycles_approx
+        );
+
         let provider = self.client.provider().clone();
+
+        tracing::info!("build_proof_request: building offer_layer_config");
 
         let offer_layer_config = OfferLayerConfigBuilder::default()
             .min_price_per_cycle(min_price_per_cycle)
@@ -367,6 +389,11 @@ impl BoundlessProver {
             .expect("Failed to build offer layer config");
 
         let exponential_backoff = ExponentialBackoff::default();
+
+        tracing::info!(
+            "build_proof_request: fetching gas price via provider.get_gas_price() (per-attempt timeout={:?})",
+            GAS_PRICE_RPC_TIMEOUT
+        );
 
         let gas_price = retry_backoff(exponential_backoff, || {
             let p = provider.clone();
@@ -403,6 +430,11 @@ impl BoundlessProver {
             FALLBACK_BASE_GAS_PRICE
         });
 
+        tracing::info!(
+            "build_proof_request: gas_price={} wei, building OfferLayer and Requirements",
+            gas_price
+        );
+
         let offer_layer = OfferLayer::new(provider, offer_layer_config);
 
         let requirements = Requirements::new(Predicate::claim_digest_match(receipt_claim_digest))
@@ -418,6 +450,11 @@ impl BoundlessProver {
             .estimate_gas_cost_upper_bound(&requirements, &dummy_request_id, gas_price)
             .unwrap();
 
+        tracing::info!(
+            "build_proof_request: gas_cost_estimate={}",
+            gas_cost_estimate
+        );
+
         let max_price_cycle = max_price_per_cycle * U256::from(total_cycles_approx);
 
         // https://github.com/boundless-xyz/boundless/blob/eced0f1eab1b0666ac1cd263ce815861a9558925/crates/boundless-market/src/request_builder/offer_layer.rs#L329
@@ -430,7 +467,15 @@ impl BoundlessProver {
         let ts = get_timestamp();
         let bidding_start = ts + bidding_start_delay;
 
-        self.client
+        tracing::info!(
+            "build_proof_request: min_price={} max_price={} bidding_start={}, assembling RequestParams",
+            min_price,
+            max_price,
+            bidding_start
+        );
+
+        let params = self
+            .client
             .new_request()
             .with_image_id(image_id)
             .with_program_url(image_url)
@@ -449,7 +494,11 @@ impl BoundlessProver {
                     .with_ramp_up_start(bidding_start),
             )
             .with_cycles(total_cycles_approx)
-            .with_journal(journal)
+            .with_journal(journal);
+
+        tracing::info!("build_proof_request: finished assembling RequestParams");
+
+        params
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -259,7 +259,7 @@ impl BoundlessProver {
             .await
             {
                 Ok(Ok(res)) => Ok(res),
-                Ok(Err(e)) => Err(backoff::Error::transient(anyhow::Error::from(e))),
+                Ok(Err(e)) => Err(backoff::Error::transient(e)),
                 Err(_elapsed) => {
                     tracing::error!(
                         "pricing_service.get_price timed out after {:?}, retrying...",
@@ -732,7 +732,7 @@ impl BoundlessProver {
                         job_id,
                         e
                     );
-                    Err(backoff::Error::transient(anyhow::Error::from(e)))
+                    Err(backoff::Error::transient(e))
                 }
                 Err(_elapsed) => {
                     tracing::error!(

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -59,6 +59,14 @@ const FALLBACK_BASE_GAS_PRICE: u128 = 1_000_000_000; // 1 gwei
 /// Duration to sleep before retrying a failed proof request in seconds
 const RETRY_RESUBMISSION_DELAY_SECS: Duration = Duration::from_secs(10);
 
+/// Per-attempt timeout for the `get_gas_price` RPC. A silent hang here would otherwise
+/// prevent `backoff` from ever observing an error and retrying.
+const GAS_PRICE_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Per-attempt timeout for the pricing service HTTP call. Same rationale: surface silent
+/// hangs as errors so `backoff` can retry.
+const PRICING_SERVICE_TIMEOUT: Duration = Duration::from_secs(30);
+
 enum ResubmitResult {
     Retry,
     Success,
@@ -244,10 +252,25 @@ impl BoundlessProver {
             bidding_start_delay,
             ..
         } = retry_backoff(exponential_backoff, || async move {
-            self.pricing_service
-                .get_price(total_cycles_approx)
-                .await
-                .map_err(backoff::Error::transient)
+            match tokio::time::timeout(
+                PRICING_SERVICE_TIMEOUT,
+                self.pricing_service.get_price(total_cycles_approx),
+            )
+            .await
+            {
+                Ok(Ok(res)) => Ok(res),
+                Ok(Err(e)) => Err(backoff::Error::transient(anyhow::Error::from(e))),
+                Err(_elapsed) => {
+                    tracing::error!(
+                        "pricing_service.get_price timed out after {:?}, retrying...",
+                        PRICING_SERVICE_TIMEOUT
+                    );
+                    Err(backoff::Error::transient(anyhow::anyhow!(
+                        "pricing_service.get_price timed out after {:?}",
+                        PRICING_SERVICE_TIMEOUT
+                    )))
+                }
+            }
         })
         .await
         .map_err(|e| {
@@ -348,15 +371,25 @@ impl BoundlessProver {
         let gas_price = retry_backoff(exponential_backoff, || {
             let p = provider.clone();
             async move {
-                match p.get_gas_price().await {
-                    Err(e) => {
+                match tokio::time::timeout(GAS_PRICE_RPC_TIMEOUT, p.get_gas_price()).await {
+                    Ok(Ok(price)) => Ok(price),
+                    Ok(Err(e)) => {
                         tracing::error!(
                             "Failed to get gas price from provider, retrying... err={}",
                             e
                         );
-                        Err(backoff::Error::transient(e))
+                        Err(backoff::Error::transient(anyhow::Error::from(e)))
                     }
-                    Ok(price) => Ok(price),
+                    Err(_elapsed) => {
+                        tracing::error!(
+                            "get_gas_price timed out after {:?}, retrying...",
+                            GAS_PRICE_RPC_TIMEOUT
+                        );
+                        Err(backoff::Error::transient(anyhow::anyhow!(
+                            "get_gas_price timed out after {:?}",
+                            GAS_PRICE_RPC_TIMEOUT
+                        )))
+                    }
                 }
             }
         })
@@ -637,16 +670,32 @@ impl BoundlessProver {
         let exponential_backoff = ExponentialBackoff::default();
 
         let price_response = retry_backoff(exponential_backoff, || async move {
-            match self.pricing_service.get_price(total_cycles_approx).await {
-                Err(e) => {
+            match tokio::time::timeout(
+                PRICING_SERVICE_TIMEOUT,
+                self.pricing_service.get_price(total_cycles_approx),
+            )
+            .await
+            {
+                Ok(Ok(res)) => Ok(res),
+                Ok(Err(e)) => {
                     tracing::error!(
                         "Failed to get price from pricing service for job: {}  | err={}",
                         job_id,
                         e
                     );
-                    Err(backoff::Error::transient(e))
+                    Err(backoff::Error::transient(anyhow::Error::from(e)))
                 }
-                Ok(res) => Ok(res),
+                Err(_elapsed) => {
+                    tracing::error!(
+                        "pricing_service.get_price timed out after {:?} for job: {}, retrying...",
+                        PRICING_SERVICE_TIMEOUT,
+                        job_id
+                    );
+                    Err(backoff::Error::transient(anyhow::anyhow!(
+                        "pricing_service.get_price timed out after {:?}",
+                        PRICING_SERVICE_TIMEOUT
+                    )))
+                }
             }
         })
         .await


### PR DESCRIPTION
# Description
After investigating the logs the only place for the boundless service to hang is the thrid party base rpc call for gas price, to prevent possible hang I wrapped the request with a timeout of 10 seconds, and added more logs so we can see better next time.