### PR TITLE
ci: Limit PR title checks to pull_request events

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   validate:
     name: Validate PR Title
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

- Only run on `pull_request` events. It was failing on `issue_comment` creation and edition

## Linked Issues
- Fixes #3178 