### PR TITLE
chore: Add rust-analyzer to rust-toolchain components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.88"
-components = ["rustfmt", "rust-src", "clippy"]
+components = ["rustfmt", "rust-src", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
# Description

Fixes 
<img width="258" height="366" alt="Screenshot 2026-08-11 at 14 11 26" src="https://github.com/user-attachments/assets/caa9f3c4-9948-43a6-b566-9ee48d4a24c3" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only toolchain configuration; no application code, security, or deployment impact.
> 
> **Overview**
> Adds **`rust-analyzer`** to the `components` list in `rust-toolchain.toml` so it is installed with the pinned **1.88** toolchain via rustup, alongside `rustfmt`, `rust-src`, and `clippy`.
> 
> This aligns the repo toolchain with typical IDE/editor setups that expect analyzer support for the same channel the project pins, without changing build or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5dbe375765f653baae1a8d6969b6e5c219f98c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->