### PR TITLE
fix(bitcoin-da): return MempoolSpaceRequestError on HTTP failure in get_fee_rate_from_mempool_space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - perf: Mine reveal prefix relying on `sign_schnorr` internal randomness.([#3192](https://github.com/chainwayxyz/citrea/pull/3192))
 - fix: use deterministic boundless patch and unpin ubuntu ci.([#3216](https://github.com/chainwayxyz/citrea/pull/3216))
+- fix(bitcoin-da): return correct error variant on mempool.space HTTP request failure. ([#3226](https://github.com/chainwayxyz/citrea/pull/3226))
 
 ## [v2.3.1](2026-03-31)
 

--- a/crates/bitcoin-da/src/fee.rs
+++ b/crates/bitcoin-da/src/fee.rs
@@ -231,7 +231,7 @@ pub(crate) async fn get_fee_rate_from_mempool_space(mempool_space_url: &str) -> 
         .await
         .map_err(|e| {
             trace!("Failed to fetch from {}: {:?}", url, e);
-            FeeServiceError::MempoolSpaceParseError
+            FeeServiceError::MempoolSpaceRequestError(e)
         })?;
 
     let json = response.json::<serde_json::Value>().await.map_err(|e| {


### PR DESCRIPTION
## Summary

`get_fee_rate_from_mempool_space` maps a network-level `reqwest::Error` (timeout, connection refused, DNS failure, etc.) to `FeeServiceError::MempoolSpaceParseError` instead of `FeeServiceError::MempoolSpaceRequestError`.

## Bug

```rust
let response = get_with_timeout(url.clone(), MEMPOOL_SPACE_TIMEOUT)
    .await
    .map_err(|e| {
        trace!("Failed to fetch from {}: {:?}", url, e);
        FeeServiceError::MempoolSpaceParseError   // ← wrong variant
    })?;
```

`MempoolSpaceParseError` is intended for JSON deserialization failures. Using it here:
1. Misleads callers and log readers who see a "parse error" for what is really a connectivity issue.
2. Wastes the existing `#[from] reqwest::Error` impl on `MempoolSpaceRequestError`, which was added precisely for this case.

## Fix

Use the correct variant so the two failure modes are distinguishable:

```rust
.map_err(|e| {
    trace!("Failed to fetch from {}: {:?}", url, e);
    FeeServiceError::MempoolSpaceRequestError(e)  // ← correct
})?;
```

## Files changed
- `crates/bitcoin-da/src/fee.rs`