### PR TITLE
chore: rename proof session recovery config

### DIFF
--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -594,7 +594,7 @@ async fn parallel_proving_test() -> Result<()> {
 //     fn light_client_prover_config() -> LightClientProverConfig {
 //         LightClientProverConfig {
 //             initial_da_height: 171,
-//             enable_recovery: false,
+//             enable_proof_session_recovery: false,
 //             ..Default::default()
 //         }
 //     }

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -78,14 +78,14 @@ impl TestCase for LightClientProvingTest {
 
     fn batch_prover_config() -> BatchProverConfig {
         BatchProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             ..Default::default()
         }
     }
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             ..Default::default()
         }
     }
@@ -218,7 +218,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
 
     fn batch_prover_config() -> BatchProverConfig {
         BatchProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             proof_sampling_number: 99999999,
             ..Default::default()
         }
@@ -226,7 +226,7 @@ impl TestCase for LightClientProvingTestMultipleProofs {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -553,14 +553,14 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
 
     fn batch_prover_config() -> BatchProverConfig {
         BatchProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             ..Default::default()
         }
     }
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -805,14 +805,14 @@ impl TestCase for LightClientBatchProofMethodIdUpdateSecurityCouncilTest {
 
     fn batch_prover_config() -> BatchProverConfig {
         BatchProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             ..Default::default()
         }
     }
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -1209,7 +1209,7 @@ impl TestCase for LightClientUnverifiableBatchProofTest {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -1469,7 +1469,7 @@ impl TestCase for VerifyChunkedTxsInLightClient {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -1847,7 +1847,7 @@ impl TestCase for UnchainedBatchProofsTest {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 164,
             ..Default::default()
         }
@@ -2112,7 +2112,7 @@ impl TestCase for UnknownL1HashBatchProofTest {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 165,
             ..Default::default()
         }
@@ -2262,7 +2262,7 @@ impl TestCase for ChainProofByCommitmentIndex {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -2478,7 +2478,7 @@ impl TestCase for ProofWithMissingCommitment {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -2627,7 +2627,7 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 164,
             ..Default::default()
         }
@@ -2946,7 +2946,7 @@ impl TestCase for ProofWithWrongPreviousCommitmentHash {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 164,
             ..Default::default()
         }
@@ -3477,7 +3477,7 @@ impl TestCase for UndecompressableBlobTest {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
+            enable_proof_session_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }

--- a/bin/citrea/tests/mock/evm/mod.rs
+++ b/bin/citrea/tests/mock/evm/mod.rs
@@ -1583,7 +1583,7 @@ async fn test_safe_finalized_tags() {
             proving_mode: citrea_common::ProverGuestRunConfig::Execute,
             // Make it impossible for proving to happen
             proof_sampling_number: 1_000_000,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig::from_env().expect("Failed to load Risc0HostConfig"),
         }),

--- a/bin/citrea/tests/mock/mod.rs
+++ b/bin/citrea/tests/mock/mod.rs
@@ -110,7 +110,7 @@ async fn test_all_flow() {
         Some(BatchProverConfig {
             proving_mode: citrea_common::ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig::from_env().expect("Failed to load Risc0HostConfig"),
         }),

--- a/bin/citrea/tests/mock/proving.rs
+++ b/bin/citrea/tests/mock/proving.rs
@@ -74,7 +74,7 @@ async fn full_node_verify_proof_and_store() {
         Some(BatchProverConfig {
             proving_mode: citrea_common::ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig::from_env().expect("Failed to load Risc0HostConfig"),
         }),
@@ -245,7 +245,7 @@ async fn test_batch_prover_prove_rpcs() {
             proving_mode: citrea_common::ProverGuestRunConfig::Execute,
             // Make it impossible for proving to happen
             proof_sampling_number: 1_000_000,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig::from_env().expect("Failed to load Risc0HostConfig"),
         }),

--- a/bin/citrea/tests/mock/rollback.rs
+++ b/bin/citrea/tests/mock/rollback.rs
@@ -144,7 +144,7 @@ async fn start_batch_prover(
         Some(BatchProverConfig {
             proving_mode: citrea_common::ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig::from_env().expect("Failed to load Risc0HostConfig"),
         }),

--- a/crates/batch-prover/src/prover.rs
+++ b/crates/batch-prover/src/prover.rs
@@ -164,7 +164,7 @@ where
     /// * `shutdown_signal` - A signal to gracefully shut down the prover service
     #[instrument(name = "BatchProver", skip_all)]
     pub async fn run(mut self, mut shutdown_signal: GracefulShutdown) {
-        self.recover_proving_sessions(self.prover_config.enable_recovery)
+        self.recover_proving_sessions(self.prover_config.enable_proof_session_recovery)
             .await;
 
         'run_loop: loop {

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -163,7 +163,7 @@ pub struct BatchProverConfig {
     /// Average number of commitments to prove
     pub proof_sampling_number: usize,
     /// If true prover will try to recover ongoing proving sessions
-    pub enable_recovery: bool,
+    pub enable_proof_session_recovery: bool,
     /// Maximum number of commitments per proof partition
     pub max_commitments_per_proof: Option<usize>,
     /// Configuration for Risc0Host
@@ -179,7 +179,7 @@ pub struct LightClientProverConfig {
     /// Average number of commitments to prove
     pub proof_sampling_number: usize,
     /// If true prover will try to recover ongoing proving sessions
-    pub enable_recovery: bool,
+    pub enable_proof_session_recovery: bool,
     /// The starting DA block to sync from
     pub initial_da_height: u64,
     /// Configuration for Risc0Host
@@ -192,7 +192,7 @@ impl Default for BatchProverConfig {
         Self {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Default::default(),
         }
@@ -204,7 +204,7 @@ impl Default for LightClientProverConfig {
         Self {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             initial_da_height: 1,
             risc0_host: Default::default(),
         }
@@ -216,7 +216,7 @@ impl FromEnv for BatchProverConfig {
         Ok(BatchProverConfig {
             proving_mode: serde_json::from_str(&format!("\"{}\"", read_env("PROVING_MODE")?))?,
             proof_sampling_number: read_env("PROOF_SAMPLING_NUMBER")?.parse()?,
-            enable_recovery: read_env("ENABLE_RECOVERY")?.parse()?,
+            enable_proof_session_recovery: read_env("ENABLE_PROOF_SESSION_RECOVERY")?.parse()?,
             max_commitments_per_proof: read_env("MAX_COMMITMENTS_PER_PROOF")
                 .ok()
                 .and_then(|val| val.parse().ok()),
@@ -230,7 +230,7 @@ impl FromEnv for LightClientProverConfig {
         Ok(LightClientProverConfig {
             proving_mode: serde_json::from_str(&format!("\"{}\"", read_env("PROVING_MODE")?))?,
             proof_sampling_number: read_env("PROOF_SAMPLING_NUMBER")?.parse()?,
-            enable_recovery: read_env("ENABLE_RECOVERY")?.parse()?,
+            enable_proof_session_recovery: read_env("ENABLE_PROOF_SESSION_RECOVERY")?.parse()?,
             initial_da_height: read_env("INITIAL_DA_HEIGHT")?.parse()?,
             risc0_host: Risc0HostConfig::from_env()?,
         })
@@ -623,7 +623,7 @@ mod tests {
         let config = r#"
             proving_mode = "skip"
             proof_sampling_number = 500
-            enable_recovery = true
+            enable_proof_session_recovery = true
         "#;
 
         let config_file = create_config_from(config);
@@ -632,7 +632,7 @@ mod tests {
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Skip,
             proof_sampling_number: 500,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Default::default(),
         };
@@ -694,14 +694,14 @@ mod tests {
     fn test_correct_prover_config_from_env() {
         std::env::set_var("PROVING_MODE", "skip");
         std::env::set_var("PROOF_SAMPLING_NUMBER", "500");
-        std::env::set_var("ENABLE_RECOVERY", "true");
+        std::env::set_var("ENABLE_PROOF_SESSION_RECOVERY", "true");
 
         let prover_config = BatchProverConfig::from_env().unwrap();
 
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Skip,
             proof_sampling_number: 500,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Default::default(),
         };
@@ -874,7 +874,7 @@ mod tests {
         let config = r#"
             proving_mode = "execute"
             proof_sampling_number = 42
-            enable_recovery = true
+            enable_proof_session_recovery = true
 
             [risc0_host]
             tx_backup_dir = "/tmp/backup"
@@ -889,7 +889,7 @@ mod tests {
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 42,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig {
                 prover: Risc0ProverConfig::Local(LocalProverConfig {
@@ -906,7 +906,7 @@ mod tests {
         let config = r#"
             proving_mode = "execute"
             proof_sampling_number = 42
-            enable_recovery = true
+            enable_proof_session_recovery = true
 
             [risc0_host.prover.Bonsai]
             api_url = "http://127.0.0.1"
@@ -926,7 +926,7 @@ mod tests {
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 42,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host,
         };
@@ -938,7 +938,7 @@ mod tests {
         let config = r#"
             proving_mode = "execute"
             proof_sampling_number = 42
-            enable_recovery = true
+            enable_proof_session_recovery = true
 
             [risc0_host.prover.Boundless.boundless]
             wallet_private_key = "abcd"
@@ -984,7 +984,7 @@ mod tests {
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 42,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig {
                 prover: Risc0ProverConfig::Boundless(Box::new(boundless_prover_config)),
@@ -999,7 +999,7 @@ mod tests {
         let config = r#"
             proving_mode = "execute"
             proof_sampling_number = 42
-            enable_recovery = true
+            enable_proof_session_recovery = true
 
             [risc0_host.prover.Boundless.boundless]
             wallet_private_key = "abcd"
@@ -1039,7 +1039,7 @@ mod tests {
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 42,
-            enable_recovery: true,
+            enable_proof_session_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig {
                 prover: Risc0ProverConfig::Boundless(Box::new(boundless_prover_config)),

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -132,7 +132,7 @@ where
         last_l1_height_scanned: StartVariant,
         mut shutdown_signal: GracefulShutdown,
     ) {
-        // if self.prover_config.enable_recovery {
+        // if self.prover_config.enable_proof_session_recovery {
         //     if let Err(e) = self.check_and_recover_ongoing_proving_sessions().await {
         //         error!("Failed to recover ongoing proving sessions: {:?}", e);
         //     }

--- a/proving-stats/configs/batch_prover_config.toml
+++ b/proving-stats/configs/batch_prover_config.toml
@@ -1,3 +1,3 @@
 proving_mode = "execute"
 proof_sampling_number = 0
-enable_recovery = true
+enable_proof_session_recovery = true

--- a/resources/configs/bitcoin-regtest/batch_prover_config.toml
+++ b/resources/configs/bitcoin-regtest/batch_prover_config.toml
@@ -1,3 +1,3 @@
 proving_mode = "execute"
 proof_sampling_number = 500
-enable_recovery = true
+enable_proof_session_recovery = true

--- a/resources/configs/bitcoin-regtest/light_client_prover_config.toml
+++ b/resources/configs/bitcoin-regtest/light_client_prover_config.toml
@@ -1,4 +1,4 @@
 initial_da_height = 1
 proving_mode = "execute"
 proof_sampling_number = 500
-enable_recovery = true
+enable_proof_session_recovery = true

--- a/resources/configs/mock/batch_prover_config.toml
+++ b/resources/configs/mock/batch_prover_config.toml
@@ -1,3 +1,3 @@
 proving_mode = "execute"
 proof_sampling_number = 500
-enable_recovery = true
+enable_proof_session_recovery = true

--- a/resources/configs/mock/light_client_prover_config.toml
+++ b/resources/configs/mock/light_client_prover_config.toml
@@ -1,4 +1,4 @@
 initial_da_height = 1
 proving_mode = "execute"
 proof_sampling_number = 500
-enable_recovery = true
+enable_proof_session_recovery = true


### PR DESCRIPTION
## Summary
- rename prover config field from enable_recovery to enable_proof_session_recovery
- rename env var from ENABLE_RECOVERY to ENABLE_PROOF_SESSION_RECOVERY
- update sample configs and tests to use the clearer proof-session-specific name

Closes #2810

## Testing
- ustfmt +stable --check crates/common/src/config/mod.rs crates/batch-prover/src/prover.rs crates/light-client-prover/src/da_block_handler.rs bin/citrea/tests/bitcoin/batch_prover_test.rs bin/citrea/tests/bitcoin/light_client_test.rs bin/citrea/tests/mock/rollback.rs bin/citrea/tests/mock/proving.rs bin/citrea/tests/mock/mod.rs bin/citrea/tests/mock/evm/mod.rs
- git diff --check

Note: full cargo fmt --check could not run from this sparse checkout because Cargo metadata requires workspace members outside the sparse path set.