### PR TITLE
fix(verifier): replace coinbase_tx.input[0] direct index with .first().ok_or()

### DIFF
--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -218,7 +218,10 @@ impl DaVerifier for BitcoinVerifier {
                 let merkle_root =
                     merkle_tree::BitcoinMerkleTree::new(inclusion_proof.wtxids).root();
 
-                let input_witness_value = coinbase_tx.input[0]
+                let input_witness_value = coinbase_tx
+                    .input
+                    .first()
+                    .ok_or(ValidationError::InvalidBlock)?
                     .witness
                     .iter()
                     .next()


### PR DESCRIPTION
Closes #3266

## Problem

In `verify_transactions`, the code directly indexes `coinbase_tx.input[0]` to access the witness data needed for SegWit commitment verification. A crafted `InclusionMultiProof` whose coinbase transaction carries an empty `input` array causes an index-out-of-bounds **panic**, crashing the verifier (denial of service).

## Fix

Replace the direct index with `.first().ok_or(ValidationError::InvalidBlock)?` so that a malformed coinbase is rejected with a structured error instead of a panic.



**File changed:** `crates/bitcoin-da/src/verifier.rs`