### PR TITLE
perf: Cache bytecode in guests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -647,12 +647,12 @@ jobs:
         if: steps.restore-test-cache.outputs.cache-hit != 'true' && steps.restore-artifact.outputs.cache-hit != 'true'
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
-      - name: Rust cache
-        if: steps.restore-test-cache.outputs.cache-hit != 'true' && steps.restore-artifact.outputs.cache-hit != 'true'
-        uses: ubicloud/rust-cache@65b3ff06b9bcc69d88c25e212f1ae3d14a0953c3 # v2.7.5
-        with:
-          prefix-key: ${{ env.RUST_CACHE_PREFIX }}
-          shared-key: build
+      # - name: Rust cache
+      #   if: steps.restore-test-cache.outputs.cache-hit != 'true' && steps.restore-artifact.outputs.cache-hit != 'true'
+      #   uses: ubicloud/rust-cache@65b3ff06b9bcc69d88c25e212f1ae3d14a0953c3 # v2.7.5
+      #   with:
+      #     prefix-key: ${{ env.RUST_CACHE_PREFIX }}
+      #     shared-key: build
       - name: Cache ethereum-tests
         if: steps.restore-test-cache.outputs.cache-hit != 'true' && steps.restore-artifact.outputs.cache-hit != 'true'
         uses: ubicloud/cache@92361f338d82d2c58a98875f1b5c95cd14cd6b2a # v4.1.2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,7 +63,7 @@ env:
   RUSTFLAGS: -D warnings
   FOUNDRY_PROFILE: ci
   BITCOIN_DOCKER_IMAGE: "bitcoin/bitcoin:30.0"
-  RUST_CACHE_PREFIX: v2-rust
+  RUST_CACHE_PREFIX: v2-rust-inv
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 # Automatically cancels a job if a new commit if pushed to the same PR, branch, or tag.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -647,12 +647,12 @@ jobs:
         if: steps.restore-test-cache.outputs.cache-hit != 'true' && steps.restore-artifact.outputs.cache-hit != 'true'
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
-      # - name: Rust cache
-      #   if: steps.restore-test-cache.outputs.cache-hit != 'true' && steps.restore-artifact.outputs.cache-hit != 'true'
-      #   uses: ubicloud/rust-cache@65b3ff06b9bcc69d88c25e212f1ae3d14a0953c3 # v2.7.5
-      #   with:
-      #     prefix-key: ${{ env.RUST_CACHE_PREFIX }}
-      #     shared-key: build
+      - name: Rust cache
+        if: steps.restore-test-cache.outputs.cache-hit != 'true' && steps.restore-artifact.outputs.cache-hit != 'true'
+        uses: ubicloud/rust-cache@65b3ff06b9bcc69d88c25e212f1ae3d14a0953c3 # v2.7.5
+        with:
+          prefix-key: ${{ env.RUST_CACHE_PREFIX }}
+          shared-key: build
       - name: Cache ethereum-tests
         if: steps.restore-test-cache.outputs.cache-hit != 'true' && steps.restore-artifact.outputs.cache-hit != 'true'
         uses: ubicloud/cache@92361f338d82d2c58a98875f1b5c95cd14cd6b2a # v4.1.2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,7 +63,7 @@ env:
   RUSTFLAGS: -D warnings
   FOUNDRY_PROFILE: ci
   BITCOIN_DOCKER_IMAGE: "bitcoin/bitcoin:30.0"
-  RUST_CACHE_PREFIX: v2-rust-inv
+  RUST_CACHE_PREFIX: v3-rust
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 # Automatically cancels a job if a new commit if pushed to the same PR, branch, or tag.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,7 +63,7 @@ env:
   RUSTFLAGS: -D warnings
   FOUNDRY_PROFILE: ci
   BITCOIN_DOCKER_IMAGE: "bitcoin/bitcoin:30.0"
-  RUST_CACHE_PREFIX: v3-rust
+  RUST_CACHE_PREFIX: v2-rust
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 # Automatically cancels a job if a new commit if pushed to the same PR, branch, or tag.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -548,7 +548,7 @@ jobs:
 
   proving-stats:
     name: Proving stats
-    runs-on: ubicloud-standard-2
+    runs-on: ubicloud-standard-30
     needs: [build, docker-setup]
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'guest-code')
     steps:

--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::time::Duration;
 
 use alloy::consensus::{SignableTransaction, TxLegacy};
@@ -1729,7 +1730,7 @@ impl BytecodeCachePruningTest {
     ///
     /// Everything else in this test would still pass if the fillers stopped
     /// overflowing the cache limit — but it would no longer prove anything.
-    fn assert_pruned_before_probe(batch_prover_dir: &std::path::Path) -> Result<()> {
+    fn assert_pruned_before_probe(batch_prover_dir: &Path) -> Result<()> {
         const PRUNE_LOG: &str = "Pruned witness caches after L2 block ";
 
         let stdout = fs::read_to_string(batch_prover_dir.join("stdout.log"))?;

--- a/bin/citrea/tests/bitcoin/batch_prover_test.rs
+++ b/bin/citrea/tests/bitcoin/batch_prover_test.rs
@@ -6,7 +6,7 @@ use alloy::consensus::{SignableTransaction, TxLegacy};
 use alloy::network::TxSigner;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::signers::Signer;
-use alloy_primitives::{Address, Bytes, TxKind, U256, U32, U64};
+use alloy_primitives::{keccak256, Address, Bytes, TxKind, U256, U32, U64};
 use async_trait::async_trait;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
@@ -1504,6 +1504,409 @@ impl InvokeCachePruningTest {
 #[tokio::test]
 async fn invoke_cache_prune_test() -> Result<()> {
     TestCaseRunner::new(InvokeCachePruningTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
+}
+
+/// Proves that the circuit must drop its decoded bytecode cache whenever the
+/// prover prunes the witness caches mid-session.
+///
+/// The guest caches decoded bytecode per code hash for a whole proving session,
+/// but only entries of the cumulative offchain log decide whether an offchain
+/// read consumes a witness hint. A cached entry that outlives its log entry
+/// makes the guest skip a read the prover *did* emit a hint for, and the next
+/// offchain read consumes that stray hint instead of its own.
+///
+/// The stale cache returns correct code — bytecode is immutable per hash — so
+/// nothing detects the skipped hint until some *other* offchain read is served
+/// the wrong value. That is why the probe below reads two targets.
+///
+/// The commitment this test proves is laid out as:
+///
+/// | L2 height | contents |
+/// |---|---|
+/// | 1 | deploy both targets and the probe |
+/// | 2 | call target 1, so the guest caches its decoded bytecode |
+/// | 3..=54 | filler deployments, overflowing the prover's witness cache limit |
+/// | 55 | call the probe, which `EXTCODESIZE`s both targets |
+struct BytecodeCachePruningTest;
+
+/// Signed transactions of [`BytecodeCachePruningTest`], grouped by their block.
+struct BytecodeCachePruningTransactions {
+    deployments: Vec<Vec<u8>>,
+    cache_warming_call: Vec<u8>,
+    filler_deployments: Vec<Vec<u8>>,
+    probe_call: Vec<u8>,
+}
+
+/// Which side of `CacheLog::prune_half` a contract's code hash must land on.
+///
+/// `prune_half` keeps the lower half of its sorted keys, and offchain code is
+/// keyed by code hash. The filler deployments dominate that key set, so a hash
+/// ground below `0x80` is kept and one ground at or above `0xf0` is dropped.
+#[derive(Clone, Copy)]
+enum PruneHalf {
+    Dropped,
+    Kept,
+}
+
+impl PruneHalf {
+    fn accepts(self, code_hash_start: u8) -> bool {
+        match self {
+            Self::Dropped => code_hash_start >= 0xf0,
+            Self::Kept => code_hash_start < 0x80,
+        }
+    }
+}
+
+#[async_trait]
+impl TestCase for BytecodeCachePruningTest {
+    fn test_config() -> TestCaseConfig {
+        TestCaseConfig {
+            with_batch_prover: true,
+            with_full_node: true,
+            ..Default::default()
+        }
+    }
+
+    fn test_env() -> TestCaseEnv {
+        TestCaseEnv {
+            // `assert_pruned_before_probe` reads the prover's own INFO logs.
+            batch_prover: vec![("RUST_LOG", "info")],
+            ..Default::default()
+        }
+    }
+
+    fn sequencer_config() -> SequencerConfig {
+        SequencerConfig {
+            max_l2_blocks_per_commitment: Self::PROBE_L2_HEIGHT,
+            mempool_conf: SequencerMempoolConfig {
+                pending_tx_limit: 1_000_000,
+                pending_tx_size: 100_000_000,
+                queue_tx_limit: 1_000_000,
+                queue_tx_size: 100_000_000,
+                base_fee_tx_limit: 1_000_000,
+                base_fee_tx_size: 100_000_000,
+                max_account_slots: 1_000_000,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(170)
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        let da = f.bitcoin_nodes.get(0).unwrap();
+        let sequencer = f.sequencer.as_mut().unwrap();
+        let batch_prover = f.batch_prover.as_mut().unwrap();
+        let full_node = f.full_node.as_mut().unwrap();
+
+        let transactions = self.create_transactions().await;
+
+        // Deploy in a block of their own: code read in the block that created it
+        // is served from REVM's journal, and would never reach the guest cache.
+        for signed_tx in transactions.deployments {
+            sequencer
+                .client
+                .http_client()
+                .eth_send_raw_transaction(signed_tx.into())
+                .await
+                .unwrap();
+        }
+        sequencer.client.send_publish_batch_request().await?;
+        sequencer
+            .wait_for_l2_height(Self::DEPLOY_L2_HEIGHT, None)
+            .await
+            .unwrap();
+
+        // Caches the first target's decoded bytecode in the guest, and only it.
+        sequencer
+            .client
+            .http_client()
+            .eth_send_raw_transaction(transactions.cache_warming_call.into())
+            .await
+            .unwrap();
+        sequencer.client.send_publish_batch_request().await?;
+        sequencer
+            .wait_for_l2_height(Self::WARM_L2_HEIGHT, None)
+            .await
+            .unwrap();
+
+        // Grow the cumulative caches past the prover's prune limit.
+        for signed_tx in transactions.filler_deployments {
+            sequencer
+                .client
+                .http_client()
+                .eth_send_raw_transaction(signed_tx.into())
+                .await
+                .unwrap();
+        }
+        for _ in 0..Self::FILLER_BLOCK_COUNT {
+            sequencer.client.send_publish_batch_request().await?;
+        }
+        sequencer
+            .wait_for_l2_height(Self::PROBE_L2_HEIGHT - 1, None)
+            .await
+            .unwrap();
+
+        // Submitted only now, so the guest can only reach the probe with a cache
+        // that pruning has already invalidated.
+        sequencer
+            .client
+            .http_client()
+            .eth_send_raw_transaction(transactions.probe_call.into())
+            .await
+            .unwrap();
+        sequencer.client.send_publish_batch_request().await?;
+
+        assert_eq!(
+            sequencer.max_l2_blocks_per_commitment(),
+            Self::PROBE_L2_HEIGHT,
+            "the probe must close the commitment this test proves"
+        );
+        sequencer
+            .wait_for_l2_height(Self::PROBE_L2_HEIGHT, None)
+            .await
+            .unwrap();
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
+
+        batch_prover
+            .wait_for_l1_height(finalized_height, None)
+            .await?;
+
+        // Without `clear_bytecode_cache`, the probe's second EXTCODESIZE consumes
+        // the offchain hint its first one left unread, fails its code hash check
+        // and panics the guest — which the framework fails this test on.
+        da.wait_mempool_len(2, Some(Duration::from_secs(300)))
+            .await?;
+
+        Self::assert_pruned_before_probe(&batch_prover.config.base.dir)?;
+
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
+
+        full_node
+            .wait_for_l1_height(finalized_height, None)
+            .await
+            .unwrap();
+
+        let last_proven_l2_data = full_node
+            .client
+            .http_client()
+            .get_last_proven_l2_height()
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(last_proven_l2_data.commitment_index, 1);
+        assert_eq!(last_proven_l2_data.height, Self::PROBE_L2_HEIGHT);
+
+        Ok(())
+    }
+}
+
+impl BytecodeCachePruningTest {
+    const DEPLOY_L2_HEIGHT: u64 = 1;
+    const WARM_L2_HEIGHT: u64 = 2;
+    /// The probe runs in the last block of the commitment, so the guest reaches
+    /// it with everything the fillers pruned away already gone.
+    const PROBE_L2_HEIGHT: u64 = 55;
+    const FILLER_BLOCK_COUNT: u64 = Self::PROBE_L2_HEIGHT - Self::WARM_L2_HEIGHT - 1;
+    /// 550 x 12 KB of contract code overflows the prover's 6 MiB witness cache
+    /// limit, and fits in the filler blocks (which hold eleven deployments each).
+    const FILLER_DEPLOY_COUNT: usize = 550;
+    const FILLER_RUNTIME_SIZE: usize = 12_000;
+    const GAS_LIMIT: u64 = 3_000_000;
+
+    /// Fails unless the prover pruned its witness caches while proving the
+    /// blocks between the cache warming call and the probe.
+    ///
+    /// Everything else in this test would still pass if the fillers stopped
+    /// overflowing the cache limit — but it would no longer prove anything.
+    fn assert_pruned_before_probe(batch_prover_dir: &std::path::Path) -> Result<()> {
+        const PRUNE_LOG: &str = "Pruned witness caches after L2 block ";
+
+        let stdout = fs::read_to_string(batch_prover_dir.join("stdout.log"))?;
+        let prune_heights = stdout
+            .lines()
+            .filter_map(|line| line.split_once(PRUNE_LOG))
+            .filter_map(|(_, height)| height.trim().parse::<u64>().ok())
+            .collect::<Vec<_>>();
+
+        assert!(
+            prune_heights
+                .iter()
+                .any(|height| (Self::WARM_L2_HEIGHT..Self::PROBE_L2_HEIGHT).contains(height)),
+            "the prover must prune between L2 blocks {} and {}, but pruned at {:?}",
+            Self::WARM_L2_HEIGHT,
+            Self::PROBE_L2_HEIGHT,
+            prune_heights,
+        );
+
+        Ok(())
+    }
+
+    async fn create_transactions(&self) -> BytecodeCachePruningTransactions {
+        let private_key: [u8; 32] =
+            hex::decode("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let mut signer = PrivateKeySigner::from_slice(&private_key).unwrap();
+        signer.set_chain_id(Some(5655));
+
+        let first_target_runtime = Self::padded_runtime(0, PruneHalf::Dropped);
+        let second_target_runtime = Self::padded_runtime(1, PruneHalf::Dropped);
+        let first_target = signer.address().create(0);
+        let second_target = signer.address().create(1);
+        let probe = signer.address().create(2);
+
+        let mut nonce = 0;
+        let mut deployments = Vec::with_capacity(3);
+        for runtime in [
+            &first_target_runtime,
+            &second_target_runtime,
+            &Self::probe_runtime(first_target, second_target),
+        ] {
+            deployments.push(
+                Self::sign_transaction(&signer, nonce, TxKind::Create, Self::init_code(runtime))
+                    .await,
+            );
+            nonce += 1;
+        }
+
+        // Calling the first target one block after its deployment forces REVM to
+        // fetch its code through EvmDb, which is what fills the guest cache. The
+        // second target is never read before the prune, so it stays out of it.
+        let cache_warming_call =
+            Self::sign_transaction(&signer, nonce, TxKind::Call(first_target), Vec::new()).await;
+        nonce += 1;
+
+        let mut filler_deployments = Vec::with_capacity(Self::FILLER_DEPLOY_COUNT);
+        for seed in 2..Self::FILLER_DEPLOY_COUNT as u64 + 2 {
+            let runtime = Self::padded_runtime(seed, PruneHalf::Kept);
+            filler_deployments.push(
+                Self::sign_transaction(&signer, nonce, TxKind::Create, Self::init_code(&runtime))
+                    .await,
+            );
+            nonce += 1;
+        }
+
+        let probe_call =
+            Self::sign_transaction(&signer, nonce, TxKind::Call(probe), Vec::new()).await;
+
+        BytecodeCachePruningTransactions {
+            deployments,
+            cache_warming_call,
+            filler_deployments,
+            probe_call,
+        }
+    }
+
+    /// Runtime that runs EXTCODESIZE against both targets and stops.
+    ///
+    /// Loading the code must not *touch* the target accounts, which a plain CALL
+    /// would: `EvmDb::commit` reads the offchain code of every touched account
+    /// that has code, and a read there would consume the hint the stale bytecode
+    /// cache skipped, papering the bug over. EXTCODESIZE only warms the account,
+    /// which keeps the test independent of what the commit path does.
+    fn probe_runtime(first_target: Address, second_target: Address) -> Vec<u8> {
+        let mut runtime = Vec::new();
+        for target in [first_target, second_target] {
+            runtime.push(0x73); // PUSH20 <target>
+            runtime.extend_from_slice(target.as_slice());
+            runtime.push(0x3b); // EXTCODESIZE
+            runtime.push(0x50); // POP
+        }
+        runtime.push(0x00); // STOP
+
+        Self::grind_code_hash(runtime, PruneHalf::Kept)
+    }
+
+    /// Zero-filled runtime of [`Self::FILLER_RUNTIME_SIZE`] bytes, unique per
+    /// `seed`, whose code hash lands in `half`.
+    fn padded_runtime(seed: u64, half: PruneHalf) -> Vec<u8> {
+        let mut runtime = vec![0; Self::FILLER_RUNTIME_SIZE - 8];
+        let tail = runtime.len() - 8;
+        runtime[tail..].copy_from_slice(&seed.to_be_bytes());
+
+        Self::grind_code_hash(runtime, half)
+    }
+
+    /// Appends eight unreachable bytes to `runtime` until its code hash lands in
+    /// `half`, deciding whether `prune_half` drops or keeps its offchain entry.
+    fn grind_code_hash(mut runtime: Vec<u8>, half: PruneHalf) -> Vec<u8> {
+        let tail = runtime.len();
+        runtime.extend_from_slice(&[0; 8]);
+
+        for candidate in 0u64.. {
+            runtime[tail..].copy_from_slice(&candidate.to_be_bytes());
+            if half.accepts(keccak256(&runtime)[0]) {
+                return runtime;
+            }
+        }
+
+        unreachable!("u64 candidates must contain a matching code hash")
+    }
+
+    fn init_code(runtime: &[u8]) -> Vec<u8> {
+        const INIT_CODE_LEN: u8 = 14;
+
+        let runtime_len = u16::try_from(runtime.len()).unwrap().to_be_bytes();
+        let mut init_code = Vec::with_capacity(INIT_CODE_LEN as usize + runtime.len());
+        init_code.extend_from_slice(&[
+            0x61,
+            runtime_len[0],
+            runtime_len[1],
+            0x60,
+            INIT_CODE_LEN,
+            0x60,
+            0x00,
+            0x39,
+            0x61,
+            runtime_len[0],
+            runtime_len[1],
+            0x60,
+            0x00,
+            0xf3,
+        ]);
+        init_code.extend_from_slice(runtime);
+        init_code
+    }
+
+    async fn sign_transaction(
+        signer: &PrivateKeySigner,
+        nonce: u64,
+        to: TxKind,
+        input: Vec<u8>,
+    ) -> Vec<u8> {
+        let mut tx = TxLegacy {
+            chain_id: Some(5655),
+            nonce,
+            gas_price: 1_000_000_000 * 1_000_000_000,
+            gas_limit: Self::GAS_LIMIT,
+            to,
+            value: U256::ZERO,
+            input: Bytes::from(input),
+        };
+
+        let signature = signer.sign_transaction(&mut tx).await.unwrap();
+        let signed_tx = tx.into_signed(signature);
+        let mut rlp_buf = Vec::with_capacity(signed_tx.rlp_encoded_length());
+        signed_tx.rlp_encode(&mut rlp_buf);
+        rlp_buf
+    }
+}
+
+#[tokio::test]
+async fn bytecode_cache_prune_test() -> Result<()> {
+    TestCaseRunner::new(BytecodeCachePruningTest)
         .set_citrea_path(get_citrea_path())
         .run()
         .await

--- a/bin/citrea/tests/bitcoin/light_client_test.rs
+++ b/bin/citrea/tests/bitcoin/light_client_test.rs
@@ -3773,7 +3773,7 @@ impl TestCase for LightClientCreateCircuitInputRpcTest {
         let circuit_input =
             LightClientCircuitInput::<BitcoinSpec>::try_from_slice(&input_response.input)?;
 
-        let input_l1_hash: [u8; 32] = circuit_input.da_block_header.hash().into();
+        let input_l1_hash: [u8; 32] = circuit_input.da_block_header.hash();
         assert_eq!(
             circuit_input.da_block_header.height(),
             batch_proof_l1_height

--- a/crates/batch-prover/src/prover.rs
+++ b/crates/batch-prover/src/prover.rs
@@ -1059,6 +1059,7 @@ fn generate_cumulative_witness<Da: DaService, DB: BatchProverLedgerOps>(
                 state_log.prune_half();
                 offchain_log.prune_half();
                 cache_prune_l2_heights.push(l2_height);
+                info!("Pruned witness caches after L2 block {}", l2_height);
             }
 
             let state_log_cache_size = state_log.estimated_cache_size();

--- a/crates/citrea-stf/src/runtime.rs
+++ b/crates/citrea-stf/src/runtime.rs
@@ -87,4 +87,8 @@ where
     ) -> Result<Self::GenesisConfig, anyhow::Error> {
         crate::genesis_config::get_genesis_config(genesis_paths)
     }
+
+    fn cache_log_pruned(&mut self) {
+        self.evm.clear_bytecode_cache();
+    }
 }

--- a/crates/evm/src/evm/db.rs
+++ b/crates/evm/src/evm/db.rs
@@ -1,6 +1,8 @@
 use core::error::Error;
 #[cfg(not(feature = "native"))]
 use std::cell::RefCell;
+#[cfg(not(feature = "native"))]
+use std::collections::BTreeMap;
 #[cfg(feature = "native")]
 use std::collections::HashMap;
 
@@ -50,9 +52,8 @@ impl std::fmt::Display for DBError {
 // is pruned; otherwise a cached hit would skip a hint the prover did emit and
 // the next offchain read would consume a value meant for someone else.
 #[cfg(not(feature = "native"))]
-std::thread_local! {
-    static BYTECODE_CACHE: RefCell<std::collections::BTreeMap<B256, Bytecode>> =
-        RefCell::default();
+thread_local! {
+    static BYTECODE_CACHE: RefCell<BTreeMap<B256, Bytecode>> = RefCell::default();
 }
 
 /// Drops every cached bytecode, so no entry outlives the cache-log entry it
@@ -70,13 +71,13 @@ pub(crate) fn clear_bytecode_cache() {}
 /// Whether the decoded bytecode of `code_hash` is already cached, which implies
 /// the offchain cache log holds the same code.
 #[cfg(not(feature = "native"))]
-pub(crate) fn is_bytecode_cached(code_hash: &B256) -> bool {
+fn is_bytecode_cached(code_hash: &B256) -> bool {
     BYTECODE_CACHE.with_borrow(|cache| cache.contains_key(code_hash))
 }
 
 /// Native execution never populates the bytecode cache, so nothing is cached.
 #[cfg(feature = "native")]
-pub(crate) fn is_bytecode_cached(_code_hash: &B256) -> bool {
+fn is_bytecode_cached(_code_hash: &B256) -> bool {
     false
 }
 
@@ -117,10 +118,12 @@ impl<'a, C: sov_modules_api::Context> EvmDb<'a, C> {
     /// Whether the offchain state already holds the code of `code_hash` — what
     /// decides if [`DatabaseCommit::commit`] still has to store it.
     ///
-    /// The commit path only asks about code hashes missing from the bytecode
-    /// cache, so this reaches the witness exactly when the code was never read
-    /// this session either: `None` for a genuinely new contract, and its stored
-    /// code for bytecode redeployed at a new address.
+    /// A cached decode already mirrors an offchain cache log entry, so it settles
+    /// the question without a read that could only confirm what the log holds —
+    /// in the circuit at the price of decoding the whole contract again. Past the
+    /// cache this reaches the witness exactly when the code was never read this
+    /// session either: `None` for a genuinely new contract, and its stored code
+    /// for bytecode redeployed at a new address.
     ///
     /// The circuit verifies that value rather than trust it. An unverified read
     /// would plant prover-supplied bytecode in the offchain cache log, which a
@@ -131,6 +134,10 @@ impl<'a, C: sov_modules_api::Context> EvmDb<'a, C> {
     ///
     /// [`DatabaseCommit::commit`]: revm::DatabaseCommit::commit
     pub(crate) fn is_code_stored(&mut self, code_hash: &B256) -> bool {
+        if is_bytecode_cached(code_hash) {
+            return true;
+        }
+
         #[cfg(not(feature = "native"))]
         let code = self
             .evm

--- a/crates/evm/src/evm/db.rs
+++ b/crates/evm/src/evm/db.rs
@@ -51,7 +51,7 @@ impl std::fmt::Display for DBError {
 // the next offchain read would consume a value meant for someone else.
 #[cfg(not(feature = "native"))]
 std::thread_local! {
-    static BYTECODE_CACHE: RefCell<std::collections::HashMap<B256, Bytecode>> =
+    static BYTECODE_CACHE: RefCell<std::collections::BTreeMap<B256, Bytecode>> =
         RefCell::default();
 }
 

--- a/crates/evm/src/evm/db.rs
+++ b/crates/evm/src/evm/db.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 #[cfg(feature = "native")]
 use std::collections::HashMap;
 
-use alloy_primitives::{keccak256, Address, B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use revm::context::DBErrorMarker;
 use revm::state::{AccountInfo as ReVmAccountInfo, Bytecode};
 use revm::Database;
@@ -87,7 +87,7 @@ pub(crate) fn is_bytecode_cached(_code_hash: &B256) -> bool {
 /// "not stored yet".
 fn verify_code_hash(code_hash: &B256, code: &Option<Bytecode>) -> Result<(), DBError> {
     code.as_ref().map_or(Ok(()), |code| {
-        if *code_hash == keccak256(code.original_byte_slice()) {
+        if *code_hash == code.hash_slow() {
             Ok(())
         } else {
             Err(DBError::CodeHashMismatch)

--- a/crates/evm/src/evm/db.rs
+++ b/crates/evm/src/evm/db.rs
@@ -35,6 +35,19 @@ impl std::fmt::Display for DBError {
     }
 }
 
+/// Session-lifetime cache of decoded bytecode, keyed by code hash.
+///
+/// Bytecode is immutable per hash and every entry was keccak-verified on its
+/// first non-cached state read, so reusing the decoded [`Bytecode`]
+/// (refcounted bytes + shared jump table) only skips repeated decode work.
+/// Guest-only: a long-running native node must not grow an unbounded map.
+#[cfg(target_os = "zkvm")]
+fn bytecode_cache() -> &'static std::sync::Mutex<std::collections::HashMap<B256, Bytecode>> {
+    static CACHE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<B256, Bytecode>>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(Default::default)
+}
+
 pub(crate) struct EvmDb<'a, C: sov_modules_api::Context> {
     pub(crate) evm: &'a Evm<C>,
     pub(crate) working_set: &'a mut WorkingSet<C::Storage>,
@@ -92,6 +105,11 @@ impl<C: sov_modules_api::Context> Database for EvmDb<'_, C> {
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         // TODO move to new_raw_with_hash for better performance
 
+        #[cfg(target_os = "zkvm")]
+        if let Some(code) = bytecode_cache().lock().unwrap().get(&code_hash).cloned() {
+            return Ok(code);
+        }
+
         if let Some(code) = self.evm.offchain_code.get_with_verification_on_no_cache(
             &code_hash,
             |val| {
@@ -108,6 +126,12 @@ impl<C: sov_modules_api::Context> Database for EvmDb<'_, C> {
             },
             &mut self.working_set.offchain_state(),
         )? {
+            #[cfg(target_os = "zkvm")]
+            bytecode_cache()
+                .lock()
+                .unwrap()
+                .insert(code_hash, code.clone());
+
             Ok(code)
         } else {
             Err(DBError::UnknownCodeHash)

--- a/crates/evm/src/evm/db.rs
+++ b/crates/evm/src/evm/db.rs
@@ -1,4 +1,6 @@
 use core::error::Error;
+#[cfg(not(feature = "native"))]
+use std::cell::RefCell;
 #[cfg(feature = "native")]
 use std::collections::HashMap;
 
@@ -35,17 +37,62 @@ impl std::fmt::Display for DBError {
     }
 }
 
-/// Session-lifetime cache of decoded bytecode, keyed by code hash.
+// Session-lifetime cache of decoded bytecode, keyed by code hash.
+//
+// Bytecode is immutable per hash and every entry was keccak-verified on its
+// first non-cached state read, so reusing the decoded Bytecode (refcounted
+// bytes + shared jump table) only skips repeated decode work. Guest-only: a
+// long-running native node must not grow an unbounded map.
+//
+// Every entry mirrors an entry of the cumulative offchain cache log, which is
+// what decides whether a read consumes an offchain witness hint. The two must
+// be dropped together, so [`clear_bytecode_cache`] is called whenever that log
+// is pruned; otherwise a cached hit would skip a hint the prover did emit and
+// the next offchain read would consume a value meant for someone else.
+#[cfg(not(feature = "native"))]
+std::thread_local! {
+    static BYTECODE_CACHE: RefCell<std::collections::HashMap<B256, Bytecode>> =
+        RefCell::default();
+}
+
+/// Drops every cached bytecode, so no entry outlives the cache-log entry it
+/// mirrors. Called whenever the cumulative offchain cache log is pruned.
+#[cfg(not(feature = "native"))]
+pub(crate) fn clear_bytecode_cache() {
+    BYTECODE_CACHE.with_borrow_mut(|cache| cache.clear());
+}
+
+/// Native execution never populates the bytecode cache, so there is nothing to
+/// clear.
+#[cfg(feature = "native")]
+pub(crate) fn clear_bytecode_cache() {}
+
+/// Whether the decoded bytecode of `code_hash` is already cached, which implies
+/// the offchain cache log holds the same code.
+#[cfg(not(feature = "native"))]
+pub(crate) fn is_bytecode_cached(code_hash: &B256) -> bool {
+    BYTECODE_CACHE.with_borrow(|cache| cache.contains_key(code_hash))
+}
+
+/// Native execution never populates the bytecode cache, so nothing is cached.
+#[cfg(feature = "native")]
+pub(crate) fn is_bytecode_cached(_code_hash: &B256) -> bool {
+    false
+}
+
+/// Checks that `code` really is the preimage of `code_hash`.
 ///
-/// Bytecode is immutable per hash and every entry was keccak-verified on its
-/// first non-cached state read, so reusing the decoded [`Bytecode`]
-/// (refcounted bytes + shared jump table) only skips repeated decode work.
-/// Guest-only: a long-running native node must not grow an unbounded map.
-#[cfg(target_os = "zkvm")]
-fn bytecode_cache() -> &'static std::sync::Mutex<std::collections::HashMap<B256, Bytecode>> {
-    static CACHE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<B256, Bytecode>>> =
-        std::sync::OnceLock::new();
-    CACHE.get_or_init(Default::default)
+/// Reading no code is not a mismatch: it means the offchain state holds no code
+/// for `code_hash`, which callers report as [`DBError::UnknownCodeHash`] or as
+/// "not stored yet".
+fn verify_code_hash(code_hash: &B256, code: &Option<Bytecode>) -> Result<(), DBError> {
+    code.as_ref().map_or(Ok(()), |code| {
+        if *code_hash == keccak256(code.original_byte_slice()) {
+            Ok(())
+        } else {
+            Err(DBError::CodeHashMismatch)
+        }
+    })
 }
 
 pub(crate) struct EvmDb<'a, C: sov_modules_api::Context> {
@@ -65,6 +112,45 @@ impl<'a, C: sov_modules_api::Context> EvmDb<'a, C> {
             working_set,
             citrea_spec,
         }
+    }
+
+    /// Whether the offchain state already holds the code of `code_hash` — what
+    /// decides if [`DatabaseCommit::commit`] still has to store it.
+    ///
+    /// The commit path only asks about code hashes missing from the bytecode
+    /// cache, so this reaches the witness exactly when the code was never read
+    /// this session either: `None` for a genuinely new contract, and its stored
+    /// code for bytecode redeployed at a new address.
+    ///
+    /// The circuit verifies that value rather than trust it. An unverified read
+    /// would plant prover-supplied bytecode in the offchain cache log, which a
+    /// later [`Database::code_by_hash`] would hand to the EVM unchecked — its
+    /// keccak check only runs on reads that miss the log. Natively the value
+    /// comes from the node's own database, on the same read path `code_by_hash`
+    /// already verifies.
+    ///
+    /// [`DatabaseCommit::commit`]: revm::DatabaseCommit::commit
+    pub(crate) fn is_code_stored(&mut self, code_hash: &B256) -> bool {
+        #[cfg(not(feature = "native"))]
+        let code = self
+            .evm
+            .offchain_code
+            .get_with_verification_on_no_cache(
+                code_hash,
+                |code| verify_code_hash(code_hash, code),
+                &mut self.working_set.offchain_state(),
+            )
+            // `commit` cannot fail, and a mismatch means the witness lied about
+            // code the circuit is about to trust: abort instead of proving it.
+            .expect("Offchain code must be the preimage of its code hash");
+
+        #[cfg(feature = "native")]
+        let code = self
+            .evm
+            .offchain_code
+            .get(code_hash, &mut self.working_set.offchain_state());
+
+        code.is_some()
     }
 
     #[cfg(feature = "native")]
@@ -105,32 +191,20 @@ impl<C: sov_modules_api::Context> Database for EvmDb<'_, C> {
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         // TODO move to new_raw_with_hash for better performance
 
-        #[cfg(target_os = "zkvm")]
-        if let Some(code) = bytecode_cache().lock().unwrap().get(&code_hash).cloned() {
+        #[cfg(not(feature = "native"))]
+        if let Some(code) = BYTECODE_CACHE.with_borrow(|cache| cache.get(&code_hash).cloned()) {
             return Ok(code);
         }
 
         if let Some(code) = self.evm.offchain_code.get_with_verification_on_no_cache(
             &code_hash,
-            |val| {
-                // if code is read as None,
-                // we don't have code for the given code_hash
-                // return true in that case so we return None from get_with_verification_on_no_cache
-                val.as_ref().map_or(Ok(()), |code| {
-                    if *code_hash == keccak256(code.original_byte_slice()) {
-                        Ok(())
-                    } else {
-                        Err(DBError::CodeHashMismatch)
-                    }
-                })
-            },
+            |code| verify_code_hash(&code_hash, code),
             &mut self.working_set.offchain_state(),
         )? {
-            #[cfg(target_os = "zkvm")]
-            bytecode_cache()
-                .lock()
-                .unwrap()
-                .insert(code_hash, code.clone());
+            #[cfg(not(feature = "native"))]
+            BYTECODE_CACHE.with_borrow_mut(|cache| {
+                cache.insert(code_hash, code.clone());
+            });
 
             Ok(code)
         } else {

--- a/crates/evm/src/evm/db_commit.rs
+++ b/crates/evm/src/evm/db_commit.rs
@@ -8,7 +8,7 @@ use revm::state::{Account, AccountInfo};
 use revm::DatabaseCommit;
 use sov_modules_api::{SpecId, StateMapAccessor};
 
-use super::db::{is_bytecode_cached, EvmDb};
+use super::db::EvmDb;
 use super::AccountInfo as DbAccountInfo;
 
 impl<C: sov_modules_api::Context> DatabaseCommit for EvmDb<'_, C> {
@@ -46,20 +46,15 @@ impl<C: sov_modules_api::Context> DatabaseCommit for EvmDb<'_, C> {
             let new_info = account.info;
 
             if let Some(ref code) = new_info.code {
-                // Cached code is already in the offchain cache log, so the read below
-                // could only confirm what is there — in the circuit at the price of
-                // decoding the whole contract again.
-                if !code.is_empty() && !is_bytecode_cached(&new_info.code_hash) {
-                    // we don't update code with analyzed code because that would mean we can change jump table
-                    // however we want without changing the code hash
-                    // that means we can fiddle with tx execution
-                    if !self.is_code_stored(&new_info.code_hash) {
-                        self.evm.offchain_code.set(
-                            &new_info.code_hash,
-                            code,
-                            &mut self.working_set.offchain_state(),
-                        );
-                    }
+                // we don't update code with analyzed code because that would mean we can change jump table
+                // however we want without changing the code hash
+                // that means we can fiddle with tx execution
+                if !code.is_empty() && !self.is_code_stored(&new_info.code_hash) {
+                    self.evm.offchain_code.set(
+                        &new_info.code_hash,
+                        code,
+                        &mut self.working_set.offchain_state(),
+                    );
                 }
             }
 

--- a/crates/evm/src/evm/db_commit.rs
+++ b/crates/evm/src/evm/db_commit.rs
@@ -8,7 +8,7 @@ use revm::state::{Account, AccountInfo};
 use revm::DatabaseCommit;
 use sov_modules_api::{SpecId, StateMapAccessor};
 
-use super::db::EvmDb;
+use super::db::{is_bytecode_cached, EvmDb};
 use super::AccountInfo as DbAccountInfo;
 
 impl<C: sov_modules_api::Context> DatabaseCommit for EvmDb<'_, C> {
@@ -46,16 +46,14 @@ impl<C: sov_modules_api::Context> DatabaseCommit for EvmDb<'_, C> {
             let new_info = account.info;
 
             if let Some(ref code) = new_info.code {
-                if !code.is_empty() {
+                // Cached code is already in the offchain cache log, so the read below
+                // could only confirm what is there — in the circuit at the price of
+                // decoding the whole contract again.
+                if !code.is_empty() && !is_bytecode_cached(&new_info.code_hash) {
                     // we don't update code with analyzed code because that would mean we can change jump table
                     // however we want without changing the code hash
                     // that means we can fiddle with tx execution
-                    if self
-                        .evm
-                        .offchain_code
-                        .get(&new_info.code_hash, &mut self.working_set.offchain_state())
-                        .is_none()
-                    {
+                    if !self.is_code_stored(&new_info.code_hash) {
                         self.evm.offchain_code.set(
                             &new_info.code_hash,
                             code,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -198,6 +198,15 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Evm<C> {
 }
 
 impl<C: sov_modules_api::Context> Evm<C> {
+    /// Clears decoded bytecode retained by the circuit execution cache.
+    ///
+    /// This must be called whenever the cumulative offchain cache log is pruned
+    /// so a cached value never outlives the witness-cache entry it mirrors.
+    /// A no-op natively, where nothing is cached.
+    pub fn clear_bytecode_cache(&self) {
+        evm::db::clear_bytecode_cache();
+    }
+
     pub(crate) fn get_db<'a>(
         &'a self,
         working_set: &'a mut WorkingSet<C::Storage>,

--- a/crates/light-client-prover/src/rpc.rs
+++ b/crates/light-client-prover/src/rpc.rs
@@ -270,7 +270,7 @@ where
             )
             .map_err(internal_rpc_error)?;
 
-        let l1_hash = l1_block.header().hash().into();
+        let l1_hash = l1_block.header().hash();
         let raw_input = borsh::to_vec(&prepared.circuit_input).map_err(internal_rpc_error)?;
         Ok(LightClientCircuitInputRpcResponse {
             l1_height: U64::from(l1_height),

--- a/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/sovereign-sdk/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -212,6 +212,10 @@ pub trait Runtime<C: Context, Da: DaSpec>:
     fn genesis_config(
         genesis_paths: &Self::GenesisPaths,
     ) -> Result<Self::GenesisConfig, anyhow::Error>;
+
+    /// Notifies the runtime that the cumulative state and offchain cache logs
+    /// have been pruned.
+    fn cache_log_pruned(&mut self) {}
 }
 
 /// Genesis parameters for a blueprint
@@ -681,6 +685,7 @@ where
                 {
                     state_log.prune_half();
                     offchain_log.prune_half();
+                    self.runtime.cache_log_pruned();
                 }
 
                 l2_height += 1;


### PR DESCRIPTION
## Testing
Added a test proving that we need to clear cache on pruning. Test fails without 
`self.runtime.cache_log_pruned();`