### PR TITLE
fix(bitcoin-da): replace debug_assert with anyhow::ensure for sequencer commitment body size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - perf: Mine reveal prefix relying on `sign_schnorr` internal randomness.([#3192](https://github.com/chainwayxyz/citrea/pull/3192))
 - fix: use deterministic boundless patch and unpin ubuntu ci.([#3216](https://github.com/chainwayxyz/citrea/pull/3216))
+- fix(bitcoin-da): replace `debug_assert!` with `anyhow::ensure!` for sequencer commitment body size. ([#3229](https://github.com/chainwayxyz/citrea/pull/3229))
 
 ## [v2.3.1](2026-03-31)
 

--- a/crates/bitcoin-da/src/helpers/builders/body_builders.rs
+++ b/crates/bitcoin-da/src/helpers/builders/body_builders.rs
@@ -780,7 +780,7 @@ pub fn create_inscription_type_4(
     network: Network,
     reveal_tx_prefix: &[u8],
 ) -> Result<DaTxs, anyhow::Error> {
-    debug_assert!(
+    anyhow::ensure!(
         body.len() < 520,
         "The body of a serialized sequencer commitment exceeds 520 bytes"
     );


### PR DESCRIPTION
## Summary

`create_inscription_type_4` uses `debug_assert!` to enforce the 520-byte limit on serialized sequencer commitment bodies. `debug_assert!` is compiled away in release builds, which means the check is silently inactive in production.

## Bug

```rust
// Only active in debug builds – stripped in release:
debug_assert!(
    body.len() < 520,
    "The body of a serialized sequencer commitment exceeds 520 bytes"
);
```

If a commitment body exceeds 520 bytes in a release build, the code proceeds to:

```rust
.push_slice(PushBytesBuf::try_from(body).expect("Cannot push sequencer commitment"))
```

`PushBytesBuf::try_from` returns `Err` for slices > 520 bytes, so `.expect(...)` **panics** the process. The caller never receives a proper `Err`.

## Fix

Replace `debug_assert!` with `anyhow::ensure!` so the guard is always active and a clean `Err` is returned instead of panicking:

```rust
anyhow::ensure!(
    body.len() < 520,
    "The body of a serialized sequencer commitment exceeds 520 bytes"
);
```

## Files changed
- `crates/bitcoin-da/src/helpers/builders/body_builders.rs`