### PR TITLE
fix(bitcoin-da): replace zip_eq with explicit length check to prevent panic on mismatched completeness_proof

### DIFF
--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -1,7 +1,6 @@
 //! This module provides the Bitcoin DA verifier implementation.
 
 use crypto_bigint::{Encoding, U256};
-use itertools::Itertools;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, DaVerifier, LatestDaState};
 use sov_rollup_interface::Network;
 
@@ -105,11 +104,15 @@ impl DaVerifier for BitcoinVerifier {
         // Optimistically assume all txs in the completeness proof are verifiable
         let mut blobs = Vec::with_capacity(completeness_proof.len());
 
-        let relevant_wtxid_iter = inclusion_proof
+        let relevant_wtxids: Vec<_> = inclusion_proof
             .wtxids
             .iter()
-            .filter(|wtxid| wtxid.starts_with(prefix));
-        for (wtxid, tx) in relevant_wtxid_iter.zip_eq(&completeness_proof) {
+            .filter(|wtxid| wtxid.starts_with(prefix))
+            .collect();
+        if relevant_wtxids.len() != completeness_proof.len() {
+            return Err(ValidationError::RelevantTxNotInProof);
+        }
+        for (wtxid, tx) in relevant_wtxids.into_iter().zip(&completeness_proof) {
             // ensure completeness proof tx matches the inclusion tx
             if &calculate_wtxid(tx) != wtxid {
                 return Err(ValidationError::RelevantTxNotInProof);


### PR DESCRIPTION
## Summary

`verify_transactions` in `BitcoinVerifier` uses `itertools::zip_eq` to pair relevant wtxids with the `completeness_proof` entries. `zip_eq` **panics** if the two iterators have different lengths. A malicious or buggy peer that submits a `completeness_proof` with a mismatched entry count can therefore **crash the verifier process** (Denial of Service) instead of receiving a clean `ValidationError`.

## Bug

```rust
let relevant_wtxid_iter = inclusion_proof
    .wtxids
    .iter()
    .filter(|wtxid| wtxid.starts_with(prefix));
for (wtxid, tx) in relevant_wtxid_iter.zip_eq(&completeness_proof) {
    // panics here if lengths differ ↑
```

The existing guard only checks `wtxids.len() == tx_count`, **not** that `completeness_proof.len() == filtered_wtxid_count`. Any input where those two values diverge causes an unrecoverable panic.

## Impact

- An attacker can craft a `completeness_proof` with one extra or one fewer entry than the number of wtxids matching the reveal prefix.
- The verifier panics instead of returning `Err(ValidationError::RelevantTxNotInProof)`.
- This terminates the node process — a clear Denial-of-Service vector.

## Fix

Collect the filtered wtxids first, check the length against `completeness_proof.len()`, then zip normally:

```rust
let relevant_wtxids: Vec<_> = inclusion_proof
    .wtxids
    .iter()
    .filter(|wtxid| wtxid.starts_with(prefix))
    .collect();
if relevant_wtxids.len() != completeness_proof.len() {
    return Err(ValidationError::RelevantTxNotInProof);
}
for (wtxid, tx) in relevant_wtxids.into_iter().zip(&completeness_proof) {
```

The `itertools::Itertools` import is also removed since `zip_eq` was its only use.

## Files changed
- `crates/bitcoin-da/src/verifier.rs`