### PR TITLE
ci: Bump proving-stats machine to ubicloud-standard-8

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -548,7 +548,7 @@ jobs:
 
   proving-stats:
     name: Proving stats
-    runs-on: ubicloud-standard-2
+    runs-on: ubicloud-standard-8
     needs: [build, docker-setup]
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'guest-code')
     steps:


### PR DESCRIPTION
Prevents workflow from running OOM