### PR TITLE
fix: stop log subscriber after send failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [Unreleased]
 ### Changed
+- fix: stop log subscription tasks after send failures
 - fix(bitcoin-da): Harden DA monitoring reveal restore ([#3329](https://github.com/chainwayxyz/citrea/pull/3329))
 - fix(rpc): Set archival state in estimate tx expenses ([#3321](https://github.com/chainwayxyz/citrea/pull/3321))
 - fix(rpc): with log config in debug trace cache ([#3323](https://github.com/chainwayxyz/citrea/pull/3323))

--- a/crates/ethereum-rpc/src/subscription.rs
+++ b/crates/ethereum-rpc/src/subscription.rs
@@ -129,7 +129,7 @@ async fn log_subscriber_task(
                                 )
                                 .unwrap();
                                 if sink.send_timeout(msg, SUBSCRIPTION_TIMEOUT).await.is_err() {
-                                    break;
+                                    return;
                                 }
                             }
                         }
@@ -195,5 +195,68 @@ async fn l2_block_event_handler<C: sov_modules_api::Context>(
             .expect("Error getting logs in block range");
 
         let _ = logs_tx.send(Arc::new(logs));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, Bytes, B256};
+    use jsonrpsee::RpcModule;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    fn test_log() -> Log {
+        Log {
+            inner: alloy_primitives::Log::new_unchecked(Address::ZERO, Vec::new(), Bytes::new()),
+            block_hash: Some(B256::ZERO),
+            block_number: Some(0),
+            block_timestamp: Some(0),
+            transaction_hash: Some(B256::ZERO),
+            transaction_index: Some(0),
+            log_index: Some(0),
+            removed: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn log_subscriber_exits_after_send_timeout() {
+        let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut module = RpcModule::new(());
+        module
+            .register_subscription(
+                "subscribe",
+                "subscription",
+                "unsubscribe",
+                move |_, pending, _, _| {
+                    let sink_tx = sink_tx.clone();
+                    async move {
+                        let sink = pending.accept().await?;
+                        sink_tx.send(sink).unwrap();
+                        Ok(())
+                    }
+                },
+            )
+            .unwrap();
+
+        // Keep the bounded notification channel open and unread so the second
+        // log notification reaches the send timeout.
+        let (_response, _notifications) = module
+            .raw_json_request(r#"{"jsonrpc":"2.0","method":"subscribe","id":1}"#, 1)
+            .await
+            .unwrap();
+        let sink = Arc::new(sink_rx.recv().await.unwrap());
+        let (logs_tx, logs_rx) = broadcast::channel(1);
+        let subscriber = tokio::spawn(log_subscriber_task(logs_rx, None, sink));
+
+        logs_tx
+            .send(Arc::new(vec![test_log(), test_log()]))
+            .unwrap();
+
+        timeout(SUBSCRIPTION_TIMEOUT + Duration::from_secs(5), subscriber)
+            .await
+            .expect("log subscriber should exit after send timeout")
+            .unwrap();
+        assert_eq!(logs_tx.receiver_count(), 0);
     }
 }


### PR DESCRIPTION
# Description

`log_subscriber_task` previously used an unlabelled `break` when sending a log notification failed. This only exited the inner log iteration, leaving the subscriber task and its broadcast receiver alive.

This change returns from the subscriber task after a send failure, consistent with the behavior of `head_subscriber_task`.

A regression test uses a real bounded `SubscriptionSink`, triggers a send timeout, and verifies that the subscriber task terminates and releases its broadcast receiver.




## Linked Issues
- Fixes https://github.com/chainwayxyz/citrea/issues/3314

## Testing

- `cargo test -p ethereum-rpc`
- `cargo +nightly fmt -p ethereum-rpc -- --check`
- 
## Docs

Added an entry to `CHANGELOG.md`. No public API documentation changes are required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow fix in RPC log subscriptions; no auth or data-handling changes. Residual risk is limited to subscription lifecycle under slow clients.
> 
> **Overview**
> Fixes log subscriptions that kept running after a notification send timeout. An unlabeled `break` only left the inner log loop, so the task and its broadcast receiver stayed alive.
> 
> `log_subscriber_task` now **returns** on send failure, matching `head_subscriber_task`. A regression test fills a bounded sink, waits for timeout, and checks the task exits and drops the receiver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f82eff263944a38d81dcabb02cb8a2d9efd90a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->