### PR TITLE
fix(bitcoin-da): harden coinbase parsing in short header proof & verifier (no panics)

### DIFF
--- a/crates/bitcoin-da/src/spec/short_proof.rs
+++ b/crates/bitcoin-da/src/spec/short_proof.rs
@@ -95,7 +95,12 @@ impl VerifiableShortHeaderProof for BitcoinHeaderShortProof {
                 // If post-segwit block, extract the commitment from the coinbase tx
                 // and compare with header.txs_commitment().
                 let script_pubkey = self.coinbase_tx.output[idx].script_pubkey.as_bytes();
-                let input_witness_value = self.coinbase_tx.input[0].witness.iter().next().unwrap();
+                let input_witness_value = self
+                    .coinbase_tx
+                    .input
+                    .first()
+                    .and_then(|input| input.witness.iter().next())
+                    .ok_or(ShortHeaderProofVerificationError::InvalidWitnessCommitmentStructure)?;
 
                 let mut vec_merkle = Vec::with_capacity(input_witness_value.len() + 32);
 
@@ -126,22 +131,23 @@ impl VerifiableShortHeaderProof for BitcoinHeaderShortProof {
             .coinbase_tx
             .input
             .first()
-            .expect("coinbase tx must have input");
+            .ok_or(ShortHeaderProofVerificationError::InvalidWitnessCommitmentStructure)?;
 
-        let push = input
-            .script_sig
-            .instructions_minimal()
-            .next()
-            .expect("should have at least one instruction")
-            .expect("should be minimal");
-
-        let script::Instruction::PushBytes(b) = push else {
-            panic!("should be push bytes");
+        let Some(Ok(push)) = input.script_sig.instructions_minimal().next() else {
+            return Err(ShortHeaderProofVerificationError::InvalidCoinbaseHeightEncoding);
         };
 
-        let height = script::read_scriptint(b.as_bytes()).expect("should work");
+        let script::Instruction::PushBytes(b) = push else {
+            return Err(ShortHeaderProofVerificationError::InvalidCoinbaseHeightEncoding);
+        };
 
-        assert!(height > 0, "height must be positive");
+        let Ok(height) = script::read_scriptint(b.as_bytes()) else {
+            return Err(ShortHeaderProofVerificationError::InvalidCoinbaseHeightEncoding);
+        };
+
+        if height <= 0 {
+            return Err(ShortHeaderProofVerificationError::InvalidCoinbaseHeightEncoding);
+        }
 
         let height = height as u64;
 
@@ -372,5 +378,216 @@ mod test {
                 }
             )
         }
+    }
+
+    // Regression test: a malformed coinbase (empty witness) must produce a
+    // graceful `Err`, never a panic. Stripping the coinbase witness keeps the
+    // txid (and thus the coinbase merkle proof) valid, so verification reaches
+    // the witness-commitment branch. Before the fix this panicked at
+    // short_proof.rs:98 (`Option::unwrap()` on `None`).
+    #[test]
+    fn shp_empty_coinbase_witness_returns_err() {
+        let mut proof = get_proof();
+
+        let mut tx = proof.coinbase_tx.deref().clone();
+        tx.input[0].witness = bitcoin::Witness::new(); // strip witness; txid unchanged
+        proof.coinbase_tx = tx.into();
+
+        assert_eq!(
+            proof.verify().unwrap_err(),
+            ShortHeaderProofVerificationError::InvalidWitnessCommitmentStructure
+        );
+    }
+
+    // ---- Exhaustive edge cases for the hardened `verify()` paths ----
+    //
+    // Each test builds a real single-transaction "block": the coinbase txid is
+    // used as the header merkle root (empty merkle proof), and `HeaderWrapper::new`
+    // computes a matching `precomputed_hash`, so `verify_hash()` and the coinbase
+    // merkle-inclusion check both pass and execution reaches the branch under test.
+    // Nothing here is stubbed: real `Transaction`/`Header` values flow through the
+    // production `verify()`.
+
+    use bitcoin::absolute::LockTime;
+    use bitcoin::transaction::Version;
+    use bitcoin::{Amount, CompactTarget, OutPoint, Script, ScriptBuf, Sequence, TxIn, TxMerkleNode, TxOut, Witness};
+
+    fn build_single_coinbase_proof(
+        coinbase: bitcoin::Transaction,
+        txs_commitment: [u8; 32],
+    ) -> BitcoinHeaderShortProof {
+        let txid = crate::helpers::calculate_txid(&coinbase);
+        let header = bitcoin::block::Header {
+            version: bitcoin::block::Version::from_consensus(0x2000_0000),
+            prev_blockhash: BlockHash::from_byte_array([0u8; 32]),
+            merkle_root: TxMerkleNode::from_byte_array(txid),
+            time: 1_700_000_000,
+            bits: CompactTarget::from_consensus(0x1703_0000),
+            nonce: 0,
+        };
+        // header height field (999) is deliberately != any script_sig height,
+        // to prove `verify()` reads the height from the coinbase, not the header.
+        let header = HeaderWrapper::new(header, 1, 999, txs_commitment);
+        BitcoinHeaderShortProof::new(header, coinbase.into(), vec![])
+    }
+
+    fn coinbase(input: Vec<TxIn>, output: Vec<TxOut>) -> bitcoin::Transaction {
+        bitcoin::Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input,
+            output,
+        }
+    }
+
+    fn txin(script_sig: Vec<u8>, witness: Witness) -> TxIn {
+        TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::from_bytes(script_sig),
+            sequence: Sequence::MAX,
+            witness,
+        }
+    }
+
+    // >= 38 bytes, starts with 0x6a24aa21a9ed -> recognised as a SegWit commitment output.
+    fn commitment_output() -> TxOut {
+        let mut spk = vec![0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+        spk.extend_from_slice(&[0u8; 32]);
+        TxOut {
+            value: Amount::from_sat(0),
+            script_pubkey: ScriptBuf::from_bytes(spk),
+        }
+    }
+
+    // A plain OP_RETURN output that is NOT a witness commitment -> drives the
+    // `None` (non-segwit) branch and on to BIP34 height parsing.
+    fn non_commitment_output() -> TxOut {
+        TxOut {
+            value: Amount::from_sat(0),
+            script_pubkey: ScriptBuf::from_bytes(vec![0x6a, 0x01, 0x00]),
+        }
+    }
+
+    use ShortHeaderProofVerificationError as E;
+
+    // --- witness-commitment branch (reaches the line-98 access) ---
+
+    #[test]
+    fn shp_commitment_branch_no_inputs_is_err() {
+        let cb = coinbase(vec![], vec![commitment_output()]);
+        assert_eq!(
+            build_single_coinbase_proof(cb, [0u8; 32]).verify().unwrap_err(),
+            E::InvalidWitnessCommitmentStructure
+        );
+    }
+
+    #[test]
+    fn shp_commitment_branch_empty_witness_is_err() {
+        // valid-looking height in script_sig, but the witness is empty
+        let cb = coinbase(
+            vec![txin(vec![0x03, 0x60, 0xAE, 0x0A], Witness::new())],
+            vec![commitment_output()],
+        );
+        assert_eq!(
+            build_single_coinbase_proof(cb, [0u8; 32]).verify().unwrap_err(),
+            E::InvalidWitnessCommitmentStructure
+        );
+    }
+
+    // --- BIP34 height parsing branch (non-segwit) ---
+
+    #[test]
+    fn shp_height_parse_no_inputs_is_err() {
+        let cb = coinbase(vec![], vec![non_commitment_output()]);
+        assert_eq!(
+            build_single_coinbase_proof(cb, [0u8; 32]).verify().unwrap_err(),
+            E::InvalidWitnessCommitmentStructure
+        );
+    }
+
+    #[test]
+    fn shp_height_empty_scriptsig_is_err() {
+        let cb = coinbase(vec![txin(vec![], Witness::new())], vec![non_commitment_output()]);
+        assert_eq!(
+            build_single_coinbase_proof(cb, [0u8; 32]).verify().unwrap_err(),
+            E::InvalidCoinbaseHeightEncoding
+        );
+    }
+
+    #[test]
+    fn shp_height_first_instruction_is_opcode_is_err() {
+        // 0x61 = OP_NOP, not a push
+        let cb = coinbase(vec![txin(vec![0x61], Witness::new())], vec![non_commitment_output()]);
+        assert_eq!(
+            build_single_coinbase_proof(cb, [0u8; 32]).verify().unwrap_err(),
+            E::InvalidCoinbaseHeightEncoding
+        );
+    }
+
+    #[test]
+    fn shp_height_int_too_long_is_err() {
+        // push of 5 bytes -> read_scriptint rejects (> 4 bytes)
+        let cb = coinbase(
+            vec![txin(vec![0x05, 1, 2, 3, 4, 5], Witness::new())],
+            vec![non_commitment_output()],
+        );
+        assert_eq!(
+            build_single_coinbase_proof(cb, [0u8; 32]).verify().unwrap_err(),
+            E::InvalidCoinbaseHeightEncoding
+        );
+    }
+
+    #[test]
+    fn shp_height_non_minimal_push_is_err() {
+        // OP_PUSHDATA1, len 1, byte 0x05 -> non-minimal -> instructions_minimal() yields Err
+        let cb = coinbase(
+            vec![txin(vec![0x4c, 0x01, 0x05], Witness::new())],
+            vec![non_commitment_output()],
+        );
+        assert_eq!(
+            build_single_coinbase_proof(cb, [0u8; 32]).verify().unwrap_err(),
+            E::InvalidCoinbaseHeightEncoding
+        );
+    }
+
+    #[test]
+    fn shp_height_negative_is_err() {
+        // push [0x81] = scriptint -1
+        let cb = coinbase(
+            vec![txin(vec![0x01, 0x81], Witness::new())],
+            vec![non_commitment_output()],
+        );
+        assert_eq!(
+            build_single_coinbase_proof(cb, [0u8; 32]).verify().unwrap_err(),
+            E::InvalidCoinbaseHeightEncoding
+        );
+    }
+
+    #[test]
+    fn shp_height_zero_is_err() {
+        // OP_PUSHBYTES_0 -> empty push -> read_scriptint == 0 -> height <= 0
+        let cb = coinbase(vec![txin(vec![0x00], Witness::new())], vec![non_commitment_output()]);
+        assert_eq!(
+            build_single_coinbase_proof(cb, [0u8; 32]).verify().unwrap_err(),
+            E::InvalidCoinbaseHeightEncoding
+        );
+    }
+
+    // --- happy path: proves the height is decoded from the coinbase script_sig
+    //     (700000), NOT taken from the header height field (999). ---
+    #[test]
+    fn shp_height_valid_nonsegwit_reads_height_from_coinbase() {
+        // 700000 = 0x0AAE60 -> minimal LE push: 0x60 0xAE 0x0A
+        let cb = coinbase(
+            vec![txin(vec![0x03, 0x60, 0xAE, 0x0A], Witness::new())],
+            vec![non_commitment_output()],
+        );
+        let info = build_single_coinbase_proof(cb, [0u8; 32])
+            .verify()
+            .expect("valid non-segwit coinbase must verify");
+        assert_eq!(info.block_height, 700_000);
+        assert_eq!(info.coinbase_txid_merkle_proof_height, 0);
+        // sanity: Script import used so the helper module stays warning-free
+        let _ = Script::from_bytes(&[]).len();
     }
 }

--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -218,10 +218,10 @@ impl DaVerifier for BitcoinVerifier {
                 let merkle_root =
                     merkle_tree::BitcoinMerkleTree::new(inclusion_proof.wtxids).root();
 
-                let input_witness_value = coinbase_tx.input[0]
-                    .witness
-                    .iter()
-                    .next()
+                let input_witness_value = coinbase_tx
+                    .input
+                    .first()
+                    .and_then(|input| input.witness.iter().next())
                     .ok_or(ValidationError::InvalidWitnessCommitmentStructure)?;
 
                 let mut vec_merkle = Vec::with_capacity(input_witness_value.len() + 32);
@@ -926,6 +926,103 @@ mod tests {
         let result =
             verifier.verify_header_chain_common(&header, &bad_state, target, expected_bits);
         assert_eq!(result, Err(ValidationError::InvalidTimestamp));
+    }
+
+    // A coinbase output with a valid SegWit-commitment script (>=38 bytes,
+    // 0x6a24aa21a9ed prefix). `tail` fills bytes [6..38] (the committed hash).
+    fn commitment_output(tail: [u8; 32]) -> bitcoin::TxOut {
+        let mut spk = vec![0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+        spk.extend_from_slice(&tail);
+        bitcoin::TxOut {
+            value: bitcoin::Amount::from_sat(0),
+            script_pubkey: bitcoin::ScriptBuf::from_bytes(spk),
+        }
+    }
+
+    // Drives `verify_transactions` to the witness-commitment branch with the given
+    // coinbase. Uses a 2-byte reveal prefix and non-matching wtxids so the relevant
+    // iterator and completeness proof are both empty (no zip_eq panic), and tx_count=2
+    // so the single-tx short-circuit is skipped.
+    fn run_verify_transactions(
+        coinbase: bitcoin::Transaction,
+    ) -> Result<Vec<crate::spec::blob::BlobWithSender>, ValidationError> {
+        use crate::spec::proof::InclusionMultiProof;
+        use crate::spec::RollupParams;
+
+        let verifier = BitcoinVerifier::new(RollupParams {
+            reveal_tx_prefix: vec![2, 2],
+            network: Network::Nightly,
+        });
+
+        let header_hex = "00000020eefac07c86494826bb8876e4e9156cc94ab0509e106d0000000000000000000049aa89bafff85ba60886976cf8203b75baf951d52ed2a5af6e8769e0df1528a436b94d6770c0021730278e2d";
+        let inner_header =
+            BitcoinHeaderWrapper::deserialize(&mut hex::decode(header_hex).unwrap().as_ref())
+                .unwrap();
+        let header = HeaderWrapper::new(*inner_header, 2, 872918, [0u8; 32]);
+
+        let inclusion_proof =
+            InclusionMultiProof::new(vec![[0u8; 32], [1u8; 32]], coinbase.into(), vec![]);
+
+        verifier.verify_transactions(&header, inclusion_proof, vec![])
+    }
+
+    fn coinbase(input: Vec<bitcoin::TxIn>, output: Vec<bitcoin::TxOut>) -> bitcoin::Transaction {
+        bitcoin::Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input,
+            output,
+        }
+    }
+
+    fn coinbase_input(witness: bitcoin::Witness) -> bitcoin::TxIn {
+        bitcoin::TxIn {
+            previous_output: bitcoin::OutPoint::null(),
+            script_sig: bitcoin::ScriptBuf::new(),
+            sequence: bitcoin::Sequence::MAX,
+            witness,
+        }
+    }
+
+    // ZERO inputs but a valid commitment output -> before fix: index OOB on input[0].
+    #[test]
+    fn verify_transactions_empty_coinbase_input_returns_err() {
+        let cb = coinbase(vec![], vec![commitment_output([0u8; 32])]);
+        assert_eq!(
+            run_verify_transactions(cb).unwrap_err(),
+            ValidationError::InvalidWitnessCommitmentStructure
+        );
+    }
+
+    // Input present but EMPTY witness -> before fix: unwrap() on None.
+    #[test]
+    fn verify_transactions_empty_coinbase_witness_returns_err() {
+        let cb = coinbase(
+            vec![coinbase_input(bitcoin::Witness::new())],
+            vec![commitment_output([0u8; 32])],
+        );
+        assert_eq!(
+            run_verify_transactions(cb).unwrap_err(),
+            ValidationError::InvalidWitnessCommitmentStructure
+        );
+    }
+
+    // VALID input + non-empty witness: the hardened code must pass the witness
+    // value through unchanged and reach the real commitment comparison, returning
+    // `IncorrectWitnessCommitment` (NOT InvalidWitnessCommitmentStructure, NOT a panic).
+    // This proves the fix does not over-reject well-formed coinbases.
+    #[test]
+    fn verify_transactions_valid_witness_reaches_commitment_check() {
+        let mut witness = bitcoin::Witness::new();
+        witness.push([0x11u8; 32]); // witness reserved value
+        let cb = coinbase(
+            vec![coinbase_input(witness)],
+            vec![commitment_output([0u8; 32])], // committed hash that won't match
+        );
+        assert_eq!(
+            run_verify_transactions(cb).unwrap_err(),
+            ValidationError::IncorrectWitnessCommitment
+        );
     }
 
     #[test]

--- a/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
+++ b/crates/sovereign-sdk/rollup-interface/src/state_machine/da.rs
@@ -231,6 +231,10 @@ pub enum ShortHeaderProofVerificationError {
     },
     /// Provided precomputed hash was incorrect
     InvalidHeaderHash,
+    /// Coinbase input/witness structure was malformed (missing input or witness commitment value)
+    InvalidWitnessCommitmentStructure,
+    /// Coinbase script_sig did not contain a valid BIP34 block height
+    InvalidCoinbaseHeightEncoding,
 }
 
 /// Latest da state to verify and apply da block changes


### PR DESCRIPTION
## Problem
Two verification paths panicked on a malformed coinbase instead of returning an error:
- `BitcoinHeaderShortProof::verify()` — `unwrap()` on the coinbase witness value and `expect()/panic!/assert!` on BIP34 height parsing.
- `verify_transactions` — direct `coinbase_tx.input[0]` index (panics on zero inputs).
These run in the batch-prover circuit and on full nodes during `setBlockInfo` execution. A `verify()` that panics violates the verification contract; a malformed input should reject the block, not crash the node / abort the prover.
## Fix
Convert every panic to a graceful error return. Adds two `ShortHeaderProofVerificationError` variants. Mirrors the existing hardening in `verifier.rs`.
## Tests
14 new edge-case tests (every converted branch + happy paths + valid pass-through). Verified red→green: reverting each fix makes the tests panic at the exact removed-panic lines.
Refs #3266