### PR TITLE
fix(sequencer): Keep producing L2 blocks on stale DA tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 ### Changed
 - fix(rpc): Set archival state in estimate tx expenses ([#3321](https://github.com/chainwayxyz/citrea/pull/3321))
+- fix(sequencer): Keep producing L2 blocks on stale DA tip ([#3324](https://github.com/chainwayxyz/citrea/pull/3324))
 
 ## [v2.7.0](2026-07-29)
 ### Changed

--- a/bin/citrea/tests/bitcoin/sequencer_test.rs
+++ b/bin/citrea/tests/bitcoin/sequencer_test.rs
@@ -1,6 +1,8 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
+use alloy_rpc_types::TransactionTrait;
+use alloy_sol_types::{sol, SolCall};
 use async_trait::async_trait;
 use bitcoin::hashes::Hash;
 use bitcoincore_rpc::RpcApi;
@@ -11,12 +13,17 @@ use citrea_e2e::test_case::{TestCase, TestCaseRunner};
 use citrea_e2e::traits::Restart;
 use citrea_e2e::Result;
 use citrea_evm::system_contracts::BitcoinLightClient;
-use citrea_evm::BITCOIN_LIGHT_CLIENT_CONTRACT_ADDRESS;
+use citrea_evm::{BITCOIN_LIGHT_CLIENT_CONTRACT_ADDRESS, SYSTEM_SIGNER};
 use sov_ledger_rpc::LedgerRpcClient;
 use tokio::time::sleep;
 
 use super::get_citrea_path;
+use crate::common::client::TestClient;
 use crate::common::make_test_client;
+
+sol! {
+    function setBlockInfo(bytes32 blockHash, bytes32 witnessRoot, uint256 coinbaseDepth);
+}
 
 struct BasicSequencerTest;
 
@@ -460,6 +467,264 @@ async fn drive_until_scanned(client: &citrea_e2e::client::Client, target: u64) -
 #[tokio::test]
 async fn test_sequencer_last_scanned_l1_height_running() -> Result<()> {
     TestCaseRunner::new(SequencerLastScannedL1HeightRunningTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
+}
+
+/// Reads a block hash out of the Bitcoin light client contract. A height the sequencer
+/// has not recorded reads back as all zeroes.
+async fn light_client_block_hash(client: &TestClient, l1_height: u64) -> Result<[u8; 32]> {
+    let res: String = client
+        .contract_call(
+            BITCOIN_LIGHT_CLIENT_CONTRACT_ADDRESS,
+            BitcoinLightClient::get_block_hash(l1_height).to_vec(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    Ok(hex::decode(&res[2..])
+        .unwrap()
+        .try_into()
+        .expect("light client block hash should be 32 bytes"))
+}
+
+/// Returns every `setBlockInfo` call included in the given L2 block range.
+async fn set_block_info_calls(
+    client: &TestClient,
+    l2_heights: std::ops::RangeInclusive<u64>,
+) -> Result<Vec<setBlockInfoCall>> {
+    let mut calls = vec![];
+
+    for l2_height in l2_heights {
+        let block = client
+            .eth_get_block_by_number_with_detail(Some(l2_height.into()))
+            .await;
+        let transactions = block
+            .transactions
+            .as_transactions()
+            .expect("detailed block response should contain full transactions");
+
+        for tx in transactions {
+            if tx.to() == Some(BitcoinLightClient::address())
+                && tx.input().starts_with(&setBlockInfoCall::SELECTOR)
+            {
+                assert_eq!(
+                    tx.inner.signer(),
+                    SYSTEM_SIGNER,
+                    "setBlockInfo must be a system transaction"
+                );
+                calls.push(setBlockInfoCall::abi_decode(tx.input(), true)?);
+            }
+        }
+    }
+
+    Ok(calls)
+}
+
+/// How the sequencer runs into the stale DA tip.
+enum StaleTip {
+    /// It is already running and the stale tip arrives over the DA block monitor.
+    WhileRunning,
+    /// It comes up against a DA node that is already behind, so its whole view of L1 is
+    /// the stale one and there is no earlier height in memory to compare against. Only
+    /// the height read back out of the light client contract stands in the way.
+    OnStartup,
+}
+
+/// A Bitcoin node that is catching up — after a restart of its own, or of the machine it
+/// shares with the sequencer — answers with a tip below one the sequencer has already
+/// folded into the Bitcoin light client contract. `setBlockInfo` takes no height, the
+/// contract counts for itself, so recording such a block fails short header proof
+/// verification and takes L2 block production down with it for as long as the node stays
+/// behind. Neither may happen: L2 blocks keep coming, L1 stays put until the node is
+/// caught up.
+///
+/// 1. Drive the sequencer until it has folded the finalized L1 tip into the contract.
+/// 2. When testing a running sequencer, let its monitor cache a newer finalized tip
+///    without producing an L2 block, leaving pending missed DA blocks.
+/// 3. Invalidate DA blocks so the node reports a finalized height below the sequencer's
+///    last good view, and let the sequencer meet it either way round.
+/// 4. Assert the sequencer keeps producing L2 blocks and records nothing for the stale
+///    tip.
+/// 5. Restore the DA chain and assert the sequencer picks up where it left off.
+async fn run_stale_da_tip_test(f: &mut TestFramework, stale_tip: StaleTip) -> Result<()> {
+    let sequencer = f.sequencer.as_mut().unwrap();
+    let da = f.bitcoin_nodes.get(0).unwrap();
+
+    let seq_test_client = make_test_client(SocketAddr::new(
+        sequencer.config.rpc_bind_host().parse()?,
+        sequencer.config.rpc_bind_port(),
+    ))
+    .await?;
+
+    // Catch the sequencer up with the finalized L1 tip.
+    da.generate(5).await?;
+    let target_l1_height = da
+        .get_finalized_height(Some(DEFAULT_FINALITY_DEPTH))
+        .await?;
+    let scanned = drive_until_scanned(&sequencer.client, target_l1_height).await?;
+    assert_eq!(scanned, target_l1_height);
+    assert_eq!(
+        light_client_block_hash(&seq_test_client, scanned + 1).await?,
+        [0u8; 32],
+        "nothing should be recorded above the scanned L1 height yet"
+    );
+
+    let last_good_finalized_height = match stale_tip {
+        StaleTip::WhileRunning => {
+            // Let the monitor observe a tip several blocks ahead of the light client,
+            // creating pending missed DA blocks without giving the sequencer a production
+            // request on which to process them.
+            da.generate(5).await?;
+            let pending_finalized_height = da
+                .get_finalized_height(Some(DEFAULT_FINALITY_DEPTH))
+                .await?;
+            assert!(pending_finalized_height > scanned + 1);
+            sleep(Duration::from_secs(1)).await;
+            pending_finalized_height
+        }
+        StaleTip::OnStartup => scanned,
+    };
+
+    // Walk the DA node's tip backwards, so the finalized height it reports drops below
+    // the last finalized height the sequencer observed.
+    let invalidated = da.get_block_hash(da.get_block_count().await? - 2).await?;
+    da.invalidate_block(&invalidated).await?;
+    let stale_finalized_height = da
+        .get_finalized_height(Some(DEFAULT_FINALITY_DEPTH))
+        .await?;
+    assert!(
+        stale_finalized_height < last_good_finalized_height,
+        "invalidating blocks should regress the finalized height"
+    );
+    if matches!(stale_tip, StaleTip::WhileRunning) {
+        assert!(
+            stale_finalized_height > scanned,
+            "the regressed tip should remain ahead of the light client"
+        );
+    }
+
+    match stale_tip {
+        // Give the DA block monitor time to observe the stale tip.
+        StaleTip::WhileRunning => sleep(Duration::from_secs(1)).await,
+        StaleTip::OnStartup => sequencer.restart(None, None).await?,
+    }
+
+    // The sequencer keeps producing L2 blocks off its last good view of L1
+    let head = sequencer.client.ledger_get_head_l2_block_height().await?;
+    for i in 1..=3 {
+        sequencer.client.send_publish_batch_request().await?;
+        sequencer.client.wait_for_l2_block(head + i, None).await?;
+    }
+
+    assert!(
+        set_block_info_calls(&seq_test_client, head + 1..=head + 3)
+            .await?
+            .is_empty(),
+        "L2 blocks produced from a stale DA tip must not contain setBlockInfo"
+    );
+
+    assert_eq!(
+        sequencer.client.ledger_get_last_scanned_l1_height().await?,
+        scanned,
+        "scanned L1 height must not move while the DA node is behind"
+    );
+    assert_eq!(
+        light_client_block_hash(&seq_test_client, scanned + 1).await?,
+        [0u8; 32],
+        "a stale DA tip must not be written to the light client contract"
+    );
+
+    // Once the DA node is whole again, the sequencer picks up where it left off.
+    da.reconsider_block(&invalidated).await?;
+    da.generate(1).await?;
+    let next_target = da
+        .get_finalized_height(Some(DEFAULT_FINALITY_DEPTH))
+        .await?;
+    assert!(next_target > scanned);
+
+    let recovery_l2_start = sequencer.client.ledger_get_head_l2_block_height().await?;
+    let scanned_after = drive_until_scanned(&sequencer.client, next_target).await?;
+    assert_eq!(scanned_after, next_target);
+    let recovery_l2_end = sequencer.client.ledger_get_head_l2_block_height().await?;
+
+    let mut expected_recovery_block_hashes = vec![];
+    for l1_height in scanned + 1..=next_target {
+        expected_recovery_block_hashes.push(
+            da.get_block_hash(l1_height)
+                .await?
+                .to_raw_hash()
+                .to_byte_array(),
+        );
+    }
+
+    let recovery_set_block_info_calls =
+        set_block_info_calls(&seq_test_client, recovery_l2_start + 1..=recovery_l2_end).await?;
+    let actual_recovery_block_hashes: Vec<[u8; 32]> = recovery_set_block_info_calls
+        .iter()
+        .map(|call| call.blockHash.into())
+        .collect();
+    assert_eq!(
+        actual_recovery_block_hashes, expected_recovery_block_hashes,
+        "catching up must include exactly one ordered setBlockInfo call per recovered L1 block"
+    );
+
+    assert_eq!(
+        light_client_block_hash(&seq_test_client, scanned + 1).await?,
+        expected_recovery_block_hashes[0],
+        "the light client should resume with the real L1 block above the scanned height"
+    );
+
+    Ok(())
+}
+
+/// Avoid commitment churn interfering with DA block accounting during the stale tip tests.
+fn stale_da_tip_sequencer_config() -> SequencerConfig {
+    SequencerConfig {
+        max_l2_blocks_per_commitment: 1000,
+        ..Default::default()
+    }
+}
+
+struct SequencerStaleDaTipTest;
+
+#[async_trait]
+impl TestCase for SequencerStaleDaTipTest {
+    fn sequencer_config() -> SequencerConfig {
+        stale_da_tip_sequencer_config()
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        run_stale_da_tip_test(f, StaleTip::WhileRunning).await
+    }
+}
+
+#[tokio::test]
+async fn test_sequencer_stale_da_tip() -> Result<()> {
+    TestCaseRunner::new(SequencerStaleDaTipTest)
+        .set_citrea_path(get_citrea_path())
+        .run()
+        .await
+}
+
+struct SequencerStaleDaTipOnStartupTest;
+
+#[async_trait]
+impl TestCase for SequencerStaleDaTipOnStartupTest {
+    fn sequencer_config() -> SequencerConfig {
+        stale_da_tip_sequencer_config()
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        run_stale_da_tip_test(f, StaleTip::OnStartup).await
+    }
+}
+
+#[tokio::test]
+async fn test_sequencer_stale_da_tip_on_startup() -> Result<()> {
+    TestCaseRunner::new(SequencerStaleDaTipOnStartupTest)
         .set_citrea_path(get_citrea_path())
         .run()
         .await

--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -59,6 +59,15 @@ pub struct SequencerMetrics {
     /// Current L1 block number
     #[metric(describe = "The height of the current L1 block put into the Bitcoin Light Client")]
     pub current_l1_block: Gauge,
+    /// Finalized L1 height as reported by the DA node
+    #[metric(describe = "The finalized L1 height that the DA node reports")]
+    pub da_reported_l1_block: Gauge,
+    /// Whether the DA node's view of L1 is being ignored
+    #[metric(describe = "1 when the sequencer ignores the DA node, 0 otherwise")]
+    pub da_behind: Gauge,
+    /// Number of L2 blocks produced on the L1 block currently held by the light client
+    #[metric(describe = "The number of L2 blocks made on the current L1 block")]
+    pub l2_blocks_on_current_l1: Gauge,
     /// The number of transactions that are dry run in the current block
     #[metric(
         describe = "The time in milliseconds it took to run transactions in the current block, this does not include the time to dry run the transactions"

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -74,6 +74,9 @@ use crate::utils::recover_raw_transaction;
 /// Maximum number of DA blocks that can be missed per L2 block
 pub const MAX_MISSED_DA_BLOCKS_PER_L2_BLOCK: u64 = 10;
 
+/// How often the warning about a DA node that is behind is repeated
+const DA_BEHIND_WARN_INTERVAL: Duration = Duration::from_secs(60);
+
 /// Returns whether a finalized L1 height should be accepted.
 ///
 /// Rejects anything below our own view of L1, which is the higher of the last height we
@@ -136,6 +139,10 @@ where
     canon_state_tx: mpsc::UnboundedSender<CanonStateNotification>,
     /// Executor for spawning async tasks
     task_executor: TaskExecutor,
+    /// How many L2 blocks were produced on the L1 block currently held by the light
+    /// client. Counted from this process' first block, so after a restart it trails the
+    /// rule enforcer's own counter until the next L1 block arrives.
+    l2_blocks_on_current_l1: u64,
 }
 
 impl<Da> CitreaSequencer<Da>
@@ -200,6 +207,7 @@ where
             backup_manager,
             canon_state_tx,
             task_executor,
+            l2_blocks_on_current_l1: 0,
         })
     }
 
@@ -466,6 +474,7 @@ where
     ) -> anyhow::Result<()> {
         let start: Instant = Instant::now();
         let l2_height = self.ledger_db.get_head_l2_block_height()?.unwrap_or(0) + 1;
+        let previous_used_l1_height = *last_used_l1_height;
         self.fork_manager.register_block(l2_height)?;
         let result = {
             if da_blocks.len() == 1 && da_blocks[0].header().height() == *last_used_l1_height {
@@ -479,6 +488,17 @@ where
 
         match result {
             Ok(l2_height) => {
+                // Mirror the counter the L2 block rule enforcer keeps, which restarts at 1
+                // on every new L1 block, so that dashboards can see the block getting
+                // close to `max_l2_blocks_per_l1`.
+                if *last_used_l1_height == previous_used_l1_height {
+                    self.l2_blocks_on_current_l1 += 1;
+                } else {
+                    self.l2_blocks_on_current_l1 = 1;
+                }
+                SM.l2_blocks_on_current_l1
+                    .set(self.l2_blocks_on_current_l1 as f64);
+
                 // Only errors when there are no receivers
                 if let Err(_closed) = self.l2_block_tx.send(l2_height) {
                     debug!("l2_block_tx is closed");
@@ -1172,13 +1192,25 @@ where
                 // Set to 1 less so that we do not skip processing the first l1 block
                 None => last_finalized_l1_height - 1,
             };
+        SM.da_reported_l1_block.set(last_finalized_l1_height as f64);
         let mut last_finalized_block =
             (last_finalized_l1_height >= last_used_l1_height).then_some(last_finalized_block);
-        // A DA node that is already behind at startup leaves us with a stale tip here. The
-        // light client contract is the better record of how far L1 got, so adopt it as our
-        // view: block accounting is unchanged either way, but logs and metrics stop
-        // reporting the stale height.
+        // Whether we are currently ignoring what the DA layer reports. A DA node that is
+        // already behind at startup leaves us with a stale tip here. The light client
+        // contract is the better record of how far L1 got, so adopt it as our view: block
+        // accounting is unchanged either way, but logs and metrics stop reporting the
+        // stale height.
+        let mut da_behind = last_finalized_block.is_none();
+        if da_behind {
+            warn!(
+                "DA node reports finalized L1 height {last_finalized_l1_height}, below the last \
+                 height {last_used_l1_height} folded into the light client. Starting off the \
+                 light client's view of L1 instead."
+            );
+        }
         last_finalized_l1_height = last_finalized_l1_height.max(last_used_l1_height);
+        SM.current_l1_block.set(last_finalized_l1_height as f64);
+        SM.da_behind.set(da_behind as u8 as f64);
 
         // Setup required workers to update our knowledge of the DA layer every X seconds (configurable).
         let (da_block_update_tx, mut da_block_update_rx) = mpsc::channel::<DaBlockData<Da>>(1);
@@ -1241,8 +1273,9 @@ where
         let mut block_production_tick = tokio::time::interval(target_block_time);
         block_production_tick.tick().await;
 
-        // Whether we are currently ignoring what the DA layer reports
-        let mut da_behind = false;
+        // A DA node stays behind for as long as it takes to catch up, so repeat the
+        // warning rather than logging it once and going quiet.
+        let mut last_da_behind_warn: Option<Instant> = None;
 
         let backup_manager = self.backup_manager.clone();
         loop {
@@ -1251,6 +1284,7 @@ where
                 da_block = da_block_update_rx.recv() => {
                     if let Some(block) = da_block {
                         let new_finalized_l1_height = block.header().height();
+                        SM.da_reported_l1_block.set(new_finalized_l1_height as f64);
                         if !should_accept_finalized_l1_height(
                             last_finalized_l1_height,
                             last_used_l1_height,
@@ -1258,14 +1292,20 @@ where
                         ) {
                             missed_da_blocks_count = 0;
                             last_finalized_block = None;
-                            if !da_behind {
-                                da_behind = true;
+                            let repeat_warning = last_da_behind_warn
+                                .is_none_or(|at| at.elapsed() >= DA_BEHIND_WARN_INTERVAL);
+                            if !da_behind || repeat_warning {
+                                last_da_behind_warn = Some(Instant::now());
                                 warn!(
                                     "Ignoring L1 height below our own view of L1, the DA node is \
                                      likely behind. L2 blocks keep being produced, L1 stays put. \
                                      New finalized height: {new_finalized_l1_height}, last finalized \
                                      height: {last_finalized_l1_height}, last used height {last_used_l1_height}"
                                 );
+                            }
+                            if !da_behind {
+                                da_behind = true;
+                                SM.da_behind.set(1.0);
                             }
 
                             SM.current_l1_block.set(last_finalized_l1_height as f64);
@@ -1275,6 +1315,8 @@ where
                         if da_behind {
                             info!("DA node caught back up at L1 height {new_finalized_l1_height}");
                             da_behind = false;
+                            last_da_behind_warn = None;
+                            SM.da_behind.set(0.0);
                         }
 
                         last_finalized_block = Some(block);

--- a/crates/sequencer/src/runner.rs
+++ b/crates/sequencer/src/runner.rs
@@ -74,6 +74,20 @@ use crate::utils::recover_raw_transaction;
 /// Maximum number of DA blocks that can be missed per L2 block
 pub const MAX_MISSED_DA_BLOCKS_PER_L2_BLOCK: u64 = 10;
 
+/// Returns whether a finalized L1 height should be accepted.
+///
+/// Rejects anything below our own view of L1, which is the higher of the last height we
+/// saw finalized and the last height already folded into the light client contract. An
+/// equal height is accepted, and dropped later by `produce_l2_block`, which skips a lone
+/// DA block the light client already holds.
+fn should_accept_finalized_l1_height(
+    last_finalized_l1_height: u64,
+    last_used_l1_height: u64,
+    new_finalized_l1_height: u64,
+) -> bool {
+    new_finalized_l1_height >= last_finalized_l1_height.max(last_used_l1_height)
+}
+
 /// The main sequencer implementation that manages block production and transaction processing
 ///
 /// This struct is responsible for:
@@ -1123,7 +1137,7 @@ where
         }
 
         // Get initial DA block data and fee rate
-        let mut last_finalized_block = match get_finalized_block(self.da_service.clone()).await {
+        let last_finalized_block = match get_finalized_block(self.da_service.clone()).await {
             Ok(block) => block,
             Err(e) => {
                 error!("{e}");
@@ -1158,6 +1172,13 @@ where
                 // Set to 1 less so that we do not skip processing the first l1 block
                 None => last_finalized_l1_height - 1,
             };
+        let mut last_finalized_block =
+            (last_finalized_l1_height >= last_used_l1_height).then_some(last_finalized_block);
+        // A DA node that is already behind at startup leaves us with a stale tip here. The
+        // light client contract is the better record of how far L1 got, so adopt it as our
+        // view: block accounting is unchanged either way, but logs and metrics stop
+        // reporting the stale height.
+        last_finalized_l1_height = last_finalized_l1_height.max(last_used_l1_height);
 
         // Setup required workers to update our knowledge of the DA layer every X seconds (configurable).
         let (da_block_update_tx, mut da_block_update_rx) = mpsc::channel::<DaBlockData<Da>>(1);
@@ -1220,20 +1241,46 @@ where
         let mut block_production_tick = tokio::time::interval(target_block_time);
         block_production_tick.tick().await;
 
+        // Whether we are currently ignoring what the DA layer reports
+        let mut da_behind = false;
+
         let backup_manager = self.backup_manager.clone();
         loop {
             tokio::select! {
                 // Receive DA block updates from DA layer worker.
                 da_block = da_block_update_rx.recv() => {
                     if let Some(block) = da_block {
-                        last_finalized_block = block;
-                        let new_finalized_l1_height = last_finalized_block.header().height();
-                        if new_finalized_l1_height < last_finalized_l1_height {
-                            info!("DA potential fork detected, known last finalized L1 height: {last_finalized_l1_height}, new finalized L1 height: {new_finalized_l1_height}")
+                        let new_finalized_l1_height = block.header().height();
+                        if !should_accept_finalized_l1_height(
+                            last_finalized_l1_height,
+                            last_used_l1_height,
+                            new_finalized_l1_height,
+                        ) {
+                            missed_da_blocks_count = 0;
+                            last_finalized_block = None;
+                            if !da_behind {
+                                da_behind = true;
+                                warn!(
+                                    "Ignoring L1 height below our own view of L1, the DA node is \
+                                     likely behind. L2 blocks keep being produced, L1 stays put. \
+                                     New finalized height: {new_finalized_l1_height}, last finalized \
+                                     height: {last_finalized_l1_height}, last used height {last_used_l1_height}"
+                                );
+                            }
+
+                            SM.current_l1_block.set(last_finalized_l1_height as f64);
+                            continue;
                         }
+
+                        if da_behind {
+                            info!("DA node caught back up at L1 height {new_finalized_l1_height}");
+                            da_behind = false;
+                        }
+
+                        last_finalized_block = Some(block);
                         last_finalized_l1_height = new_finalized_l1_height;
 
-                        info!("New finalized L1 block at height {}", last_finalized_l1_height);
+                        info!("New finalized L1 block at height {last_finalized_l1_height}");
 
                         missed_da_blocks_count = self.da_blocks_missed(last_finalized_l1_height, last_used_l1_height);
                     }
@@ -1266,7 +1313,8 @@ where
                                 missed_da_blocks_count = 0;
                             }
                             let _l2_lock = backup_manager.start_l2_processing().await;
-                            self.produce_l2_block(vec![last_finalized_block.clone()], l1_fee_rate, &mut last_used_l1_height).await?;
+                            let da_blocks = last_finalized_block.clone().into_iter().collect();
+                            self.produce_l2_block(da_blocks, l1_fee_rate, &mut last_used_l1_height).await?;
                         },
                         Some(SequencerRpcMessage::HaltCommitments) => {
                             // Forward halt signal to commitment service
@@ -1296,8 +1344,6 @@ where
                     // last_finalized_block. If there are missed DA blocks, we start producing
                     // empty blocks at ~2 second rate, 1 L2 block per respective missed DA block
                     // until we know we caught up with L1.
-                    let da_block = last_finalized_block.clone();
-
                     if missed_da_blocks_count > 0 {
                         if let Err(e) = self.process_missed_da_blocks(missed_da_blocks_count, &mut last_used_l1_height, l1_fee_rate).await {
                             error!("Sequencer error: {}", e);
@@ -1310,7 +1356,8 @@ where
                     }
 
                     let _l2_lock = backup_manager.start_l2_processing().await;
-                    self.produce_l2_block(vec![da_block.clone()], l1_fee_rate, &mut last_used_l1_height).await?;
+                    let da_blocks = last_finalized_block.clone().into_iter().collect();
+                    self.produce_l2_block(da_blocks, l1_fee_rate, &mut last_used_l1_height).await?;
                 },
                 _ = &mut shutdown_signal => {
                     info!("Shutting down sequencer");
@@ -1703,5 +1750,32 @@ where
         }
 
         Ok((all_txs, working_set_to_discard))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_accept_finalized_l1_height;
+
+    #[test]
+    fn finalized_l1_height_acceptance() {
+        let cases = [
+            ("advancing tip", 194, 194, 195, true),
+            ("unchanged tip", 194, 194, 194, true),
+            ("regressed tip", 194, 194, 54, false),
+            ("stale tip on startup", 54, 194, 54, false),
+            ("partially synced tip", 54, 194, 193, false),
+            ("resynced to light client height", 54, 194, 194, true),
+            ("synced tip", 54, 194, 195, true),
+            ("pending DA catch-up", 194, 190, 195, true),
+        ];
+
+        for (case, last_finalized, last_used, new_finalized, expected) in cases {
+            assert_eq!(
+                should_accept_finalized_l1_height(last_finalized, last_used, new_finalized),
+                expected,
+                "{case}"
+            );
+        }
     }
 }


### PR DESCRIPTION
# Description

- Fix issue where sequencer was failing to produce L2 block erroring in `setBlockInfo`
- Prevent `SetBlockInfo` while DA is behind after a restart


Fixes #3320 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sequencer L1 sync and when system `setBlockInfo` runs; incorrect acceptance logic could stall L1 updates or accept bad tips, but behavior is covered by unit and E2E tests.
> 
> **Overview**
> When the Bitcoin DA node reports a **finalized L1 height below** what the sequencer already folded into the Bitcoin light client (e.g. after restart or while the node is catching up), the sequencer no longer treats that as a fork or feeds those blocks into `setBlockInfo`. It **ignores the regressed tip**, keeps **L2 block production going** without new L1 updates, and **resumes L1 catch-up** once the DA node reports heights at or above the light-client view.
> 
> **`should_accept_finalized_l1_height`** gates DA monitor updates; rejected tips clear the cached finalized block so `produce_l2_block` runs with **no DA payload** (no `setBlockInfo`). Startup uses the same rule when the initial DA tip is stale. **Metrics** add `da_reported_l1_block`, `da_behind`, and `l2_blocks_on_current_l1`; warnings repeat on a 60s interval while behind.
> 
> **Bitcoin E2E tests** cover stale tips **while running** and **on startup** (invalidate/reconsider blocks), asserting L2 continues, scanned L1 height is frozen, and recovery emits ordered `setBlockInfo` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 168d82ee99813aa4758fac74e3e6f7d18cb8b0eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->