### PR TITLE
fix(bitcoin-da): widen mine_reveal_prefix iterations counter from u32 to u64

### DIFF
--- a/crates/bitcoin-da/src/helpers/builders/body_builders.rs
+++ b/crates/bitcoin-da/src/helpers/builders/body_builders.rs
@@ -87,7 +87,7 @@ fn mine_reveal_prefix(
     prefix: &[u8],
     label: &str,
 ) {
-    let mut iterations = 0u32;
+    let mut iterations = 0u64;
     loop {
         let reveal_wtxid = reveal_tx.compute_wtxid();
         if reveal_wtxid


### PR DESCRIPTION
Fixes #3250

## Problem

The `mine_reveal_prefix` loop counter is `u32`. In release builds it wraps silently at 4,294,967,295, corrupting the progress log. In debug builds it panics on overflow.

## Fix

Change `let mut iterations = 0u32;` → `let mut iterations = 0u64;`.