### PR TITLE
fix(bitcoin-da): bounds-check vout before indexing transaction outputs in tx_signer

### DIFF
--- a/crates/bitcoin-da/src/tx_signer.rs
+++ b/crates/bitcoin-da/src/tx_signer.rs
@@ -185,14 +185,19 @@ impl TxSigner {
 
             for input in commit.input.iter() {
                 if let Some(entry) = all_tx_map.get(&input.previous_output.txid) {
+                    let vout = input.previous_output.vout as usize;
+                    let Some(txout) = entry.output.get(vout) else {
+                        return Err(BitcoinServiceError::InvalidTransaction(format!(
+                            "chunk commit input vout {vout} is out of bounds (tx has {} outputs)",
+                            entry.output.len()
+                        )));
+                    };
                     inputs.push(SignRawTransactionInput {
                         txid: input.previous_output.txid,
                         vout: input.previous_output.vout,
-                        script_pub_key: entry.output[input.previous_output.vout as usize]
-                            .script_pubkey
-                            .clone(),
+                        script_pub_key: txout.script_pubkey.clone(),
                         redeem_script: None,
-                        amount: Some(entry.output[input.previous_output.vout as usize].value),
+                        amount: Some(txout.value),
                     });
                 }
             }
@@ -228,14 +233,19 @@ impl TxSigner {
 
         for input in commit.input.iter() {
             if let Some(entry) = all_tx_map.get(&input.previous_output.txid) {
+                let vout = input.previous_output.vout as usize;
+                let Some(txout) = entry.output.get(vout) else {
+                    return Err(BitcoinServiceError::InvalidTransaction(format!(
+                        "aggregate commit input vout {vout} is out of bounds (tx has {} outputs)",
+                        entry.output.len()
+                    )));
+                };
                 inputs.push(SignRawTransactionInput {
                     txid: input.previous_output.txid,
                     vout: input.previous_output.vout,
-                    script_pub_key: entry.output[input.previous_output.vout as usize]
-                        .script_pubkey
-                        .clone(),
+                    script_pub_key: txout.script_pubkey.clone(),
                     redeem_script: None,
-                    amount: Some(entry.output[input.previous_output.vout as usize].value),
+                    amount: Some(txout.value),
                 });
             }
         }


### PR DESCRIPTION
## Summary

In `sign_chunked_transaction` (`crates/bitcoin-da/src/tx_signer.rs`), when building the `SignRawTransactionInput` list, the code indexes into a transaction output vector using the `vout` from the previous outpoint:

```rust
script_pub_key: entry.output[input.previous_output.vout as usize]
    .script_pubkey
    .clone(),
// ...
amount: Some(entry.output[input.previous_output.vout as usize].value),
```

This pattern appears twice — once inside the per-chunk loop and once for the aggregate commit. There is **no bounds check**: if `input.previous_output.vout` is greater than or equal to `entry.output.len()` (which can happen if a transaction is malformed, a chain re-org produces a different output count, or the in-memory `all_tx_map` is stale), the index operation will **panic** and crash the signing task.

## Fix

Replace direct indexing with `.get(vout)` and return a typed `BitcoinServiceError::InvalidTransaction` if the output is missing:

```rust
let vout = input.previous_output.vout as usize;
let Some(txout) = entry.output.get(vout) else {
    return Err(BitcoinServiceError::InvalidTransaction(format!(
        "chunk commit input vout {vout} is out of bounds (tx has {} outputs)",
        entry.output.len()
    )));
};
inputs.push(SignRawTransactionInput {
    txid: input.previous_output.txid,
    vout: input.previous_output.vout,
    script_pub_key: txout.script_pubkey.clone(),
    redeem_script: None,
    amount: Some(txout.value),
});
```

Applied to both the chunk-commit loop and the aggregate-commit loop.

cc @jfldde @eyusufatik