### PR TITLE
fix(bitcoin-da): avoid monitored_txs write lock across RPC in monitor_transaction

### DIFF
--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -481,9 +481,6 @@ impl MonitoringService {
         kind: MonitoredTxKind,
     ) -> Result<()> {
         let txid = tx.id;
-
-        // Fetch block height before acquiring the write lock to avoid
-        // holding the lock across async network I/O.
         let current_height = self.client.get_block_count().await?;
 
         let mut monitored_txs = self.monitored_txs.write().await;

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -482,6 +482,10 @@ impl MonitoringService {
     ) -> Result<()> {
         let txid = tx.id;
 
+        // Fetch block height before acquiring the write lock to avoid
+        // holding the lock across async network I/O.
+        let current_height = self.client.get_block_count().await?;
+
         let mut monitored_txs = self.monitored_txs.write().await;
         if monitored_txs.contains_key(&txid) {
             return Err(MonitorError::AlreadyMonitored);
@@ -493,8 +497,6 @@ impl MonitoringService {
             };
             prev_tx.next_txid = Some(txid);
         }
-
-        let current_height = self.client.get_block_count().await?;
 
         self.total_size
             .fetch_add(tx.tx.total_size(), Ordering::SeqCst);


### PR DESCRIPTION
Fixes #3252

## Problem

`monitor_transaction` holds the `monitored_txs` write lock while calling `get_block_count()`, blocking all concurrent readers/writers for a full network round-trip — same pattern as #3234.

## Fix

Move `self.client.get_block_count().await?` to before the write lock is acquired.