### PR TITLE
fix(bitcoin-da): replace output[0] direct index with .first().ok_or() in bump_fee_cpfp

### DIFF
--- a/crates/bitcoin-da/src/fee.rs
+++ b/crates/bitcoin-da/src/fee.rs
@@ -159,8 +159,12 @@ impl FeeService {
             .require_network(self.network)
             .map_err(|_| FeeServiceError::InvalidAddressNetwork)?;
 
+        let parent_output = parent_tx
+            .output
+            .first()
+            .ok_or(FeeServiceError::PsbtRetrievalFailure)?;
         let mut outputs = HashMap::new();
-        outputs.insert(change_address.to_string(), parent_tx.output[0].value);
+        outputs.insert(change_address.to_string(), parent_output.value);
         let options = WalletCreateFundedPsbtOptions {
             add_inputs: Some(true),
             fee_rate: Some(Amount::from_btc(fee_rate / 100_000.0)?), // sat/vB to BTC/kB


### PR DESCRIPTION
## Bug

In `crates/bitcoin-da/src/fee.rs`, `bump_fee_cpfp` accesses `parent_tx.output[0]` directly without a bounds check:

```rust
// Before (panics if outputs are empty)
outputs.insert(change_address.to_string(), parent_tx.output[0].value);
```

**Impact:** If `parent_tx` has no outputs due to a malformed transaction or an unexpected state from the DA layer, this panics and crashes the entire Bitcoin DA service — taking down commitment submissions and proof broadcasting with it.

This is consistent with the pattern of `.unwrap()`/direct-index panics that have been addressed in other parts of this crate.

## Fix

Replaced with `.first().ok_or()` to propagate a structured `FeeServiceError` instead of panicking:

```rust
// After (returns structured error)
let parent_output = parent_tx
    .output
    .first()
    .ok_or(FeeServiceError::PsbtRetrievalFailure)?;
outputs.insert(change_address.to_string(), parent_output.value);
```

cc @eyusufatik @jfldde