### PR TITLE
fix(bitcoin-da): replace output[0] direct index with .first().ok_or() in validate_txs_fee_rate

### DIFF
--- a/crates/bitcoin-da/src/fee.rs
+++ b/crates/bitcoin-da/src/fee.rs
@@ -289,8 +289,16 @@ pub(crate) fn validate_txs_fee_rate(
 
         // Validate reveal
         let reveal_tx = &tx.reveal.tx;
-        let input_amount = commit_tx.output[0].value;
-        let output_amount = reveal_tx.output[0].value;
+        let input_amount = commit_tx
+            .output
+            .first()
+            .ok_or(BitcoinServiceError::FeeCalculation(fee_rate))?
+            .value;
+        let output_amount = reveal_tx
+            .output
+            .first()
+            .ok_or(BitcoinServiceError::FeeCalculation(fee_rate))?
+            .value;
 
         // Add reveal utxo to utxo_map, used by chunking txs
         utxo_map.insert((tx.reveal_txid(), 0), output_amount);


### PR DESCRIPTION
## Bug

In `crates/bitcoin-da/src/fee.rs`, `validate_txs_fee_rate` accesses transaction outputs by direct index without bounds checks:

```rust
// Before (panics if outputs are empty)
let input_amount = commit_tx.output[0].value;
let output_amount = reveal_tx.output[0].value;
```

**Impact:** If either `commit_tx` or `reveal_tx` has no outputs (e.g. due to a malformed transaction, RPC response corruption, or an edge case in transaction construction), both of these lines panic unconditionally. Since `validate_txs_fee_rate` runs in the DA service hot path before broadcasting transactions, a single malformed transaction can crash the service entirely and halt all commitment submissions.

## Fix

Replaced both direct indexes with `.first().ok_or()` to return a structured `BitcoinServiceError::FeeCalculation` instead of panicking, consistent with how other out-of-bounds cases are handled in this crate:

```rust
// After (structured error propagation)
let input_amount = commit_tx
    .output
    .first()
    .ok_or(BitcoinServiceError::FeeCalculation(fee_rate))?
    .value;
let output_amount = reveal_tx
    .output
    .first()
    .ok_or(BitcoinServiceError::FeeCalculation(fee_rate))?
    .value;
```

cc @eyusufatik @jfldde