### PR TITLE
fix: return dense L2 block ranges

### DIFF
--- a/crates/common/src/l2.rs
+++ b/crates/common/src/l2.rs
@@ -249,7 +249,7 @@ async fn get_l2_blocks_range(
             .get_l2_block_range(U64::from(start_l2_height), U64::from(end_l2_height))
             .await;
         match l2_blocks {
-            Ok(l2_blocks) => Ok(l2_blocks.into_iter().flatten().collect::<Vec<_>>()),
+            Ok(l2_blocks) => Ok(l2_blocks),
             Err(e) => match e {
                 JsonrpseeError::Call(e) => {
                     if e.message().eq("Response is too big") {

--- a/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/rpc.rs
+++ b/crates/sovereign-sdk/full-node/db/sov-db/src/ledger_db/rpc.rs
@@ -61,16 +61,16 @@ impl LedgerRpcProvider for LedgerDB {
         &self,
         start: u64,
         end: u64,
-    ) -> Result<Vec<Option<L2BlockResponse>>, anyhow::Error> {
+    ) -> Result<Vec<L2BlockResponse>, anyhow::Error> {
         anyhow::ensure!(start <= end, "start must be <= end");
 
         let l2_block_ids: Vec<_> = (start..=end).map(L2BlockIdentifier::Number).collect();
         let mut out = Vec::with_capacity(l2_block_ids.len());
         for l2_block_id in &l2_block_ids {
             if let Some(l2_block) = self.get_l2_block(l2_block_id)? {
-                out.push(Some(l2_block));
+                out.push(l2_block);
             } else {
-                out.push(None);
+                anyhow::bail!("L2 block {l2_block_id:?} is missing from the requested range");
             }
         }
         Ok(out)

--- a/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/node/rpc/mod.rs
@@ -394,7 +394,7 @@ pub trait LedgerRpcProvider {
         &self,
         start: u64,
         end: u64,
-    ) -> Result<Vec<Option<L2BlockResponse>>, anyhow::Error>;
+    ) -> Result<Vec<L2BlockResponse>, anyhow::Error>;
 
     /// Returns the L2 genesis state root
     fn get_l2_genesis_state_root(&self) -> Result<Option<Vec<u8>>, anyhow::Error>;


### PR DESCRIPTION
## Summary
- change ledger L2 block range RPC provider return type from Vec<Option<L2BlockResponse>> to Vec<L2BlockResponse>
- return an error when a requested block in the range is unexpectedly missing
- remove client-side flattening of missing blocks

Closes #2631

## Testing
- rustfmt +stable --check on changed Rust files
- git diff --check