### PR TITLE
fix(bitcoin-da): correct doc comment on INITIAL_TESTNET4_STATE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - perf: Mine reveal prefix relying on `sign_schnorr` internal randomness.([#3192](https://github.com/chainwayxyz/citrea/pull/3192))
 - fix: use deterministic boundless patch and unpin ubuntu ci.([#3216](https://github.com/chainwayxyz/citrea/pull/3216))
+- fix(bitcoin-da): correct doc comment on `INITIAL_TESTNET4_STATE`. ([#3227](https://github.com/chainwayxyz/citrea/pull/3227))
 
 ## [v2.3.1](2026-03-31)
 

--- a/crates/bitcoin-da/src/network_constants.rs
+++ b/crates/bitcoin-da/src/network_constants.rs
@@ -77,7 +77,7 @@ pub const INITIAL_MAINNET_STATE: LatestDaState = LatestDaState {
     ],
 };
 
-/// Initial regtest state.
+/// Initial testnet4 state.
 pub const INITIAL_TESTNET4_STATE: LatestDaState = LatestDaState {
     block_hash: [
         177, 30, 245, 240, 148, 228, 201, 10, 169, 117, 171, 23, 153, 213, 126, 0, 82, 34, 206,


### PR DESCRIPTION
## Summary

Small but confusing copy-paste error in `network_constants.rs`: the doc comment on `INITIAL_TESTNET4_STATE` reads **"Initial regtest state."** instead of **"Initial testnet4 state."**

## Bug

```rust
/// Initial regtest state.   // ← wrong network name
pub const INITIAL_TESTNET4_STATE: LatestDaState = LatestDaState { ... };
```

The three constants that follow the same pattern are:
- `INITIAL_MAINNET_STATE` – correctly documented
- `INITIAL_TESTNET4_STATE` – says "regtest" (bug)
- `INITIAL_SIGNET_STATE` – correctly documented

## Fix

```rust
/// Initial testnet4 state.   // ← corrected
pub const INITIAL_TESTNET4_STATE: LatestDaState = LatestDaState { ... };
```

## Files changed
- `crates/bitcoin-da/src/network_constants.rs`