### PR TITLE
ci: Bump codecov to v7.0.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -260,7 +260,7 @@ jobs:
           name: e2e-test-dir-coverage
           path: ${{ runner.temp }}/coverage
       - name: Upload coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true # optional (default = false)
           files: ./lcov.info


### PR DESCRIPTION
# Description

- Fix signature verification issues on CI. See https://github.com/codecov/codecov-action/releases/tag/v7.0.0
> ⚠️ Due to migration issues with keybase, we are unable to update our keys under the codecovsecurity account. We have deleted the account and are using codecovsecops with the original gpg key
