### PR TITLE
refactor: remove proving session recovery paths

### DIFF
--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -594,7 +594,6 @@ async fn parallel_proving_test() -> Result<()> {
 //     fn light_client_prover_config() -> LightClientProverConfig {
 //         LightClientProverConfig {
 //             initial_da_height: 171,
-//             enable_recovery: false,
 //             ..Default::default()
 //         }
 //     }

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -78,14 +78,12 @@ impl TestCase for LightClientProvingTest {
 
     fn batch_prover_config() -> BatchProverConfig {
         BatchProverConfig {
-            enable_recovery: false,
             ..Default::default()
         }
     }
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             ..Default::default()
         }
     }
@@ -218,7 +216,6 @@ impl TestCase for LightClientProvingTestMultipleProofs {
 
     fn batch_prover_config() -> BatchProverConfig {
         BatchProverConfig {
-            enable_recovery: false,
             proof_sampling_number: 99999999,
             ..Default::default()
         }
@@ -226,7 +223,6 @@ impl TestCase for LightClientProvingTestMultipleProofs {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -553,14 +549,12 @@ impl TestCase for LightClientBatchProofMethodIdUpdateTest {
 
     fn batch_prover_config() -> BatchProverConfig {
         BatchProverConfig {
-            enable_recovery: false,
             ..Default::default()
         }
     }
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -805,14 +799,12 @@ impl TestCase for LightClientBatchProofMethodIdUpdateSecurityCouncilTest {
 
     fn batch_prover_config() -> BatchProverConfig {
         BatchProverConfig {
-            enable_recovery: false,
             ..Default::default()
         }
     }
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -1209,7 +1201,6 @@ impl TestCase for LightClientUnverifiableBatchProofTest {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -1469,7 +1460,6 @@ impl TestCase for VerifyChunkedTxsInLightClient {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -1847,7 +1837,6 @@ impl TestCase for UnchainedBatchProofsTest {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 164,
             ..Default::default()
         }
@@ -2112,7 +2101,6 @@ impl TestCase for UnknownL1HashBatchProofTest {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 165,
             ..Default::default()
         }
@@ -2262,7 +2250,6 @@ impl TestCase for ChainProofByCommitmentIndex {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -2478,7 +2465,6 @@ impl TestCase for ProofWithMissingCommitment {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }
@@ -2627,7 +2613,6 @@ impl TestCase for ProofAndCommitmentWithWrongDaPubkey {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 164,
             ..Default::default()
         }
@@ -2946,7 +2931,6 @@ impl TestCase for ProofWithWrongPreviousCommitmentHash {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 164,
             ..Default::default()
         }
@@ -3477,7 +3461,6 @@ impl TestCase for UndecompressableBlobTest {
 
     fn light_client_prover_config() -> LightClientProverConfig {
         LightClientProverConfig {
-            enable_recovery: false,
             initial_da_height: 171,
             ..Default::default()
         }

--- a/bin/citrea/tests/mock/evm/mod.rs
+++ b/bin/citrea/tests/mock/evm/mod.rs
@@ -1583,7 +1583,6 @@ async fn test_safe_finalized_tags() {
             proving_mode: citrea_common::ProverGuestRunConfig::Execute,
             // Make it impossible for proving to happen
             proof_sampling_number: 1_000_000,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig::from_env().expect("Failed to load Risc0HostConfig"),
         }),

--- a/bin/citrea/tests/mock/mod.rs
+++ b/bin/citrea/tests/mock/mod.rs
@@ -110,7 +110,6 @@ async fn test_all_flow() {
         Some(BatchProverConfig {
             proving_mode: citrea_common::ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig::from_env().expect("Failed to load Risc0HostConfig"),
         }),

--- a/bin/citrea/tests/mock/proving.rs
+++ b/bin/citrea/tests/mock/proving.rs
@@ -74,7 +74,6 @@ async fn full_node_verify_proof_and_store() {
         Some(BatchProverConfig {
             proving_mode: citrea_common::ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig::from_env().expect("Failed to load Risc0HostConfig"),
         }),
@@ -245,7 +244,6 @@ async fn test_batch_prover_prove_rpcs() {
             proving_mode: citrea_common::ProverGuestRunConfig::Execute,
             // Make it impossible for proving to happen
             proof_sampling_number: 1_000_000,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig::from_env().expect("Failed to load Risc0HostConfig"),
         }),

--- a/bin/citrea/tests/mock/rollback.rs
+++ b/bin/citrea/tests/mock/rollback.rs
@@ -144,7 +144,6 @@ async fn start_batch_prover(
         Some(BatchProverConfig {
             proving_mode: citrea_common::ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig::from_env().expect("Failed to load Risc0HostConfig"),
         }),

--- a/crates/batch-prover/src/prover.rs
+++ b/crates/batch-prover/src/prover.rs
@@ -13,8 +13,6 @@ use citrea_primitives::compression::compress_blob;
 use citrea_primitives::forks::fork_from_block_number;
 use citrea_primitives::{network_to_dev_mode, MAX_TX_BODY_SIZE, MAX_WITNESS_CACHE_SIZE};
 use citrea_stf::runtime::{CitreaRuntime, DefaultContext};
-use futures::stream::FuturesUnordered;
-use futures::StreamExt;
 use prover_services::{ParallelProverService, ProofData, ProofWithDuration};
 use rand::Rng;
 use reth_tasks::shutdown::GracefulShutdown;
@@ -31,7 +29,7 @@ use sov_rollup_interface::da::SequencerCommitment;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::zk::batch_proof::input::v3::{BatchProofCircuitInputV3, PrevHashProof};
 use sov_rollup_interface::zk::batch_proof::output::BatchProofCircuitOutput;
-use sov_rollup_interface::zk::{Proof, ProofWithJob, ReceiptType, ZkvmHost};
+use sov_rollup_interface::zk::{Proof, ReceiptType, ZkvmHost};
 use sov_rollup_interface::Network;
 use sov_state::Witness;
 use tokio::select;
@@ -164,8 +162,7 @@ where
     /// * `shutdown_signal` - A signal to gracefully shut down the prover service
     #[instrument(name = "BatchProver", skip_all)]
     pub async fn run(mut self, mut shutdown_signal: GracefulShutdown) {
-        self.recover_proving_sessions(self.prover_config.enable_recovery)
-            .await;
+        self.recover_proving_sessions().await;
 
         'run_loop: loop {
             select! {
@@ -749,59 +746,10 @@ where
         });
     }
 
-    /// This function recovers proving sessions that were not completed before the node was restarted.
-    /// It retrieves all pending proving jobs from the ledger database,
-    /// starts the recovery process for each job, and waits for the proofs to be generated.
-    /// Once a proof is generated, it extracts the proof output, stores the proof in the ledger database.
-    /// This function will also recover proofs of jobs that are pending for DA submission,
-    /// and submit the recovered proofs to the DA service with them.
+    /// Recovers proofs of jobs that are pending for DA submission and resubmits them.
     #[instrument(name = "recovery", skip_all)]
-    async fn recover_proving_sessions(&self, enable_proof_session_recovery: bool) {
-        let mut proofs = if enable_proof_session_recovery {
-            // recover proving sessions
-            let proving_jobs = self
-                .prover_service
-                .start_session_recovery()
-                .expect("Failed to start proving session recovery");
-            let mut proving_jobs = proving_jobs
-                .into_iter()
-                .map(|rx| async move { rx.await.expect("Proof recovery channel closed abruptly") })
-                .collect::<FuturesUnordered<_>>();
-
-            info!("Recovering {} proving sessions", proving_jobs.len());
-
-            let mut proofs = HashMap::with_capacity(proving_jobs.len());
-            while let Some(ProofWithJob {
-                job_id,
-                proof,
-                info,
-            }) = proving_jobs.next().await
-            {
-                info!("Proving job finished {}", job_id);
-
-                let output = extract_proof_output::<Vm>(
-                    &job_id,
-                    &proof,
-                    &self.code_commitments_by_spec,
-                    self.network,
-                );
-
-                // stores proof and marks job as waiting for da
-                self.ledger_db
-                    .put_proof_by_job_id(job_id, proof.clone(), output.into(), info)
-                    .expect("Should put proof to db");
-
-                info!("Completed proving job {}", job_id);
-
-                proofs.insert(job_id, proof);
-
-                // TODO: there is a quite small chance that proving has started, but job commitment indices
-                // pending commitments haven't been updated in db, maybe we should also try to recover that?
-            }
-            proofs
-        } else {
-            HashMap::new()
-        };
+    async fn recover_proving_sessions(&self) {
+        let mut proofs = HashMap::new();
 
         // merge proofs of da submission pending jobs
         let job_ids = self

--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -162,8 +162,6 @@ pub struct BatchProverConfig {
     pub proving_mode: ProverGuestRunConfig,
     /// Average number of commitments to prove
     pub proof_sampling_number: usize,
-    /// If true prover will try to recover ongoing proving sessions
-    pub enable_recovery: bool,
     /// Maximum number of commitments per proof partition
     pub max_commitments_per_proof: Option<usize>,
     /// Configuration for Risc0Host
@@ -178,8 +176,6 @@ pub struct LightClientProverConfig {
     pub proving_mode: ProverGuestRunConfig,
     /// Average number of commitments to prove
     pub proof_sampling_number: usize,
-    /// If true prover will try to recover ongoing proving sessions
-    pub enable_recovery: bool,
     /// The starting DA block to sync from
     pub initial_da_height: u64,
     /// Configuration for Risc0Host
@@ -192,7 +188,6 @@ impl Default for BatchProverConfig {
         Self {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Default::default(),
         }
@@ -204,7 +199,6 @@ impl Default for LightClientProverConfig {
         Self {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 0,
-            enable_recovery: true,
             initial_da_height: 1,
             risc0_host: Default::default(),
         }
@@ -216,7 +210,6 @@ impl FromEnv for BatchProverConfig {
         Ok(BatchProverConfig {
             proving_mode: serde_json::from_str(&format!("\"{}\"", read_env("PROVING_MODE")?))?,
             proof_sampling_number: read_env("PROOF_SAMPLING_NUMBER")?.parse()?,
-            enable_recovery: read_env("ENABLE_RECOVERY")?.parse()?,
             max_commitments_per_proof: read_env("MAX_COMMITMENTS_PER_PROOF")
                 .ok()
                 .and_then(|val| val.parse().ok()),
@@ -230,7 +223,6 @@ impl FromEnv for LightClientProverConfig {
         Ok(LightClientProverConfig {
             proving_mode: serde_json::from_str(&format!("\"{}\"", read_env("PROVING_MODE")?))?,
             proof_sampling_number: read_env("PROOF_SAMPLING_NUMBER")?.parse()?,
-            enable_recovery: read_env("ENABLE_RECOVERY")?.parse()?,
             initial_da_height: read_env("INITIAL_DA_HEIGHT")?.parse()?,
             risc0_host: Risc0HostConfig::from_env()?,
         })
@@ -623,7 +615,6 @@ mod tests {
         let config = r#"
             proving_mode = "skip"
             proof_sampling_number = 500
-            enable_recovery = true
         "#;
 
         let config_file = create_config_from(config);
@@ -632,7 +623,6 @@ mod tests {
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Skip,
             proof_sampling_number: 500,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Default::default(),
         };
@@ -694,14 +684,12 @@ mod tests {
     fn test_correct_prover_config_from_env() {
         std::env::set_var("PROVING_MODE", "skip");
         std::env::set_var("PROOF_SAMPLING_NUMBER", "500");
-        std::env::set_var("ENABLE_RECOVERY", "true");
 
         let prover_config = BatchProverConfig::from_env().unwrap();
 
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Skip,
             proof_sampling_number: 500,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Default::default(),
         };
@@ -874,7 +862,6 @@ mod tests {
         let config = r#"
             proving_mode = "execute"
             proof_sampling_number = 42
-            enable_recovery = true
 
             [risc0_host]
             tx_backup_dir = "/tmp/backup"
@@ -889,7 +876,6 @@ mod tests {
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 42,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig {
                 prover: Risc0ProverConfig::Local(LocalProverConfig {
@@ -906,7 +892,6 @@ mod tests {
         let config = r#"
             proving_mode = "execute"
             proof_sampling_number = 42
-            enable_recovery = true
 
             [risc0_host.prover.Bonsai]
             api_url = "http://127.0.0.1"
@@ -926,7 +911,6 @@ mod tests {
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 42,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host,
         };
@@ -938,7 +922,6 @@ mod tests {
         let config = r#"
             proving_mode = "execute"
             proof_sampling_number = 42
-            enable_recovery = true
 
             [risc0_host.prover.Boundless.boundless]
             wallet_private_key = "abcd"
@@ -984,7 +967,6 @@ mod tests {
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 42,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig {
                 prover: Risc0ProverConfig::Boundless(Box::new(boundless_prover_config)),
@@ -999,7 +981,6 @@ mod tests {
         let config = r#"
             proving_mode = "execute"
             proof_sampling_number = 42
-            enable_recovery = true
 
             [risc0_host.prover.Boundless.boundless]
             wallet_private_key = "abcd"
@@ -1039,7 +1020,6 @@ mod tests {
         let expected = BatchProverConfig {
             proving_mode: ProverGuestRunConfig::Execute,
             proof_sampling_number: 42,
-            enable_recovery: true,
             max_commitments_per_proof: None,
             risc0_host: Risc0HostConfig {
                 prover: Risc0ProverConfig::Boundless(Box::new(boundless_prover_config)),

--- a/crates/light-client-prover/src/da_block_handler.rs
+++ b/crates/light-client-prover/src/da_block_handler.rs
@@ -132,7 +132,6 @@ where
         last_l1_height_scanned: StartVariant,
         mut shutdown_signal: GracefulShutdown,
     ) {
-        // if self.prover_config.enable_recovery {
         //     if let Err(e) = self.check_and_recover_ongoing_proving_sessions().await {
         //         error!("Failed to recover ongoing proving sessions: {:?}", e);
         //     }

--- a/crates/prover-services/src/parallel.rs
+++ b/crates/prover-services/src/parallel.rs
@@ -95,7 +95,7 @@ where
         data: ProofData,
         receipt_type: ReceiptType,
     ) -> anyhow::Result<ProofWithDuration> {
-        let job_id = Uuid::new_v4();
+        let job_id = Uuid::nil();
         let rx = self.start_proving(data, receipt_type, job_id).await?;
         Ok(rx.await?)
     }
@@ -235,11 +235,6 @@ where
         Ok(tx_and_proof)
     }
 
-    /// Starts a session recovery.
-    pub fn start_session_recovery(&self) -> anyhow::Result<Vec<oneshot::Receiver<ProofWithJob>>> {
-        let vm = self.vm.clone();
-        vm.start_session_recovery()
-    }
 }
 
 /// Runs the zkVM proving session. Decides on whether to produce a real proof or a fake proof based on the proof mode.

--- a/crates/risc0/src/host/bonsai.rs
+++ b/crates/risc0/src/host/bonsai.rs
@@ -7,8 +7,7 @@ use citrea_common::config::risc0::BonsaiProverConfig;
 use citrea_common::utils::is_dev_mode_enabled_via_environment;
 use metrics::gauge;
 use risc0_zkvm::{compute_image_id, AssumptionReceipt, Digest, InnerAssumptionReceipt, Receipt};
-use sov_db::ledger_db::{BonsaiLedgerOps, LedgerDB};
-use sov_db::schema::types::{BonsaiSession, BonsaiSessionKind};
+use sov_db::ledger_db::LedgerDB;
 use sov_rollup_interface::zk::{
     BonsaiProvingSessionInfo, ProofWithJob, ProvingSessionInfo, ReceiptType,
 };
@@ -19,11 +18,10 @@ use uuid::Uuid;
 #[derive(Clone)]
 pub struct BonsaiProver {
     client: Client,
-    ledger_db: LedgerDB,
 }
 
 impl BonsaiProver {
-    pub fn new(ledger_db: LedgerDB, config: BonsaiProverConfig) -> Self {
+    pub fn new(_ledger_db: LedgerDB, config: BonsaiProverConfig) -> Self {
         assert!(
             !is_dev_mode_enabled_via_environment(),
             "RISC0_DEV_MODE should not be set for bonsai"
@@ -32,7 +30,7 @@ impl BonsaiProver {
         let client = Client::from_parts(config.api_url, config.api_key, risc0_zkvm::VERSION)
             .expect("Bonsai client build cannot fail");
 
-        Self { client, ledger_db }
+        Self { client }
     }
 
     pub fn prove(
@@ -78,15 +76,6 @@ impl BonsaiProver {
             job_id, session.uuid
         );
 
-        let db_session = BonsaiSession {
-            kind: BonsaiSessionKind::StarkSession(session.uuid.clone()),
-            image_id: image_id.into(),
-            receipt_type,
-        };
-        self.ledger_db
-            .upsert_pending_bonsai_session(job_id, db_session)
-            .context("Failed to upsert bonsai stark session")?;
-
         let rx = self.spawn_handler(job_id, session, image_id, receipt_type);
 
         Ok(rx)
@@ -129,12 +118,6 @@ impl BonsaiProver {
                         return;
                     };
 
-                    if let Err(e) = this.ledger_db.remove_pending_bonsai_session(job_id) {
-                        error!(
-                            "Failed to remove pending bonsai session job: {} err={}",
-                            job_id, e
-                        );
-                    }
                 }
                 Err(e) => error!(
                     "Failed to handle Bonsai proving session job: {} err={}",
@@ -172,15 +155,6 @@ impl BonsaiProver {
         }
 
         let snark_session = self.client.create_snark(session.uuid.clone())?;
-
-        let db_session = BonsaiSession {
-            kind: BonsaiSessionKind::SnarkSession(session.uuid, snark_session.uuid.clone()),
-            image_id: image_id.into(),
-            receipt_type,
-        };
-        self.ledger_db
-            .upsert_pending_bonsai_session(job_id, db_session)
-            .context("Failed to upsert bonsai snark session")?;
 
         let groth16_receipt = self.wait_snark_receipt(&snark_session).await?;
         groth16_receipt
@@ -256,45 +230,6 @@ impl BonsaiProver {
         }
     }
 
-    /// Starts the recovery of proving jobs from db by starting a background task, returning list of
-    /// receiver channels that return the associated job id and proof result on finish.
-    pub fn start_recovery(&self) -> anyhow::Result<Vec<oneshot::Receiver<ProofWithJob>>> {
-        let sessions = self.ledger_db.get_pending_bonsai_sessions()?;
-        info!("Recovering Bonsai sessions: {:?}", sessions);
-        if sessions.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let mut rxs = vec![];
-        for (job_id, session) in sessions {
-            info!(
-                "Recovering bonsai session, job_id={} session={:?}",
-                job_id, session
-            );
-
-            let rx = match session.kind {
-                BonsaiSessionKind::StarkSession(id) => self.spawn_handler(
-                    job_id,
-                    SessionId::new(id),
-                    session.image_id.into(),
-                    session.receipt_type,
-                ),
-                BonsaiSessionKind::SnarkSession(id, _) => {
-                    // TODO: check if create snark call creates a new snark session every time and update if needed
-                    self.spawn_handler(
-                        job_id,
-                        SessionId::new(id),
-                        session.image_id.into(),
-                        session.receipt_type,
-                    )
-                }
-            };
-
-            rxs.push(rx);
-        }
-
-        Ok(rxs)
-    }
 }
 
 // Only proven assumptions that are succinct are supported by Bonsai.

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -25,8 +25,7 @@ use risc0_zkvm::{
     compute_image_id, default_executor, AssumptionReceipt, Digest, ExecutorEnvBuilder,
     Groth16Receipt, InnerReceipt, Journal, MaybePruned, Receipt, ReceiptClaim,
 };
-use sov_db::ledger_db::{BoundlessLedgerOps, LedgerDB};
-use sov_db::schema::types::BoundlessSession;
+use sov_db::ledger_db::LedgerDB;
 use sov_rollup_interface::zk::{
     BoundlessProvingSessionInfo, ProofWithJob, ProvingSessionInfo, ReceiptType,
 };
@@ -322,17 +321,7 @@ impl BoundlessProver {
         );
 
         // Start boundless proving session
-        let (req_id, request_expiry) = self
-            .send_request(
-                request,
-                job_id,
-                image_id,
-                journal.clone(),
-                receipt_claim.clone(),
-                receipt_type,
-                total_cycles_approx,
-            )
-            .await?;
+        let (req_id, request_expiry) = self.send_request(request, job_id, image_id).await?;
 
         let rx = self.spawn_handler(
             job_id,
@@ -507,10 +496,6 @@ impl BoundlessProver {
         request: RequestParams,
         job_id: Uuid,
         image_id: Digest,
-        journal: Journal,
-        receipt_claim: ReceiptClaim,
-        receipt_type: ReceiptType,
-        total_cycles_approx: u64,
     ) -> Result<(String, u64), ClientError> {
         // Start boundless proving session
         tracing::info!(
@@ -539,19 +524,6 @@ impl BoundlessProver {
             job_id,
             req_id
         );
-
-        let db_session = BoundlessSession {
-            request_id: req_id.clone(),
-            request_expiry,
-            image_id: image_id.into(),
-            journal_bytes: journal.bytes.to_vec(),
-            receipt_claim_bytes: borsh::to_vec(&receipt_claim).expect("should serialize"),
-            receipt_type,
-            total_cycles_approx,
-        };
-        self.ledger_db
-            .upsert_pending_boundless_session(job_id, db_session)
-            .context("Failed to upsert boundless session")?;
 
         Ok((req_id.to_string(), request_expiry))
     }
@@ -595,13 +567,6 @@ impl BoundlessProver {
                             return;
                         };
 
-                        if let Err(e) = this.ledger_db.remove_pending_boundless_session(job_id) {
-                            tracing::error!(
-                                "Failed to remove pending boundless session job: {} err={}",
-                                job_id,
-                                e
-                            );
-                        }
                         tracing::info!(
                             "Boundless proving job finished: {} | Boundless request id: {}",
                             job_id,
@@ -689,13 +654,8 @@ impl BoundlessProver {
         receipt_claim: ReceiptClaim,
         total_cycles_approx: u64,
         image_id: Digest,
-        receipt_type: ReceiptType,
+        _receipt_type: ReceiptType,
     ) -> anyhow::Result<ResubmitResult> {
-        // Remove failed job from pending boundless sessions
-        self.ledger_db
-            .remove_pending_boundless_session(job_id)
-            .expect("Failed to remove pending boundless session on error");
-
         // Get data of failed order
         // Queries first offchain, and then onchain.
         let Ok((failed_request, _signature)) = self
@@ -832,18 +792,8 @@ impl BoundlessProver {
             )
             .await;
 
-        let (new_req_id, new_exp_time) = match self
-            .send_request(
-                new_request,
-                job_id,
-                image_id,
-                journal.clone(),
-                receipt_claim.clone(),
-                receipt_type,
-                total_cycles_approx,
-            )
-            .await
-        {
+        let (new_req_id, new_exp_time) =
+            match self.send_request(new_request, job_id, image_id).await {
             Ok((req_id, exp_time)) => (req_id, exp_time),
             Err(e) => {
                 tracing::error!(
@@ -910,44 +860,6 @@ impl BoundlessProver {
         Ok(full_snark_receipt)
     }
 
-    // Starts the recovery of proving jobs from db by starting a background task, returning list of
-    /// receiver channels that return the associated job id and proof result on finish.
-    pub fn start_recovery(&self) -> anyhow::Result<Vec<oneshot::Receiver<ProofWithJob>>> {
-        let sessions = self.ledger_db.get_pending_boundless_sessions()?;
-        tracing::info!(
-            "Found {} pending boundless sessions to recover",
-            sessions.len()
-        );
-        if sessions.is_empty() {
-            tracing::info!("No pending boundless sessions to recover");
-            return Ok(vec![]);
-        }
-
-        let mut rxs = vec![];
-        for (job_id, session) in sessions {
-            tracing::info!(
-                "Recovering boundless session, job_id={} session={:?}",
-                job_id,
-                session
-            );
-
-            let rx = self.spawn_handler(
-                job_id,
-                session.receipt_type,
-                session.request_id,
-                session.image_id.into(),
-                Journal {
-                    bytes: session.journal_bytes,
-                },
-                borsh::from_slice(&session.receipt_claim_bytes)
-                    .expect("Failed to deserialize receipt claim from bytes"),
-                session.request_expiry,
-                session.total_cycles_approx,
-            );
-            rxs.push(rx);
-        }
-        Ok(rxs)
-    }
 }
 
 /// Return UNIX timestamp in seconds

--- a/crates/risc0/src/host/mod.rs
+++ b/crates/risc0/src/host/mod.rs
@@ -130,11 +130,6 @@ impl ZkvmHost for Risc0Host {
         Ok(T::try_from_slice(&journal.bytes)?)
     }
 
-    fn start_session_recovery(
-        &self,
-    ) -> Result<Vec<oneshot::Receiver<ProofWithJob>>, anyhow::Error> {
-        self.prover.start_prover_session_recovery()
-    }
 }
 
 impl Zkvm for Risc0Host {
@@ -193,18 +188,3 @@ pub enum Prover {
     Boundless(BoundlessProver),
 }
 
-impl Prover {
-    /// Start recovery for prover if it supports it
-    pub fn start_prover_session_recovery(
-        &self,
-    ) -> anyhow::Result<Vec<oneshot::Receiver<ProofWithJob>>> {
-        match self {
-            Prover::Local(_) => {
-                info!("Skipping proving recovery...");
-                Ok(vec![])
-            }
-            Prover::Boundless(prover) => prover.start_recovery(),
-            Prover::Bonsai(prover) => prover.start_recovery(),
-        }
-    }
-}

--- a/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
+++ b/crates/sovereign-sdk/adapters/mock-zkvm/src/lib.rs
@@ -119,7 +119,7 @@ impl MockZkvm {
             let mut committed_data = self.committed_data.lock().unwrap();
             let proof = committed_data.pop_front().unwrap_or_default();
             chan.send(ProofWithJob {
-                job_id: Uuid::now_v7(),
+                job_id: Uuid::nil(),
                 proof,
                 // mock proving info
                 info: ProvingSessionInfo::Local(LocalProvingSessionInfo {
@@ -229,11 +229,6 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvm {
         T::try_from_slice(&data.hint).map_err(Into::into)
     }
 
-    fn start_session_recovery(
-        &self,
-    ) -> Result<Vec<oneshot::Receiver<ProofWithJob>>, anyhow::Error> {
-        unimplemented!()
-    }
 }
 
 /// A mock implementing the Guest.

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/zk/mod.rs
@@ -135,10 +135,6 @@ pub trait ZkvmHost: Zkvm + Clone + Send {
     /// Extracts public input and receipt from the proof.
     fn extract_output<T: BorshDeserialize>(proof: &Proof) -> Result<T, Self::Error>;
 
-    /// Host recovers pending proving sessions and returns proving results
-    fn start_session_recovery(&self)
-        -> Result<Vec<oneshot::Receiver<ProofWithJob>>, anyhow::Error>;
-
     /// Host adds an assumption to the proving session
     /// Assumptions are used for recursive proving
     fn add_assumption(&mut self, receipt_buf: Vec<u8>);

--- a/proving-stats/configs/batch_prover_config.toml
+++ b/proving-stats/configs/batch_prover_config.toml
@@ -1,3 +1,2 @@
 proving_mode = "execute"
 proof_sampling_number = 0
-enable_recovery = true

--- a/resources/configs/bitcoin-regtest/batch_prover_config.toml
+++ b/resources/configs/bitcoin-regtest/batch_prover_config.toml
@@ -1,3 +1,2 @@
 proving_mode = "execute"
 proof_sampling_number = 500
-enable_recovery = true

--- a/resources/configs/bitcoin-regtest/light_client_prover_config.toml
+++ b/resources/configs/bitcoin-regtest/light_client_prover_config.toml
@@ -1,4 +1,3 @@
 initial_da_height = 1
 proving_mode = "execute"
 proof_sampling_number = 500
-enable_recovery = true

--- a/resources/configs/mock/batch_prover_config.toml
+++ b/resources/configs/mock/batch_prover_config.toml
@@ -1,3 +1,2 @@
 proving_mode = "execute"
 proof_sampling_number = 500
-enable_recovery = true

--- a/resources/configs/mock/light_client_prover_config.toml
+++ b/resources/configs/mock/light_client_prover_config.toml
@@ -1,4 +1,3 @@
 initial_da_height = 1
 proving_mode = "execute"
 proof_sampling_number = 500
-enable_recovery = true


### PR DESCRIPTION
## Summary
- Remove proving session recovery flow from batch prover startup and related host/service APIs.
- Remove `enable_recovery` from prover configs and config files.
- Clean up tests and remaining references related to proving session recovery.

## Validation
- cargo check -p sov-rollup-interface --features native
- cargo check -p sov-mock-zkvm --features sov-rollup-interface/native
- cargo check -p prover-services --features sov-rollup-interface/native
- cargo check -p citrea-risc0-adapter --features native
- cargo check -p citrea-common
- cargo check -p citrea-batch-prover

Closes #3272