### PR TITLE
fix: Use price related fields in Boundless pricing client as U256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - refactor: remove proving session recovery ([#3288](https://github.com/chainwayxyz/citrea/pull/3288))\
   **Removed env var:**\
     `ENABLE_RECOVERY`
+- fix: Use price related fields in Boundless pricing client as U256. ([#3291](https://github.com/chainwayxyz/citrea/pull/3291))
 
 ## [v2.4.0](2026-04-06)
 This version updates RocksDB, underlying database of Citrea nodes.

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -293,14 +293,8 @@ impl BoundlessProver {
                 image_id,
                 image_url,
                 input_url,
-                U256::from(cmp::min(
-                    min_price_wei_per_cycle,
-                    max_possible_price_wei_per_cycle,
-                )),
-                U256::from(cmp::min(
-                    max_price_wei_per_cycle,
-                    max_possible_price_wei_per_cycle,
-                )),
+                cmp::min(min_price_wei_per_cycle, max_possible_price_wei_per_cycle),
+                cmp::min(max_price_wei_per_cycle, max_possible_price_wei_per_cycle),
                 lock_timeout,
                 timeout,
                 ramp_up_period,
@@ -753,10 +747,10 @@ impl BoundlessProver {
                 let min_price_per_cycle = min_price_per_cycle
                     .saturating_mul(U256::from(MIN_PRICE_INCREASE_MULTIPLIER))
                     .div_ceil(U256::from(MIN_PRICE_INCREASE_DIVISOR))
-                    .min(U256::from(max_possible_price_wei_per_cycle));
+                    .min(max_possible_price_wei_per_cycle);
                 let max_price_per_cycle = max_price_per_cycle
                     .saturating_mul(U256::from(MAX_PRICE_INCREASE_RATIO))
-                    .min(U256::from(max_possible_price_wei_per_cycle));
+                    .min(max_possible_price_wei_per_cycle);
                 (min_price_per_cycle, max_price_per_cycle, lock_timeout)
             }
         };

--- a/crates/risc0/src/host/boundless.rs
+++ b/crates/risc0/src/host/boundless.rs
@@ -345,7 +345,7 @@ impl BoundlessProver {
         lock_timeout: u64,
         timeout: u64,
         ramp_up_period: u64,
-        lock_stake: u64,
+        lock_stake: U256,
         bidding_start_delay: u64,
         total_cycles_approx: u64,
         journal: Journal,
@@ -368,7 +368,7 @@ impl BoundlessProver {
             .lock_timeout(lock_timeout as u32)
             .timeout(timeout as u32)
             .ramp_up_period(ramp_up_period as u32)
-            .lock_collateral(U256::from(lock_stake))
+            .lock_collateral(lock_stake)
             .bidding_start_delay(bidding_start_delay)
             .build()
             .expect("Failed to build offer layer config");
@@ -475,7 +475,7 @@ impl BoundlessProver {
                     .with_lock_timeout(lock_timeout as u32)
                     .with_timeout(timeout as u32)
                     .with_ramp_up_period(ramp_up_period as u32)
-                    .with_lock_collateral(U256::from(lock_stake))
+                    .with_lock_collateral(lock_stake)
                     .with_ramp_up_start(bidding_start),
             )
             .with_cycles(total_cycles_approx)

--- a/crates/risc0/src/host/pricing_service.rs
+++ b/crates/risc0/src/host/pricing_service.rs
@@ -10,10 +10,10 @@ use tracing::info;
 /// Response structure for the pricing API
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PriceResponse {
-    pub min_price_wei_per_cycle: u64,
-    pub max_price_wei_per_cycle: u64,
+    pub min_price_wei_per_cycle: U256,
+    pub max_price_wei_per_cycle: U256,
     pub lock_timeout: u64,
-    pub max_possible_price_wei_per_cycle: u64,
+    pub max_possible_price_wei_per_cycle: U256,
     pub lock_stake: U256,
     pub ramp_up_period: u64,
     pub timeout: u64,

--- a/crates/risc0/src/host/pricing_service.rs
+++ b/crates/risc0/src/host/pricing_service.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
+use boundless_market::alloy::primitives::U256;
 use citrea_common::PricingServiceConfig;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -13,7 +14,7 @@ pub struct PriceResponse {
     pub max_price_wei_per_cycle: u64,
     pub lock_timeout: u64,
     pub max_possible_price_wei_per_cycle: u64,
-    pub lock_stake: u64,
+    pub lock_stake: U256,
     pub ramp_up_period: u64,
     pub timeout: u64,
     pub bidding_start_delay: u64,


### PR DESCRIPTION
# Description
The server now emits lock stake and price related data as hex string (e.g. `"0x2b5e3af16b1880000"`) because the value exceeds`u64::MAX` deserialized here directly into `U256` since that's the type the Boundless contract takes anyway.                                           

Also fixes rounding errors on the server side