### PR TITLE
fix: clarify transaction pair backup error

### DIFF
--- a/crates/bitcoin-da/src/helpers/backup.rs
+++ b/crates/bitcoin-da/src/helpers/backup.rs
@@ -33,7 +33,7 @@ pub(crate) fn backup_txs_to_file(
             | TransactionKind::SequencerCommitment => {
                 if txs.len() != 1 {
                     return Err(BitcoinServiceError::TransactionBackupError(format!(
-                        "Expected exactly 2 transactions for {:?}, got {}",
+                        "Expected exactly 1 transaction pair for {:?}, got {}",
                         tx.kind,
                         txs.len()
                     )));


### PR DESCRIPTION
# Description

Correct the backup error message for the single transaction-pair path. `SignedTxPair` contains both a commit and reveal transaction, while the guarded slice counts transaction pairs.

## Linked Issues

- Fixes #3246 
## Testing

`git diff --check` passed. Rust tests were unavailable because Cargo is not installed in the sandbox.

## Docs

No documentation changes are required. This patch clarifies an internal error message only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only an internal error string changes; backup logic and validation behavior are unchanged.
> 
> **Overview**
> Updates the **`TransactionBackupError`** text in `backup_txs_to_file` when `Complete`, `BatchProofMethodId`, or `SequencerCommitment` kinds receive more than one slice entry.
> 
> The message now says **exactly 1 transaction pair** instead of **exactly 2 transactions**, matching the `txs.len() != 1` check on `SignedTxPair` slices (each pair already holds commit and reveal raw txs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c554a685d17d116189b09a64fabf3997e7c531. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->