### PR TITLE
fix(rpc): Set archival state in estimate tx expenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## [Unreleased]
+### Changed
+- fix(rpc): Set archival state in estimate tx expenses ([#3321](https://github.com/chainwayxyz/citrea/pull/3321))
 
 ## [v2.7.0](2026-07-29)
 ### Changed

--- a/bin/citrea/tests/bitcoin/full_node.rs
+++ b/bin/citrea/tests/bitcoin/full_node.rs
@@ -1,7 +1,8 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use alloy_primitives::{Address, U256, U32, U64};
+use alloy_primitives::{Address, TxKind, U256, U32, U64};
+use alloy_rpc_types::{BlockNumberOrTag, TransactionInput, TransactionRequest};
 use async_trait::async_trait;
 use bitcoin::hashes::Hash;
 use bitcoin::Txid;
@@ -14,12 +15,14 @@ use citrea_e2e::config::{
 };
 use citrea_e2e::framework::TestFramework;
 use citrea_e2e::test_case::{TestCase, TestCaseRunner};
-use citrea_e2e::traits::Restart;
+use citrea_e2e::traits::{NodeT, Restart};
 use citrea_e2e::Result;
-use citrea_evm::AccountInfo;
+use citrea_evm::smart_contracts::SimpleStorageContract;
+use citrea_evm::{AccountInfo, EvmRpcClient};
 use citrea_fullnode::rpc::FullNodeRpcClient;
 use citrea_light_client_prover::circuit::initial_values::bitcoinda::NIGHTLY_INITIAL_BATCH_PROOF_METHOD_IDS;
 use citrea_light_client_prover::rpc::LightClientProverRpcClient;
+use citrea_stf::runtime::DefaultContext;
 use reth_tasks::TaskManager;
 use risc0_zkvm::{FakeReceipt, InnerReceipt, MaybePruned, ReceiptClaim};
 use sov_db::schema::types::L2HeightAndIndex;
@@ -4029,6 +4032,165 @@ impl TestCase for StateDiffRpcTest {
 #[tokio::test]
 async fn test_full_node_state_diff_rpc() -> Result<()> {
     TestCaseRunner::new(StateDiffRpcTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
+}
+
+struct EstimateTxExpensesHonorsBlockTagTest;
+
+#[async_trait]
+impl TestCase for EstimateTxExpensesHonorsBlockTagTest {
+    fn test_config() -> TestCaseConfig {
+        TestCaseConfig {
+            with_full_node: true,
+            with_batch_prover: true,
+            ..Default::default()
+        }
+    }
+
+    fn sequencer_config() -> SequencerConfig {
+        SequencerConfig {
+            // will generate a commitment for blocks 1-2
+            max_l2_blocks_per_commitment: 2,
+            ..Default::default()
+        }
+    }
+
+    fn scan_l1_start_height() -> Option<u64> {
+        Some(150)
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        let da = f.bitcoin_nodes.get_mut(0).unwrap();
+        let sequencer = f.sequencer.as_ref().expect("Sequencer not running");
+        let full_node = f.full_node.as_ref().expect("Full node not running");
+
+        let seq_test_client = make_test_client(SocketAddr::new(
+            sequencer.config().rpc_bind_host().parse()?,
+            sequencer.config().rpc_bind_port(),
+        ))
+        .await
+        .unwrap();
+
+        let contract = SimpleStorageContract::default();
+        let contract_address = seq_test_client.from_addr.create(0);
+
+        // Block 1 is empty, so that a numbered tag reaches the pre-deployment state.
+        sequencer.client.send_publish_batch_request().await?;
+        sequencer.wait_for_l2_height(1, None).await?;
+
+        // Block 2 deploys the contract
+        let _ = seq_test_client
+            .deploy_contract(contract.byte_code(), None)
+            .await
+            .unwrap();
+        sequencer.client.send_publish_batch_request().await?;
+        sequencer.wait_for_l2_height(2, None).await?;
+
+        // Block 3 sets a storage slot
+        let _ = seq_test_client
+            .contract_transaction(contract_address, contract.set_call_data(478), None)
+            .await;
+        sequencer.client.send_publish_batch_request().await?;
+        sequencer.wait_for_l2_height(3, None).await?;
+        full_node.wait_for_l2_height(3, None).await?;
+
+        // Let sequencer generate the commitment for blocks 1-2, so the safe tag points to block 2
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(finalized_height, None).await?;
+
+        let set_storage_tx_request = TransactionRequest {
+            from: Some(seq_test_client.from_addr),
+            to: Some(TxKind::Call(contract_address)),
+            input: TransactionInput::new(contract.set_call_data(5).into()),
+            ..Default::default()
+        };
+
+        // Helper functions to estimate gas and diff size at a given block tag.
+        let estimate_at = async |tag: BlockNumberOrTag| {
+            EvmRpcClient::<DefaultContext>::eth_estimate_gas(
+                full_node.client.http_client(),
+                set_storage_tx_request.clone(),
+                Some(tag),
+                None,
+            )
+            .await
+            .unwrap()
+        };
+
+        let diff_size_at = async |tag: BlockNumberOrTag| {
+            EvmRpcClient::<DefaultContext>::eth_estimate_diff_size(
+                full_node.client.http_client(),
+                set_storage_tx_request.clone(),
+                Some(tag),
+                None,
+            )
+            .await
+            .unwrap()
+        };
+
+        let no_contract = estimate_at(BlockNumberOrTag::Earliest).await;
+        let slot_unset = estimate_at(BlockNumberOrTag::Number(2)).await;
+        let slot_set = estimate_at(BlockNumberOrTag::Latest).await;
+
+        // No contract is just a plain call to an empty account. Beyond that, SSTORE is priced off
+        // the slot's current value: overwriting one that already holds a value pays less than
+        // writing one that is still zero (cold write).
+        assert!(no_contract < slot_set);
+        assert!(slot_set < slot_unset);
+
+        // Number 0 and finalized point to the genesis block
+        assert_eq!(estimate_at(BlockNumberOrTag::Number(0)).await, no_contract);
+        assert_eq!(estimate_at(BlockNumberOrTag::Finalized).await, no_contract);
+        // Safe points to the block number 2
+        assert_eq!(estimate_at(BlockNumberOrTag::Safe).await, slot_unset);
+        // Block 3 is the latest block
+        assert_eq!(estimate_at(BlockNumberOrTag::Number(3)).await, slot_set);
+
+        let diff_no_contract = diff_size_at(BlockNumberOrTag::Earliest).await;
+        let diff_slot_unset = diff_size_at(BlockNumberOrTag::Number(2)).await;
+        let diff_slot_set = diff_size_at(BlockNumberOrTag::Latest).await;
+
+        // The same three-way split applies to the diff size's gas field.
+        assert!(diff_no_contract.gas < diff_slot_set.gas);
+        assert!(diff_slot_set.gas < diff_slot_unset.gas);
+
+        // The diff size only splits two ways: touching no contract writes no storage, while
+        // writing a slot costs the same diff whether or not it already held a value.
+        assert!(diff_no_contract.l1_diff_size < diff_slot_unset.l1_diff_size);
+        assert_eq!(diff_slot_unset.l1_diff_size, diff_slot_set.l1_diff_size);
+
+        // eth_estimateGas adds an l1 fee overhead to the gas estimate depending on the base fee and l1 fee of the block.
+        // Compare block 1 and pending through the diff size endpoint to avoid the overhead.
+        assert_eq!(
+            diff_size_at(BlockNumberOrTag::Number(1)).await,
+            diff_no_contract
+        );
+        assert_eq!(diff_size_at(BlockNumberOrTag::Pending).await, diff_slot_set);
+
+        // Mine the batch proof so that the full node can process it and update its finalized tag
+        da.wait_mempool_len(2, None).await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
+        full_node.wait_for_l1_height(finalized_height, None).await?;
+
+        // The finalized tag now points to block 2, which corresponds to the slot being unset.
+        assert_eq!(estimate_at(BlockNumberOrTag::Finalized).await, slot_unset);
+        assert_eq!(
+            diff_size_at(BlockNumberOrTag::Finalized).await,
+            diff_slot_unset
+        );
+
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn estimate_tx_expenses_honors_block_tag() -> Result<()> {
+    TestCaseRunner::new(EstimateTxExpensesHonorsBlockTagTest)
         .set_citrea_path(get_citrea_path())
         .run()
         .await

--- a/crates/evm/src/query.rs
+++ b/crates/evm/src/query.rs
@@ -958,12 +958,19 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 )
             }
         };
+        // Set evm state to block if needed
+        let block_num = block_env.number;
+        match block_number {
+            None | Some(BlockNumberOrTag::Pending | BlockNumberOrTag::Latest) => {}
+            _ => set_state_to_end_of_evm_block::<C>(block_num, working_set),
+        };
+
         let cfg = self
             .cfg
             .get(working_set)
             .expect("EVM chain config should be set");
 
-        let citrea_spec_id = fork_fn(block_env.number).spec_id;
+        let citrea_spec_id = fork_fn(block_num).spec_id;
         let evm_spec_id = citrea_spec_id_to_evm_spec_id(citrea_spec_id);
 
         let cfg_env = get_cfg_env(cfg, evm_spec_id);

--- a/crates/evm/src/tests/queries/estimate_gas_tests.rs
+++ b/crates/evm/src/tests/queries/estimate_gas_tests.rs
@@ -9,22 +9,15 @@ use alloy_rpc_types::{TransactionInput, TransactionRequest};
 use jsonrpsee::core::RpcResult;
 use reth_rpc_eth_types::RpcInvalidTransactionError;
 use serde_json::json;
-use sov_db::ledger_db::{LedgerDB, NodeLedgerOps};
-use sov_db::schema::types::{L2HeightAndIndex, L2HeightStatus};
+use sov_db::ledger_db::LedgerDB;
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::hooks::HookL2BlockInfo;
-use sov_modules_api::utils::generate_address;
-use sov_modules_api::{Context, Module, Spec, WorkingSet};
+use sov_modules_api::{Spec, WorkingSet};
 
-use crate::call::CallMessage;
 use crate::query::MIN_TRANSACTION_GAS;
 use crate::smart_contracts::{CallerContract, SimpleStorageContract};
-use crate::tests::get_test_seq_pub_key;
 use crate::tests::queries::{init_evm, init_evm_single_block, init_evm_with_caller_contract};
 use crate::tests::test_signer::TestSigner;
-use crate::tests::utils::{
-    commit, create_contract_transaction, get_fork_fn_latest, set_arg_message,
-};
+use crate::tests::utils::get_fork_fn_latest;
 use crate::{EstimatedDiffSize, Evm};
 
 type C = DefaultContext;
@@ -718,150 +711,4 @@ fn test_estimate_gas_no_balance() {
         get_fork_fn_latest(),
     );
     assert!(result.is_err());
-}
-
-#[test]
-fn test_estimate_tx_expenses_honors_block_tag() {
-    let (mut evm, _, prover_storage, signer, l2_height, ledger_db) =
-        init_evm(sov_modules_api::SpecId::latest());
-    assert_eq!(l2_height, 4);
-
-    let spec_id = sov_modules_api::SpecId::latest();
-    let l1_fee_rate = 1;
-
-    let contract = SimpleStorageContract::default();
-    let contract_address = signer.address().create(9);
-
-    // Block 4 deploys the contract
-    // Block 5 sets a storage slot
-    let blocks = [
-        (
-            4,
-            [102u8; 32],
-            vec![create_contract_transaction(
-                &signer,
-                9,
-                SimpleStorageContract::default(),
-            )],
-        ),
-        (
-            5,
-            [103u8; 32],
-            vec![set_arg_message(contract_address, &signer, 10, 478)],
-        ),
-    ];
-
-    let mut pre_state_root = [101u8; 32];
-    for (height, post_state_root, txs) in blocks {
-        let mut working_set = WorkingSet::new(prover_storage.clone());
-
-        let l2_block_info = HookL2BlockInfo {
-            l2_height: height,
-            pre_state_root,
-            current_spec: spec_id,
-            sequencer_pub_key: get_test_seq_pub_key(),
-            l1_fee_rate,
-            timestamp: 24,
-        };
-
-        evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
-
-        let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, height, spec_id, l1_fee_rate);
-        evm.call(CallMessage { txs }, &context, &mut working_set)
-            .unwrap();
-
-        evm.end_l2_block_hook(&l2_block_info, &mut working_set);
-        evm.finalize_hook(&post_state_root, &mut working_set.accessory_state());
-
-        commit(working_set, prover_storage.clone());
-        pre_state_root = post_state_root;
-    }
-
-    let set_storage_tx_request = TransactionRequest {
-        from: Some(signer.address()),
-        to: Some(TxKind::Call(contract_address)),
-        input: TransactionInput::new(contract.set_call_data(5).into()),
-        ..Default::default()
-    };
-
-    // Helper functions to estimate gas and diff size at a given block tag.
-    let estimate_at = |tag: BlockNumberOrTag| {
-        evm.eth_estimate_gas_inner(
-            set_storage_tx_request.clone(),
-            Some(tag),
-            None,
-            &mut WorkingSet::new(prover_storage.clone()),
-            &ledger_db,
-            get_fork_fn_latest(),
-        )
-        .unwrap()
-    };
-
-    let diff_size_at = |tag: BlockNumberOrTag| {
-        evm.eth_estimate_diff_size_inner(
-            set_storage_tx_request.clone(),
-            Some(tag),
-            None,
-            &mut WorkingSet::new(prover_storage.clone()),
-            &ledger_db,
-            get_fork_fn_latest(),
-        )
-        .unwrap()
-    };
-
-    // Helper function to manipulate safe and finalized tags to point to a given block number.
-    let point_tag_at = |status: L2HeightStatus, l1_height: u64, height: u64| {
-        ledger_db
-            .set_l2_height_status(
-                status,
-                l1_height,
-                L2HeightAndIndex {
-                    height,
-                    commitment_index: 1,
-                },
-            )
-            .unwrap()
-    };
-
-    // A request for block N rewinds to archival version N + 1, which is right in production
-    // where genesis is committed on its own. `init_evm` commits genesis together with block 1,
-    // so every version here holds one block more: a request for block N observes the state
-    // after block N + 1. That is why block 3 already sees the contract deployed in block 4.
-    let no_contract = estimate_at(BlockNumberOrTag::Number(2));
-    let slot_unset = estimate_at(BlockNumberOrTag::Number(3));
-    let slot_set = estimate_at(BlockNumberOrTag::Latest);
-
-    // No contract is just a plain call to an empty account. Beyond that, SSTORE is priced off the
-    // slot's current value: overwriting one that already holds a value pays less than
-    // writing one that is still zero (cold write).
-    assert!(no_contract < slot_set);
-    assert!(slot_set < slot_unset);
-    // Other tags landing in the same states agree with them.
-    assert_eq!(estimate_at(BlockNumberOrTag::Earliest), no_contract);
-    assert_eq!(estimate_at(BlockNumberOrTag::Number(4)), slot_set);
-    assert_eq!(estimate_at(BlockNumberOrTag::Pending), slot_set);
-
-    let diff_no_contract = diff_size_at(BlockNumberOrTag::Number(2));
-    let diff_slot_unset = diff_size_at(BlockNumberOrTag::Number(3));
-    let diff_slot_set = diff_size_at(BlockNumberOrTag::Latest);
-
-    // The same three-way split applies to the diff size's gas field.
-    assert!(diff_no_contract.gas < diff_slot_set.gas);
-    assert!(diff_slot_set.gas < diff_slot_unset.gas);
-
-    // The diff size only splits two ways: touching no contract writes no storage, while writing
-    // a slot costs the same diff whether or not it already held a value.
-    assert!(diff_no_contract.l1_diff_size < diff_slot_unset.l1_diff_size);
-    assert_eq!(diff_slot_unset.l1_diff_size, diff_slot_set.l1_diff_size);
-
-    // Point safe tag to block 4, finalized tag to block 3
-    // Safe should see the slot set, finalized should see the slot unset.
-    point_tag_at(L2HeightStatus::Committed, 1, 4);
-    point_tag_at(L2HeightStatus::Proven, 1, 3);
-
-    assert_eq!(estimate_at(BlockNumberOrTag::Safe), slot_set);
-    assert_eq!(estimate_at(BlockNumberOrTag::Finalized), slot_unset);
-    assert_eq!(diff_size_at(BlockNumberOrTag::Safe), diff_slot_set);
-    assert_eq!(diff_size_at(BlockNumberOrTag::Finalized), diff_slot_unset);
 }

--- a/crates/evm/src/tests/queries/estimate_gas_tests.rs
+++ b/crates/evm/src/tests/queries/estimate_gas_tests.rs
@@ -9,15 +9,22 @@ use alloy_rpc_types::{TransactionInput, TransactionRequest};
 use jsonrpsee::core::RpcResult;
 use reth_rpc_eth_types::RpcInvalidTransactionError;
 use serde_json::json;
-use sov_db::ledger_db::LedgerDB;
+use sov_db::ledger_db::{LedgerDB, NodeLedgerOps};
+use sov_db::schema::types::{L2HeightAndIndex, L2HeightStatus};
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::{Spec, WorkingSet};
+use sov_modules_api::hooks::HookL2BlockInfo;
+use sov_modules_api::utils::generate_address;
+use sov_modules_api::{Context, Module, Spec, WorkingSet};
 
+use crate::call::CallMessage;
 use crate::query::MIN_TRANSACTION_GAS;
 use crate::smart_contracts::{CallerContract, SimpleStorageContract};
+use crate::tests::get_test_seq_pub_key;
 use crate::tests::queries::{init_evm, init_evm_single_block, init_evm_with_caller_contract};
 use crate::tests::test_signer::TestSigner;
-use crate::tests::utils::get_fork_fn_latest;
+use crate::tests::utils::{
+    commit, create_contract_transaction, get_fork_fn_latest, set_arg_message,
+};
 use crate::{EstimatedDiffSize, Evm};
 
 type C = DefaultContext;
@@ -711,4 +718,150 @@ fn test_estimate_gas_no_balance() {
         get_fork_fn_latest(),
     );
     assert!(result.is_err());
+}
+
+#[test]
+fn test_estimate_tx_expenses_honors_block_tag() {
+    let (mut evm, _, prover_storage, signer, l2_height, ledger_db) =
+        init_evm(sov_modules_api::SpecId::latest());
+    assert_eq!(l2_height, 4);
+
+    let spec_id = sov_modules_api::SpecId::latest();
+    let l1_fee_rate = 1;
+
+    let contract = SimpleStorageContract::default();
+    let contract_address = signer.address().create(9);
+
+    // Block 4 deploys the contract
+    // Block 5 sets a storage slot
+    let blocks = [
+        (
+            4,
+            [102u8; 32],
+            vec![create_contract_transaction(
+                &signer,
+                9,
+                SimpleStorageContract::default(),
+            )],
+        ),
+        (
+            5,
+            [103u8; 32],
+            vec![set_arg_message(contract_address, &signer, 10, 478)],
+        ),
+    ];
+
+    let mut pre_state_root = [101u8; 32];
+    for (height, post_state_root, txs) in blocks {
+        let mut working_set = WorkingSet::new(prover_storage.clone());
+
+        let l2_block_info = HookL2BlockInfo {
+            l2_height: height,
+            pre_state_root,
+            current_spec: spec_id,
+            sequencer_pub_key: get_test_seq_pub_key(),
+            l1_fee_rate,
+            timestamp: 24,
+        };
+
+        evm.begin_l2_block_hook(&l2_block_info, &mut working_set);
+
+        let sender_address = generate_address::<C>("sender");
+        let context = C::new(sender_address, height, spec_id, l1_fee_rate);
+        evm.call(CallMessage { txs }, &context, &mut working_set)
+            .unwrap();
+
+        evm.end_l2_block_hook(&l2_block_info, &mut working_set);
+        evm.finalize_hook(&post_state_root, &mut working_set.accessory_state());
+
+        commit(working_set, prover_storage.clone());
+        pre_state_root = post_state_root;
+    }
+
+    let set_storage_tx_request = TransactionRequest {
+        from: Some(signer.address()),
+        to: Some(TxKind::Call(contract_address)),
+        input: TransactionInput::new(contract.set_call_data(5).into()),
+        ..Default::default()
+    };
+
+    // Helper functions to estimate gas and diff size at a given block tag.
+    let estimate_at = |tag: BlockNumberOrTag| {
+        evm.eth_estimate_gas_inner(
+            set_storage_tx_request.clone(),
+            Some(tag),
+            None,
+            &mut WorkingSet::new(prover_storage.clone()),
+            &ledger_db,
+            get_fork_fn_latest(),
+        )
+        .unwrap()
+    };
+
+    let diff_size_at = |tag: BlockNumberOrTag| {
+        evm.eth_estimate_diff_size_inner(
+            set_storage_tx_request.clone(),
+            Some(tag),
+            None,
+            &mut WorkingSet::new(prover_storage.clone()),
+            &ledger_db,
+            get_fork_fn_latest(),
+        )
+        .unwrap()
+    };
+
+    // Helper function to manipulate safe and finalized tags to point to a given block number.
+    let point_tag_at = |status: L2HeightStatus, l1_height: u64, height: u64| {
+        ledger_db
+            .set_l2_height_status(
+                status,
+                l1_height,
+                L2HeightAndIndex {
+                    height,
+                    commitment_index: 1,
+                },
+            )
+            .unwrap()
+    };
+
+    // A request for block N rewinds to archival version N + 1, which is right in production
+    // where genesis is committed on its own. `init_evm` commits genesis together with block 1,
+    // so every version here holds one block more: a request for block N observes the state
+    // after block N + 1. That is why block 3 already sees the contract deployed in block 4.
+    let no_contract = estimate_at(BlockNumberOrTag::Number(2));
+    let slot_unset = estimate_at(BlockNumberOrTag::Number(3));
+    let slot_set = estimate_at(BlockNumberOrTag::Latest);
+
+    // No contract is just a plain call to an empty account. Beyond that, SSTORE is priced off the
+    // slot's current value: overwriting one that already holds a value pays less than
+    // writing one that is still zero (cold write).
+    assert!(no_contract < slot_set);
+    assert!(slot_set < slot_unset);
+    // Other tags landing in the same states agree with them.
+    assert_eq!(estimate_at(BlockNumberOrTag::Earliest), no_contract);
+    assert_eq!(estimate_at(BlockNumberOrTag::Number(4)), slot_set);
+    assert_eq!(estimate_at(BlockNumberOrTag::Pending), slot_set);
+
+    let diff_no_contract = diff_size_at(BlockNumberOrTag::Number(2));
+    let diff_slot_unset = diff_size_at(BlockNumberOrTag::Number(3));
+    let diff_slot_set = diff_size_at(BlockNumberOrTag::Latest);
+
+    // The same three-way split applies to the diff size's gas field.
+    assert!(diff_no_contract.gas < diff_slot_set.gas);
+    assert!(diff_slot_set.gas < diff_slot_unset.gas);
+
+    // The diff size only splits two ways: touching no contract writes no storage, while writing
+    // a slot costs the same diff whether or not it already held a value.
+    assert!(diff_no_contract.l1_diff_size < diff_slot_unset.l1_diff_size);
+    assert_eq!(diff_slot_unset.l1_diff_size, diff_slot_set.l1_diff_size);
+
+    // Point safe tag to block 4, finalized tag to block 3
+    // Safe should see the slot set, finalized should see the slot unset.
+    point_tag_at(L2HeightStatus::Committed, 1, 4);
+    point_tag_at(L2HeightStatus::Proven, 1, 3);
+
+    assert_eq!(estimate_at(BlockNumberOrTag::Safe), slot_set);
+    assert_eq!(estimate_at(BlockNumberOrTag::Finalized), slot_unset);
+    assert_eq!(diff_size_at(BlockNumberOrTag::Safe), diff_slot_set);
+    assert_eq!(diff_size_at(BlockNumberOrTag::Finalized), diff_slot_unset);
 }


### PR DESCRIPTION
# Description

In `estimate_tx_expenses`, the call to `set_state_to_end_of_evm_block` is missing, resulting in all block tags executing against the latest state in `eth_estimateGas` and `eth_estimateDiffsize` endpoints.
The call to `set_state_to_end_of_evm_block` was removed [here](https://github.com/chainwayxyz/citrea/pull/1303/changes#diff-874b0b70e7fb99e3b14a1c3cb6edff6f4601094f2f9b6b20b76b478a74bc77a6L683), this PR restores it.

## Testing
Added `test_estimate_tx_expenses_honors_block_tag` evm test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RPC simulation behavior for historical block tags on widely used estimate endpoints; incorrect estimates before the fix could mislead users, but the change aligns behavior with other eth_call-style APIs.
> 
> **Overview**
> **Fixes block-tag handling for gas and diff-size estimates.** `estimate_tx_expenses` again calls `set_state_to_end_of_evm_block` when the request uses a historical or tagged block (anything other than default, `latest`, or `pending`). Without this, simulations always ran against the latest state, so gas and L1 diff estimates were wrong for `safe`, `finalized`, numbered blocks, etc.
> 
> Fork/spec resolution now uses the resolved block number from the block env consistently.
> 
> An e2e test deploys a contract across blocks, drives L1 commitments and proofs, and asserts `eth_estimateGas` and `eth_estimateDiffSize` differ across `earliest`, numbered blocks, `safe`, `finalized`, `latest`, and `pending` as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e598aa54ab456a6e6050933a42253593dab3e681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->