### PR TITLE
ci: Fix nix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ permissions:
 
 on:
   push:
-    branches:
-      - ci/fix-nix-release
     tags:
       - "v*.*.*"
 
@@ -82,7 +80,6 @@ jobs:
           path: artifacts/
 
       - name: Attest build provenance
-        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: |
@@ -93,66 +90,30 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Compute release tag
-        id: vars
-        shell: bash
-        run: echo "release_tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
-
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: release-build-*-${{ steps.vars.outputs.release_tag }}
+          pattern: release-build-*-${{ github.ref_name }}
           path: artifacts
           merge-multiple: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-      - name: Smoke test Linux release binaries
-        shell: bash
-        run: |
-          set -euo pipefail
-          chmod +x \
-            "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
-            "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-linux-arm64" \
-            "artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
-            "artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-arm64"
-
-          for image in debian:trixie-slim ubuntu:24.04; do
-            for arch in amd64 arm64; do
-              docker run --rm \
-                --platform "linux/${arch}" \
-                -v "$PWD/artifacts:/artifacts:ro" \
-                "${image}" \
-                "/artifacts/citrea-${{ steps.vars.outputs.release_tag }}-linux-${arch}" --version
-
-              docker run --rm \
-                --platform "linux/${arch}" \
-                -v "$PWD/artifacts:/artifacts:ro" \
-                "${image}" \
-                "/artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-${arch}" --version
-            done
-          done
 
       - name: Generate SHA256SUMS.txt
         shell: bash
         run: |
           set -euo pipefail
           (cd artifacts && shasum -a 256 \
-            "citrea-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
-            "citrea-${{ steps.vars.outputs.release_tag }}-linux-arm64" \
-            "citrea-${{ steps.vars.outputs.release_tag }}-osx-arm64" \
-            "citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
-            "citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-arm64" \
-            "citrea-cli-${{ steps.vars.outputs.release_tag }}-osx-arm64" \
+            "citrea-${{ github.ref_name }}-linux-amd64" \
+            "citrea-${{ github.ref_name }}-linux-arm64" \
+            "citrea-${{ github.ref_name }}-osx-arm64" \
+            "citrea-cli-${{ github.ref_name }}-linux-amd64" \
+            "citrea-cli-${{ github.ref_name }}-linux-arm64" \
+            "citrea-cli-${{ github.ref_name }}-osx-arm64" \
             > "SHA256SUMS.txt")
 
       - name: Install Cosign
-        if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign SHA256SUMS.txt
-        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
           set -euo pipefail
@@ -161,7 +122,6 @@ jobs:
             artifacts/SHA256SUMS.txt
 
       - name: Verify signed SHA256SUMS.txt
-        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         env:
           CERTIFICATE_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
@@ -178,11 +138,10 @@ jobs:
       - name: Upload packaged artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: release-bundle-${{ steps.vars.outputs.release_tag }}
+          name: release-bundle-${{ github.ref_name }}
           path: artifacts/
 
       - name: Attach to release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: Release ${{ github.ref_name }}
@@ -209,7 +168,6 @@ jobs:
             artifacts/citrea-cli-${{ github.ref_name }}-osx-arm64
 
   update-dockerhub:
-    if: startsWith(github.ref, 'refs/tags/')
     needs: [package]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
             runner: ubicloud-standard-30
           - platform: linux-arm64
             runner: ubicloud-standard-30-arm
+          - platform: osx-arm64
+            runner: macos-latest
 
     runs-on: ${{ matrix.runner }}
     steps:
@@ -43,6 +45,9 @@ jobs:
 
       - name: Build
         run: nix build ./nix#citrea
+
+      - name: Rebuild to verify reproducibility
+        run: nix build ./nix#citrea --rebuild
 
       - name: Hash binaries
         id: hash
@@ -136,8 +141,10 @@ jobs:
           (cd artifacts && shasum -a 256 \
             "citrea-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
             "citrea-${{ steps.vars.outputs.release_tag }}-linux-arm64" \
+            "citrea-${{ steps.vars.outputs.release_tag }}-osx-arm64" \
             "citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
             "citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-arm64" \
+            "citrea-cli-${{ steps.vars.outputs.release_tag }}-osx-arm64" \
             > "SHA256SUMS.txt")
 
       - name: Install Cosign
@@ -185,8 +192,10 @@ jobs:
             It includes:
             - citrea-${{ github.ref_name }}-linux-amd64
             - citrea-${{ github.ref_name }}-linux-arm64
+            - citrea-${{ github.ref_name }}-osx-arm64
             - citrea-cli-${{ github.ref_name }}-linux-amd64
             - citrea-cli-${{ github.ref_name }}-linux-arm64
+            - citrea-cli-${{ github.ref_name }}-osx-arm64
             - SHA256SUMS.txt
             - SHA256SUMS.txt.sigstore.json
           files: |
@@ -194,8 +203,10 @@ jobs:
             artifacts/SHA256SUMS.txt.sigstore.json
             artifacts/citrea-${{ github.ref_name }}-linux-amd64
             artifacts/citrea-${{ github.ref_name }}-linux-arm64
+            artifacts/citrea-${{ github.ref_name }}-osx-arm64
             artifacts/citrea-cli-${{ github.ref_name }}-linux-amd64
             artifacts/citrea-cli-${{ github.ref_name }}-linux-arm64
+            artifacts/citrea-cli-${{ github.ref_name }}-osx-arm64
 
   update-dockerhub:
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Compute release tag
         id: vars
         shell: bash
@@ -105,9 +102,6 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Smoke test Linux release binaries
         shell: bash
@@ -133,32 +127,6 @@ jobs:
                 "${image}" \
                 "/artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-${arch}" --version
             done
-          done
-
-      - name: Smoke test full-node Docker images
-        shell: bash
-        run: |
-          set -euo pipefail
-          cp "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-linux-amd64" docker/full-node/citrea-amd64
-          cp "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-linux-arm64" docker/full-node/citrea-arm64
-
-          mkdir -p docker/full-node/genesis
-          cp -r resources/genesis/mainnet docker/full-node/genesis/
-          cp -r resources/genesis/testnet docker/full-node/genesis/
-
-          for arch in amd64 arm64; do
-            image="citrea-full-node-smoke:${arch}"
-            docker buildx build \
-              --platform "linux/${arch}" \
-              --load \
-              -t "${image}" \
-              docker/full-node
-
-            docker run --rm \
-              --platform "linux/${arch}" \
-              --entrypoint ./citrea \
-              "${image}" \
-              --version
           done
 
       - name: Generate SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
             runner: ubicloud-standard-30
           - platform: linux-arm64
             runner: ubicloud-standard-30-arm
-          - platform: osx-arm64
-            runner: macos-latest
 
     runs-on: ${{ matrix.runner }}
     steps:
@@ -45,9 +43,6 @@ jobs:
 
       - name: Build
         run: nix build ./nix#citrea
-
-      - name: Rebuild to verify reproducibility
-        run: nix build ./nix#citrea --rebuild
 
       - name: Hash binaries
         id: hash
@@ -141,10 +136,8 @@ jobs:
           (cd artifacts && shasum -a 256 \
             "citrea-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
             "citrea-${{ steps.vars.outputs.release_tag }}-linux-arm64" \
-            "citrea-${{ steps.vars.outputs.release_tag }}-osx-arm64" \
             "citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
             "citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-arm64" \
-            "citrea-cli-${{ steps.vars.outputs.release_tag }}-osx-arm64" \
             > "SHA256SUMS.txt")
 
       - name: Install Cosign
@@ -192,10 +185,8 @@ jobs:
             It includes:
             - citrea-${{ github.ref_name }}-linux-amd64
             - citrea-${{ github.ref_name }}-linux-arm64
-            - citrea-${{ github.ref_name }}-osx-arm64
             - citrea-cli-${{ github.ref_name }}-linux-amd64
             - citrea-cli-${{ github.ref_name }}-linux-arm64
-            - citrea-cli-${{ github.ref_name }}-osx-arm64
             - SHA256SUMS.txt
             - SHA256SUMS.txt.sigstore.json
           files: |
@@ -203,10 +194,8 @@ jobs:
             artifacts/SHA256SUMS.txt.sigstore.json
             artifacts/citrea-${{ github.ref_name }}-linux-amd64
             artifacts/citrea-${{ github.ref_name }}-linux-arm64
-            artifacts/citrea-${{ github.ref_name }}-osx-arm64
             artifacts/citrea-cli-${{ github.ref_name }}-linux-amd64
             artifacts/citrea-cli-${{ github.ref_name }}-linux-arm64
-            artifacts/citrea-cli-${{ github.ref_name }}-osx-arm64
 
   update-dockerhub:
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ permissions:
 
 on:
   push:
+    branches:
+      - ci/fix-nix-release
     tags:
       - "v*.*.*"
 
@@ -80,6 +82,7 @@ jobs:
           path: artifacts/
 
       - name: Attest build provenance
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: |
@@ -90,30 +93,66 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Compute release tag
+        id: vars
+        shell: bash
+        run: echo "release_tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: release-build-*-${{ github.ref_name }}
+          pattern: release-build-*-${{ steps.vars.outputs.release_tag }}
           path: artifacts
           merge-multiple: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Smoke test Linux release binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x \
+            "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
+            "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-linux-arm64" \
+            "artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
+            "artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-arm64"
+
+          for image in debian:trixie-slim ubuntu:24.04; do
+            for arch in amd64 arm64; do
+              docker run --rm \
+                --platform "linux/${arch}" \
+                -v "$PWD/artifacts:/artifacts:ro" \
+                "${image}" \
+                "/artifacts/citrea-${{ steps.vars.outputs.release_tag }}-linux-${arch}" --version
+
+              docker run --rm \
+                --platform "linux/${arch}" \
+                -v "$PWD/artifacts:/artifacts:ro" \
+                "${image}" \
+                "/artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-${arch}" --version
+            done
+          done
 
       - name: Generate SHA256SUMS.txt
         shell: bash
         run: |
           set -euo pipefail
           (cd artifacts && shasum -a 256 \
-            "citrea-${{ github.ref_name }}-linux-amd64" \
-            "citrea-${{ github.ref_name }}-linux-arm64" \
-            "citrea-${{ github.ref_name }}-osx-arm64" \
-            "citrea-cli-${{ github.ref_name }}-linux-amd64" \
-            "citrea-cli-${{ github.ref_name }}-linux-arm64" \
-            "citrea-cli-${{ github.ref_name }}-osx-arm64" \
+            "citrea-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
+            "citrea-${{ steps.vars.outputs.release_tag }}-linux-arm64" \
+            "citrea-${{ steps.vars.outputs.release_tag }}-osx-arm64" \
+            "citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-amd64" \
+            "citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-arm64" \
+            "citrea-cli-${{ steps.vars.outputs.release_tag }}-osx-arm64" \
             > "SHA256SUMS.txt")
 
       - name: Install Cosign
+        if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign SHA256SUMS.txt
+        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
           set -euo pipefail
@@ -122,6 +161,7 @@ jobs:
             artifacts/SHA256SUMS.txt
 
       - name: Verify signed SHA256SUMS.txt
+        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         env:
           CERTIFICATE_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
@@ -138,10 +178,11 @@ jobs:
       - name: Upload packaged artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: release-bundle-${{ github.ref_name }}
+          name: release-bundle-${{ steps.vars.outputs.release_tag }}
           path: artifacts/
 
       - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: Release ${{ github.ref_name }}
@@ -168,6 +209,7 @@ jobs:
             artifacts/citrea-cli-${{ github.ref_name }}-osx-arm64
 
   update-dockerhub:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [package]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Compute release tag
         id: vars
         shell: bash
@@ -102,6 +105,9 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Smoke test Linux release binaries
         shell: bash
@@ -127,6 +133,32 @@ jobs:
                 "${image}" \
                 "/artifacts/citrea-cli-${{ steps.vars.outputs.release_tag }}-linux-${arch}" --version
             done
+          done
+
+      - name: Smoke test full-node Docker images
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-linux-amd64" docker/full-node/citrea-amd64
+          cp "artifacts/citrea-${{ steps.vars.outputs.release_tag }}-linux-arm64" docker/full-node/citrea-arm64
+
+          mkdir -p docker/full-node/genesis
+          cp -r resources/genesis/mainnet docker/full-node/genesis/
+          cp -r resources/genesis/testnet docker/full-node/genesis/
+
+          for arch in amd64 arm64; do
+            image="citrea-full-node-smoke:${arch}"
+            docker buildx build \
+              --platform "linux/${arch}" \
+              --load \
+              -t "${image}" \
+              docker/full-node
+
+            docker run --rm \
+              --platform "linux/${arch}" \
+              --entrypoint ./citrea \
+              "${image}" \
+              --version
           done
 
       - name: Generate SHA256SUMS.txt

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -31,6 +31,18 @@
         # Workspace root is one level up from this flake (which lives in `nix/`).
         workspaceRoot = ../.;
 
+        # Release artifacts run outside the Nix store, so Linux binaries need the
+        # distro-standard dynamic loader instead of Nix's glibc interpreter path.
+        linuxElfInterpreter =
+          if system == "x86_64-linux" then
+            "/lib64/ld-linux-x86-64.so.2"
+          else if system == "aarch64-linux" then
+            "/lib/ld-linux-aarch64.so.1"
+          else if pkgs.stdenv.hostPlatform.isLinux then
+            throw "Unsupported Linux release system: ${system}"
+          else
+            "";
+
         # Source filtering: Rust sources + non-Rust assets the workspace consumes at
         # compile time. Anything else is excluded so deps-only caching isn't invalidated
         # by unrelated changes.
@@ -125,25 +137,41 @@
               strip $out/bin/citrea-cli
             '';
 
-            postFixup = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
-              otool="${pkgs.darwin.cctools}/bin/otool"
-              install_name_tool="${pkgs.darwin.cctools}/bin/install_name_tool"
-              codesign_allocate="${pkgs.darwin.binutils.bintools}/bin/codesign_allocate"
-              codesign="${pkgs.darwin.sigtool}/bin/codesign"
-              for bin in $out/bin/citrea $out/bin/citrea-cli; do
-                chmod +w "$bin"
+            postFixup =
+              pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
+                otool="${pkgs.darwin.cctools}/bin/otool"
+                install_name_tool="${pkgs.darwin.cctools}/bin/install_name_tool"
+                codesign_allocate="${pkgs.darwin.binutils.bintools}/bin/codesign_allocate"
+                codesign="${pkgs.darwin.sigtool}/bin/codesign"
+                for bin in $out/bin/citrea $out/bin/citrea-cli; do
+                  chmod +w "$bin"
 
-                LIBICONV_PATH="$("$otool" -L "$bin" | awk '/libiconv\.2\.dylib/{print $1; exit}')"
-                if [ -n "$LIBICONV_PATH" ]; then
-                  "$install_name_tool" \
-                    -change "$LIBICONV_PATH" /usr/lib/libiconv.2.dylib \
-                    "$bin"
-                fi
+                  LIBICONV_PATH="$("$otool" -L "$bin" | awk '/libiconv\.2\.dylib/{print $1; exit}')"
+                  if [ -n "$LIBICONV_PATH" ]; then
+                    "$install_name_tool" \
+                      -change "$LIBICONV_PATH" /usr/lib/libiconv.2.dylib \
+                      "$bin"
+                  fi
 
-                CODESIGN_ALLOCATE="$codesign_allocate" "$codesign" -f -s - "$bin"
-                chmod 555 "$bin"
-              done
-            '';
+                  CODESIGN_ALLOCATE="$codesign_allocate" "$codesign" -f -s - "$bin"
+                  chmod 555 "$bin"
+                done
+              ''
+              + pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+                patchelf="${pkgs.patchelf}/bin/patchelf"
+                for bin in $out/bin/citrea $out/bin/citrea-cli; do
+                  chmod +w "$bin"
+
+                  "$patchelf" --set-interpreter "${linuxElfInterpreter}" "$bin"
+                  actual_interpreter="$("$patchelf" --print-interpreter "$bin")"
+                  if [ "$actual_interpreter" != "${linuxElfInterpreter}" ]; then
+                    echo "failed to patch ELF interpreter for $bin" >&2
+                    exit 1
+                  fi
+
+                  chmod 555 "$bin"
+                done
+              '';
           });
 
           default = self.packages.${system}.citrea;


### PR DESCRIPTION
# Description

- [Fix linux binaries internal paths](https://github.com/chainwayxyz/citrea/commit/5fec2f4c4dee1e4c8db7e3f642488bfd689bf036)
- Fixes v2.5.0 linux releases failing with `./entrypoint.sh: line 70: ./citrea: cannot execute: required file not found`

# Testing
Test run can be seen at https://github.com/chainwayxyz/citrea/actions/runs/27007408791