### PR TITLE
fix(bitcoin-da): replace unwrap() with ok_or on empty coinbase witness in short_proof verify

### DIFF
--- a/crates/bitcoin-da/src/spec/short_proof.rs
+++ b/crates/bitcoin-da/src/spec/short_proof.rs
@@ -95,7 +95,11 @@ impl VerifiableShortHeaderProof for BitcoinHeaderShortProof {
                 // If post-segwit block, extract the commitment from the coinbase tx
                 // and compare with header.txs_commitment().
                 let script_pubkey = self.coinbase_tx.output[idx].script_pubkey.as_bytes();
-                let input_witness_value = self.coinbase_tx.input[0].witness.iter().next().unwrap();
+                let input_witness_value = self.coinbase_tx.input[0]
+                    .witness
+                    .iter()
+                    .next()
+                    .ok_or(ShortHeaderProofVerificationError::InvalidCoinbaseMerkleProof)?;
 
                 let mut vec_merkle = Vec::with_capacity(input_witness_value.len() + 32);
 
@@ -371,6 +375,19 @@ mod test {
                     actual: [0; 32]
                 }
             )
+
+        // segwit coinbase tx with empty witness — must return error, not panic
+        {
+            let mut proof = get_proof();
+            // Clear the witness on input[0] so .witness.iter().next() returns None
+            let mut tx = proof.coinbase_tx.deref().clone();
+            tx.input[0].witness = bitcoin::Witness::new();
+            proof.coinbase_tx = tx.into();
+
+            assert_eq!(
+                proof.verify().unwrap_err(),
+                ShortHeaderProofVerificationError::InvalidCoinbaseMerkleProof
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

In `BitcoinHeaderShortProof::verify()` (`crates/bitcoin-da/src/spec/short_proof.rs`), when a SegWit witness commitment is detected in a coinbase output, the code unconditionally unwraps the first witness element of `coinbase_tx.input[0]`:

```rust
// BEFORE (panics if witness is empty)
let input_witness_value = self.coinbase_tx.input[0].witness.iter().next().unwrap();
```

If the coinbase transaction's first input has an empty witness (e.g. from an adversarially crafted proof or a malformed block), this line panics the process instead of returning a proper error. The same pattern is handled correctly in `verifier.rs` via `ok_or(ValidationError::InvalidWitnessCommitmentStructure)`, but the equivalent guard was missing in `short_proof.rs`.

## Fix

Replace the `.unwrap()` with `.ok_or(ShortHeaderProofVerificationError::InvalidCoinbaseMerkleProof)?` so the error propagates cleanly:

```rust
// AFTER (returns Err instead of panicking)
let input_witness_value = self.coinbase_tx.input[0]
    .witness
    .iter()
    .next()
    .ok_or(ShortHeaderProofVerificationError::InvalidCoinbaseMerkleProof)?;
```

A regression test is added that strips the witness from the coinbase input and asserts `verify()` returns `Err(InvalidCoinbaseMerkleProof)` rather than panicking.

## Impact

Without this fix, any caller passing a proof whose coinbase tx has an empty witness on its first input will trigger an unrecoverable panic. This is reachable from external/adversarial input in proof-verification flows.

---
*Fixes a panic-on-empty-witness bug; similar in spirit to the guard added to `parsers.rs::get_script` in #3231.*