### PR TITLE
fix(bitcoin-da): use fee_rate in validate_txs_fee_rate comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - perf: Mine reveal prefix relying on `sign_schnorr` internal randomness.([#3192](https://github.com/chainwayxyz/citrea/pull/3192))
 - fix: use deterministic boundless patch and unpin ubuntu ci.([#3216](https://github.com/chainwayxyz/citrea/pull/3216))
+- fix(bitcoin-da): use `fee_rate` in `validate_txs_fee_rate` fee comparisons. ([#3225](https://github.com/chainwayxyz/citrea/pull/3225))
 
 ## [v2.3.1](2026-03-31)
 

--- a/crates/bitcoin-da/src/fee.rs
+++ b/crates/bitcoin-da/src/fee.rs
@@ -278,7 +278,7 @@ pub(crate) fn validate_txs_fee_rate(
             .sum();
         let output_amount = commit_tx.output.iter().map(|tx| tx.value).sum();
 
-        if (input_amount - output_amount) < Amount::from_sat(commit_tx.vsize() as u64) {
+        if (input_amount - output_amount) < Amount::from_sat((commit_tx.vsize() as f64 * fee_rate).ceil() as u64) {
             return Err(BitcoinServiceError::FeeCalculation(fee_rate));
         }
 
@@ -295,7 +295,7 @@ pub(crate) fn validate_txs_fee_rate(
         // Add reveal utxo to utxo_map, used by chunking txs
         utxo_map.insert((tx.reveal_txid(), 0), output_amount);
 
-        if (input_amount - output_amount) < Amount::from_sat(reveal_tx.vsize() as u64) {
+        if (input_amount - output_amount) < Amount::from_sat((reveal_tx.vsize() as f64 * fee_rate).ceil() as u64) {
             return Err(BitcoinServiceError::FeeCalculation(fee_rate));
         }
     }


### PR DESCRIPTION
## Summary

`validate_txs_fee_rate` receives a `fee_rate` parameter (in sat/vB) but the two fee-sufficiency checks compare `(input_amount - output_amount)` against just `Amount::from_sat(tx.vsize() as u64)`, which implicitly assumes 1 sat/vB regardless of the configured fee rate.

## Bug

```rust
// Before – always validates against 1 sat/vB:
if (input_amount - output_amount) < Amount::from_sat(commit_tx.vsize() as u64) {
    return Err(BitcoinServiceError::FeeCalculation(fee_rate));
}
```

If the system is operating at, say, 5 sat/vB, this check still passes a transaction that only carries a 1 sat/vB fee, so `FeeCalculation` errors are never surfaced for under-paying transactions at the actual fee rate.

## Fix

Multiply `vsize` by `fee_rate` (rounded up) in both the commit-tx and reveal-tx checks:

```rust
// After – validates against the actual fee rate:
if (input_amount - output_amount) < Amount::from_sat((commit_tx.vsize() as f64 * fee_rate).ceil() as u64) {
    return Err(BitcoinServiceError::FeeCalculation(fee_rate));
}
```

## Files changed
- `crates/bitcoin-da/src/fee.rs`