### PR TITLE
fix(bitcoin-da): handle empty txs list in DA queue instead of panicking with unwrap

### DIFF
--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -298,7 +298,11 @@ impl BitcoinService {
                                 .await
                             {
                                 Ok(txs) => {
-                                    let txid = txs.last().unwrap()[1].id;
+                                    let Some(last_tx_pair) = txs.last() else {
+                                        error!("send_transaction_with_fee_rate returned an empty transaction list; skipping");
+                                        break;
+                                    };
+                                    let txid = last_tx_pair[1].id;
                                     let tx_id = TxidWrapper(txid);
                                     info!(%txid, "Sent tx to BitcoinDA");
                                     let _ = request.notify.send(Ok(tx_id));


### PR DESCRIPTION
## Summary

In `run_da_queue` (`crates/bitcoin-da/src/service.rs`), after a successful call to `send_transaction_with_fee_rate`, the code extracts the broadcast txid with:

```rust
Ok(txs) => {
    let txid = txs.last().unwrap()[1].id;
```

`send_transaction_with_fee_rate` returns `Vec<[TxWithId; 2]>` — one element per `SignedTxPair`. While under normal conditions the vec always contains at least one element, there is no contract that enforces this. A defensive `unwrap()` here will **panic the entire DA service** if the vec ever comes back empty (e.g. due to a future refactor or an edge case in chunked-transaction building).

## Fix

Replace the `unwrap()` with a `let-else` guard that logs an error and breaks out of the inner retry loop rather than crashing:

```rust
Ok(txs) => {
    let Some(last_tx_pair) = txs.last() else {
        error!("send_transaction_with_fee_rate returned an empty transaction list; skipping");
        break;
    };
    let txid = last_tx_pair[1].id;
```

## Impact

- **Before**: empty `txs` panics the DA queue task, requiring a node restart.
- **After**: the condition is logged and the request loop exits cleanly, allowing the outer `loop` to pick up the next request.

cc @jfldde @eyusufatik