### PR TITLE
fix(bitcoin-da): replace available_utxos[0] with .first().ok_or() in service.rs

### DIFF
--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -415,7 +415,10 @@ impl BitcoinService {
         let network = self.network;
         let da_private_key = self.da_private_key.expect("No private key set");
         // get address from a utxo
-        let address = utxo_context.available_utxos[0]
+        let address = utxo_context
+            .available_utxos
+            .first()
+            .ok_or(BitcoinServiceError::MissingUTXO)?
             .address
             .clone()
             .ok_or(BitcoinServiceError::MissingAddress)?


### PR DESCRIPTION
Fixes #3258

## Problem

`available_utxos[0]` panics on an empty slice instead of returning a typed error.

## Fix

Replace with `.first().ok_or(BitcoinServiceError::MissingUTXO)?`.