### PR TITLE
fix(evm): reject reversed log filter ranges

### DIFF
--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1728,6 +1728,11 @@ impl<C: sov_modules_api::Context> Evm<C> {
                     .map(|num| convert_block_number(num, start_block))
                     .transpose()?
                     .flatten();
+
+                if matches!((from, to), (Some(from), Some(to)) if to < from) {
+                    return Err(EthFilterError::InvalidBlockRangeParams);
+                }
+
                 let (from_block_number, to_block_number) =
                     get_filter_block_range(from, to, start_block);
                 self.get_logs_in_block_range(

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1750,6 +1750,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
     /// Returns all logs in the given _inclusive_ range that match the filter
     ///
     /// Returns an error if:
+    ///  - block range is invalid
     ///  - underlying database error
     ///  - amount of matches exceeds configured limit
     pub fn get_logs_in_block_range(

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -1755,6 +1755,10 @@ impl<C: sov_modules_api::Context> Evm<C> {
         to_block_number: u64,
         max_logs_per_response: usize,
     ) -> Result<Vec<Log>, EthFilterError> {
+        if to_block_number < from_block_number {
+            return Err(EthFilterError::InvalidBlockRangeParams);
+        }
+
         let max_blocks_per_filter: u64 = get_max_blocks_per_filter();
         if to_block_number - from_block_number >= max_blocks_per_filter {
             return Err(EthFilterError::QueryExceedsMaxBlocks(max_blocks_per_filter));

--- a/crates/evm/src/tests/queries/log_tests.rs
+++ b/crates/evm/src/tests/queries/log_tests.rs
@@ -4,6 +4,7 @@ use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use alloy_eips::BlockNumberOrTag;
 use alloy_network::BlockResponse;
 use alloy_rpc_types::{Filter, FilterBlockOption, FilterSet};
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
 use reth_rpc::eth::filter::EthFilterError;
 use reth_rpc_eth_types::EthApiError;
 use revm::primitives::{B256, U256};
@@ -431,6 +432,42 @@ fn reversed_log_filter_range_is_rejected() {
         result,
         Err(EthFilterError::InvalidBlockRangeParams)
     ));
+}
+
+#[test]
+fn reversed_future_log_filter_range_is_rejected_by_eth_get_logs() {
+    let (evm, mut working_set, _, _, _, _) = init_evm(SpecId::latest());
+    let head = evm
+        .blocks
+        .last(&mut working_set.accessory_state())
+        .expect("Head block must be set")
+        .header
+        .number;
+
+    let filter = |from_block, to_block| Filter {
+        block_option: FilterBlockOption::Range {
+            from_block: Some(BlockNumberOrTag::Number(from_block)),
+            to_block: Some(BlockNumberOrTag::Number(to_block)),
+        },
+        address: FilterSet::default(),
+        topics: [
+            FilterSet::default(),
+            FilterSet::default(),
+            FilterSet::default(),
+            FilterSet::default(),
+        ],
+    };
+
+    let error = evm
+        .eth_get_logs(filter(head + 2, head + 1), &mut working_set)
+        .unwrap_err();
+
+    assert_eq!(error.code(), INVALID_PARAMS_CODE);
+    assert_eq!(error.message(), "invalid block range params");
+
+    assert!(evm
+        .eth_get_logs(filter(head + 1, head + 2), &mut working_set)
+        .is_ok());
 }
 
 #[test]

--- a/crates/evm/src/tests/queries/log_tests.rs
+++ b/crates/evm/src/tests/queries/log_tests.rs
@@ -4,6 +4,7 @@ use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use alloy_eips::BlockNumberOrTag;
 use alloy_network::BlockResponse;
 use alloy_rpc_types::{Filter, FilterBlockOption, FilterSet};
+use reth_rpc::eth::filter::EthFilterError;
 use reth_rpc_eth_types::EthApiError;
 use revm::primitives::{B256, U256};
 use sov_modules_api::default_context::DefaultContext;
@@ -404,6 +405,32 @@ fn log_filter_test_with_range() {
     let rpc_logs = evm.eth_get_logs(filter, &mut working_set).unwrap();
     // In the last block we have 2 logs
     assert_eq!(rpc_logs.len(), 2);
+}
+
+#[test]
+fn reversed_log_filter_range_is_rejected() {
+    let (evm, mut working_set, _, _, _, _) = init_evm(SpecId::latest());
+
+    let filter = Filter {
+        block_option: FilterBlockOption::Range {
+            from_block: Some(BlockNumberOrTag::Number(10)),
+            to_block: Some(BlockNumberOrTag::Number(1)),
+        },
+        address: FilterSet::default(),
+        topics: [
+            FilterSet::default(),
+            FilterSet::default(),
+            FilterSet::default(),
+            FilterSet::default(),
+        ],
+    };
+
+    let result = evm.logs_for_filter(filter, &mut working_set);
+
+    assert!(matches!(
+        result,
+        Err(EthFilterError::InvalidBlockRangeParams)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## 1. Purpose

An `eth_getLogs` request can contain a reversed block range. In a reversed range, `fromBlock` is greater than `toBlock`.

The previous code normalized the range before it validated the endpoint order. This caused two problems:

- A reversed range could reach unsigned subtraction and cause a panic or an incorrect range-limit error.
- If both endpoints were above the current block head, normalization changed both endpoints to the head. For example, `{fromBlock: H+2, toBlock: H+1}` became `(H, H)`. The request then succeeded.

This PR rejects reversed ranges before normalization removes the original endpoint order.

## 2. Implementation

`crates/evm/src/query.rs` now validates the range at two points:

- `logs_for_filter` compares the resolved endpoints before it normalizes them.
- `get_logs_in_block_range` checks the normalized endpoints before it subtracts them.

Both checks return `EthFilterError::InvalidBlockRangeParams` for a reversed range.

The function documentation now lists an invalid block range as a possible error.

## 3. Behavior

This change has the following effects:

- A reversed range returns a JSON-RPC invalid-params error.
- A reversed future range cannot become `(H, H)` and succeed.
- An ordered range keeps its existing behavior.
- An ordered future range keeps its existing normalization behavior.
- Filter limits and log matching do not change.

## 4. Tests

`crates/evm/src/tests/queries/log_tests.rs` contains tests for:

- A reversed normalized range: `10 -> 1`.
- A reversed future range: `H+2 -> H+1`.
- JSON-RPC error conversion through `eth_getLogs`.
- An ordered future range that remains valid.

## 5. Review Guide

Review `crates/evm/src/query.rs`:

- Confirm that `logs_for_filter` checks the endpoint order before normalization.
- Confirm that `get_logs_in_block_range` checks the endpoint order before subtraction.
- Confirm that the error documentation includes invalid ranges.

Review `crates/evm/src/tests/queries/log_tests.rs`:

- Confirm that the tests cover both reversed-range paths.
- Confirm that the public RPC test checks the invalid-params code and message.
- Confirm that the ordered-future control remains valid.

## 6. Risk

The change affects only reversed ranges.

This PR does not change block-tag conversion, ordered-range normalization, filter limits, or log matching.

## 7. Validation

The following commands passed:

- `git diff --check`
- `cargo fmt --all -- --check`

The following commands could not complete in the local environment:

- `cargo test -p citrea-evm` stopped during dependency compilation. `alloy-primitives 0.8.26` references the unavailable `getrandom::getrandom` function.
- `SKIP_GUEST_BUILD=1 make lint` stopped because `dprint` is not installed.
