### PR TITLE
fix(rpc): with log config in debug trace cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 ### Changed
 - fix(rpc): Set archival state in estimate tx expenses ([#3321](https://github.com/chainwayxyz/citrea/pull/3321))
+- fix(rpc): with log config in debug trace cache ([#3323](https://github.com/chainwayxyz/citrea/pull/3323))
 
 ## [v2.7.0](2026-07-29)
 ### Changed

--- a/bin/citrea/tests/mock/evm/tracing.rs
+++ b/bin/citrea/tests/mock/evm/tracing.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use alloy_primitives::ruint::aliases::U256;
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{keccak256, Address, Bytes};
 use alloy_rpc_types::{BlockId, BlockNumberOrTag, TransactionInput, TransactionRequest};
 use alloy_rpc_types_trace::geth::call::FlatCallFrame;
 use alloy_rpc_types_trace::geth::mux::{MuxConfig, MuxFrame};
@@ -10,13 +10,15 @@ use alloy_rpc_types_trace::geth::GethTrace::{
     self, CallTracer, FlatCallTracer, FourByteTracer, MuxTracer, PreStateTracer,
 };
 use alloy_rpc_types_trace::geth::{
-    CallConfig, CallFrame, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
+    CallConfig, CallFrame, CallLogFrame, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
     GethDebugTracingCallOptions, GethDebugTracingOptions, PreStateConfig, PreStateFrame,
     TraceResult,
 };
 // use citrea::initialize_logging;
 use citrea_common::SequencerConfig;
-use citrea_evm::smart_contracts::{CallerContract, SimpleStorageContract};
+use citrea_evm::smart_contracts::{
+    AnotherLogEvent, CallerContract, LogEvent, LogsContract, SimpleStorageContract, TestContract,
+};
 use citrea_stf::genesis_config::GenesisPaths;
 use reth_tasks::TaskManager;
 use serde_json::{self, json};
@@ -520,6 +522,155 @@ async fn test_call_tracer() -> Result<(), Box<dyn std::error::Error>> {
 
     task_manager.graceful_shutdown();
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_call_tracer_with_log() -> Result<(), Box<dyn std::error::Error>> {
+    let (task_manager, test_client, _contract_info) = init_sequencer().await?;
+
+    let logs_contract = LogsContract::default();
+    let deploy_logs_contract_req = test_client
+        .deploy_contract(logs_contract.byte_code(), None)
+        .await?;
+
+    test_client.send_publish_batch_request().await;
+
+    let logs_contract_address = deploy_logs_contract_req
+        .get_receipt()
+        .await?
+        .contract_address
+        .unwrap();
+
+    // publishEvent emits a Log and then an AnotherLog event
+    let test_msg = "5655".to_string();
+    let publish_event_req = test_client
+        .contract_transaction(
+            logs_contract_address,
+            logs_contract.publish_event(test_msg.clone()),
+            None,
+        )
+        .await;
+
+    test_client.send_publish_batch_request().await;
+
+    let tx_hash = publish_event_req.get_receipt().await?.transaction_hash;
+
+    let with_log_trace = test_client
+        .debug_trace_transaction(
+            tx_hash,
+            Some(
+                GethDebugTracingOptions::default()
+                    .with_tracer(GethDebugTracerType::BuiltInTracer(
+                        GethDebugBuiltInTracerType::CallTracer,
+                    ))
+                    .with_call_config(CallConfig {
+                        only_top_call: Some(false),
+                        with_log: Some(true),
+                    }),
+            ),
+        )
+        .await
+        .try_into_call_frame()
+        .unwrap();
+
+    let (log_payload, another_log_payload) = decode_call_frame_logs(&with_log_trace.logs);
+
+    assert_eq!(log_payload.address, logs_contract_address);
+    assert_eq!(log_payload.sender, test_client.from_addr);
+    assert_eq!(log_payload.contractAddress, logs_contract_address);
+    // senderMessage is an indexed string, so the event only carries its hash
+    assert_eq!(log_payload.senderMessage, keccak256(test_msg));
+    assert_eq!(log_payload.message, "Hello World!");
+    assert_eq!(another_log_payload.address, logs_contract_address);
+    assert_eq!(another_log_payload.contractAddress, logs_contract_address);
+
+    // The same request is now served from the trace cache
+    let cached_with_log_trace = test_client
+        .debug_trace_transaction(
+            tx_hash,
+            Some(
+                GethDebugTracingOptions::default()
+                    .with_tracer(GethDebugTracerType::BuiltInTracer(
+                        GethDebugBuiltInTracerType::CallTracer,
+                    ))
+                    .with_call_config(CallConfig {
+                        only_top_call: Some(false),
+                        with_log: Some(true),
+                    }),
+            ),
+        )
+        .await
+        .try_into_call_frame()
+        .unwrap();
+
+    assert_eq!(cached_with_log_trace, with_log_trace);
+
+    // withlog false must strip the logs off the cached trace and change nothing else
+    let without_log_trace = test_client
+        .debug_trace_transaction(
+            tx_hash,
+            Some(
+                GethDebugTracingOptions::default()
+                    .with_tracer(GethDebugTracerType::BuiltInTracer(
+                        GethDebugBuiltInTracerType::CallTracer,
+                    ))
+                    .with_call_config(CallConfig {
+                        only_top_call: Some(false),
+                        with_log: Some(false),
+                    }),
+            ),
+        )
+        .await
+        .try_into_call_frame()
+        .unwrap();
+
+    assert_eq!(
+        without_log_trace,
+        CallFrame {
+            logs: vec![],
+            ..with_log_trace.clone()
+        }
+    );
+
+    // no call config at all defaults to withlog false
+    let default_config_trace = test_client
+        .debug_trace_transaction(
+            tx_hash,
+            Some(GethDebugTracingOptions::default().with_tracer(
+                GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer),
+            )),
+        )
+        .await
+        .try_into_call_frame()
+        .unwrap();
+
+    assert_eq!(default_config_trace, without_log_trace);
+
+    task_manager.graceful_shutdown();
+    Ok(())
+}
+
+fn decode_call_frame_logs(
+    logs: &[CallLogFrame],
+) -> (
+    alloy_primitives::Log<LogEvent>,
+    alloy_primitives::Log<AnotherLogEvent>,
+) {
+    assert_eq!(logs.len(), 2);
+
+    let into_log = |log: &CallLogFrame| {
+        alloy_primitives::Log::new_unchecked(
+            log.address.unwrap(),
+            log.topics.clone().unwrap(),
+            log.data.clone().unwrap(),
+        )
+    };
+
+    let log_payload = LogsContract::decode_log_event(&into_log(&logs[0])).unwrap();
+    let another_log_payload =
+        LogsContract::decode_another_log_event(&into_log(&logs[1])).unwrap();
+
+    (log_payload, another_log_payload)
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/bin/citrea/tests/mock/evm/tracing.rs
+++ b/bin/citrea/tests/mock/evm/tracing.rs
@@ -10,9 +10,9 @@ use alloy_rpc_types_trace::geth::GethTrace::{
     self, CallTracer, FlatCallTracer, FourByteTracer, MuxTracer, PreStateTracer,
 };
 use alloy_rpc_types_trace::geth::{
-    CallConfig, CallFrame, CallLogFrame, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
-    GethDebugTracingCallOptions, GethDebugTracingOptions, PreStateConfig, PreStateFrame,
-    TraceResult,
+    CallConfig, CallFrame, CallLogFrame, FourByteFrame, GethDebugBuiltInTracerType,
+    GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions, PreStateConfig,
+    PreStateFrame, TraceResult,
 };
 // use citrea::initialize_logging;
 use citrea_common::SequencerConfig;
@@ -667,8 +667,7 @@ fn decode_call_frame_logs(
     };
 
     let log_payload = LogsContract::decode_log_event(&into_log(&logs[0])).unwrap();
-    let another_log_payload =
-        LogsContract::decode_another_log_event(&into_log(&logs[1])).unwrap();
+    let another_log_payload = LogsContract::decode_another_log_event(&into_log(&logs[1])).unwrap();
 
     (log_payload, another_log_payload)
 }

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -492,17 +492,6 @@ fn convert_call_trace_into_4byte_map(
 }
 
 fn create_trace_cache_opts() -> GethDebugTracingOptions {
-    // Get the traces with call tracer onlytopcall false and withlog true and always cache this way
-    let call_config = serde_json::to_value(CallConfig {
-        only_top_call: Some(false),
-        with_log: Some(true),
-    })
-    .expect("CallConfig must be serializable");
-    GethDebugTracingOptions {
-        tracer: Some(GethDebugTracerType::BuiltInTracer(
-            GethDebugBuiltInTracerType::CallTracer,
-        )),
-        tracer_config: GethDebugTracerConfig(call_config),
-        ..Default::default()
-    }
+    // Get the traces with call tracer onlytopcall None (false) and withlog true and always cache this way
+    GethDebugTracingOptions::call_tracer(CallConfig::default().with_log())
 }

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -234,15 +234,15 @@ fn apply_call_config(call_frame: CallFrame, call_config: CallConfig) -> CallFram
         new_call_frame.calls = vec![];
     }
     if !call_config.with_log.unwrap_or(false) {
-        remove_logs_from_call_frame(&mut vec![new_call_frame.clone()]);
+        remove_logs_from_call_frame(&mut new_call_frame);
     }
     new_call_frame
 }
 
-fn remove_logs_from_call_frame(call_frame: &mut Vec<CallFrame>) {
-    for frame in call_frame {
-        frame.logs = vec![];
-        remove_logs_from_call_frame(&mut frame.calls);
+fn remove_logs_from_call_frame(call_frame: &mut CallFrame) {
+    call_frame.logs = vec![];
+    for frame in &mut call_frame.calls {
+        remove_logs_from_call_frame(frame);
     }
 }
 

--- a/crates/ethereum-rpc/src/trace.rs
+++ b/crates/ethereum-rpc/src/trace.rs
@@ -493,10 +493,11 @@ fn convert_call_trace_into_4byte_map(
 
 fn create_trace_cache_opts() -> GethDebugTracingOptions {
     // Get the traces with call tracer onlytopcall false and withlog true and always cache this way
-    let mut call_config_map = serde_json::Map::new();
-    call_config_map.insert("only_top_call".to_string(), serde_json::Value::Bool(false));
-    call_config_map.insert("with_log".to_string(), serde_json::Value::Bool(true));
-    let call_config = serde_json::Value::Object(call_config_map);
+    let call_config = serde_json::to_value(CallConfig {
+        only_top_call: Some(false),
+        with_log: Some(true),
+    })
+    .expect("CallConfig must be serializable");
     GethDebugTracingOptions {
         tracer: Some(GethDebugTracerType::BuiltInTracer(
             GethDebugBuiltInTracerType::CallTracer,


### PR DESCRIPTION
# Description
The `withLog` option in the call tracer config was ignored by `debug_traceTransaction` and `debug_traceBlock*` endpoints. Two issues in the `debug_trace_by_block_number` function that are fixed by this PR:

1. The tracer options we used to fill the cache were serialized with snake_case keys instead of camelCase, so cached traces never included logs.
2. When applying the call config, the frame was not actually mutated, so any logs would be left in place when `withLog` was false.

## Testing
Added `test_call_tracer_with_log` mock e2e test



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> RPC debug tracing only; fixes incorrect cache keys and log stripping with no auth, state, or consensus impact.
> 
> **Overview**
> Fixes **call tracer `withLog`** handling for `debug_traceTransaction` and block trace paths that reuse the trace cache.
> 
> **Cache fill:** `create_trace_cache_opts` now builds options via `GethDebugTracingOptions::call_tracer(CallConfig::default().with_log())` instead of a hand-built JSON map with snake_case keys, so cached traces actually include logs.
> 
> **Applying config:** `remove_logs_from_call_frame` mutates a single `CallFrame` tree (including nested `calls`) instead of cloning into a temporary vec, so `withLog: false` correctly strips logs from the frame returned to the client.
> 
> Adds mock e2e **`test_call_tracer_with_log`** covering cache hits, `withLog` true/false, and default config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda45404f9d670f14d95c799589d775f264a0fa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->