### PR TITLE
fix(bitcoin-da): use checked_sub in validate_txs_fee_rate to prevent Amount underflow

### DIFF
--- a/crates/bitcoin-da/src/fee.rs
+++ b/crates/bitcoin-da/src/fee.rs
@@ -278,7 +278,7 @@ pub(crate) fn validate_txs_fee_rate(
             .sum();
         let output_amount = commit_tx.output.iter().map(|tx| tx.value).sum();
 
-        if (input_amount - output_amount) < Amount::from_sat(commit_tx.vsize() as u64) {
+        if input_amount.checked_sub(output_amount).map_or(true, |diff| diff < Amount::from_sat(commit_tx.vsize() as u64)) {
             return Err(BitcoinServiceError::FeeCalculation(fee_rate));
         }
 
@@ -295,7 +295,7 @@ pub(crate) fn validate_txs_fee_rate(
         // Add reveal utxo to utxo_map, used by chunking txs
         utxo_map.insert((tx.reveal_txid(), 0), output_amount);
 
-        if (input_amount - output_amount) < Amount::from_sat(reveal_tx.vsize() as u64) {
+        if input_amount.checked_sub(output_amount).map_or(true, |diff| diff < Amount::from_sat(reveal_tx.vsize() as u64)) {
             return Err(BitcoinServiceError::FeeCalculation(fee_rate));
         }
     }


### PR DESCRIPTION
Fixes #3264

## Problem

`bitcoin::Amount` subtraction panics (debug) or wraps (release) when `output_amount > input_amount`.

## Fix

Replace `(input_amount - output_amount) < threshold` with:
```rust
input_amount.checked_sub(output_amount).map_or(true, |diff| diff < threshold)
```
for both the commit and reveal checks.