### PR TITLE
chore: move StorageRootHash out of zk module

### DIFF
--- a/crates/batch-prover/src/l2_syncer.rs
+++ b/crates/batch-prover/src/l2_syncer.rs
@@ -26,7 +26,7 @@ use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::fork::ForkManager;
 use sov_rollup_interface::rpc::block::L2BlockResponse;
 use sov_rollup_interface::services::da::DaService;
-use sov_rollup_interface::zk::StorageRootHash;
+use sov_rollup_interface::StorageRootHash;
 use tokio::select;
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tracing::{error, info, instrument};

--- a/crates/common/src/l2.rs
+++ b/crates/common/src/l2.rs
@@ -19,7 +19,7 @@ use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::fork::ForkManager;
 use sov_rollup_interface::rpc::block::L2BlockResponse;
 use sov_rollup_interface::services::da::DaService;
-use sov_rollup_interface::zk::StorageRootHash;
+use sov_rollup_interface::StorageRootHash;
 use sov_state::storage::NativeStorage;
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -12,7 +12,7 @@ pub mod utils;
 
 pub use config::*;
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::zk::StorageRootHash;
+use sov_rollup_interface::StorageRootHash;
 
 type L2BlockHash = [u8; 32];
 

--- a/crates/fullnode/src/l2_syncer.rs
+++ b/crates/fullnode/src/l2_syncer.rs
@@ -24,7 +24,7 @@ use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::fork::ForkManager;
 use sov_rollup_interface::rpc::block::L2BlockResponse;
 use sov_rollup_interface::services::da::DaService;
-use sov_rollup_interface::zk::StorageRootHash;
+use sov_rollup_interface::StorageRootHash;
 use tokio::select;
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tracing::{error, info, instrument};

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -53,7 +53,7 @@ use sov_rollup_interface::fork::ForkManager;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::stf::{L2BlockResult, StateTransitionError};
 use sov_rollup_interface::transaction::Transaction;
-use sov_rollup_interface::zk::StorageRootHash;
+use sov_rollup_interface::StorageRootHash;
 use sov_state::storage::NativeStorage;
 use sov_state::{ProverStorage, ReadWriteLog};
 use tokio::sync::mpsc::UnboundedReceiver;

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/l2_block.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/schema/types/l2_block.rs
@@ -5,7 +5,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use sov_rollup_interface::block::{L2Block, L2Header, SignedL2Header};
 use sov_rollup_interface::rpc::block::{L2BlockResponse, L2HeaderResponse};
 use sov_rollup_interface::transaction::Transaction;
-use sov_rollup_interface::zk::StorageRootHash;
+use sov_rollup_interface::StorageRootHash;
 
 use super::DbHash;
 

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/mod.rs
@@ -11,6 +11,9 @@ pub use bytes::{Buf, BufMut, Bytes, BytesMut};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+/// A cryptographic commitment to the contents of storage.
+pub type StorageRootHash = [u8; 32];
+
 /// A marker trait for general addresses.
 pub trait BasicAddress:
     Eq

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/stf.rs
@@ -4,7 +4,7 @@
 //! The most important trait in this module is the [`StateTransitionFunction`], which defines the
 //! main event loop of the rollup.
 
-use super::zk::StorageRootHash;
+use super::StorageRootHash;
 use crate::RefCount;
 
 /// The configuration of a full node of the rollup which creates zk proofs.

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v3.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/input/v3.rs
@@ -5,7 +5,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use crate::block::{L2Block, L2Header};
 use crate::da::SequencerCommitment;
 use crate::witness::Witness;
-use crate::zk::StorageRootHash;
+use crate::StorageRootHash;
 
 type InputV3Part2<Witness> = VecDeque<Vec<(u64, L2Block, Witness, Witness)>>;
 

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/v3.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/batch_proof/output/v3.rs
@@ -4,7 +4,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use super::CumulativeStateDiff;
-use crate::zk::StorageRootHash;
+use crate::StorageRootHash;
 
 /// The public output of a SNARK batch proof in Sovereign, this struct makes a claim that
 /// the state of the rollup has transitioned from `initial_state_root` to `final_state_root`

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/light_client_proof/output.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/light_client_proof/output.rs
@@ -2,7 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::da::LatestDaState;
-use crate::zk::StorageRootHash;
+use crate::StorageRootHash;
 
 /// The output of light client proof
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize, PartialEq)]

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
@@ -205,8 +205,5 @@ pub trait Matches<T> {
     fn matches(&self, other: &T) -> bool;
 }
 
-/// A cryptographic commitment to the contents of this storage
-pub type StorageRootHash = [u8; 32];
-
 /// Alias to jmt::proof::SparseMerkleProof.
 pub type SparseMerkleProofSha2 = jmt::proof::SparseMerkleProof<sha2::Sha256>;


### PR DESCRIPTION
## Summary
- move StorageRootHash from the zk module to the state machine/root rollup interface exports
- update internal and downstream imports to use sov_rollup_interface::StorageRootHash

Closes #1652

## Testing
- rustfmt +stable --check on changed Rust files, excluding crates/common/src/lib.rs because sparse checkout is missing sibling modules needed by rustfmt module resolution
- git diff --cached --check