### PR TITLE
ci: Stricter advisory checks for workspace members

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -63,3 +63,4 @@ ignore = [
   "RUSTSEC-2026-0048", # aws-lc-sys: CRL distribution point scope check (no CRL config in project)
   "RUSTSEC-2026-0049", # rustls-webpki: CRL DP matching logic (no CRL config in project)
 ]
+unsound = "all"


### PR DESCRIPTION
# Description

- Fix `cargo-deny` CI check not catching unsound errors for workspace members

Reference commit: https://github.com/EmbarkStudios/cargo-deny/commit/d12c5383a775aa117c106be1ba87d66fc8a9e598