### PR TITLE
chore: rename SlotNumber to L1BlockNumber

### DIFF
--- a/bin/citrea/tests/mock/rollback.rs
+++ b/bin/citrea/tests/mock/rollback.rs
@@ -22,7 +22,7 @@ use sov_db::schema::tables::{
     CommitmentIndicesByL1, VerifiedBatchProofsBySlotNumber, BATCH_PROVER_LEDGER_TABLES,
     FULL_NODE_LEDGER_TABLES, SEQUENCER_LEDGER_TABLES,
 };
-use sov_db::schema::types::SlotNumber;
+use sov_db::schema::types::L1BlockNumber;
 use sov_db::state_db::StateDB;
 use sov_mock_da::{MockAddress, MockDaService};
 use sov_rollup_interface::rpc::SequencerCommitmentResponse;
@@ -686,11 +686,11 @@ async fn test_batch_prover_rollback() -> Result<(), anyhow::Error> {
         instantiate_dbs(&new_full_node_db_dir, FULL_NODE_LEDGER_TABLES).unwrap();
     let ledger_db = ledger_db.inner();
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(7))
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(7))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(9))
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(9))
         .unwrap()
         .is_some());
 
@@ -780,11 +780,11 @@ async fn test_batch_prover_rollback() -> Result<(), anyhow::Error> {
         instantiate_dbs(&new_full_node_db_dir, FULL_NODE_LEDGER_TABLES).unwrap();
     let fn_ledger_db = fn_ledger_db.inner();
     assert!(fn_ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(9))
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(9))
         .unwrap()
         .is_some());
     assert!(fn_ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(11))
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(11))
         .unwrap()
         .is_none());
 
@@ -793,11 +793,11 @@ async fn test_batch_prover_rollback() -> Result<(), anyhow::Error> {
         instantiate_dbs(&new_batch_prover_db_dir, BATCH_PROVER_LEDGER_TABLES).unwrap();
     let bp_ledger_db = bp_ledger_db.inner();
     assert!(bp_ledger_db
-        .get::<CommitmentIndicesByL1>(&SlotNumber(8))
+        .get::<CommitmentIndicesByL1>(&L1BlockNumber(8))
         .unwrap()
         .is_some());
     assert!(bp_ledger_db
-        .get::<CommitmentIndicesByL1>(&SlotNumber(10))
+        .get::<CommitmentIndicesByL1>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
 

--- a/crates/batch-prover/src/l1_syncer.rs
+++ b/crates/batch-prover/src/l1_syncer.rs
@@ -14,7 +14,7 @@ use citrea_common::utils::shutdown_requested;
 use citrea_common::{RollupPublicKeys, StartVariant};
 use reth_tasks::shutdown::GracefulShutdown;
 use sov_db::ledger_db::BatchProverLedgerOps;
-use sov_db::schema::types::SlotNumber;
+use sov_db::schema::types::L1BlockNumber;
 use sov_modules_api::DaSpec;
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::services::da::{DaService, SlotData};
@@ -211,7 +211,7 @@ where
                             .put_commitment_by_index(commitment)
                             .expect("Should store commitment");
                         self.ledger_db
-                            .put_commitment_index_by_l1(SlotNumber(l1_height), index)
+                            .put_commitment_index_by_l1(L1BlockNumber(l1_height), index)
                             .expect("Should put commitment index by l1");
                         self.ledger_db
                             .put_prover_pending_commitment(index)
@@ -222,7 +222,7 @@ where
 
             // Set last scanned l1 height
             self.ledger_db
-                .set_last_scanned_l1_height(SlotNumber(l1_height))
+                .set_last_scanned_l1_height(L1BlockNumber(l1_height))
                 .expect("Should put prover last scanned l1 height");
 
             BPM.current_l1_block.set(l1_height as f64);

--- a/crates/batch-prover/src/rpc.rs
+++ b/crates/batch-prover/src/rpc.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use sov_db::ledger_db::BatchProverLedgerOps;
 use sov_db::schema::types::batch_proof::StoredBatchProofOutput;
 use sov_db::schema::types::job_status::JobStatus;
-use sov_db::schema::types::{L2BlockNumber, SlotNumber};
+use sov_db::schema::types::{L1BlockNumber, L2BlockNumber};
 use sov_modules_api::{BatchProofCircuitOutputV3, SpecId, Zkvm};
 use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::da::{DaTxRequest, SequencerCommitment};
@@ -369,7 +369,7 @@ where
             // This might cause some duplicate commitment indices appear in l1 -> index table which is ok
             self.context
                 .ledger_db
-                .put_commitment_index_by_l1(SlotNumber(l1_height), commitment.index)
+                .put_commitment_index_by_l1(L1BlockNumber(l1_height), commitment.index)
                 .map_err(internal_rpc_error)?;
             self.context
                 .ledger_db
@@ -709,7 +709,7 @@ where
     async fn get_commitment_indices_by_l1(&self, l1_height: u64) -> RpcResult<Option<Vec<u32>>> {
         self.context
             .ledger_db
-            .get_prover_commitment_indices_by_l1(SlotNumber(l1_height))
+            .get_prover_commitment_indices_by_l1(L1BlockNumber(l1_height))
             .map_err(internal_rpc_error)
     }
 

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -23,7 +23,7 @@ use rs_merkle::algorithms::Sha256;
 use rs_merkle::MerkleTree;
 use sov_db::ledger_db::NodeLedgerOps;
 use sov_db::schema::types::l2_block::StoredL2Block;
-use sov_db::schema::types::{L2BlockNumber, L2HeightAndIndex, L2HeightStatus, SlotNumber};
+use sov_db::schema::types::{L1BlockNumber, L2BlockNumber, L2HeightAndIndex, L2HeightStatus};
 use sov_modules_api::{DaSpec, Zkvm};
 use sov_rollup_interface::da::{BlockHeaderTrait, SequencerCommitment};
 use sov_rollup_interface::services::da::{DaService, SlotData};
@@ -347,7 +347,7 @@ where
         }
 
         self.ledger_db
-            .set_last_scanned_l1_height(SlotNumber(l1_height))
+            .set_last_scanned_l1_height(L1BlockNumber(l1_height))
             .map_err(|e| anyhow!("Could not set last scanned l1 height: {e}"))?;
 
         FM.current_l1_block.set(l1_height as f64);

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -16,7 +16,7 @@ use prover_services::{ParallelProverService, ProofData, ProofWithDuration};
 use reth_tasks::shutdown::GracefulShutdown;
 use sov_db::ledger_db::{LightClientProverLedgerOps, SharedLedgerOps};
 use sov_db::schema::types::light_client_proof::StoredLightClientProofOutput;
-use sov_db::schema::types::SlotNumber;
+use sov_db::schema::types::L1BlockNumber;
 use sov_modules_api::Zkvm;
 use sov_prover_storage_manager::{ProverStorage, ProverStorageManager};
 use sov_rollup_interface::da::BlockHeaderTrait;
@@ -302,7 +302,7 @@ where
         LPM.set_lcp_proving_time(proof_with_duration.duration);
 
         self.ledger_db
-            .set_last_scanned_l1_height(SlotNumber(l1_block.header().height()))
+            .set_last_scanned_l1_height(L1BlockNumber(l1_block.header().height()))
             .expect("Saving last scanned l1 height to ledger db");
 
         LPM.current_l1_block.set(l1_height as f64);

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -870,7 +870,7 @@ where
         // TODO: https://github.com/chainwayxyz/citrea/issues/1992
         // // connect L1 and L2 height
         // self.ledger_db.extend_l2_range_of_l1_slot(
-        //     SlotNumber(da_block.header().height()),
+        //     L1BlockNumber(da_block.header().height()),
         //     L2BlockNumber(l2_height),
         // )?;
 

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -34,8 +34,8 @@ use crate::schema::types::light_client_proof::{
     StoredLightClientProof, StoredLightClientProofOutput,
 };
 use crate::schema::types::{
-    BonsaiSession, BoundlessSession, L2BlockNumber, L2HeightAndIndex, L2HeightRange,
-    L2HeightStatus, SlotNumber,
+    BonsaiSession, BoundlessSession, L1BlockNumber, L2BlockNumber, L2HeightAndIndex, L2HeightRange,
+    L2HeightStatus,
 };
 
 /// Implementation of database migrator
@@ -236,7 +236,7 @@ impl SharedLedgerOps for LedgerDB {
     #[instrument(level = "trace", skip(self), err, ret)]
     fn extend_l2_range_of_l1_slot(
         &self,
-        l1_height: SlotNumber,
+        l1_height: L1BlockNumber,
         l2_height: L2BlockNumber,
     ) -> Result<(), anyhow::Error> {
         let current_range = self.db.get::<L2RangeByL1Height>(&l1_height)?;
@@ -270,7 +270,7 @@ impl SharedLedgerOps for LedgerDB {
     /// Sets l1 height of l1 hash
     #[instrument(level = "trace", skip(self), err, ret)]
     fn set_l1_height_of_l1_hash(&self, hash: [u8; 32], height: u64) -> anyhow::Result<()> {
-        self.db.put::<SlotByHash>(&hash, &SlotNumber(height))
+        self.db.put::<SlotByHash>(&hash, &L1BlockNumber(height))
     }
 
     /// Gets l1 height of l1 hash
@@ -288,7 +288,7 @@ impl SharedLedgerOps for LedgerDB {
         commitment: SequencerCommitment,
     ) -> anyhow::Result<()> {
         // get commitments
-        let commitments = self.db.get::<CommitmentsByNumber>(&SlotNumber(height))?;
+        let commitments = self.db.get::<CommitmentsByNumber>(&L1BlockNumber(height))?;
 
         match commitments {
             // If there were other commitments, upsert
@@ -296,7 +296,7 @@ impl SharedLedgerOps for LedgerDB {
                 if !commitments.contains(&commitment) {
                     commitments.push(commitment);
                     self.db
-                        .put::<CommitmentsByNumber>(&SlotNumber(height), &commitments)
+                        .put::<CommitmentsByNumber>(&L1BlockNumber(height), &commitments)
                 } else {
                     Ok(())
                 }
@@ -304,7 +304,7 @@ impl SharedLedgerOps for LedgerDB {
             // Else insert
             None => self
                 .db
-                .put::<CommitmentsByNumber>(&SlotNumber(height), &vec![commitment]),
+                .put::<CommitmentsByNumber>(&L1BlockNumber(height), &vec![commitment]),
         }
     }
 
@@ -387,14 +387,14 @@ impl SharedLedgerOps for LedgerDB {
 
     /// Get the last scanned slot by the prover
     #[instrument(level = "trace", skip(self), err, ret)]
-    fn get_last_scanned_l1_height(&self) -> anyhow::Result<Option<SlotNumber>> {
+    fn get_last_scanned_l1_height(&self) -> anyhow::Result<Option<L1BlockNumber>> {
         self.db.get::<ProverLastScannedSlot>(&())
     }
 
     /// Set the last scanned slot by the prover
     /// Called by the prover.
     #[instrument(level = "trace", skip(self), err, ret)]
-    fn set_last_scanned_l1_height(&self, l1_height: SlotNumber) -> anyhow::Result<()> {
+    fn set_last_scanned_l1_height(&self, l1_height: L1BlockNumber) -> anyhow::Result<()> {
         self.db.put::<ProverLastScannedSlot>(&(), &l1_height)
     }
 
@@ -476,8 +476,9 @@ impl LightClientProverLedgerOps for LedgerDB {
         };
 
         let mut schema_batch = SchemaBatch::new();
-        schema_batch.put::<LightClientProofBySlotNumber>(&SlotNumber(l1_height), &data_to_store)?;
-        schema_batch.put::<ProvingSessionInfoBySlotNumber>(&SlotNumber(l1_height), &info)?;
+        schema_batch
+            .put::<LightClientProofBySlotNumber>(&L1BlockNumber(l1_height), &data_to_store)?;
+        schema_batch.put::<ProvingSessionInfoBySlotNumber>(&L1BlockNumber(l1_height), &info)?;
 
         self.db.write_schemas(schema_batch)
     }
@@ -487,7 +488,7 @@ impl LightClientProverLedgerOps for LedgerDB {
         l1_height: u64,
     ) -> anyhow::Result<Option<StoredLightClientProof>> {
         self.db
-            .get::<LightClientProofBySlotNumber>(&SlotNumber(l1_height))
+            .get::<LightClientProofBySlotNumber>(&L1BlockNumber(l1_height))
     }
 
     fn get_proving_session_info_by_l1_height(
@@ -495,7 +496,7 @@ impl LightClientProverLedgerOps for LedgerDB {
         l1_height: u64,
     ) -> anyhow::Result<Option<ProvingSessionInfo>> {
         self.db
-            .get::<ProvingSessionInfoBySlotNumber>(&SlotNumber(l1_height))
+            .get::<ProvingSessionInfoBySlotNumber>(&L1BlockNumber(l1_height))
     }
 }
 
@@ -550,7 +551,11 @@ impl BatchProverLedgerOps for LedgerDB {
     }
 
     #[instrument(level = "trace", skip(self), err)]
-    fn put_commitment_index_by_l1(&self, l1_height: SlotNumber, index: u32) -> anyhow::Result<()> {
+    fn put_commitment_index_by_l1(
+        &self,
+        l1_height: L1BlockNumber,
+        index: u32,
+    ) -> anyhow::Result<()> {
         let mut indices = self
             .db
             .get::<CommitmentIndicesByL1>(&l1_height)?
@@ -723,7 +728,7 @@ impl BatchProverLedgerOps for LedgerDB {
     #[instrument(level = "trace", skip(self), err)]
     fn get_prover_commitment_indices_by_l1(
         &self,
-        l1_height: SlotNumber,
+        l1_height: L1BlockNumber,
     ) -> anyhow::Result<Option<Vec<u32>>> {
         self.db.get::<CommitmentIndicesByL1>(&l1_height)
     }
@@ -872,7 +877,7 @@ impl NodeLedgerOps for LedgerDB {
     ) -> anyhow::Result<()> {
         let verified_proofs = self
             .db
-            .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(l1_height))?;
+            .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(l1_height))?;
 
         match verified_proofs {
             Some(mut verified_proofs) => {
@@ -882,12 +887,12 @@ impl NodeLedgerOps for LedgerDB {
                 };
                 verified_proofs.push(stored_verified_proof);
                 self.db.put::<VerifiedBatchProofsBySlotNumber>(
-                    &SlotNumber(l1_height),
+                    &L1BlockNumber(l1_height),
                     &verified_proofs,
                 )
             }
             None => self.db.put(
-                &SlotNumber(l1_height),
+                &L1BlockNumber(l1_height),
                 &vec![StoredVerifiedProof {
                     proof,
                     proof_output,
@@ -902,7 +907,7 @@ impl NodeLedgerOps for LedgerDB {
         &self,
         height: u64,
     ) -> anyhow::Result<Option<Vec<SequencerCommitment>>> {
-        self.db.get::<CommitmentsByNumber>(&SlotNumber(height))
+        self.db.get::<CommitmentsByNumber>(&L1BlockNumber(height))
     }
 
     fn get_highest_l2_height_for_status(

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/rpc.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/rpc.rs
@@ -9,7 +9,7 @@ use crate::schema::tables::{
     CommitmentsByNumber, L2BlockByHash, L2BlockByNumber, SequencerCommitmentByIndex, SlotByHash,
     VerifiedBatchProofsBySlotNumber,
 };
-use crate::schema::types::{L2BlockNumber, SlotNumber};
+use crate::schema::types::{L1BlockNumber, L2BlockNumber};
 
 fn check_if_l2_block_pruned(ledger_db: &LedgerDB, l2_height: u64) -> Result<(), anyhow::Error> {
     let last_pruned_l2_height = ledger_db.get_last_pruned_l2_height()?;
@@ -88,7 +88,7 @@ impl LedgerRpcProvider for LedgerDB {
         &self,
         height: u64,
     ) -> Result<Option<Vec<SequencerCommitmentResponse>>, anyhow::Error> {
-        match self.db.get::<CommitmentsByNumber>(&SlotNumber(height))? {
+        match self.db.get::<CommitmentsByNumber>(&L1BlockNumber(height))? {
             Some(commitments) => Ok(Some(
                 commitments
                     .into_iter()
@@ -112,7 +112,7 @@ impl LedgerRpcProvider for LedgerDB {
     ) -> Result<Option<Vec<VerifiedBatchProofResponse>>, anyhow::Error> {
         match self
             .db
-            .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(height))?
+            .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(height))?
         {
             Some(stored_proofs) => Ok(Some(
                 stored_proofs

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/traits.rs
@@ -18,8 +18,8 @@ use crate::schema::types::light_client_proof::{
     StoredLightClientProof, StoredLightClientProofOutput,
 };
 use crate::schema::types::{
-    BonsaiSession, BoundlessSession, L2BlockNumber, L2HeightAndIndex, L2HeightRange,
-    L2HeightStatus, SlotNumber,
+    BonsaiSession, BoundlessSession, L1BlockNumber, L2BlockNumber, L2HeightAndIndex, L2HeightRange,
+    L2HeightStatus,
 };
 
 /// Shared ledger operations
@@ -41,7 +41,7 @@ pub trait SharedLedgerOps {
     /// Records the L2 height that was created as a l2 block of an L1 height
     fn extend_l2_range_of_l1_slot(
         &self,
-        l1_height: SlotNumber,
+        l1_height: L1BlockNumber,
         l2_height: L2BlockNumber,
     ) -> Result<()>;
 
@@ -88,10 +88,10 @@ pub trait SharedLedgerOps {
     fn get_last_commitment(&self) -> anyhow::Result<Option<SequencerCommitment>>;
 
     /// Get the last scanned slot
-    fn get_last_scanned_l1_height(&self) -> Result<Option<SlotNumber>>;
+    fn get_last_scanned_l1_height(&self) -> Result<Option<L1BlockNumber>>;
 
     /// Set the last scanned slot
-    fn set_last_scanned_l1_height(&self, l1_height: SlotNumber) -> Result<()>;
+    fn set_last_scanned_l1_height(&self, l1_height: L1BlockNumber) -> Result<()>;
 
     /// Get the last pruned block number
     fn get_last_pruned_l2_height(&self) -> Result<Option<u64>>;
@@ -228,7 +228,7 @@ pub trait BatchProverLedgerOps: SharedLedgerOps + Send + Sync {
     fn delete_prover_pending_commitments(&self, indices: Vec<u32>) -> Result<()>;
 
     /// Put commitment indices found in the L1 height
-    fn put_commitment_index_by_l1(&self, l1_height: SlotNumber, index: u32) -> Result<()>;
+    fn put_commitment_index_by_l1(&self, l1_height: L1BlockNumber, index: u32) -> Result<()>;
 
     /// Inserts a new prover job with its corresponding commitment indices, marking job as running
     #[allow(clippy::ptr_arg)]
@@ -280,7 +280,7 @@ pub trait BatchProverLedgerOps: SharedLedgerOps + Send + Sync {
     /// Get commitment indices by l1 height
     fn get_prover_commitment_indices_by_l1(
         &self,
-        l1_height: SlotNumber,
+        l1_height: L1BlockNumber,
     ) -> Result<Option<Vec<u32>>>;
 
     /// Get job status (non-existent job IS RUNNING)

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/tables.rs
@@ -23,8 +23,9 @@ use super::types::batch_proof::{StoredBatchProof, StoredVerifiedProof};
 use super::types::l2_block::StoredL2Block;
 use super::types::light_client_proof::StoredLightClientProof;
 use super::types::{
-    AccessoryKey, AccessoryStateValue, BonsaiSession, BoundlessSession, DbHash, JmtValue, L1Height,
-    L2BlockNumber, L2HeightAndIndex, L2HeightRange, L2HeightStatus, SlotNumber, StateKey,
+    AccessoryKey, AccessoryStateValue, BonsaiSession, BoundlessSession, DbHash, JmtValue,
+    L1BlockNumber, L1Height, L2BlockNumber, L2HeightAndIndex, L2HeightRange, L2HeightStatus,
+    StateKey,
 };
 
 /// A list of all tables used by the StateDB. These tables store rollup state - meaning
@@ -343,12 +344,12 @@ define_table_with_seek_key_codec!(
 
 define_table_with_default_codec!(
     /// A "secondary index" for slot data by hash
-    (SlotByHash) DbHash => SlotNumber
+    (SlotByHash) DbHash => L1BlockNumber
 );
 
 define_table_with_default_codec!(
     /// The primary source for sequencer commitment data
-    (CommitmentsByNumber) SlotNumber => Vec<SequencerCommitment>
+    (CommitmentsByNumber) L1BlockNumber => Vec<SequencerCommitment>
 );
 
 define_table_with_seek_key_codec!(
@@ -363,7 +364,7 @@ define_table_with_seek_key_codec!(
 
 define_table_with_default_codec!(
     /// list of commitment indices by l1 height
-    (CommitmentIndicesByL1) SlotNumber => Vec<u32>
+    (CommitmentIndicesByL1) L1BlockNumber => Vec<u32>
 );
 
 define_table_with_default_codec!(
@@ -418,7 +419,7 @@ define_table_with_default_codec!(
 
 define_table_with_default_codec!(
     /// The primary source of reverse look-up L2 height ranges for L1 heights
-    (L2RangeByL1Height) SlotNumber => L2HeightRange
+    (L2RangeByL1Height) L1BlockNumber => L2HeightRange
 );
 
 define_table_with_default_codec!(
@@ -436,7 +437,7 @@ define_table_with_seek_key_codec!(
     /// Full node also uses this table to store the last slot it scanned
     /// However, we don't rename here to avoid breaking changes on deployed nodes
     /// and prover.
-    (ProverLastScannedSlot) () => SlotNumber
+    (ProverLastScannedSlot) () => L1BlockNumber
 );
 
 define_table_without_codec!(
@@ -506,27 +507,27 @@ impl ValueCodec<StaleNodes> for () {
 
 define_table_with_default_codec!(
     /// Light client proof data by l1 height
-    (LightClientProofBySlotNumber) SlotNumber => StoredLightClientProof
+    (LightClientProofBySlotNumber) L1BlockNumber => StoredLightClientProof
 );
 
 define_table_with_seek_key_codec!(
     /// Proving session information by slot number
-    (ProvingSessionInfoBySlotNumber) SlotNumber => ProvingSessionInfo
+    (ProvingSessionInfoBySlotNumber) L1BlockNumber => ProvingSessionInfo
 );
 
 define_table_with_default_codec!(
     /// Old version of ProofsBySlotNumber
-    (ProofsBySlotNumber) SlotNumber => Vec<StoredBatchProof>
+    (ProofsBySlotNumber) L1BlockNumber => Vec<StoredBatchProof>
 );
 
 define_table_with_default_codec!(
     /// Proof data on L1 slot
-    (ProofsBySlotNumberV2) SlotNumber => Vec<StoredBatchProof>
+    (ProofsBySlotNumberV2) L1BlockNumber => Vec<StoredBatchProof>
 );
 
 define_table_with_seek_key_codec!(
     /// Proof data on L1 slot verified by full node
-    (VerifiedBatchProofsBySlotNumber) SlotNumber => Vec<StoredVerifiedProof>
+    (VerifiedBatchProofsBySlotNumber) L1BlockNumber => Vec<StoredVerifiedProof>
 );
 
 define_table_with_seek_key_codec!(

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/mod.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/mod.rs
@@ -102,7 +102,7 @@ macro_rules! u64_wrapper {
     };
 }
 
-u64_wrapper!(SlotNumber);
+u64_wrapper!(L1BlockNumber);
 u64_wrapper!(L2BlockNumber);
 
 /// Bonsai session

--- a/crates/storage-ops/src/pruning/ledger/slots.rs
+++ b/crates/storage-ops/src/pruning/ledger/slots.rs
@@ -5,7 +5,7 @@ use sov_db::schema::tables::{
     CommitmentsByNumber, L2RangeByL1Height, LightClientProofBySlotNumber, ProofsBySlotNumber,
     ProofsBySlotNumberV2, ShortHeaderProofBySlotHash, SlotByHash, VerifiedBatchProofsBySlotNumber,
 };
-use sov_db::schema::types::{L2BlockNumber, SlotNumber};
+use sov_db::schema::types::{L1BlockNumber, L2BlockNumber};
 use sov_schema_db::{ScanDirection, SchemaBatch, DB};
 
 pub(crate) fn prune_slots(
@@ -78,7 +78,7 @@ pub(crate) fn prune_slots(
 fn prune_slot_by_hash(
     node_type: NodeType,
     ledger_db: &DB,
-    slot_number: SlotNumber,
+    slot_number: L1BlockNumber,
     batch: &mut SchemaBatch,
     shutdown_signal: Option<&GracefulShutdown>,
 ) -> anyhow::Result<()> {
@@ -111,7 +111,7 @@ fn prune_slot_by_hash(
 
 fn prune_verified_proofs_by_slot_number(
     ledger_db: &DB,
-    slot_number: SlotNumber,
+    slot_number: L1BlockNumber,
     batch: &mut SchemaBatch,
     shutdown_signal: Option<&GracefulShutdown>,
 ) -> anyhow::Result<()> {

--- a/crates/storage-ops/src/rollback/mod.rs
+++ b/crates/storage-ops/src/rollback/mod.rs
@@ -5,7 +5,7 @@ use futures::future;
 use ledger::rollback_ledger;
 use native::rollback_native_db;
 use sov_db::schema::tables::ProverLastScannedSlot;
-use sov_db::schema::types::SlotNumber;
+use sov_db::schema::types::L1BlockNumber;
 use sov_db::state_db::StateDB;
 use state::rollback_state_db;
 use tracing::info;
@@ -87,7 +87,7 @@ impl Rollback {
 
                     let last_scanned_l1_height = ledger_db
                         .get::<ProverLastScannedSlot>(&())?
-                        .unwrap_or(SlotNumber(0))
+                        .unwrap_or(L1BlockNumber(0))
                         .0;
 
                     if last_scanned_l1_height < l1_target {

--- a/crates/storage-ops/src/rollback/node/batch_prover.rs
+++ b/crates/storage-ops/src/rollback/node/batch_prover.rs
@@ -7,7 +7,7 @@ use sov_db::schema::tables::{
     ProverPendingCommitments, ProverStateDiffs, SequencerCommitmentByIndex,
     ShortHeaderProofBySlotHash, SlotByHash,
 };
-use sov_db::schema::types::{L2BlockNumber, SlotNumber};
+use sov_db::schema::types::{L1BlockNumber, L2BlockNumber};
 use sov_schema_db::{ScanDirection, SchemaBatch, DB};
 
 use crate::increment_table_counter;
@@ -148,13 +148,13 @@ impl BatchProverLedgerRollback {
         for record in commitment_indices_by_l1 {
             let l1_height = record?.key;
 
-            if l1_height <= SlotNumber(l1_target) {
+            if l1_height <= L1BlockNumber(l1_target) {
                 break;
             }
 
             let iter_end = last_deleted_slot.unwrap_or(l1_height.0);
             for i in l1_height.0..=iter_end {
-                batch.delete::<CommitmentIndicesByL1>(&SlotNumber(i))?;
+                batch.delete::<CommitmentIndicesByL1>(&L1BlockNumber(i))?;
                 increment_table_counter!("CommitmentIndicesByl1", rollback_result);
 
                 if let Some(slot_hash) = l1_cache.get(&i) {
@@ -210,7 +210,7 @@ impl LedgerNodeRollback for BatchProverLedgerRollback {
 
             let _ = self
                 .ledger_db
-                .put::<ProverLastScannedSlot>(&(), &SlotNumber(l1_target));
+                .put::<ProverLastScannedSlot>(&(), &L1BlockNumber(l1_target));
         }
 
         let _ = self.ledger_db.flush();

--- a/crates/storage-ops/src/rollback/node/fullnode.rs
+++ b/crates/storage-ops/src/rollback/node/fullnode.rs
@@ -6,7 +6,7 @@ use sov_db::schema::tables::{
     PendingProofs, PendingSequencerCommitments, ProverLastScannedSlot, SequencerCommitmentByIndex,
     ShortHeaderProofBySlotHash, SlotByHash, VerifiedBatchProofsBySlotNumber,
 };
-use sov_db::schema::types::{L2BlockNumber, L2HeightStatus, SlotNumber};
+use sov_db::schema::types::{L1BlockNumber, L2BlockNumber, L2HeightStatus};
 use sov_schema_db::{ScanDirection, SchemaBatch, DB};
 
 use crate::increment_table_counter;
@@ -89,13 +89,13 @@ impl FullNodeLedgerRollback {
             .get::<ProverLastScannedSlot>(&())?
             .unwrap_or_default();
         for i in l1_target + 1..=last_scanned_l1_height.0 {
-            batch.delete::<L2RangeByL1Height>(&SlotNumber(i))?;
+            batch.delete::<L2RangeByL1Height>(&L1BlockNumber(i))?;
             increment_table_counter!("L2RangeByL1Height", rollback_result);
 
-            batch.delete::<CommitmentsByNumber>(&SlotNumber(i))?;
+            batch.delete::<CommitmentsByNumber>(&L1BlockNumber(i))?;
             increment_table_counter!("CommitmentsByNumber", rollback_result);
 
-            batch.delete::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(i))?;
+            batch.delete::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(i))?;
             increment_table_counter!("VerifiedBatchProofsBySlotNumber", rollback_result);
 
             batch.delete::<L2StatusHeights>(&(L2HeightStatus::Committed, i))?;
@@ -213,7 +213,7 @@ impl LedgerNodeRollback for FullNodeLedgerRollback {
 
             let _ = self
                 .ledger_db
-                .put::<ProverLastScannedSlot>(&(), &SlotNumber(l1_target));
+                .put::<ProverLastScannedSlot>(&(), &L1BlockNumber(l1_target));
         }
         let _ = self.ledger_db.flush();
         Ok(rollback_result)

--- a/crates/storage-ops/src/rollback/node/light_client.rs
+++ b/crates/storage-ops/src/rollback/node/light_client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use sov_db::schema::tables::{LightClientProofBySlotNumber, ProverLastScannedSlot};
-use sov_db::schema::types::SlotNumber;
+use sov_db::schema::types::L1BlockNumber;
 use sov_schema_db::{ScanDirection, SchemaBatch, DB};
 
 use crate::increment_table_counter;
@@ -37,7 +37,7 @@ impl LightClientLedgerRollback {
 
             let slot_height = record.key;
 
-            if slot_height <= SlotNumber(l1_target) {
+            if slot_height <= L1BlockNumber(l1_target) {
                 break;
             }
 
@@ -59,7 +59,7 @@ impl LedgerNodeRollback for LightClientLedgerRollback {
 
             let _ = self
                 .ledger_db
-                .put::<ProverLastScannedSlot>(&(), &SlotNumber(l1_target));
+                .put::<ProverLastScannedSlot>(&(), &L1BlockNumber(l1_target));
         }
 
         let _ = self.ledger_db.flush();

--- a/crates/storage-ops/src/rollback/node/sequencer.rs
+++ b/crates/storage-ops/src/rollback/node/sequencer.rs
@@ -4,7 +4,7 @@ use sov_db::schema::tables::{
     CommitmentsByNumber, L2BlockByHash, L2BlockByNumber, L2RangeByL1Height,
     SequencerCommitmentByIndex, StateDiffByBlockNumber,
 };
-use sov_db::schema::types::{L2BlockNumber, SlotNumber};
+use sov_db::schema::types::{L1BlockNumber, L2BlockNumber};
 use sov_schema_db::{ScanDirection, SchemaBatch, DB};
 
 use crate::increment_table_counter;
@@ -94,16 +94,16 @@ impl SequencerLedgerRollback {
 
             let slot_height = record.key;
 
-            if slot_height <= SlotNumber(l1_target) {
+            if slot_height <= L1BlockNumber(l1_target) {
                 break;
             }
 
             let iter_end = last_deleted_slot.unwrap_or(slot_height.0);
             for i in slot_height.0..=iter_end {
-                batch.delete::<L2RangeByL1Height>(&SlotNumber(i))?;
+                batch.delete::<L2RangeByL1Height>(&L1BlockNumber(i))?;
                 increment_table_counter!("L2RangeByL1Height", rollback_result);
 
-                batch.delete::<CommitmentsByNumber>(&SlotNumber(i))?;
+                batch.delete::<CommitmentsByNumber>(&L1BlockNumber(i))?;
                 increment_table_counter!("CommitmentsByNumber", rollback_result);
             }
             last_deleted_slot = Some(slot_height.0);

--- a/crates/storage-ops/src/tests.rs
+++ b/crates/storage-ops/src/tests.rs
@@ -18,7 +18,7 @@ use sov_db::schema::types::l2_block::{StoredL2Block, StoredTransaction};
 use sov_db::schema::types::light_client_proof::{
     StoredLatestDaState, StoredLightClientProof, StoredLightClientProofOutput,
 };
-use sov_db::schema::types::{L2BlockNumber, SlotNumber};
+use sov_db::schema::types::{L1BlockNumber, L2BlockNumber};
 use sov_db::state_db::StateDB;
 use sov_schema_db::DB;
 use sov_state::Storage;
@@ -376,7 +376,7 @@ fn prepare_slots_data(ledger_db: &DB) {
     for da_slot_height in 2u64..=20 {
         ledger_db
             .put::<L2RangeByL1Height>(
-                &SlotNumber(da_slot_height),
+                &L1BlockNumber(da_slot_height),
                 &(
                     L2BlockNumber(da_slot_height - 1),
                     L2BlockNumber(da_slot_height),
@@ -384,20 +384,20 @@ fn prepare_slots_data(ledger_db: &DB) {
             )
             .unwrap();
         ledger_db
-            .put::<CommitmentsByNumber>(&SlotNumber(da_slot_height), &vec![])
+            .put::<CommitmentsByNumber>(&L1BlockNumber(da_slot_height), &vec![])
             .unwrap();
         ledger_db
-            .put::<ProofsBySlotNumber>(&SlotNumber(da_slot_height), &vec![])
+            .put::<ProofsBySlotNumber>(&L1BlockNumber(da_slot_height), &vec![])
             .unwrap();
         ledger_db
-            .put::<ProofsBySlotNumberV2>(&SlotNumber(da_slot_height), &vec![])
+            .put::<ProofsBySlotNumberV2>(&L1BlockNumber(da_slot_height), &vec![])
             .unwrap();
         ledger_db
-            .put::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(da_slot_height), &vec![])
+            .put::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(da_slot_height), &vec![])
             .unwrap();
         ledger_db
             .put::<LightClientProofBySlotNumber>(
-                &SlotNumber(da_slot_height),
+                &L1BlockNumber(da_slot_height),
                 &StoredLightClientProof {
                     proof: vec![1; 32],
                     light_client_proof_output: StoredLightClientProofOutput {
@@ -419,85 +419,85 @@ fn prepare_slots_data(ledger_db: &DB) {
             )
             .unwrap();
         ledger_db
-            .put::<SlotByHash>(&[da_slot_height as u8; 32], &SlotNumber(da_slot_height))
+            .put::<SlotByHash>(&[da_slot_height as u8; 32], &L1BlockNumber(da_slot_height))
             .unwrap();
     }
 
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(2))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(2))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(10))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(10))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(20))
-        .unwrap()
-        .is_some());
-
-    assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(2))
-        .unwrap()
-        .is_some());
-    assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(10))
-        .unwrap()
-        .is_some());
-    assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(20))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(2))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(10))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(20))
-        .unwrap()
-        .is_some());
-
-    assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(2))
-        .unwrap()
-        .is_some());
-    assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(10))
-        .unwrap()
-        .is_some());
-    assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(20))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(2))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(10))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(20))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(2))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(2))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(10))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(10))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(20))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(20))
+        .unwrap()
+        .is_some());
+
+    assert!(ledger_db
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(2))
+        .unwrap()
+        .is_some());
+    assert!(ledger_db
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(10))
+        .unwrap()
+        .is_some());
+    assert!(ledger_db
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(20))
+        .unwrap()
+        .is_some());
+
+    assert!(ledger_db
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(2))
+        .unwrap()
+        .is_some());
+    assert!(ledger_db
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(10))
+        .unwrap()
+        .is_some());
+    assert!(ledger_db
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 }
@@ -514,81 +514,81 @@ pub fn test_pruning_ledger_db_fullnode_slots() {
 
     // SHOULD NOT CHANGE
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(2))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(10))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(20))
-        .unwrap()
-        .is_some());
-
-    assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(2))
-        .unwrap()
-        .is_some());
-    assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(10))
-        .unwrap()
-        .is_some());
-    assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(20))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(2))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(2))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(10))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(10))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(20))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(20))
+        .unwrap()
+        .is_some());
+
+    assert!(ledger_db
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(2))
+        .unwrap()
+        .is_some());
+    assert!(ledger_db
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(10))
+        .unwrap()
+        .is_some());
+    assert!(ledger_db
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     // SHOULD BE PRUNED UP TO 10
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(2))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(2))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(10))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(20))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(2))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(10))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(20))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(2))
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(10))
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(20))
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 }
@@ -605,81 +605,81 @@ pub fn test_pruning_ledger_db_light_client_slots() {
 
     // SHOULD NOT CHANGE
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(2))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(10))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(20))
-        .unwrap()
-        .is_some());
-
-    assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(2))
-        .unwrap()
-        .is_some());
-    assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(10))
-        .unwrap()
-        .is_some());
-    assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(20))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(2))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(2))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(10))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(10))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(20))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(20))
+        .unwrap()
+        .is_some());
+
+    assert!(ledger_db
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(2))
+        .unwrap()
+        .is_some());
+    assert!(ledger_db
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(10))
+        .unwrap()
+        .is_some());
+    assert!(ledger_db
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     // SHOULD BE PRUNED UP TO 10
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(2))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(2))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(10))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(20))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(2))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(10))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(20))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(2))
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(10))
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(20))
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 }
@@ -696,81 +696,81 @@ pub fn test_pruning_ledger_db_batch_prover_slots() {
 
     // SHOULD NOT CHANGE
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(2))
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(10))
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<LightClientProofBySlotNumber>(&SlotNumber(20))
+        .get::<LightClientProofBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(2))
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(10))
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_some());
     assert!(ledger_db
-        .get::<VerifiedBatchProofsBySlotNumber>(&SlotNumber(20))
+        .get::<VerifiedBatchProofsBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     // SHOULD BE PRUNED UP TO 10
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(2))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(2))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(10))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<L2RangeByL1Height>(&SlotNumber(20))
+        .get::<L2RangeByL1Height>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(2))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(10))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<CommitmentsByNumber>(&SlotNumber(20))
+        .get::<CommitmentsByNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(2))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(2))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(10))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<ProofsBySlotNumber>(&SlotNumber(20))
+        .get::<ProofsBySlotNumber>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 
     assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(2))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(2))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(10))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(10))
         .unwrap()
         .is_none());
     assert!(ledger_db
-        .get::<ProofsBySlotNumberV2>(&SlotNumber(20))
+        .get::<ProofsBySlotNumberV2>(&L1BlockNumber(20))
         .unwrap()
         .is_some());
 }


### PR DESCRIPTION
## Summary
- rename the ledger schema wrapper type SlotNumber to L1BlockNumber
- update ledger, prover, full node, storage ops, and tests to use the clearer type name
- leave existing *BySlotNumber table names unchanged to avoid DB/table migration churn

Closes #2130

## Testing
- ustfmt +stable --check on all changed Rust files
- git diff --cached --check

Note: full Cargo checks were not run because this is a sparse checkout and Cargo resolves missing unrelated workspace members.