### PR TITLE
feat: forward configured RPC headers to the sequencer

### DIFF
--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -51,7 +51,7 @@ fn is_unsafe_forward_header(name: &HeaderName) -> bool {
             | "proxy-connection"
             | "proxy-authenticate"
             | "proxy-authorization"
-            | "te"
+            | "te" // codespell:ignore te
             | "trailer"
             | "transfer-encoding"
             | "upgrade"

--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -1,13 +1,17 @@
 //! Common RPC crate provides helper methods that are needed in rpc servers
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
 use backoff::future::retry as retry_backoff;
 use backoff::ExponentialBackoff;
-use futures::future::BoxFuture;
+use futures::future::{BoxFuture, Either};
 use futures::FutureExt;
+use hyper::header::{HeaderMap, HeaderName};
 use hyper::Method;
 use jsonrpsee::core::RegisterMethodError;
+use jsonrpsee::http_client::transport::HttpBackend;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder, HttpRequest};
 use jsonrpsee::server::middleware::http::ProxyGetRequestLayer;
 use jsonrpsee::server::middleware::rpc::RpcServiceT;
 use jsonrpsee::types::error::{INTERNAL_ERROR_CODE, INTERNAL_ERROR_MSG};
@@ -16,6 +20,8 @@ use jsonrpsee::{MethodResponse, RpcModule};
 use sov_db::ledger_db::{LedgerDB, SharedLedgerOps};
 use sov_db::schema::types::L2BlockNumber;
 use sov_rollup_interface::services::da::DaService;
+use tokio::task::futures::TaskLocalFuture;
+use tower::util::MapRequest;
 use tower_http::cors::{Any, CorsLayer};
 
 mod auth;
@@ -27,6 +33,149 @@ pub mod utils;
 
 // Exit early if head_batch_num is below this threshold
 const BLOCK_NUM_THRESHOLD: u64 = 2;
+const RPC_FORWARD_HEADERS_ENV: &str = "RPC_FORWARD_HEADERS";
+
+#[derive(Clone)]
+struct ForwardedHeaders(Arc<HeaderMap>);
+
+// Forwarding work moved to a newly spawned task must propagate this context explicitly.
+tokio::task_local! {
+    static FORWARDED_HEADERS: Arc<HeaderMap>;
+}
+
+fn is_unsafe_forward_header(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "connection"
+            | "keep-alive"
+            | "proxy-connection"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+            | "host"
+            | "content-length"
+            | "expect"
+            | "content-type"
+            | "accept"
+            | "content-encoding"
+            | "accept-encoding"
+    )
+}
+
+fn parse_forward_header_names(value: Option<&str>) -> HashSet<HeaderName> {
+    let Some(value) = value
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("null"))
+    else {
+        return HashSet::new();
+    };
+
+    value
+        .split(',')
+        .filter_map(|value| {
+            let value = value.trim();
+            if value.is_empty() {
+                return None;
+            }
+
+            match HeaderName::from_bytes(value.as_bytes()) {
+                Ok(name) if !is_unsafe_forward_header(&name) => Some(name),
+                Ok(name) => {
+                    tracing::warn!(header = %name, "Ignoring unsafe RPC forward header");
+                    None
+                }
+                Err(error) => {
+                    tracing::warn!(header = value, %error, "Ignoring invalid RPC forward header");
+                    None
+                }
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn forward_header_names_from_env() -> Arc<HashSet<HeaderName>> {
+    Arc::new(parse_forward_header_names(
+        std::env::var(RPC_FORWARD_HEADERS_ENV).ok().as_deref(),
+    ))
+}
+
+pub(crate) fn capture_forwarded_headers(
+    mut request: jsonrpsee::server::HttpRequest,
+    configured_headers: &HashSet<HeaderName>,
+) -> jsonrpsee::server::HttpRequest {
+    if configured_headers.is_empty() {
+        return request;
+    }
+
+    let mut forwarded_headers = HeaderMap::new();
+    for (name, value) in request.headers() {
+        if configured_headers.contains(name) {
+            forwarded_headers.append(name.clone(), value.clone());
+        }
+    }
+
+    if !forwarded_headers.is_empty() {
+        request
+            .extensions_mut()
+            .insert(ForwardedHeaders(Arc::new(forwarded_headers)));
+    }
+
+    request
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ForwardHeaders<S>(pub S);
+
+impl<'a, S> RpcServiceT<'a> for ForwardHeaders<S>
+where
+    S: RpcServiceT<'a>,
+{
+    type Future = Either<S::Future, TaskLocalFuture<Arc<HeaderMap>, S::Future>>;
+
+    fn call(&self, request: Request<'a>) -> Self::Future {
+        let forwarded_headers = request
+            .extensions()
+            .get::<ForwardedHeaders>()
+            .map(|headers| Arc::clone(&headers.0));
+        let future = self.0.call(request);
+
+        match forwarded_headers {
+            Some(headers) => Either::Right(FORWARDED_HEADERS.scope(headers, future)),
+            None => Either::Left(future),
+        }
+    }
+}
+
+fn attach_forwarded_headers(mut request: HttpRequest) -> HttpRequest {
+    let Ok(forwarded_headers) = FORWARDED_HEADERS.try_with(Arc::clone) else {
+        return request;
+    };
+
+    for name in forwarded_headers.keys() {
+        request.headers_mut().remove(name);
+    }
+    for (name, value) in forwarded_headers.iter() {
+        request.headers_mut().append(name.clone(), value.clone());
+    }
+
+    request
+}
+
+pub type ForwardingHttpClient = HttpClient<MapRequest<HttpBackend, fn(HttpRequest) -> HttpRequest>>;
+
+pub fn build_forwarding_http_client(
+    target: impl AsRef<str>,
+) -> Result<ForwardingHttpClient, jsonrpsee::core::client::Error> {
+    let middleware = tower::ServiceBuilder::new()
+        .map_request(attach_forwarded_headers as fn(HttpRequest) -> HttpRequest);
+
+    HttpClientBuilder::default()
+        .set_http_middleware(middleware)
+        .build(target)
+}
 
 /// Register the healthcheck rpc
 pub fn register_healthcheck_rpc<T: Send + Sync + 'static>(
@@ -162,5 +311,176 @@ where
             resp
         }
         .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::sync::Mutex;
+
+    use hyper::header::{HeaderValue, ACCEPT, AUTHORIZATION};
+    use jsonrpsee::types::Id;
+    use jsonrpsee::ResponsePayload;
+    use tokio::sync::Barrier;
+
+    use super::*;
+
+    #[test]
+    fn parses_and_captures_forwarded_headers() {
+        for value in [
+            None,
+            Some(""),
+            Some("   "),
+            Some(", ,"),
+            Some("null"),
+            Some(" NuLl "),
+        ] {
+            assert!(parse_forward_header_names(value).is_empty());
+        }
+
+        let configured_headers = parse_forward_header_names(Some(
+            " X-Trace-ID, x-trace-id, X-Forward-IP, bad header, host, , ",
+        ));
+        assert_eq!(configured_headers.len(), 2);
+        assert!(configured_headers.contains(&HeaderName::from_static("x-trace-id")));
+        assert!(configured_headers.contains(&HeaderName::from_static("x-forward-ip")));
+
+        let mut request = jsonrpsee::server::HttpRequest::new(jsonrpsee::server::HttpBody::empty());
+        request
+            .headers_mut()
+            .append("x-trace-id", HeaderValue::from_static("first"));
+        request.headers_mut().append(
+            "x-trace-id",
+            HeaderValue::from_bytes(b"opaque\xfa").unwrap(),
+        );
+        request
+            .headers_mut()
+            .insert("x-not-forwarded", HeaderValue::from_static("excluded"));
+
+        let request = capture_forwarded_headers(request, &configured_headers);
+        let forwarded_headers = request.extensions().get::<ForwardedHeaders>().unwrap();
+        let values = forwarded_headers
+            .0
+            .get_all("x-trace-id")
+            .iter()
+            .map(HeaderValue::as_bytes)
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, vec![b"first".as_slice(), b"opaque\xfa".as_slice()]);
+        assert!(!forwarded_headers.0.contains_key("x-not-forwarded"));
+        assert_eq!(request.headers().get_all("x-trace-id").iter().count(), 2);
+
+        let request = capture_forwarded_headers(
+            jsonrpsee::server::HttpRequest::new(jsonrpsee::server::HttpBody::empty()),
+            &configured_headers,
+        );
+        assert!(request.extensions().get::<ForwardedHeaders>().is_none());
+    }
+
+    #[tokio::test]
+    async fn attaches_forwarded_headers_and_is_noop_without_context() {
+        let mut request = HttpRequest::new(jsonrpsee::http_client::HttpBody::empty());
+        request
+            .headers_mut()
+            .insert(ACCEPT, HeaderValue::from_static("application/json"));
+        request
+            .headers_mut()
+            .insert(AUTHORIZATION, HeaderValue::from_static("original"));
+        let original_headers = request.headers().clone();
+
+        let request = attach_forwarded_headers(request);
+        assert_eq!(request.headers(), &original_headers);
+
+        let mut forwarded_headers = HeaderMap::new();
+        forwarded_headers.append(AUTHORIZATION, HeaderValue::from_static("first"));
+        forwarded_headers.append(AUTHORIZATION, HeaderValue::from_static("second"));
+
+        let request = FORWARDED_HEADERS
+            .scope(Arc::new(forwarded_headers), async move {
+                attach_forwarded_headers(request)
+            })
+            .await;
+        let authorization_values = request
+            .headers()
+            .get_all(AUTHORIZATION)
+            .iter()
+            .map(HeaderValue::as_bytes)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            authorization_values,
+            vec![b"first".as_slice(), b"second".as_slice()]
+        );
+        assert_eq!(
+            request.headers().get(ACCEPT),
+            Some(&HeaderValue::from_static("application/json"))
+        );
+    }
+
+    type ObservedHeaders = Vec<(u64, Vec<Vec<u8>>)>;
+
+    #[derive(Clone)]
+    struct InspectForwardedHeaders {
+        barrier: Arc<Barrier>,
+        observed: Arc<Mutex<ObservedHeaders>>,
+    }
+
+    impl<'a> RpcServiceT<'a> for InspectForwardedHeaders {
+        type Future = BoxFuture<'a, MethodResponse>;
+
+        fn call(&self, request: Request<'a>) -> Self::Future {
+            let id = *request.id().as_number().unwrap();
+            let barrier = Arc::clone(&self.barrier);
+            let observed = Arc::clone(&self.observed);
+
+            async move {
+                barrier.wait().await;
+                let request = attach_forwarded_headers(HttpRequest::new(
+                    jsonrpsee::http_client::HttpBody::empty(),
+                ));
+                let values = request
+                    .headers()
+                    .get_all("x-trace-id")
+                    .iter()
+                    .map(|value| value.as_bytes().to_vec())
+                    .collect();
+                observed.lock().unwrap().push((id, values));
+
+                MethodResponse::response(Id::Number(id), ResponsePayload::success(()), usize::MAX)
+            }
+            .boxed()
+        }
+    }
+
+    fn request_with_forwarded_header(id: u64, value: &'static str) -> Request<'static> {
+        let mut request = Request::new(Cow::Borrowed("test"), None, Id::Number(id));
+        let mut headers = HeaderMap::new();
+        headers.insert("x-trace-id", HeaderValue::from_static(value));
+        request
+            .extensions_mut()
+            .insert(ForwardedHeaders(Arc::new(headers)));
+        request
+    }
+
+    #[tokio::test]
+    async fn isolates_forwarded_headers_between_requests() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let service = ForwardHeaders(InspectForwardedHeaders {
+            barrier: Arc::new(Barrier::new(2)),
+            observed: Arc::clone(&observed),
+        });
+
+        let first = service.call(request_with_forwarded_header(1, "first"));
+        let second = service.call(request_with_forwarded_header(2, "second"));
+        tokio::join!(first, second);
+
+        let mut observed = observed.lock().unwrap().clone();
+        observed.sort_by_key(|(id, _)| *id);
+        assert_eq!(
+            observed,
+            vec![(1, vec![b"first".to_vec()]), (2, vec![b"second".to_vec()])]
+        );
+        assert!(FORWARDED_HEADERS.try_with(|_| ()).is_err());
     }
 }

--- a/crates/common/src/rpc/server.rs
+++ b/crates/common/src/rpc/server.rs
@@ -34,7 +34,11 @@ pub fn start_rpc_server(
     let max_response_body_size = rpc_config.max_response_body_size;
     let batch_requests_limit = rpc_config.batch_requests_limit;
 
+    let forward_headers = super::forward_header_names_from_env();
     let middleware = tower::ServiceBuilder::new()
+        .map_request(move |request: jsonrpsee::server::HttpRequest| {
+            super::capture_forwarded_headers(request, &forward_headers)
+        })
         .layer(super::get_cors_layer())
         .layer(super::get_healthcheck_proxy_layer())
         .layer(TimeoutLayer::new(Duration::from_secs(rpc_config.timeout)));
@@ -42,7 +46,8 @@ pub fn start_rpc_server(
     let rpc_middleware = RpcServiceBuilder::new()
         .layer_fn(move |s| super::auth::Auth::new(s, rpc_config.api_key.clone()))
         .layer_fn(super::Logger)
-        .layer_fn(RpcMetrics);
+        .layer_fn(RpcMetrics)
+        .layer_fn(super::ForwardHeaders);
 
     task_executor.spawn_with_signal(move |cancellation_token| {
         async move {

--- a/crates/ethereum-rpc/src/ethereum.rs
+++ b/crates/ethereum-rpc/src/ethereum.rs
@@ -2,8 +2,8 @@ use std::sync::{Arc, Mutex};
 
 use alloy_primitives::U256;
 use alloy_rpc_types_trace::geth::TraceResult;
+use citrea_common::rpc::ForwardingHttpClient;
 use citrea_evm::{CitreaFilter, Evm};
-use jsonrpsee::http_client::HttpClient;
 use rustc_version_runtime::version;
 use schnellru::{ByLength, LruMap};
 use sov_db::ledger_db::LedgerDB;
@@ -34,7 +34,7 @@ pub struct Ethereum<C: sov_modules_api::Context, Da: DaService> {
     pub(crate) gas_price_oracle: GasPriceOracle<C>,
     pub(crate) storage: C::Storage,
     pub(crate) ledger_db: LedgerDB,
-    pub(crate) sequencer_client: Option<HttpClient>,
+    pub(crate) sequencer_client: Option<ForwardingHttpClient>,
     pub(crate) web3_client_version: String,
     pub(crate) trace_cache: Mutex<LruMap<u64, Vec<TraceResult>, ByLength>>,
     pub(crate) subscription_manager: Option<SubscriptionManager>,
@@ -48,7 +48,7 @@ impl<C: sov_modules_api::Context, Da: DaService> Ethereum<C, Da> {
         eth_rpc_config: EthRpcConfig,
         storage: C::Storage,
         ledger_db: LedgerDB,
-        sequencer_client: Option<HttpClient>,
+        sequencer_client: Option<ForwardingHttpClient>,
         l2_block_rx: &Option<broadcast::Receiver<u64>>,
         task_executor: reth_tasks::TaskExecutor,
     ) -> Self {

--- a/crates/ethereum-rpc/src/lib.rs
+++ b/crates/ethereum-rpc/src/lib.rs
@@ -17,8 +17,8 @@ use alloy_rpc_types_trace::geth::{
     GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
     TraceResult,
 };
-use citrea_common::rpc::eip_7966;
 use citrea_common::rpc::utils::internal_rpc_error;
+use citrea_common::rpc::{build_forwarding_http_client, eip_7966};
 use citrea_common::RpcConfig;
 use citrea_evm::{generate_eth_proof, Evm, FilterKind};
 use citrea_sequencer::SequencerRpcClient;
@@ -26,7 +26,6 @@ pub use ethereum::{EthRpcConfig, Ethereum};
 pub use gas_price::fee_history::FeeHistoryCacheConfig;
 pub use gas_price::gas_oracle::GasPriceOracleConfig;
 use jsonrpsee::core::{RpcResult, SubscriptionResult};
-use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::{PendingSubscriptionSink, RpcModule};
@@ -951,7 +950,7 @@ where
         eth_rpc_config,
         storage,
         ledger_db,
-        sequencer_client_url.map(|url| HttpClientBuilder::default().build(url).unwrap()),
+        sequencer_client_url.map(|url| build_forwarding_http_client(url).unwrap()),
         &l2_block_rx,
         task_executor,
     ));


### PR DESCRIPTION
## Summary

- add `RPC_FORWARD_HEADERS` as a comma-separated allowlist for forwarding selected inbound JSON-RPC headers
- preserve opaque header values and duplicates while isolating headers per request
- apply forwarding to the shared sequencer client so all foreground proxy paths inherit it
- reject transport-owned headers that could alter downstream framing or routing

## Why

Full nodes and batch provers proxy selected RPC work to the sequencer. Operators need configured request metadata such as tracing or forwarding headers to survive that hop without forwarding every inbound header.

## Validation

- `cargo test -p citrea-common rpc::tests`
- `cargo test -p citrea-common -p ethereum-rpc -- --test-threads=1`
- `cargo check -p citrea-common -p ethereum-rpc`
- `SKIP_GUEST_BUILD=1 cargo clippy -p citrea-common -p ethereum-rpc --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check` with nightly rustfmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RPC proxying and can forward operator-allowlisted headers (including auth-like ones) to the sequencer. Hop-by-hop headers are blocked, but misconfiguration could leak request metadata.
> 
> **Overview**
> Full-node RPC can now pass selected inbound HTTP headers through to the sequencer on proxied JSON-RPC calls, so tracing and similar metadata survive that hop.
> 
> Operators set `RPC_FORWARD_HEADERS` to a comma-separated allowlist. Capture happens in HTTP middleware, request-local task context isolates concurrent calls, and the sequencer `HttpClient` reattaches those headers. Hop-by-hop and framing headers (`host`, `content-length`, `transfer-encoding`, etc.) are always dropped; invalid names are ignored. Duplicate and opaque values are preserved.
> 
> Wired into the shared sequencer client used by ethereum RPC proxy paths. Unit tests cover parsing, attach/no-op, and isolation across concurrent requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f4f4755a0081855ac16c8730c732b2a3d24c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->