### PR TITLE
Add root check-no-std Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ lint-fix:  ## dprint fmt, cargo fmt, fix and clippy. Skip clippy on guest code s
 check-features: ## Checks that project compiles with all combinations of features.
 	cargo hack check --workspace --feature-powerset --exclude-features default --all-targets
 
+check-no-std: ## Checks that no-std modules compile without std
+	$(MAKE) -C crates/sovereign-sdk/module-system/sov-modules-core check-no-std
+
 find-unused-deps: ## Prints unused dependencies for project. Note: requires nightly
 	cargo +nightly udeps --all-targets --all-features
 


### PR DESCRIPTION
# Description

This PR adds a root-level `check-no-std` Makefile target.

`CONTRIBUTING.md` asks contributors to run `make check-no-std`, but the root Makefile did not define that target. The actual no-std check already exists under `crates/sovereign-sdk/module-system/sov-modules-core`, so this target forwards to the existing implementation.

This keeps the documented contributor workflow working from the repository root.



## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
- Ran `make -n check-no-std`
- Ran `make help | rg "check-no-std|check-features|find-unused"`
- Ran `git diff --check`

## Docs

No docs update needed. This makes the existing documented command available.
