### PR TITLE
fix(batch-prover): guard against empty commitments slice in PartitionState::new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - perf: Mine reveal prefix relying on `sign_schnorr` internal randomness.([#3192](https://github.com/chainwayxyz/citrea/pull/3192))
 - fix: use deterministic boundless patch and unpin ubuntu ci.([#3216](https://github.com/chainwayxyz/citrea/pull/3216))
+- fix(batch-prover): guard against empty commitments slice in `PartitionState::new`. ([#3228](https://github.com/chainwayxyz/citrea/pull/3228))
 
 ## [v2.3.1](2026-03-31)
 

--- a/crates/batch-prover/src/partition.rs
+++ b/crates/batch-prover/src/partition.rs
@@ -67,6 +67,7 @@ impl<'a> PartitionState<'a> {
         commitments: &'a [SequencerCommitment],
         ledger_db: impl BatchProverLedgerOps,
     ) -> anyhow::Result<Self> {
+        anyhow::ensure!(!commitments.is_empty(), "commitments slice must not be empty");
         let start_l2_height = if commitments[0].index == 1 {
             // If this is the first commitment ever, start from 1
             get_tangerine_activation_height_non_zero()


### PR DESCRIPTION
## Summary

`PartitionState::new` indexes `commitments[0]` unconditionally on the very first line of the function body. If an empty slice is ever passed (e.g. through a future call site or a test), the process panics with an index-out-of-bounds error rather than returning a descriptive `Err`.

## Bug

```rust
pub fn new(
    commitments: &'a [SequencerCommitment],
    ledger_db: impl BatchProverLedgerOps,
) -> anyhow::Result<Self> {
    // panics if commitments is empty ↓
    let start_l2_height = if commitments[0].index == 1 {
```

There is no compile-time guarantee (e.g. `NonEmpty`) nor any runtime check that `commitments` is non-empty before this access.

## Fix

Add an `anyhow::ensure!` at the top of the constructor so the invariant is enforced explicitly and the caller receives a clean `Err` instead of a panic:

```rust
pub fn new(
    commitments: &'a [SequencerCommitment],
    ledger_db: impl BatchProverLedgerOps,
) -> anyhow::Result<Self> {
    anyhow::ensure!(!commitments.is_empty(), "commitments slice must not be empty");
    let start_l2_height = if commitments[0].index == 1 {
```

## Files changed
- `crates/batch-prover/src/partition.rs`