### PR TITLE
fix(bitcoin-da): avoid holding write lock across async RPC calls in handle_evicted

### DIFF
--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -790,7 +790,11 @@ impl MonitoringService {
             let txs = self.monitored_txs.read().await;
             txs.iter()
                 .filter_map(|(txid, monitored_tx)| {
-                    if let TxStatus::Evicted { rebroadcast_attempts, .. } = &monitored_tx.status {
+                    if let TxStatus::Evicted {
+                        rebroadcast_attempts,
+                        ..
+                    } = &monitored_tx.status
+                    {
                         if *rebroadcast_attempts < self.config.max_rebroadcast_attempts {
                             return Some((*txid, monitored_tx.status.clone()));
                         }
@@ -804,7 +808,11 @@ impl MonitoringService {
         let mut outcomes: Vec<(Txid, TxStatus)> = Vec::with_capacity(candidates.len());
         for (txid, status) in &candidates {
             let now = get_timestamp();
-            let attempts = if let TxStatus::Evicted { rebroadcast_attempts, .. } = status {
+            let attempts = if let TxStatus::Evicted {
+                rebroadcast_attempts,
+                ..
+            } = status
+            {
                 *rebroadcast_attempts
             } else {
                 0

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -783,35 +783,59 @@ impl MonitoringService {
     }
 
     async fn handle_evicted(&self) -> Result<()> {
-        let mut txs = self.monitored_txs.write().await;
-
-        for (txid, monitored_tx) in txs.iter_mut() {
-            if let TxStatus::Evicted {
-                rebroadcast_attempts,
-                ..
-            } = &monitored_tx.status
-            {
-                if *rebroadcast_attempts < self.config.max_rebroadcast_attempts {
-                    let now = get_timestamp();
-
-                    match self.attempt_rebroadcast(txid, &monitored_tx.status).await {
-                        Ok(_) => {
-                            info!("Attempted to rebroadcast tx {txid}");
-                            monitored_tx.status = TxStatus::Evicted {
-                                last_seen: now,
-                                rebroadcast_attempts: rebroadcast_attempts + 1,
-                                last_error: None,
-                            }
-                        }
-                        Err(e) => {
-                            info!("Failed to rebroadcast tx {txid}: {e}");
-                            monitored_tx.status = TxStatus::Evicted {
-                                last_seen: now,
-                                rebroadcast_attempts: rebroadcast_attempts + 1,
-                                last_error: Some(e.to_string()),
-                            };
+        // Collect evicted txids and their current statuses without holding the write lock.
+        // Holding a tokio write lock across async RPC calls blocks all concurrent readers
+        // for the entire duration of the network requests, causing severe starvation.
+        let candidates: Vec<(Txid, TxStatus)> = {
+            let txs = self.monitored_txs.read().await;
+            txs.iter()
+                .filter_map(|(txid, monitored_tx)| {
+                    if let TxStatus::Evicted { rebroadcast_attempts, .. } = &monitored_tx.status {
+                        if *rebroadcast_attempts < self.config.max_rebroadcast_attempts {
+                            return Some((*txid, monitored_tx.status.clone()));
                         }
                     }
+                    None
+                })
+                .collect()
+        };
+
+        // Perform all async rebroadcast attempts without holding any lock.
+        let mut outcomes: Vec<(Txid, TxStatus)> = Vec::with_capacity(candidates.len());
+        for (txid, status) in &candidates {
+            let now = get_timestamp();
+            let attempts = if let TxStatus::Evicted { rebroadcast_attempts, .. } = status {
+                *rebroadcast_attempts
+            } else {
+                0
+            };
+            let new_status = match self.attempt_rebroadcast(txid, status).await {
+                Ok(_) => {
+                    info!("Attempted to rebroadcast tx {txid}");
+                    TxStatus::Evicted {
+                        last_seen: now,
+                        rebroadcast_attempts: attempts + 1,
+                        last_error: None,
+                    }
+                }
+                Err(e) => {
+                    info!("Failed to rebroadcast tx {txid}: {e}");
+                    TxStatus::Evicted {
+                        last_seen: now,
+                        rebroadcast_attempts: attempts + 1,
+                        last_error: Some(e.to_string()),
+                    }
+                }
+            };
+            outcomes.push((*txid, new_status));
+        }
+
+        // Re-acquire the write lock only to flush the status updates — no async work inside.
+        if !outcomes.is_empty() {
+            let mut txs = self.monitored_txs.write().await;
+            for (txid, new_status) in outcomes {
+                if let Some(monitored_tx) = txs.get_mut(&txid) {
+                    monitored_tx.status = new_status;
                 }
             }
         }


### PR DESCRIPTION
## Summary

`MonitoringService::handle_evicted` acquires an exclusive write lock on `monitored_txs` at the top of the function and then calls `self.attempt_rebroadcast(...).await` **inside the lock** for every evicted transaction. `attempt_rebroadcast` issues one or two live Bitcoin RPC calls (`get_transaction`, `send_raw_transaction`) which can be arbitrarily slow (timeouts, slow node, etc.).

Holding a `tokio::sync::RwLock` write guard across an async `.await` point is a well-known Tokio anti-pattern that blocks **all** concurrent readers of `monitored_txs` for the entire duration of the network I/O.

## Bug

```rust
async fn handle_evicted(&self) -> Result<()> {
    let mut txs = self.monitored_txs.write().await; // ← write lock acquired

    for (txid, monitored_tx) in txs.iter_mut() {
        ...
        match self.attempt_rebroadcast(txid, &monitored_tx.status).await { // ← async RPC held inside lock
```

While this lock is held, the following methods are blocked:
- `get_monitored_txs` (called by many consumers)
- `get_tx_status`
- `get_last_tx`
- `get_in_mempool_commit_transaction_ids` (used in UTXO filtering during transaction sends)
- Any concurrent call to `check_transactions`, `update_txs_status`, etc.

With up to 15 rebroadcast attempts × (RPC timeout) per call, this can stall the entire DA service.

## Fix

Split the function into three phases, each with minimal lock scope:

1. **Read phase** — acquire a read lock, snapshot the evicted candidates, release the lock.
2. **Async phase** — perform all RPC rebroadcasts without holding any lock.
3. **Write phase** — re-acquire the write lock only to flush the resulting status updates (no async work inside).

```rust
async fn handle_evicted(&self) -> Result<()> {
    // Phase 1: snapshot under read lock (released immediately)
    let candidates: Vec<(Txid, TxStatus)> = {
        let txs = self.monitored_txs.read().await;
        txs.iter().filter_map(...).collect()
    };

    // Phase 2: async RPC work — no lock held
    let mut outcomes = vec![];
    for (txid, status) in &candidates {
        let new_status = match self.attempt_rebroadcast(txid, status).await { ... };
        outcomes.push((txid, new_status));
    }

    // Phase 3: write lock held only for in-memory updates — no async work
    if !outcomes.is_empty() {
        let mut txs = self.monitored_txs.write().await;
        for (txid, new_status) in outcomes { txs.get_mut(&txid).map(|tx| tx.status = new_status); }
    }
    Ok(())
}
```

## Files changed
- `crates/bitcoin-da/src/monitoring.rs`