### PR TITLE
fix(fullnode): pending commitment overwrites & failing pending proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   **New env vars:**\
   `SEQUENCER_MEMPOOL_ADDITIONAL_VALIDATION_TASKS`: Number of additional parallel transaction validation tasks in the sequencer mempool (default: 4)\
   `SEQUENCER_DRY_RUN_TIME_LIMIT_MS`: Time budget in milliseconds for the sequencer's per-block transaction-selection (dry run) loop (default: 500)
+- fix(fullnode): pending commitment overwrites & failing pending proofs ([#3317](https://github.com/chainwayxyz/citrea/pull/3317))
 ### Added
 - feat: full node state diff rpc ([#3310](https://github.com/chainwayxyz/citrea/pull/3310))
 

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -4257,49 +4257,26 @@ impl TestCase for PendingCommitmentNotOverwrittenTest {
 
         let sequencer_client = sequencer.client.http_client();
 
-        let merkle_root_1 = calculate_merkle_root(
-            &sequencer_client
-                .get_l2_block_range(U64::from(1), U64::from(10))
-                .await?,
-        );
-        let merkle_root_2 = calculate_merkle_root(
-            &sequencer_client
-                .get_l2_block_range(U64::from(11), U64::from(20))
-                .await?,
-        );
-        let merkle_root_3a = calculate_merkle_root(
-            &sequencer_client
-                .get_l2_block_range(U64::from(21), U64::from(30))
-                .await?,
-        );
-        let merkle_root_3b = calculate_merkle_root(
-            &sequencer_client
-                .get_l2_block_range(U64::from(21), U64::from(29))
-                .await?,
-        );
-
-        let commitment_1 = SequencerCommitment {
-            merkle_root: merkle_root_1,
-            l2_end_block_number: 10,
-            index: 1,
-        };
-        let commitment_2 = SequencerCommitment {
-            merkle_root: merkle_root_2,
-            l2_end_block_number: 20,
-            index: 2,
-        };
-        // Two conflicting commitments at index 3.
+        let mut commitments = Vec::with_capacity(4);
+        // The last two are conflicting commitments at index 3.
         // Both are valid against the L2 blocks the full node has synced.
-        let commitment_3a = SequencerCommitment {
-            merkle_root: merkle_root_3a,
-            l2_end_block_number: 30,
-            index: 3,
-        };
-        let commitment_3b = SequencerCommitment {
-            merkle_root: merkle_root_3b,
-            l2_end_block_number: 29,
-            index: 3,
-        };
+        let commitments_ranges = [(1, (1, 10)), (2, (11, 20)), (3, (21, 30)), (3, (21, 29))];
+
+        for (index, (start, end)) in commitments_ranges {
+            let merkle_root = calculate_merkle_root(
+                &sequencer_client
+                    .get_l2_block_range(U64::from(start), U64::from(end))
+                    .await?,
+            );
+            commitments.push(SequencerCommitment {
+                merkle_root,
+                l2_end_block_number: end,
+                index,
+            });
+        }
+
+        let [commitment_1, commitment_2, commitment_3a, commitment_3b] =
+            <[SequencerCommitment; 4]>::try_from(commitments).unwrap();
         assert_ne!(
             commitment_3a.serialize_and_calculate_sha_256(),
             commitment_3b.serialize_and_calculate_sha_256()

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -1266,6 +1266,161 @@ async fn test_conflicting_commitments() -> Result<()> {
     .await
 }
 
+struct ConflictingPendingCommitmentTest {
+    task_manager: TaskManager,
+}
+
+#[async_trait]
+impl TestCase for ConflictingPendingCommitmentTest {
+    fn test_config() -> TestCaseConfig {
+        TestCaseConfig {
+            with_full_node: true,
+            with_sequencer: true,
+            ..Default::default()
+        }
+    }
+
+    fn sequencer_config() -> SequencerConfig {
+        SequencerConfig {
+            // High enough that the sequencer never publishes commitments on its own
+            max_l2_blocks_per_commitment: 10_000,
+            ..Default::default()
+        }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(150)
+    }
+
+    async fn cleanup(self) -> Result<()> {
+        self.task_manager
+            .graceful_shutdown_with_timeout(Duration::from_secs(1));
+        Ok(())
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        /*
+            A commitment that is already pending must not lose its index to a conflicting one.
+
+            The sequencer publishes L2 blocks 1-10, then two conflicting commitments are sent at
+            index 1: commitment A : L2 [1, 1000], commitment B : L2 [1, 10].
+            Without the pending conflict check, commitment B is processed straight away and takes
+            index 1 from commitment A, which is still sitting in the pending table.
+        */
+        let task_executor = self.task_manager.executor();
+
+        let da = f.bitcoin_nodes.get_mut(0).unwrap();
+        let sequencer = f.sequencer.as_ref().unwrap();
+        let full_node = f.full_node.as_ref().unwrap();
+
+        let sequencer_da_service =
+            spawn_bitcoin_da_sequencer_service(&task_executor, &da.config, Self::test_config().dir)
+                .await;
+
+        for _ in 1..=10 {
+            sequencer.client.send_publish_batch_request().await?;
+        }
+        full_node.wait_for_l2_height(10, None).await?;
+
+        let commitment_a = SequencerCommitment {
+            merkle_root: [0xAA; 32],
+            l2_end_block_number: 1000,
+            index: 1,
+        };
+        let merkle_root_b = calculate_merkle_root(
+            &sequencer
+                .client
+                .http_client()
+                .get_l2_block_range(U64::from(1), U64::from(10))
+                .await?,
+        );
+        let commitment_b = SequencerCommitment {
+            merkle_root: merkle_root_b,
+            l2_end_block_number: 10,
+            index: 1,
+        };
+
+        // Commitment A reaches beyond the synced L2 blocks, so it is stored as pending
+        sequencer_da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(commitment_a.clone()),
+                1.0,
+            )
+            .await
+            .unwrap();
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        assert!(
+            full_node
+                .client
+                .http_client()
+                .get_last_committed_l2_height()
+                .await?
+                .is_none(),
+            "Commitment A should be pending, not processed"
+        );
+
+        // Commitment B covers an already synced L2 range, but index 1 is taken by pending
+        // commitment A, so it must be discarded
+        sequencer_da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(commitment_b.clone()),
+                1.0,
+            )
+            .await
+            .unwrap();
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        assert!(
+            full_node
+                .client
+                .http_client()
+                .get_sequencer_commitment_by_index(U32::from(1))
+                .await?
+                .is_none(),
+            "Conflicting commitment B must not take index 1 from pending commitment A"
+        );
+        assert!(full_node
+            .client
+            .http_client()
+            .get_last_committed_l2_height()
+            .await?
+            .is_none());
+
+        // Commitment B should have been discarded, not halted the full node
+        da.generate(1).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        let last_scanned_l1_height = full_node
+            .client
+            .http_client()
+            .get_last_scanned_l1_height()
+            .await?;
+        assert_eq!(last_scanned_l1_height.to::<u64>(), l1_height);
+
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_conflicting_pending_commitment() -> Result<()> {
+    TestCaseRunner::new(ConflictingPendingCommitmentTest {
+        task_manager: TaskManager::current(),
+    })
+    .set_citrea_path(get_citrea_path())
+    .run()
+    .await
+}
+
 struct OutOfRangeProofTest {
     task_manager: TaskManager,
 }

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -4379,7 +4379,7 @@ impl TestCase for PendingCommitmentNotOverwrittenTest {
             .await?
             .unwrap();
         assert_eq!(
-            stored_commitment_3.merkle_root, merkle_root_3a,
+            stored_commitment_3.merkle_root, commitment_3a.merkle_root,
             "Conflicting commitment 3b must not replace pending commitment 3a"
         );
         assert_eq!(

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -1300,13 +1300,13 @@ impl TestCase for ConflictingPendingCommitmentTest {
 
     async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
         /*
-            A commitment that is already pending must not lose its index to a conflicting one.
+        A commitment that is already pending must not lose its index to a conflicting one.
 
-            The sequencer publishes L2 blocks 1-10, then two conflicting commitments are sent at
-            index 1: commitment A : L2 [1, 1000], commitment B : L2 [1, 10].
-            Without the pending conflict check, commitment B is processed straight away and takes
-            index 1 from commitment A, which is still sitting in the pending table.
-        */
+        The sequencer publishes L2 blocks 1-10, then two conflicting commitments are sent at
+        index 1: commitment A : L2 [1, 1000], commitment B : L2 [1, 10].
+        Without the pending conflict check, commitment B is processed straight away and takes
+        index 1 from commitment A, which is still sitting in the pending table.
+         */
         let task_executor = self.task_manager.executor();
 
         let da = f.bitcoin_nodes.get_mut(0).unwrap();

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -4288,7 +4288,7 @@ impl TestCase for PendingCommitmentNotOverwrittenTest {
             l2_end_block_number: 20,
             index: 2,
         };
-        // Two conflicting commitments at index 3. 
+        // Two conflicting commitments at index 3.
         // Both are valid against the L2 blocks the full node has synced.
         let commitment_3a = SequencerCommitment {
             merkle_root: merkle_root_3a,
@@ -4335,7 +4335,7 @@ impl TestCase for PendingCommitmentNotOverwrittenTest {
             "Commitment 2 should be pending, not processed"
         );
 
-        // Send commitment 3a. 
+        // Send commitment 3a.
         // Its predecessor (2) is only pending, not processed, so 3a is stored as pending.
         sequencer_da_service
             .send_transaction_with_fee_rate(
@@ -4502,9 +4502,7 @@ impl TestCase for PendingProofDroppedOnPermanentErrorTest {
         let sequencer_client = sequencer.client.http_client();
 
         let mut commitments = Vec::with_capacity(4);
-        let commitments_ranges = [
-            (1, (1, 10)), (2, (11, 20)), (3, (21, 30)), (4, (31, 40))
-        ];
+        let commitments_ranges = [(1, (1, 10)), (2, (11, 20)), (3, (21, 30)), (4, (31, 40))];
 
         for (index, (start, end)) in commitments_ranges {
             let merkle_root = calculate_merkle_root(
@@ -4619,9 +4617,7 @@ impl TestCase for PendingProofDroppedOnPermanentErrorTest {
         da.wait_mempool_len(4, None).await?;
         da.generate(DEFAULT_FINALITY_DEPTH).await?;
         let proofs_l1_height = da.get_finalized_height(None).await?;
-        full_node
-            .wait_for_l1_height(proofs_l1_height, None)
-            .await?;
+        full_node.wait_for_l1_height(proofs_l1_height, None).await?;
 
         assert!(full_node
             .client

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -4188,3 +4188,246 @@ async fn test_full_node_state_diff_rpc() -> Result<()> {
         .run()
         .await
 }
+
+struct PendingCommitmentNotOverwrittenTest {
+    task_manager: TaskManager,
+}
+
+#[async_trait]
+impl TestCase for PendingCommitmentNotOverwrittenTest {
+    fn test_config() -> TestCaseConfig {
+        TestCaseConfig {
+            with_full_node: true,
+            with_sequencer: true,
+            ..Default::default()
+        }
+    }
+
+    fn sequencer_config() -> SequencerConfig {
+        SequencerConfig {
+            // High enough that the sequencer never publishes commitments on its own,
+            // every commitment in this test is crafted and sent manually.
+            max_l2_blocks_per_commitment: 10_000,
+            ..Default::default()
+        }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(150)
+    }
+
+    async fn cleanup(self) -> Result<()> {
+        self.task_manager
+            .graceful_shutdown_with_timeout(Duration::from_secs(1));
+        Ok(())
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        /*
+        A commitment that is only pending must not lose its index to a conflicting pending commitment.
+
+        Sequencer publishes L2 blocks 1-30, full node syncs them.
+        Commitments used, all of them valid against the synced L2 blocks:
+            commitment 1  : L2 [1, 10]
+            commitment 2  : L2 [11, 20]
+            commitment 3a : L2 [21, 30]
+            commitment 3b : L2 [21, 29]
+
+        DA writes, in order:
+            commitment 2  -> pending,
+            commitment 3a -> pending,
+            commitment 3b -> must be rejected because index 3 is already pending,
+            commitment 1  -> unblocks the chain, commitments 1, 2 and 3a get processed
+         */
+        let task_executor = self.task_manager.executor();
+
+        let da = f.bitcoin_nodes.get_mut(0).unwrap();
+        let sequencer = f.sequencer.as_ref().unwrap();
+        let full_node = f.full_node.as_ref().unwrap();
+
+        let sequencer_da_service =
+            spawn_bitcoin_da_sequencer_service(&task_executor, &da.config, Self::test_config().dir)
+                .await;
+
+        for _ in 1..=30 {
+            sequencer.client.send_publish_batch_request().await?;
+        }
+        sequencer.client.wait_for_l2_block(30, None).await?;
+        full_node.wait_for_l2_height(30, None).await?;
+
+        let sequencer_client = sequencer.client.http_client();
+
+        let merkle_root_1 = calculate_merkle_root(
+            &sequencer_client
+                .get_l2_block_range(U64::from(1), U64::from(10))
+                .await?,
+        );
+        let merkle_root_2 = calculate_merkle_root(
+            &sequencer_client
+                .get_l2_block_range(U64::from(11), U64::from(20))
+                .await?,
+        );
+        let merkle_root_3a = calculate_merkle_root(
+            &sequencer_client
+                .get_l2_block_range(U64::from(21), U64::from(30))
+                .await?,
+        );
+        let merkle_root_3b = calculate_merkle_root(
+            &sequencer_client
+                .get_l2_block_range(U64::from(21), U64::from(29))
+                .await?,
+        );
+
+        let commitment_1 = SequencerCommitment {
+            merkle_root: merkle_root_1,
+            l2_end_block_number: 10,
+            index: 1,
+        };
+        let commitment_2 = SequencerCommitment {
+            merkle_root: merkle_root_2,
+            l2_end_block_number: 20,
+            index: 2,
+        };
+        // Two conflicting commitments at index 3. 
+        // Both are valid against the L2 blocks the full node has synced.
+        let commitment_3a = SequencerCommitment {
+            merkle_root: merkle_root_3a,
+            l2_end_block_number: 30,
+            index: 3,
+        };
+        let commitment_3b = SequencerCommitment {
+            merkle_root: merkle_root_3b,
+            l2_end_block_number: 29,
+            index: 3,
+        };
+        assert_ne!(
+            commitment_3a.serialize_and_calculate_sha_256(),
+            commitment_3b.serialize_and_calculate_sha_256()
+        );
+
+        // Send commitment 2 first. Index 1 is unknown so it is stored as pending.
+        sequencer_da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(commitment_2.clone()),
+                1.0,
+            )
+            .await
+            .unwrap();
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        assert!(full_node
+            .client
+            .http_client()
+            .get_last_committed_l2_height()
+            .await?
+            .is_none());
+        assert!(
+            full_node
+                .client
+                .http_client()
+                .get_sequencer_commitment_by_index(U32::from(2))
+                .await?
+                .is_none(),
+            "Commitment 2 should be pending, not processed"
+        );
+
+        // Send commitment 3a. 
+        // Its predecessor (2) is only pending, not processed, so 3a is stored as pending.
+        sequencer_da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(commitment_3a.clone()),
+                1.0,
+            )
+            .await
+            .unwrap();
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        assert!(
+            full_node
+                .client
+                .http_client()
+                .get_sequencer_commitment_by_index(U32::from(3))
+                .await?
+                .is_none(),
+            "Commitment 3a should be pending, not processed"
+        );
+
+        // Send the conflicting commitment 3b. It must not replace pending commitment 3a.
+        sequencer_da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(commitment_3b.clone()),
+                1.0,
+            )
+            .await
+            .unwrap();
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        // Send commitment 1, which makes the whole pending chain processable.
+        sequencer_da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(commitment_1.clone()),
+                1.0,
+            )
+            .await
+            .unwrap();
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        // Process one more L1 block to make sure pending commitments are drained
+        da.generate(1).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        // Commitment 3a was seen first at index 3, so it stays canonical and the conflicting
+        // commitment 3b is discarded
+        let stored_commitment_3 = full_node
+            .client
+            .http_client()
+            .get_sequencer_commitment_by_index(U32::from(3))
+            .await?
+            .unwrap();
+        assert_eq!(
+            stored_commitment_3.merkle_root, merkle_root_3a,
+            "Conflicting commitment 3b must not replace pending commitment 3a"
+        );
+        assert_eq!(
+            stored_commitment_3.l2_end_block_number.to::<u64>(),
+            commitment_3a.l2_end_block_number
+        );
+
+        let committed_height = full_node
+            .client
+            .http_client()
+            .get_last_committed_l2_height()
+            .await?
+            .unwrap();
+        assert_eq!(committed_height.commitment_index, 3);
+        assert_eq!(committed_height.height, commitment_3a.l2_end_block_number);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_pending_commitment_not_overwritten() -> Result<()> {
+    TestCaseRunner::new(PendingCommitmentNotOverwrittenTest {
+        task_manager: TaskManager::current(),
+    })
+    .set_citrea_path(get_citrea_path())
+    .run()
+    .await
+}

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -4431,3 +4431,307 @@ async fn test_pending_commitment_not_overwritten() -> Result<()> {
     .run()
     .await
 }
+
+struct PendingProofDroppedOnPermanentErrorTest {
+    task_manager: TaskManager,
+}
+
+#[async_trait]
+impl TestCase for PendingProofDroppedOnPermanentErrorTest {
+    fn test_config() -> TestCaseConfig {
+        TestCaseConfig {
+            with_full_node: true,
+            with_sequencer: true,
+            ..Default::default()
+        }
+    }
+
+    fn sequencer_config() -> SequencerConfig {
+        SequencerConfig {
+            // High enough that the sequencer never publishes commitments on its own,
+            // every commitment in this test is crafted and sent manually.
+            max_l2_blocks_per_commitment: 10_000,
+            ..Default::default()
+        }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(150)
+    }
+
+    async fn cleanup(self) -> Result<()> {
+        self.task_manager
+            .graceful_shutdown_with_timeout(Duration::from_secs(1));
+        Ok(())
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        /*
+        A pending proof that can never become valid must be dropped.
+
+        DA writes, in order:
+            commitment 2 (L2: 11-20)
+            commitment 3 (L2: 21-30), 4 (L2: 31-40)
+            proof [3, 3] -> has invalid pre state root.
+            proof [3, 4]
+            commitment 1 (L2: 1-10)
+            proof [1, 2]
+
+        If the failing proof over [3, 3] were kept in the pending proofs table instead, every retry
+        would stop at it and the proven height would stay at commitment index 2 forever.
+         */
+        let task_executor = self.task_manager.executor();
+
+        let da = f.bitcoin_nodes.get_mut(0).unwrap();
+        let sequencer = f.sequencer.as_ref().unwrap();
+        let full_node = f.full_node.as_ref().unwrap();
+
+        let sequencer_da_service =
+            spawn_bitcoin_da_sequencer_service(&task_executor, &da.config, Self::test_config().dir)
+                .await;
+        let prover_da_service =
+            spawn_bitcoin_da_prover_service(&task_executor, &da.config, Self::test_config().dir)
+                .await;
+
+        for _ in 1..=40 {
+            sequencer.client.send_publish_batch_request().await?;
+        }
+        sequencer.client.wait_for_l2_block(40, None).await?;
+        full_node.wait_for_l2_height(40, None).await?;
+
+        let sequencer_client = sequencer.client.http_client();
+
+        let mut commitments = Vec::with_capacity(4);
+        let commitments_ranges = [
+            (1, (1, 10)), (2, (11, 20)), (3, (21, 30)), (4, (31, 40))
+        ];
+
+        for (index, (start, end)) in commitments_ranges {
+            let merkle_root = calculate_merkle_root(
+                &sequencer_client
+                    .get_l2_block_range(U64::from(start), U64::from(end))
+                    .await?,
+            );
+            commitments.push(SequencerCommitment {
+                merkle_root,
+                l2_end_block_number: end,
+                index,
+            });
+        }
+
+        let genesis_state_root: [u8; 32] = full_node
+            .client
+            .http_client()
+            .get_l2_genesis_state_root()
+            .await?
+            .unwrap()
+            .0
+            .try_into()
+            .unwrap();
+
+        let mut state_roots = Vec::with_capacity(4);
+        for commitment in &commitments {
+            state_roots.push(
+                sequencer_client
+                    .get_l2_block_by_number(U64::from(commitment.l2_end_block_number))
+                    .await?
+                    .unwrap()
+                    .header
+                    .state_root,
+            );
+        }
+        let [commitment_1, commitment_2, commitment_3, commitment_4] =
+            <[SequencerCommitment; 4]>::try_from(commitments).unwrap();
+        let [state_root_1, state_root_2, state_root_3, state_root_4] =
+            <[[u8; 32]; 4]>::try_from(state_roots).unwrap();
+
+        // Send commitment 2 first. Its predecessor is unknown so it is stored as pending.
+        sequencer_da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(commitment_2.clone()),
+                1.0,
+            )
+            .await
+            .unwrap();
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        // Commitments 3 and 4 follow, both pending as well
+        for commitment in [&commitment_3, &commitment_4] {
+            sequencer_da_service
+                .send_transaction_with_fee_rate(
+                    DaTxRequest::SequencerCommitment(commitment.clone()),
+                    1.0,
+                )
+                .await
+                .unwrap();
+        }
+
+        da.wait_mempool_len(4, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        assert!(
+            full_node
+                .client
+                .http_client()
+                .get_last_committed_l2_height()
+                .await?
+                .is_none(),
+            "Commitments 2, 3 and 4 should all be pending"
+        );
+
+        // Proof over [3, 3] with a false initial state root, and a correct proof over [3, 4].
+        // Both reference commitments that are only pending, so both are stored as pending before
+        // their initial state root is checked.
+        let l1_hash = da.get_block_hash(l1_height).await?;
+        let invalid_proof_3 = create_serialized_fake_receipt_batch_proof_with_state_roots(
+            [1; 32], // false initial state root
+            commitment_3.l2_end_block_number,
+            None,
+            false,
+            l1_hash.as_raw_hash().to_byte_array(),
+            vec![commitment_3.clone()],
+            vec![state_root_3],
+            Some(commitment_2.serialize_and_calculate_sha_256()),
+        );
+        let proof_34 = create_serialized_fake_receipt_batch_proof_with_state_roots(
+            state_root_2,
+            commitment_4.l2_end_block_number,
+            None,
+            false,
+            l1_hash.as_raw_hash().to_byte_array(),
+            vec![commitment_3.clone(), commitment_4.clone()],
+            vec![state_root_3, state_root_4],
+            Some(commitment_2.serialize_and_calculate_sha_256()),
+        );
+        for proof in [invalid_proof_3, proof_34] {
+            prover_da_service
+                .send_transaction_with_fee_rate(DaTxRequest::ZKProof(proof), 1.0)
+                .await
+                .unwrap();
+        }
+
+        da.wait_mempool_len(4, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let proofs_l1_height = da.get_finalized_height(None).await?;
+        full_node
+            .wait_for_l1_height(proofs_l1_height, None)
+            .await?;
+
+        assert!(full_node
+            .client
+            .http_client()
+            .get_last_proven_l2_height()
+            .await?
+            .is_none());
+
+        // Send commitment 1, which makes the whole pending chain processable
+        sequencer_da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(commitment_1.clone()),
+                1.0,
+            )
+            .await
+            .unwrap();
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        // Process one more L1 block to make sure pending commitments are drained
+        da.generate(1).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        let committed_height = full_node
+            .client
+            .http_client()
+            .get_last_committed_l2_height()
+            .await?
+            .unwrap();
+        assert_eq!(committed_height.commitment_index, 4);
+        assert_eq!(committed_height.height, commitment_4.l2_end_block_number);
+
+        // The proof over [3, 3] failed on its initial state root by now, and the proof over [3, 4]
+        // is still waiting for commitments 1 and 2 to be proven
+        assert!(full_node
+            .client
+            .http_client()
+            .get_last_proven_l2_height()
+            .await?
+            .is_none());
+
+        // Send a proof over commitment range [1, 2], which moves the proven index to 2 and lets
+        // the pending proof over [3, 4] be processed
+        let l1_hash = da.get_block_hash(l1_height).await?;
+        let proof_12 = create_serialized_fake_receipt_batch_proof_with_state_roots(
+            genesis_state_root,
+            commitment_2.l2_end_block_number,
+            None,
+            false,
+            l1_hash.as_raw_hash().to_byte_array(),
+            vec![commitment_1.clone(), commitment_2.clone()],
+            vec![state_root_1, state_root_2],
+            None,
+        );
+        prover_da_service
+            .send_transaction_with_fee_rate(DaTxRequest::ZKProof(proof_12), 1.0)
+            .await
+            .unwrap();
+
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        // Process one more L1 block to make sure pending proofs are drained
+        da.generate(1).await?;
+        let l1_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(l1_height, None).await?;
+
+        let proven_height = full_node
+            .client
+            .http_client()
+            .get_last_proven_l2_height()
+            .await?
+            .unwrap();
+        assert_eq!(
+            proven_height.commitment_index, 4,
+            "The proof over [3, 4] should have been processed"
+        );
+        assert_eq!(proven_height.height, commitment_4.l2_end_block_number);
+
+        // Only the proof over [3, 4] was applied out of the two proofs sent in that L1 block
+        let verified_proofs = full_node
+            .client
+            .http_client()
+            .get_verified_batch_proofs_by_slot_height(U64::from(proofs_l1_height))
+            .await?
+            .unwrap();
+        assert_eq!(verified_proofs.len(), 1);
+        assert_eq!(
+            verified_proofs[0]
+                .proof_output
+                .sequencer_commitment_index_range,
+            (U32::from(3), U32::from(4))
+        );
+
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_pending_proof_dropped_on_permanent_error() -> Result<()> {
+    TestCaseRunner::new(PendingProofDroppedOnPermanentErrorTest {
+        task_manager: TaskManager::current(),
+    })
+    .set_citrea_path(get_citrea_path())
+    .run()
+    .await
+}

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -458,10 +458,16 @@ where
                             sequencer_commitment.index,
                             sequencer_commitment.index - 1
                         );
-                    self.ledger_db.store_pending_commitment(
-                        sequencer_commitment.clone(),
-                        found_in_l1_block_height,
-                    )?;
+                    if self
+                        .ledger_db
+                        .get_pending_commitment_by_index(sequencer_commitment.index)?
+                        .is_none()
+                    {
+                        self.ledger_db.store_pending_commitment(
+                            sequencer_commitment.clone(),
+                            found_in_l1_block_height,
+                        )?;
+                    }
                     return Ok(ProcessingResult::Pending);
                 }
             }

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -440,6 +440,29 @@ where
             }
         }
 
+        fn insert_pending_commitment_if_not_exists<DB: NodeLedgerOps>(
+            ledger_db: &DB,
+            sequencer_commitment: &SequencerCommitment,
+            found_in_l1_block_height: u64,
+        ) -> Result<(), anyhow::Error> {
+            let index = sequencer_commitment.index;
+            if let Some((existing_commitment, _)) = ledger_db
+                .get_pending_commitment_by_index(sequencer_commitment.index)?
+            {
+                if existing_commitment != *sequencer_commitment {
+                   warn!("Found a conflicting pending commitment on index {index}\nDA: {sequencer_commitment:?}\nDB:{existing_commitment:?}");
+                } else {
+                    warn!("Pending commitment with index {index} already exists in DB, skipping insert.");
+                }
+            } else {
+                ledger_db.store_pending_commitment(
+                    sequencer_commitment.clone(),
+                    found_in_l1_block_height,
+                )?;
+            }
+            Ok(())
+        }
+
         // Determine the starting L2 height for this commitment
         // For first commitment (index 1), start at Tangerine fork height
         // Otherwise, start at previous commitment's end height + 1
@@ -458,16 +481,11 @@ where
                             sequencer_commitment.index,
                             sequencer_commitment.index - 1
                         );
-                    if self
-                        .ledger_db
-                        .get_pending_commitment_by_index(sequencer_commitment.index)?
-                        .is_none()
-                    {
-                        self.ledger_db.store_pending_commitment(
-                            sequencer_commitment.clone(),
-                            found_in_l1_block_height,
-                        )?;
-                    }
+                    insert_pending_commitment_if_not_exists(
+                        &self.ledger_db,
+                        sequencer_commitment,
+                        found_in_l1_block_height,
+                    )?;
                     return Ok(ProcessingResult::Pending);
                 }
             }
@@ -491,21 +509,12 @@ where
                 end_l2_height,
                 hex::encode(sequencer_commitment.merkle_root)
             );
-            // Store as pending if we haven't synced all needed L2 blocks yet
-            if self
-                .ledger_db
-                .get_pending_commitment_by_index(sequencer_commitment.index)?
-                .is_none()
-            {
-                self.ledger_db.store_pending_commitment(
-                    sequencer_commitment.clone(),
-                    found_in_l1_block_height,
-                )?;
-                return Ok(ProcessingResult::Pending);
-            } else {
-                // Keep as pending if already stored as pending
-                return Ok(ProcessingResult::Pending);
-            }
+            insert_pending_commitment_if_not_exists(
+                &self.ledger_db,
+                sequencer_commitment,
+                found_in_l1_block_height,
+            )?;
+            return Ok(ProcessingResult::Pending);
         }
 
         // Verify the merkle root matches the L2 blocks

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -943,7 +943,21 @@ where
                     warn!(
                         "Failed to process pending proof with index {min_index}-{max_index}: {e:?}"
                     );
-                    self.ledger_db.remove_pending_proof(min_index, max_index)?;
+                    match e {
+                        ProcessingError::HaltingError(HaltingError::Proof(e)) => {
+                            return Err(HaltingError::Proof(e).into());
+                        }
+                        ProcessingError::SkippableError(SkippableError::Proof(_)) => {
+                            self.ledger_db.remove_pending_proof(min_index, max_index)?;
+                        }
+                        ProcessingError::Other(_) => {
+                            // Stop processing further pending proofs as they may depend on this one
+                            break;
+                        }
+                        _ => { 
+                            unreachable!("Unexpected error type while processing pending proof: {e:?}");
+                        }
+                    }
                 }
                 Ok(ProcessingResult::Success) => {
                     info!("Successfully processed pending proof for commitment index range {min_index}-{max_index}");

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -447,12 +447,10 @@ where
         ) -> Result<(), anyhow::Error> {
             let index = sequencer_commitment.index;
             if let Some((existing_commitment, _)) = ledger_db
-                .get_pending_commitment_by_index(sequencer_commitment.index)?
+                .get_pending_commitment_by_index(index)?
             {
                 if existing_commitment != *sequencer_commitment {
                    warn!("Found a conflicting pending commitment on index {index}\nDA: {sequencer_commitment:?}\nDB:{existing_commitment:?}");
-                } else {
-                    warn!("Pending commitment with index {index} already exists in DB, skipping insert.");
                 }
             } else {
                 ledger_db.store_pending_commitment(

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -464,9 +464,12 @@ where
             if let Some((existing_commitment, _)) =
                 ledger_db.get_pending_commitment_by_index(index)?
             {
-                if existing_commitment != *sequencer_commitment {
-                    warn!("Found a conflicting pending commitment on index {index}\nDA: {sequencer_commitment:?}\nDB:{existing_commitment:?}");
-                }
+                // Conflicting commitments are discarded at the top of `process_sequencer_commitment`,
+                // so anything reaching here matches what is already pending
+                assert!(
+                    existing_commitment == *sequencer_commitment,
+                    "Found a conflicting pending commitment on index {index}\nDA: {sequencer_commitment:?}\nDB:{existing_commitment:?}"
+                );
             } else {
                 ledger_db.store_pending_commitment(
                     sequencer_commitment.clone(),

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -446,11 +446,11 @@ where
             found_in_l1_block_height: u64,
         ) -> Result<(), anyhow::Error> {
             let index = sequencer_commitment.index;
-            if let Some((existing_commitment, _)) = ledger_db
-                .get_pending_commitment_by_index(index)?
+            if let Some((existing_commitment, _)) =
+                ledger_db.get_pending_commitment_by_index(index)?
             {
                 if existing_commitment != *sequencer_commitment {
-                   warn!("Found a conflicting pending commitment on index {index}\nDA: {sequencer_commitment:?}\nDB:{existing_commitment:?}");
+                    warn!("Found a conflicting pending commitment on index {index}\nDA: {sequencer_commitment:?}\nDB:{existing_commitment:?}");
                 }
             } else {
                 ledger_db.store_pending_commitment(
@@ -952,8 +952,10 @@ where
                             // Stop processing further pending proofs as they may depend on this one
                             break;
                         }
-                        _ => { 
-                            unreachable!("Unexpected error type while processing pending proof: {e:?}");
+                        _ => {
+                            unreachable!(
+                                "Unexpected error type while processing pending proof: {e:?}"
+                            );
                         }
                     }
                 }

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -414,6 +414,21 @@ where
             return Ok(ProcessingResult::Discarded);
         }
 
+        // Skip if a different commitment is already pending at this index
+        // The first commitment seen at an index stays canonical, even while it is still pending
+        if let Some((pending_commitment, _)) = self
+            .ledger_db
+            .get_pending_commitment_by_index(sequencer_commitment.index)?
+        {
+            if pending_commitment != *sequencer_commitment {
+                warn!(
+                    "Conflicting sequencer commitment at index {}.\nAlready pending: {:?}\nConflicting: {:?}",
+                    sequencer_commitment.index, pending_commitment, sequencer_commitment
+                );
+                return Ok(ProcessingResult::Discarded);
+            }
+        }
+
         let end_l2_height = sequencer_commitment.l2_end_block_number;
         // Check if this commitment advances the chain state
         // We only accept strictly increasing heights and indices

--- a/crates/fullnode/src/da_block_handler.rs
+++ b/crates/fullnode/src/da_block_handler.rs
@@ -934,7 +934,7 @@ where
                     warn!(
                         "Failed to process pending proof with index {min_index}-{max_index}: {e:?}"
                     );
-                    break;
+                    self.ledger_db.remove_pending_proof(min_index, max_index)?;
                 }
                 Ok(ProcessingResult::Success) => {
                     info!("Successfully processed pending proof for commitment index range {min_index}-{max_index}");


### PR DESCRIPTION
# Description
Fixes for the full node DA block handling:

1. Commitments that were pending due to missing predecessors could be overwritten with a conflicting commitment if the sequencer posts them. This creates a divergence between the full node and the light client prover, as the LCP discards a second commitment for the same index.

Added a guard at the top of `process_sequencer_commitment` that checks the pending commitments table as well, and discards a conflicting commitment for the same index.

2. When processing pending proofs, we break the loop on all `ProcessingError`s and don't remove the failing proof from the table. This means unrecoverable proof errors like `PreStateRootMismatch` can starve the remaining pending proofs.

Propagated `HaltingError`s back to the caller (currently not thrown for proofs), removed proofs and continued on `SkippableError`s, break'd the loop in case of `Other`.

## Testing
Added three e2e tests: `PendingCommitmentNotOverwrittenTest`, `ConflictingPendingCommitmentTest`, and `PendingProofDroppedOnPermanentErrorTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches full node L1 commitment and proof processing, which affects committed/proven height progression; fixes reduce divergence from LCP but incorrect handling could still stall or mis-order sync.
> 
> **Overview**
> Fixes **full node** DA handling so pending sequencer commitments and batch proofs behave consistently with the light client prover.
> 
> **Pending commitments:** A conflicting commitment at the same index is now **discarded** if another commitment is already pending at that index—the first one seen stays canonical. Pending inserts go through `insert_pending_commitment_if_not_exists` so a pending slot is not overwritten.
> 
> **Pending proofs:** When retrying pending proofs, **skippable** proof errors (e.g. `PreStateRootMismatch`) **remove** the proof from the pending table and continue; **halting** proof errors propagate; other errors still stop the loop.
> 
> Adds e2e coverage: conflicting pending commitments, pending commitment not overwritten by a later conflict, and dropping permanently invalid pending proofs so later proofs can advance proven height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50eb8421a71a94e02a99de882c0fe98562092d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->