### PR TITLE
fix(bitcoin-da): replace .transaction().unwrap() with ? in restore_from_utxos

### DIFF
--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -381,8 +381,7 @@ impl MonitoringService {
                 .client
                 .get_transaction(&reveal_txid, None)
                 .await?
-                .transaction()
-                .unwrap();
+                .transaction()?;
 
             let reveal_wtxid = reveal_tx.compute_wtxid();
             let reveal_hash = reveal_wtxid.as_raw_hash().to_byte_array();
@@ -396,8 +395,7 @@ impl MonitoringService {
                     .client
                     .get_transaction(&commit_txid, None)
                     .await?
-                    .transaction()
-                    .unwrap();
+                    .transaction()?;
 
                 txs.push([
                     TxWithId {


### PR DESCRIPTION
Fixes #3248

## Problem

`restore_from_utxos` calls `.transaction().unwrap()` on RPC results for both reveal and commit transactions. Malformed RPC bytes panic the entire monitoring service.

## Fix

Replace both `.transaction().unwrap()` calls with `.transaction()?` to propagate errors through the `Result` chain.