### PR TITLE
fix(backup): hold L1/L2 processing locks until all backup tasks fully complete

### DIFF
--- a/crates/common/src/backup/manager.rs
+++ b/crates/common/src/backup/manager.rs
@@ -193,10 +193,6 @@ impl BackupManager {
             }
         }
 
-        // Wait for all dbs to start backing up under lock before releasing
-        drop(l2_lock);
-        drop(l1_lock);
-
         let mut backup_id = None;
         for handle in handles {
             let result = handle.await??;
@@ -210,6 +206,11 @@ impl BackupManager {
                 anyhow::ensure!(backup_id == current_id, "Backup id mismatch");
             }
         }
+
+        // Release processing locks only after all backup tasks have fully completed,
+        // ensuring no L1/L2 modifications occur during the backup window.
+        drop(l2_lock);
+        drop(l1_lock);
 
         let backup_id = backup_id.ok_or(anyhow::anyhow!("Failed to get backup_id"))?;
         let info = CreateBackupInfo {


### PR DESCRIPTION
## Summary

In `create_backup`, the L1 and L2 processing locks are acquired to ensure database consistency across all three databases during backup. However, they are currently released **before** the spawned blocking backup tasks finish:

```rust
// Wait for all dbs to start backing up under lock before releasing
drop(l2_lock);
drop(l1_lock);

let mut backup_id = None;
for handle in handles {
    let result = handle.await??;
```

The comment itself says "start backing up" — but the intent is clearly to hold the lock for the **duration** of the backup, not just while spawning. Since `tokio::task::spawn_blocking` dispatches tasks to a thread pool and returns immediately, dropping the locks here allows L1/L2 block processing to resume while RocksDB is still writing backup files. This produces **inconsistent backups** where some databases reflect a later state than others.

## Fix

Move `drop(l2_lock)` and `drop(l1_lock)` to **after** the `for handle in handles { handle.await?? }` loop, so the locks are held for the entire backup window — exactly as the design intent requires.

## Impact

- **Without fix**: Backup can capture mismatched states (e.g. L1 processed block N+1 while L2 backup still at N), leading to corruption or failed restore.
- **With fix**: All three databases are snapshotted under the same consistent lock window.

cc @jfldde @eyusufatik