### PR TITLE
fix(ethereum-rpc): propagate error instead of panicking with unwrap in suggest_tip_cap

### DIFF
--- a/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
+++ b/crates/ethereum-rpc/src/gas_price/gas_oracle.rs
@@ -256,9 +256,8 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
     pub fn suggest_tip_cap(&self, working_set: &mut WorkingSet<C::Storage>) -> EthResult<u128> {
         let header = &self
             .provider
-            .get_block_by_number(None, None, working_set, &self.ledger_db)
-            .unwrap()
-            .unwrap()
+            .get_block_by_number(None, None, working_set, &self.ledger_db)?
+            .ok_or(EthApiError::UnknownBlockNumber)?
             .header;
 
         let mut last_price = self.last_price.lock();


### PR DESCRIPTION
## Summary

`suggest_tip_cap` in `crates/ethereum-rpc/src/gas_price/gas_oracle.rs` fetches the latest block header with two chained `.unwrap()` calls:

```rust
let header = &self
    .provider
    .get_block_by_number(None, None, working_set, &self.ledger_db)
    .unwrap()   // panics if Err
    .unwrap()   // panics if None (block not found)
    .header;
```

`get_block_by_number` returns `Result<Option<Block>>`. The outer `.unwrap()` panics on any database or RPC error; the inner `.unwrap()` panics if no block is found — for example right after genesis when the chain is empty, or if the ledger DB is temporarily unavailable.

Because `suggest_tip_cap` is called from the `eth_gasPrice` and `eth_maxPriorityFeePerGas` RPC handlers, a panic here **crashes the RPC server thread** rather than returning a proper JSON-RPC error to the client.

## Fix

Replace both `.unwrap()` calls with `?` and `.ok_or(EthApiError::UnknownBlockNumber)?` so that errors are surfaced as proper `EthResult` values:

```rust
let header = &self
    .provider
    .get_block_by_number(None, None, working_set, &self.ledger_db)?
    .ok_or(EthApiError::UnknownBlockNumber)?
    .header;
```

This propagates the error up to the RPC handler, which converts it to a standard JSON-RPC error response — consistent with how every other method in the oracle handles failures.

cc @jfldde @eyusufatik