### PR TITLE
fix(bitcoin-da): report computed witness commitment hash as actual value in WrongTxCommitment error

### DIFF
--- a/crates/bitcoin-da/src/spec/short_proof.rs
+++ b/crates/bitcoin-da/src/spec/short_proof.rs
@@ -110,7 +110,7 @@ impl VerifiableShortHeaderProof for BitcoinHeaderShortProof {
                         expected: script_pubkey[6..38]
                             .try_into()
                             .expect("Must have hash in witness commitment output"),
-                        actual: Into::<[u8; 32]>::into(self.header.txs_commitment()),
+                        actual: commitment,
                     });
                 }
             }


### PR DESCRIPTION
## Summary

In `BitcoinHeaderShortProof::verify`, the segwit witness commitment check computes `commitment = SHA256d(txs_commitment || witness_nonce)` and compares it to `script_pubkey[6..38]`. When they do not match, the `WrongTxCommitment` error is returned with an incorrect `actual` field: it reports the raw `txs_commitment` (wtxid merkle root) instead of the computed `commitment` hash that was actually compared.

## Bug

```rust
let commitment = calculate_double_sha256(&vec_merkle); // SHA256d(root || nonce)

if script_pubkey[6..38] != commitment {
    return Err(ShortHeaderProofVerificationError::WrongTxCommitment {
        expected: script_pubkey[6..38].try_into()...,
        actual: Into::<[u8; 32]>::into(self.header.txs_commitment()), // ← wrong!
    });
}
```

The `actual` field should be `commitment` — the value that was directly compared — not the raw `txs_commitment` input. The two are different: `commitment` is derived from `txs_commitment` via double-SHA256, so reporting `txs_commitment` as `actual` gives the caller completely wrong data about why verification failed.

## Impact

- Any code consuming `WrongTxCommitment` (automated checks, circuit logic, debugging tools) receives incorrect cryptographic data.
- Debugging a mismatched witness commitment becomes impossible because the reported `actual` is not the value that failed comparison.
- The error can mislead automated checks into believing a different commitment was produced than what was actually computed.

## Fix

```rust
if script_pubkey[6..38] != commitment {
    return Err(ShortHeaderProofVerificationError::WrongTxCommitment {
        expected: script_pubkey[6..38].try_into()...,
        actual: commitment, // ← correct: the value that was actually compared
    });
}
```

## Files changed
- `crates/bitcoin-da/src/spec/short_proof.rs`