### PR TITLE
fix(bitcoin-da): correct "Expected exactly 2 transactions" error message in backup.rs

### DIFF
--- a/crates/bitcoin-da/src/helpers/backup.rs
+++ b/crates/bitcoin-da/src/helpers/backup.rs
@@ -33,7 +33,7 @@ pub(crate) fn backup_txs_to_file(
             | TransactionKind::SequencerCommitment => {
                 if txs.len() != 1 {
                     return Err(BitcoinServiceError::TransactionBackupError(format!(
-                        "Expected exactly 2 transactions for {:?}, got {}",
+                        "Expected exactly 1 transaction pair for {:?}, got {}",
                         tx.kind,
                         txs.len()
                     )));


### PR DESCRIPTION
Fixes #3246

## Problem

The single-tx backup path in `backup.rs` reports `"Expected exactly 2 transactions"` but the guard is `txs.len() != 1` where `txs: &[SignedTxPair]`. The message conflates individual transactions with transaction pairs.

## Fix

Change the error message to `"Expected exactly 1 transaction pair for {:?}, got {}"`.