### PR TITLE
fix(bitcoin-da): propagate get_block_info error in determine_tx_status instead of .unwrap_or(0)

### DIFF
--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -707,9 +707,8 @@ impl MonitoringService {
             let block_height = self
                 .client
                 .get_block_info(&block_hash)
-                .await
-                .map(|header| header.height as u64)
-                .unwrap_or(0);
+                .await?
+                .height as u64;
 
             if confirmations >= self.finality_depth {
                 TxStatus::Finalized {

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -704,11 +704,7 @@ impl MonitoringService {
                 .info
                 .blockhash
                 .ok_or(MonitorError::BlockHashNotSet)?;
-            let block_height = self
-                .client
-                .get_block_info(&block_hash)
-                .await?
-                .height as u64;
+            let block_height = self.client.get_block_info(&block_hash).await?.height as u64;
 
             if confirmations >= self.finality_depth {
                 TxStatus::Finalized {


### PR DESCRIPTION
Fixes #3262

## Problem

`.unwrap_or(0)` on `get_block_info` in `determine_tx_status` silently uses `block_height: 0` on RPC failures, corrupting finality calculations.

## Fix

Replace with `.await?.height as u64;` to propagate the error.