### PR TITLE
chore: fix unclosed code block in backup module documentation

### DIFF
--- a/crates/common/src/backup/mod.rs
+++ b/crates/common/src/backup/mod.rs
@@ -36,6 +36,7 @@
 //! ├── ledger/       # Required - stores ledger database
 //! ├── state/        # Required - stores state database
 //! ├── native-db/    # Required - stores native database
+//! ```
 mod manager;
 pub mod metadata;
 mod rpc;


### PR DESCRIPTION
# Description

Add missing closing backticks to the directory structure code block in the backup module's documentation comment. 

The code block was opened with ```text but never closed, which could cause documentation rendering issues.




## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
