### PR TITLE
fix: validate coinbase inputs before access

### DIFF
--- a/crates/bitcoin-da/src/verifier.rs
+++ b/crates/bitcoin-da/src/verifier.rs
@@ -218,7 +218,10 @@ impl DaVerifier for BitcoinVerifier {
                 let merkle_root =
                     merkle_tree::BitcoinMerkleTree::new(inclusion_proof.wtxids).root();
 
-                let input_witness_value = coinbase_tx.input[0]
+                let input_witness_value = coinbase_tx
+                    .input
+                    .first()
+                    .ok_or(ValidationError::InvalidBlock)?
                     .witness
                     .iter()
                     .next()


### PR DESCRIPTION
# Description

Prevent malformed coinbase transactions from panicking the verifier when the input list is empty. Replace direct indexing with `.first().ok_or(ValidationError::InvalidBlock)?`, allowing callers to handle the malformed proof as a structured validation error.

## Linked Issues

- Fixes #3266 
## Testing

`git diff --check` passed. Rust tests were unavailable because Cargo is not installed in the sandbox.

## Docs

No documentation changes are required. This patch hardens existing proof validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive change in DA proof validation; returns an existing error type and does not alter successful validation paths for valid blocks.
> 
> **Overview**
> Hardens **SegWit witness commitment** checks in `verify_transactions` when a commitment output is present on the coinbase.
> 
> Previously the verifier read `coinbase_tx.input[0]` directly, which could **panic** if a malformed inclusion proof supplied a coinbase with **no inputs**. The change uses `.first().ok_or(ValidationError::InvalidBlock)?` so an empty input list is rejected as a normal validation error instead of crashing the node.
> 
> Witness commitment parsing after the first input is unchanged; only the access pattern is safer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f77e1b1a9b665cfe9f49293eecd84aee8ae94f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->