### PR TITLE
fix: handle empty utxo context

### DIFF
--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -414,7 +414,10 @@ impl BitcoinService {
         let network = self.network;
         let da_private_key = self.da_private_key.expect("No private key set");
         // get address from a utxo
-        let address = utxo_context.available_utxos[0]
+        let address = utxo_context
+            .available_utxos
+            .first()
+            .ok_or(BitcoinServiceError::MissingUTXO)?
             .address
             .clone()
             .ok_or(BitcoinServiceError::MissingAddress)?


### PR DESCRIPTION
# Description

Prevent `create_da_transactions_with_fee_rate` from panicking when the UTXO context contains no available UTXOs. The code now returns `BitcoinServiceError::MissingUTXO` through the existing typed error path.

## Linked Issues

- Fixes #3258 
## Testing

`git diff --check` passed. Rust tests were unavailable because Cargo is not installed in the sandbox.

## Docs

No documentation changes are required. This patch hardens existing transaction creation logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change on transaction creation; uses an existing error type and does not alter fee or signing logic.
> 
> **Overview**
> **`create_da_transactions_with_fee_rate`** no longer indexes `available_utxos[0]` when building inscription transactions. It uses **`first()`** and returns **`BitcoinServiceError::MissingUTXO`** when the slice is empty, matching the existing typed error used elsewhere (e.g. UTXO manager).
> 
> This removes a panic path when the UTXO context has no available entries while still allowing the DA queue to surface a recoverable error instead of crashing the task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7161e38260737f6e5e807cbede1a8eccd81fd14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->