### PR TITLE
fix(bitcoin-da): use checked_sub in validate_txs_fee_rate to prevent underflow panic

### DIFF
--- a/crates/bitcoin-da/src/fee.rs
+++ b/crates/bitcoin-da/src/fee.rs
@@ -278,7 +278,10 @@ pub(crate) fn validate_txs_fee_rate(
             .sum();
         let output_amount = commit_tx.output.iter().map(|tx| tx.value).sum();
 
-        if (input_amount - output_amount) < Amount::from_sat(commit_tx.vsize() as u64) {
+        let fee_paid = input_amount
+            .checked_sub(output_amount)
+            .unwrap_or(Amount::ZERO);
+        if fee_paid < Amount::from_sat(commit_tx.vsize() as u64) {
             return Err(BitcoinServiceError::FeeCalculation(fee_rate));
         }
 
@@ -295,7 +298,10 @@ pub(crate) fn validate_txs_fee_rate(
         // Add reveal utxo to utxo_map, used by chunking txs
         utxo_map.insert((tx.reveal_txid(), 0), output_amount);
 
-        if (input_amount - output_amount) < Amount::from_sat(reveal_tx.vsize() as u64) {
+        let fee_paid = input_amount
+            .checked_sub(output_amount)
+            .unwrap_or(Amount::ZERO);
+        if fee_paid < Amount::from_sat(reveal_tx.vsize() as u64) {
             return Err(BitcoinServiceError::FeeCalculation(fee_rate));
         }
     }


### PR DESCRIPTION
## Summary

`validate_txs_fee_rate` in `crates/bitcoin-da/src/fee.rs` computes the fee paid by a commit transaction as:

```rust
let input_amount: Amount = commit_tx
    .input
    .iter()
    .flat_map(|input| {
        utxo_map
            .get(&(input.previous_output.txid, input.previous_output.vout))
            .cloned()
    })
    .sum();
let output_amount = commit_tx.output.iter().map(|tx| tx.value).sum();

if (input_amount - output_amount) < Amount::from_sat(commit_tx.vsize() as u64) {
```

`flat_map` silently drops any input whose `(txid, vout)` key is absent from `utxo_map`. If that happens — e.g. the UTXO map was built from a stale or incomplete context — `input_amount` may be zero while `output_amount` is non-zero. `bitcoin::Amount` subtraction panics on underflow in debug builds and wraps to a huge value in release builds; either outcome is wrong:

- **Debug**: node crashes with a subtraction-with-overflow panic.
- **Release**: the wrapped value passes the fee check silently, allowing a zero-fee transaction to be accepted.

The same issue exists for the reveal tx check: `input_amount - output_amount`.

## Fix

Replace bare `-` with `checked_sub(...).unwrap_or(Amount::ZERO)` so that a missing input is treated as zero fee paid and the check fails safely with `Err(BitcoinServiceError::FeeCalculation)`:

```rust
let fee_paid = input_amount
    .checked_sub(output_amount)
    .unwrap_or(Amount::ZERO);
if fee_paid < Amount::from_sat(commit_tx.vsize() as u64) {
    return Err(BitcoinServiceError::FeeCalculation(fee_rate));
}
```

cc @jfldde @eyusufatik