### PR TITLE
fix: Harden monitoring reveal restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## [Unreleased]
+### Changed
+fix: Harden DA monitoring reveal restore ([#3329](https://github.com/chainwayxyz/citrea/pull/3329))
+
 
 ## [v2.7.0](2026-07-29)
 ### Changed

--- a/bin/citrea/src/rollup/bitcoin.rs
+++ b/bin/citrea/src/rollup/bitcoin.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use bitcoin_da::fee::FeeService;
+use bitcoin_da::helpers::builders::da_public_key;
 use bitcoin_da::monitoring::MonitoringService;
 use bitcoin_da::network_constants::get_network_constants;
 use bitcoin_da::rpc::create_rpc_module as create_da_rpc_module;
@@ -149,10 +150,15 @@ impl RollupBlueprint for BitcoinRollup {
 
         let network = network_to_bitcoin_network(&chain_params.network);
         let network_constants = get_network_constants(&network);
+        let expected_da_public_key = da_config
+            .parse_da_private_key()?
+            .as_ref()
+            .map(da_public_key);
         let (monitoring_service, block_rx) = MonitoringService::new(
             client.clone(),
             da_config.monitoring.clone(),
             network_constants.finality_depth,
+            expected_da_public_key,
         );
         let monitoring_service = Arc::new(monitoring_service);
 

--- a/bin/citrea/tests/bitcoin/da_restore.rs
+++ b/bin/citrea/tests/bitcoin/da_restore.rs
@@ -1,0 +1,267 @@
+//! Restore of the DA transaction chain from wallet-visible transactions.
+//!
+//! Anyone can make an inscription of their own visible to a sequencer or a batch prover by
+//! paying dust to one of its addresses, so restore has to treat what it finds as hostile input
+//! and still come up with a chain the node can build on.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bitcoin::secp256k1::SecretKey;
+use bitcoin::{Address, Transaction};
+use bitcoin_da::helpers::builders::test_utils::test_create_foreign_inscription;
+use bitcoin_da::service::BitcoinService;
+use bitcoin_da::spec::utxo::UTXO;
+use bitcoincore_rpc::json::AddressType;
+use bitcoincore_rpc::{Auth, Client, RpcApi};
+use citrea_e2e::bitcoin::BitcoinNode;
+use citrea_e2e::config::{BitcoinConfig, TestCaseConfig};
+use citrea_e2e::framework::TestFramework;
+use citrea_e2e::node::NodeKind;
+use citrea_e2e::test_case::{TestCase, TestCaseRunner};
+use citrea_e2e::traits::NodeT;
+use citrea_e2e::Result;
+use citrea_primitives::REVEAL_TX_PREFIX;
+use reth_tasks::TaskManager;
+use sov_rollup_interface::da::{DaTxRequest, SequencerCommitment};
+
+use super::get_citrea_path;
+use crate::bitcoin::utils::get_default_service;
+
+/// Not one of the node's keys: the inscription is the attacker's own.
+const ATTACKER_DA_PRIVATE_KEY: &str =
+    "1212121212121212121212121212121212121212121212121212121212121212";
+const ATTACKER_WALLET: &str = "da-restore-attacker";
+
+struct DaRestoreWithHostileUtxosTest {
+    task_manager: TaskManager,
+}
+
+impl DaRestoreWithHostileUtxosTest {
+    /// Opens an RPC client on `wallet` of the DA node.
+    async fn wallet_client(da: &BitcoinNode, wallet: &str) -> Result<Client> {
+        let url = format!("http://127.0.0.1:{}/wallet/{wallet}", da.config.rpc_port);
+        Ok(Client::new(
+            &url,
+            Auth::UserPass(da.config.rpc_user.clone(), da.config.rpc_password.clone()),
+        )
+        .await?)
+    }
+
+    /// Publishes a commit/reveal pair that the victim's wallet can see but did not create: the
+    /// commit pays it change, and the reveal can either pay vout 0 to the victim or keep it for
+    /// the attacker. Additional victim outputs exercise duplicate `list_unspent` entries.
+    async fn publish_foreign_inscription(
+        &self,
+        da: &BitcoinNode,
+        attacker: &Client,
+        victim_address: &Address,
+        victim_owns_vout_zero: bool,
+        additional_victim_outputs: usize,
+        confirm: bool,
+    ) -> Result<Transaction> {
+        let utxos: Vec<UTXO> = attacker
+            .list_unspent(Some(1), None, None, None, None)
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        assert!(!utxos.is_empty(), "attacker wallet is not funded");
+
+        let attacker_address = attacker
+            .get_new_address(None, Some(AddressType::Bech32m))
+            .await?
+            .assume_checked();
+        let reveal_recipient = if victim_owns_vout_zero {
+            victim_address.clone()
+        } else {
+            attacker_address
+        };
+
+        let (commit, reveal) = test_create_foreign_inscription(
+            vec![7u8; 1024],
+            &SecretKey::from_str(ATTACKER_DA_PRIVATE_KEY).unwrap(),
+            utxos,
+            reveal_recipient,
+            victim_address.clone(),
+            additional_victim_outputs,
+            1.0,
+            1.0,
+            bitcoin::Network::Regtest,
+            REVEAL_TX_PREFIX,
+        )
+        .expect("Failed to build foreign inscription");
+
+        // Only the commit inputs are the attacker's to sign; signing is witness-only, so the
+        // txid the reveal already commits to is unchanged.
+        let signed_commit = attacker
+            .sign_raw_transaction_with_wallet(&commit, None, None)
+            .await?;
+        assert!(signed_commit.complete, "attacker could not sign its commit");
+
+        attacker.send_raw_transaction(&signed_commit.hex).await?;
+        attacker.send_raw_transaction(&reveal).await?;
+        if confirm {
+            da.generate(1).await?;
+        }
+
+        Ok(reveal)
+    }
+}
+
+#[async_trait]
+impl TestCase for DaRestoreWithHostileUtxosTest {
+    fn test_config() -> TestCaseConfig {
+        TestCaseConfig {
+            with_sequencer: true,
+            ..Default::default()
+        }
+    }
+
+    fn bitcoin_config() -> BitcoinConfig {
+        BitcoinConfig {
+            extra_args: vec!["-fallbackfee=0.00001"],
+            ..Default::default()
+        }
+    }
+
+    async fn cleanup(self) -> Result<()> {
+        self.task_manager
+            .graceful_shutdown_with_timeout(Duration::from_secs(1));
+        Ok(())
+    }
+
+    async fn run_test(&mut self, f: &mut TestFramework) -> Result<()> {
+        let task_executor = self.task_manager.executor();
+        let da = f.bitcoin_nodes.get(0).unwrap();
+
+        let victim = Self::wallet_client(da, &NodeKind::Bitcoin.to_string()).await?;
+        let victim_address = victim.get_new_address(None, None).await?.assume_checked();
+
+        da.client()
+            .create_wallet(ATTACKER_WALLET, None, None, None, None)
+            .await?;
+        da.fund_wallet(ATTACKER_WALLET.to_string(), 5).await?;
+
+        // Mature the attacker's coinbases so it can fund its own commit.
+        da.generate(101).await?;
+        let attacker = Self::wallet_client(da, ATTACKER_WALLET).await?;
+
+        // Hostile pairs covering every restore predicate an attacker can satisfy without the
+        // victim's DA key:
+        // - with vout 0 and vout 1 both owned by the victim;
+        // - with only a later output owned by the victim;
+        // - an unconfirmed single-output reveal whose vout 0 is owned by the victim, which
+        //   passes ownership and shape checks so only DA-key authentication rejects it.
+        let duplicated_reveal = self
+            .publish_foreign_inscription(da, &attacker, &victim_address, true, 1, true)
+            .await?;
+        let poisoning_reveal = self
+            .publish_foreign_inscription(da, &attacker, &victim_address, false, 1, true)
+            .await?;
+        let rbf_reveal = self
+            .publish_foreign_inscription(da, &attacker, &victim_address, true, 0, false)
+            .await?;
+
+        let unspent = victim.list_unspent(Some(0), None, None, None, None).await?;
+        let duplicated_txid = duplicated_reveal.compute_txid();
+        assert_eq!(
+            unspent
+                .iter()
+                .filter(|utxo| utxo.txid == duplicated_txid)
+                .count(),
+            2,
+            "the victim wallet should see the hostile reveal twice"
+        );
+
+        // Restore runs here, and panics if it errors: a hostile pair must not take startup down.
+        let da_service: std::sync::Arc<BitcoinService> =
+            get_default_service(&task_executor, &da.config).await;
+
+        let monitored = da_service.monitoring.get_monitored_txs().await;
+        for reveal in [&duplicated_reveal, &poisoning_reveal, &rbf_reveal] {
+            assert!(
+                !monitored.contains_key(&reveal.compute_txid()),
+                "a reveal the wallet only witnessed was restored as part of our chain"
+            );
+        }
+
+        // The tip must be something we can sign for, so publication keeps working.
+        let txs = da_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(SequencerCommitment {
+                    merkle_root: [1; 32],
+                    index: 1,
+                    l2_end_block_number: 10,
+                }),
+                1.0,
+            )
+            .await
+            .expect("hostile UTXOs must not stall DA publication");
+
+        let [commit, reveal] = &txs[0];
+        for hostile in [&duplicated_reveal, &poisoning_reveal, &rbf_reveal] {
+            assert_ne!(
+                commit.tx.input[0].previous_output.txid,
+                hostile.compute_txid(),
+                "commit chained from a hostile reveal"
+            );
+        }
+        // Publication is synchronous, so our pair is in the mempool by now. Assert on txids and
+        // not on a mempool length, since the sequencer publishes to the same node.
+        let mempool = da.get_raw_mempool().await?;
+        for txid in [commit.id, reveal.id, rbf_reveal.compute_txid()] {
+            assert!(
+                mempool.contains(&txid),
+                "{txid} is missing from the mempool"
+            );
+        }
+
+        // A fresh service must still restore and chain from an honest unconfirmed reveal, which
+        // guards the positive path of the DA-key check.
+        let restarted_service = get_default_service(&task_executor, &da.config).await;
+        let restored = restarted_service.monitoring.get_monitored_txs().await;
+        assert!(restored.contains_key(&commit.id));
+        assert!(restored.contains_key(&reveal.id));
+        assert_eq!(
+            restarted_service.monitoring.get_last_tx().await.unwrap().0,
+            reveal.id
+        );
+
+        let chained_txs = restarted_service
+            .send_transaction_with_fee_rate(
+                DaTxRequest::SequencerCommitment(SequencerCommitment {
+                    merkle_root: [2; 32],
+                    index: 2,
+                    l2_end_block_number: 20,
+                }),
+                1.0,
+            )
+            .await
+            .expect("an honest restored reveal must remain a usable chain tip");
+        assert_eq!(
+            chained_txs[0][0].tx.input[0].previous_output.txid,
+            reveal.id
+        );
+        let mempool = da.get_raw_mempool().await?;
+        for txid in [chained_txs[0][0].id, chained_txs[0][1].id] {
+            assert!(
+                mempool.contains(&txid),
+                "{txid} is missing from the mempool"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_da_restore_with_hostile_utxos() -> Result<()> {
+    TestCaseRunner::new(DaRestoreWithHostileUtxosTest {
+        task_manager: TaskManager::current(),
+    })
+    .set_citrea_path(get_citrea_path())
+    .run()
+    .await
+}

--- a/bin/citrea/tests/bitcoin/mod.rs
+++ b/bin/citrea/tests/bitcoin/mod.rs
@@ -16,6 +16,8 @@ pub mod bitcoin_test;
 pub mod bitcoin_verifier;
 #[cfg(feature = "testing")]
 pub mod da_queue;
+#[cfg(feature = "testing")]
+pub mod da_restore;
 pub mod fork;
 #[cfg(feature = "testing")]
 pub mod full_node;

--- a/bin/citrea/tests/bitcoin/utils.rs
+++ b/bin/citrea/tests/bitcoin/utils.rs
@@ -8,6 +8,7 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use anyhow::bail;
 use bitcoin_da::fee::FeeService;
+use bitcoin_da::helpers::builders::da_public_key;
 use bitcoin_da::monitoring::{MonitoringConfig, MonitoringService};
 use bitcoin_da::network_constants::get_network_constants;
 use bitcoin_da::service::{network_to_bitcoin_network, BitcoinService, BitcoinServiceConfig};
@@ -221,10 +222,16 @@ pub async fn spawn_bitcoin_da_service(
 
     let network = network_to_bitcoin_network(&chain_params.network);
     let network_constants = get_network_constants(&network);
+    let expected_da_public_key = da_config
+        .parse_da_private_key()
+        .unwrap()
+        .as_ref()
+        .map(da_public_key);
     let (monitoring_service, block_rx) = MonitoringService::new(
         client.clone(),
         da_config.monitoring.clone(),
         network_constants.finality_depth,
+        expected_da_public_key,
     );
     let monitoring_service = Arc::new(monitoring_service);
 

--- a/crates/bitcoin-da/src/helpers/builders/body_builders.rs
+++ b/crates/bitcoin-da/src/helpers/builders/body_builders.rs
@@ -79,7 +79,7 @@ pub enum DaTxs {
 }
 
 /// Mine the reveal transaction's prefix using `sign_schnorr` internal randomness
-fn mine_reveal_prefix(
+pub(crate) fn mine_reveal_prefix(
     commit_tx: &Transaction,
     reveal_tx: &mut Transaction,
     tapscript_hash: bitcoin::TapLeafHash,

--- a/crates/bitcoin-da/src/helpers/builders/body_builders.rs
+++ b/crates/bitcoin-da/src/helpers/builders/body_builders.rs
@@ -10,7 +10,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::key::{TapTweak, TweakedPublicKey, UntweakedKeypair};
 use bitcoin::opcodes::all::{OP_CHECKSIGVERIFY, OP_NIP};
 use bitcoin::script::PushBytesBuf;
-use bitcoin::secp256k1::{SecretKey, XOnlyPublicKey};
+use bitcoin::secp256k1::SecretKey;
 use bitcoin::{Address, Network, Transaction};
 use metrics::histogram;
 use secp256k1::SECP256K1;
@@ -20,7 +20,8 @@ use tracing::{info, instrument, trace, warn};
 
 use super::{
     build_commit_transaction, build_control_block, build_reveal_transaction, build_witness,
-    get_size_reveal, sign_blob_with_private_key, update_witness, TransactionKind, TxWithId,
+    da_keypair, get_size_reveal, sign_blob_with_private_key, update_witness, TransactionKind,
+    TxWithId,
 };
 use crate::spec::utxo::UTXO;
 use crate::utxo_manager::UtxoContext;
@@ -207,8 +208,7 @@ pub fn create_inscription_type_0(
     } = utxo_context;
 
     // Create reveal key
-    let key_pair = UntweakedKeypair::from_secret_key(SECP256K1, da_private_key);
-    let (public_key, _parity) = XOnlyPublicKey::from_keypair(&key_pair);
+    let (key_pair, public_key) = da_keypair(da_private_key);
 
     let kind = TransactionKind::Complete;
     let kind_bytes = kind.to_bytes();
@@ -351,8 +351,7 @@ pub fn create_inscription_type_1(
     } = utxo_context;
 
     // Create reveal key
-    let key_pair = UntweakedKeypair::from_secret_key(SECP256K1, da_private_key);
-    let (public_key, _parity) = XOnlyPublicKey::from_keypair(&key_pair);
+    let (key_pair, public_key) = da_keypair(da_private_key);
 
     let mut commit_chunks: Vec<Transaction> = vec![];
     let mut reveal_chunks: Vec<Transaction> = vec![];
@@ -645,8 +644,7 @@ pub fn create_inscription_type_3(
     } = utxo_context;
 
     // Create reveal key
-    let key_pair = UntweakedKeypair::from_secret_key(SECP256K1, da_private_key);
-    let (public_key, _parity) = XOnlyPublicKey::from_keypair(&key_pair);
+    let (key_pair, public_key) = da_keypair(da_private_key);
 
     let kind = TransactionKind::BatchProofMethodId;
     let kind_bytes = kind.to_bytes();
@@ -791,8 +789,7 @@ pub fn create_inscription_type_4(
     } = utxo_context;
 
     // Create reveal key
-    let key_pair = UntweakedKeypair::from_secret_key(SECP256K1, da_private_key);
-    let (public_key, _parity) = XOnlyPublicKey::from_keypair(&key_pair);
+    let (key_pair, public_key) = da_keypair(da_private_key);
 
     let kind = TransactionKind::SequencerCommitment;
     let kind_bytes = kind.to_bytes();

--- a/crates/bitcoin-da/src/helpers/builders/mod.rs
+++ b/crates/bitcoin-da/src/helpers/builders/mod.rs
@@ -17,6 +17,7 @@ use bitcoin::absolute::LockTime;
 use bitcoin::blockdata::script;
 use bitcoin::hashes::Hash;
 use bitcoin::key::constants::SCHNORR_SIGNATURE_SIZE;
+use bitcoin::key::UntweakedKeypair;
 use bitcoin::secp256k1::{self, All, Keypair, Message, Secp256k1, SecretKey};
 use bitcoin::sighash::{Prevouts, SighashCache};
 use bitcoin::taproot::{ControlBlock, LeafVersion, TaprootBuilder};
@@ -462,6 +463,18 @@ fn choose_utxos(
     let leftovers: Vec<_> = leftovers_set.copied().cloned().collect();
 
     Ok((chosen_utxos, sum, leftovers))
+}
+
+/// Derives the untweaked keypair and the x-only public key of the DA private key
+pub fn da_keypair(da_private_key: &SecretKey) -> (UntweakedKeypair, XOnlyPublicKey) {
+    let key_pair = UntweakedKeypair::from_secret_key(SECP256K1, da_private_key);
+    let (public_key, _parity) = XOnlyPublicKey::from_keypair(&key_pair);
+    (key_pair, public_key)
+}
+
+/// X-only public key that controls reveals produced with `da_private_key`.
+pub fn da_public_key(da_private_key: &SecretKey) -> XOnlyPublicKey {
+    da_keypair(da_private_key).1
 }
 
 /// Signs a message with a private key

--- a/crates/bitcoin-da/src/helpers/builders/test_utils.rs
+++ b/crates/bitcoin-da/src/helpers/builders/test_utils.rs
@@ -20,7 +20,7 @@ use super::{
     build_commit_transaction, build_control_block, build_reveal_transaction, build_witness,
     da_keypair, get_size_reveal, sign_blob_with_private_key, update_witness, TransactionKind,
 };
-use crate::helpers::builders::body_builders::DaTxs;
+use crate::helpers::builders::body_builders::{mine_reveal_prefix, DaTxs};
 use crate::helpers::builders::TxWithId;
 use crate::spec::utxo::UTXO;
 use crate::{REVEAL_OUTPUT_AMOUNT, REVEAL_OUTPUT_THRESHOLD};
@@ -64,106 +64,86 @@ pub fn test_create_foreign_inscription(
         reveal_script_builder = reveal_script_builder
             .push_slice(PushBytesBuf::try_from(chunk.to_vec()).expect("Cannot push body chunk"));
     }
-    let reveal_script_builder = reveal_script_builder.push_opcode(OP_ENDIF);
+    // Nonce is kept for legacy reasons but is now fixed at 16.
+    let nonce: i64 = 16; // >= 16 to avoid OP_PUSHNUM_X interpretation
+    let reveal_script = reveal_script_builder
+        .push_opcode(OP_ENDIF)
+        .push_slice(nonce.to_le_bytes())
+        // drop the second item, bc there is a big chance it's 0 (tx kind) and nonce is >= 16
+        .push_opcode(OP_NIP)
+        .into_script();
+
+    let (control_block, merkle_root, tapscript_hash) =
+        build_control_block(&reveal_script, public_key, SECP256K1);
+    let commit_tx_address = Address::p2tr(SECP256K1, public_key, merkle_root, network);
 
     let dust = Amount::from_sat(REVEAL_OUTPUT_AMOUNT);
     let victim_total = dust * victim_outputs as u64;
 
-    let mut nonce: i64 = 16;
-    loop {
-        if nonce % 1000 == 0 {
-            trace!(nonce, "Trying to find commit & reveal nonce for chunk");
-            if nonce > 16384 {
-                warn!("Too many iterations finding nonce for chunk");
-            }
-        }
-        let mut reveal_script_builder = reveal_script_builder.clone();
-        reveal_script_builder = reveal_script_builder
-            .push_slice(nonce.to_le_bytes())
-            .push_opcode(OP_NIP);
-        nonce += 1;
+    let reveal_value = REVEAL_OUTPUT_AMOUNT;
+    let size = get_size_reveal(
+        reveal_recipient.script_pubkey(),
+        reveal_value,
+        &reveal_script,
+        &control_block,
+    ) + victim_outputs * EXTRA_OUTPUT_VSIZE;
+    let fee = (size as f64 * reveal_fee_rate).ceil() as u64;
+    let reveal_input_value = fee + reveal_value + REVEAL_OUTPUT_THRESHOLD + victim_total.to_sat();
 
-        let reveal_script = reveal_script_builder.into_script();
-        let (control_block, merkle_root, tapscript_hash) =
-            build_control_block(&reveal_script, public_key, SECP256K1);
-        let commit_tx_address = Address::p2tr(SECP256K1, public_key, merkle_root, network);
+    let (unsigned_commit_tx, _leftover_utxos) = build_commit_transaction(
+        None,
+        utxos,
+        commit_tx_address,
+        victim.clone(),
+        reveal_input_value,
+        commit_fee_rate,
+    )?;
 
-        let reveal_value = REVEAL_OUTPUT_AMOUNT;
-        let size = get_size_reveal(
-            reveal_recipient.script_pubkey(),
-            reveal_value,
-            &reveal_script,
-            &control_block,
-        ) + victim_outputs * EXTRA_OUTPUT_VSIZE;
-        let fee = (size as f64 * reveal_fee_rate).ceil() as u64;
-        let reveal_input_value =
-            fee + reveal_value + REVEAL_OUTPUT_THRESHOLD + victim_total.to_sat();
+    let mut outputs = vec![TxOut {
+        value: Amount::from_sat(reveal_value + REVEAL_OUTPUT_THRESHOLD),
+        script_pubkey: reveal_recipient.script_pubkey(),
+    }];
+    outputs.extend((0..victim_outputs).map(|_| TxOut {
+        value: dust,
+        script_pubkey: victim.script_pubkey(),
+    }));
 
-        let (mut unsigned_commit_tx, _leftover_utxos) = build_commit_transaction(
-            None,
-            utxos.clone(),
-            commit_tx_address,
-            victim.clone(),
-            reveal_input_value,
-            commit_fee_rate,
-        )?;
+    let mut reveal_tx = Transaction {
+        lock_time: LockTime::ZERO,
+        version: Version(2),
+        input: vec![TxIn {
+            previous_output: bitcoin::OutPoint {
+                txid: unsigned_commit_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: script::Builder::new().into_script(),
+            witness: bitcoin::Witness::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        }],
+        output: outputs,
+    };
 
-        let mut outputs = vec![TxOut {
-            value: Amount::from_sat(reveal_value + REVEAL_OUTPUT_THRESHOLD),
-            script_pubkey: reveal_recipient.script_pubkey(),
-        }];
-        outputs.extend((0..victim_outputs).map(|_| TxOut {
-            value: dust,
-            script_pubkey: victim.script_pubkey(),
-        }));
+    build_witness(
+        &unsigned_commit_tx,
+        &mut reveal_tx,
+        tapscript_hash,
+        reveal_script,
+        control_block,
+        &key_pair,
+        SECP256K1,
+    );
 
-        let mut reveal_tx = Transaction {
-            lock_time: LockTime::ZERO,
-            version: Version(2),
-            input: vec![TxIn {
-                previous_output: bitcoin::OutPoint {
-                    txid: unsigned_commit_tx.compute_txid(),
-                    vout: 0,
-                },
-                script_sig: script::Builder::new().into_script(),
-                witness: bitcoin::Witness::new(),
-                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-            }],
-            output: outputs,
-        };
+    mine_reveal_prefix(
+        &unsigned_commit_tx,
+        &mut reveal_tx,
+        tapscript_hash,
+        &key_pair,
+        SECP256K1,
+        reveal_tx_prefix,
+        "chunk",
+    );
 
-        build_witness(
-            &unsigned_commit_tx,
-            &mut reveal_tx,
-            tapscript_hash,
-            reveal_script,
-            control_block,
-            &key_pair,
-            SECP256K1,
-        );
-
-        let min_commit_value = Amount::from_sat(fee + reveal_value) + victim_total;
-        while unsigned_commit_tx.output[0].value >= min_commit_value
-            && reveal_tx.output[0].value > dust
-        {
-            let reveal_hash = reveal_tx.compute_wtxid().as_raw_hash().to_byte_array();
-            if reveal_hash.starts_with(reveal_tx_prefix) {
-                return Ok((unsigned_commit_tx, reveal_tx));
-            }
-
-            unsigned_commit_tx.output[0].value -= Amount::ONE_SAT;
-            unsigned_commit_tx.output[1].value += Amount::ONE_SAT;
-            reveal_tx.output[0].value -= Amount::ONE_SAT;
-            reveal_tx.input[0].previous_output.txid = unsigned_commit_tx.compute_txid();
-            update_witness(
-                &unsigned_commit_tx,
-                &mut reveal_tx,
-                tapscript_hash,
-                &key_pair,
-                SECP256K1,
-            );
-        }
-    }
+    Ok((unsigned_commit_tx, reveal_tx))
 }
 
 /// Creates a single chunk transaction for testing purposes as if

--- a/crates/bitcoin-da/src/helpers/builders/test_utils.rs
+++ b/crates/bitcoin-da/src/helpers/builders/test_utils.rs
@@ -2,26 +2,169 @@
 
 use core::result::Result::Ok;
 
+use bitcoin::absolute::LockTime;
 use bitcoin::blockdata::opcodes::all::{OP_ENDIF, OP_IF};
 use bitcoin::blockdata::opcodes::OP_FALSE;
 use bitcoin::blockdata::script;
 use bitcoin::hashes::Hash;
-use bitcoin::key::{TapTweak, TweakedPublicKey, UntweakedKeypair};
+use bitcoin::key::{TapTweak, TweakedPublicKey};
 use bitcoin::opcodes::all::{OP_CHECKSIGVERIFY, OP_NIP};
 use bitcoin::script::PushBytesBuf;
-use bitcoin::secp256k1::{SecretKey, XOnlyPublicKey};
-use bitcoin::{Address, Amount, Network};
+use bitcoin::secp256k1::SecretKey;
+use bitcoin::transaction::Version;
+use bitcoin::{Address, Amount, Network, Sequence, Transaction, TxIn, TxOut};
 use secp256k1::SECP256K1;
 use tracing::{trace, warn};
 
 use super::{
     build_commit_transaction, build_control_block, build_reveal_transaction, build_witness,
-    get_size_reveal, sign_blob_with_private_key, update_witness, TransactionKind,
+    da_keypair, get_size_reveal, sign_blob_with_private_key, update_witness, TransactionKind,
 };
 use crate::helpers::builders::body_builders::DaTxs;
 use crate::helpers::builders::TxWithId;
 use crate::spec::utxo::UTXO;
 use crate::{REVEAL_OUTPUT_AMOUNT, REVEAL_OUTPUT_THRESHOLD};
+
+/// Vbytes an extra P2TR output adds to a transaction, rounded up.
+const EXTRA_OUTPUT_VSIZE: usize = 45;
+
+/// Creates the commit/reveal pair a permissionless Bitcoin user can publish to poison another
+/// node's DA chain restore. A genuine chunk inscription, prefix-mined and parseable, differing
+/// from what the production builders emit only in its output layout:
+///
+/// - the commit pays its change to `victim`, making the parent a transaction of the victim's
+///   wallet, so `gettransaction` on it succeeds;
+/// - the reveal pays vout 0 to `reveal_recipient` and appends `victim_outputs` dust outputs to
+///   `victim`, to exercise both foreign vout 0 and duplicate wallet output shapes.
+///
+/// Returns the still-unsigned commit — its inputs are the caller's to sign — and the reveal.
+#[allow(clippy::too_many_arguments)]
+pub fn test_create_foreign_inscription(
+    body: Vec<u8>,
+    da_private_key: &SecretKey,
+    utxos: Vec<UTXO>,
+    reveal_recipient: Address,
+    victim: Address,
+    victim_outputs: usize,
+    commit_fee_rate: f64,
+    reveal_fee_rate: f64,
+    network: Network,
+    reveal_tx_prefix: &[u8],
+) -> Result<(Transaction, Transaction), anyhow::Error> {
+    let (key_pair, public_key) = da_keypair(da_private_key);
+
+    let kind_bytes = TransactionKind::Chunks.to_bytes();
+    let mut reveal_script_builder = script::Builder::new()
+        .push_x_only_key(&public_key)
+        .push_opcode(OP_CHECKSIGVERIFY)
+        .push_slice(PushBytesBuf::from(kind_bytes))
+        .push_opcode(OP_FALSE)
+        .push_opcode(OP_IF);
+    for chunk in body.chunks(520) {
+        reveal_script_builder = reveal_script_builder
+            .push_slice(PushBytesBuf::try_from(chunk.to_vec()).expect("Cannot push body chunk"));
+    }
+    let reveal_script_builder = reveal_script_builder.push_opcode(OP_ENDIF);
+
+    let dust = Amount::from_sat(REVEAL_OUTPUT_AMOUNT);
+    let victim_total = dust * victim_outputs as u64;
+
+    let mut nonce: i64 = 16;
+    loop {
+        if nonce % 1000 == 0 {
+            trace!(nonce, "Trying to find commit & reveal nonce for chunk");
+            if nonce > 16384 {
+                warn!("Too many iterations finding nonce for chunk");
+            }
+        }
+        let mut reveal_script_builder = reveal_script_builder.clone();
+        reveal_script_builder = reveal_script_builder
+            .push_slice(nonce.to_le_bytes())
+            .push_opcode(OP_NIP);
+        nonce += 1;
+
+        let reveal_script = reveal_script_builder.into_script();
+        let (control_block, merkle_root, tapscript_hash) =
+            build_control_block(&reveal_script, public_key, SECP256K1);
+        let commit_tx_address = Address::p2tr(SECP256K1, public_key, merkle_root, network);
+
+        let reveal_value = REVEAL_OUTPUT_AMOUNT;
+        let size = get_size_reveal(
+            reveal_recipient.script_pubkey(),
+            reveal_value,
+            &reveal_script,
+            &control_block,
+        ) + victim_outputs * EXTRA_OUTPUT_VSIZE;
+        let fee = (size as f64 * reveal_fee_rate).ceil() as u64;
+        let reveal_input_value =
+            fee + reveal_value + REVEAL_OUTPUT_THRESHOLD + victim_total.to_sat();
+
+        let (mut unsigned_commit_tx, _leftover_utxos) = build_commit_transaction(
+            None,
+            utxos.clone(),
+            commit_tx_address,
+            victim.clone(),
+            reveal_input_value,
+            commit_fee_rate,
+        )?;
+
+        let mut outputs = vec![TxOut {
+            value: Amount::from_sat(reveal_value + REVEAL_OUTPUT_THRESHOLD),
+            script_pubkey: reveal_recipient.script_pubkey(),
+        }];
+        outputs.extend((0..victim_outputs).map(|_| TxOut {
+            value: dust,
+            script_pubkey: victim.script_pubkey(),
+        }));
+
+        let mut reveal_tx = Transaction {
+            lock_time: LockTime::ZERO,
+            version: Version(2),
+            input: vec![TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: unsigned_commit_tx.compute_txid(),
+                    vout: 0,
+                },
+                script_sig: script::Builder::new().into_script(),
+                witness: bitcoin::Witness::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            }],
+            output: outputs,
+        };
+
+        build_witness(
+            &unsigned_commit_tx,
+            &mut reveal_tx,
+            tapscript_hash,
+            reveal_script,
+            control_block,
+            &key_pair,
+            SECP256K1,
+        );
+
+        let min_commit_value = Amount::from_sat(fee + reveal_value) + victim_total;
+        while unsigned_commit_tx.output[0].value >= min_commit_value
+            && reveal_tx.output[0].value > dust
+        {
+            let reveal_hash = reveal_tx.compute_wtxid().as_raw_hash().to_byte_array();
+            if reveal_hash.starts_with(reveal_tx_prefix) {
+                return Ok((unsigned_commit_tx, reveal_tx));
+            }
+
+            unsigned_commit_tx.output[0].value -= Amount::ONE_SAT;
+            unsigned_commit_tx.output[1].value += Amount::ONE_SAT;
+            reveal_tx.output[0].value -= Amount::ONE_SAT;
+            reveal_tx.input[0].previous_output.txid = unsigned_commit_tx.compute_txid();
+            update_witness(
+                &unsigned_commit_tx,
+                &mut reveal_tx,
+                tapscript_hash,
+                &key_pair,
+                SECP256K1,
+            );
+        }
+    }
+}
 
 /// Creates a single chunk transaction for testing purposes as if
 /// it was of a Complete kind.
@@ -38,8 +181,7 @@ pub fn test_create_single_chunk(
     network: Network,
     reveal_tx_prefix: &[u8],
 ) -> Result<DaTxs, anyhow::Error> {
-    let key_pair = UntweakedKeypair::from_secret_key(SECP256K1, da_private_key);
-    let (public_key, _parity) = XOnlyPublicKey::from_keypair(&key_pair);
+    let (key_pair, public_key) = da_keypair(da_private_key);
 
     let kind = TransactionKind::Chunks;
     let kind_bytes = kind.to_bytes();
@@ -190,8 +332,7 @@ pub fn test_create_single_aggregate(
     reveal_tx_prefix: &[u8],
 ) -> Result<DaTxs, anyhow::Error> {
     // sign the body for authentication of the sequencer
-    let key_pair = UntweakedKeypair::from_secret_key(SECP256K1, da_private_key);
-    let (public_key, _parity) = XOnlyPublicKey::from_keypair(&key_pair);
+    let (key_pair, public_key) = da_keypair(da_private_key);
     let (signature, signer_public_key) = sign_blob_with_private_key(&reveal_body, da_private_key);
 
     let kind = TransactionKind::Aggregate;

--- a/crates/bitcoin-da/src/helpers/parsers.rs
+++ b/crates/bitcoin-da/src/helpers/parsers.rs
@@ -157,6 +157,10 @@ pub enum ParserError {
     /// Invalid opcode in the script.
     #[error("Invalid opcode in the script")]
     UnexpectedOpcode,
+    /// The reveal was not signed by the expected DA key.
+    #[cfg(feature = "native")]
+    #[error("Invalid DA reveal signature")]
+    InvalidDaRevealSignature,
     /// Body was not parsed correctly.
     #[error("Body was not parsed correctly")]
     InvalidBody,
@@ -180,6 +184,231 @@ pub fn parse_relevant_transaction(tx: &Transaction) -> Result<ParsedTransaction,
 
     parse_transaction(&mut instructions)
 }
+
+/// DA-key authentication of reveal transactions. Native-only: the circuit never authenticates a
+/// reveal against the DA key, so none of this is compiled into the guest.
+#[cfg(feature = "native")]
+mod reveal_auth {
+    use bitcoin::hashes::Hash;
+    use bitcoin::secp256k1::Message;
+    use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
+    use bitcoin::taproot::{LeafVersion, Signature as TaprootSignature};
+    use bitcoin::{TapLeafHash, Transaction, TxOut, XOnlyPublicKey};
+    use secp256k1::SECP256K1;
+
+    use super::{get_script, parse_transaction, ParsedTransaction, ParserError};
+
+    /// Parses a relevant transaction only if it was signed by `expected_public_key`.
+    ///
+    /// Verifying the reveal's BIP341 signature proves the DA key authorized it. Finding the
+    /// public key in a witness would not: public keys can be copied into any transaction.
+    pub fn parse_relevant_transaction_signed_by(
+        tx: &Transaction,
+        spent_output: &TxOut,
+        expected_public_key: &XOnlyPublicKey,
+    ) -> Result<ParsedTransaction, ParserError> {
+        if tx.input.len() != 1 {
+            return Err(ParserError::InvalidDaRevealSignature);
+        }
+
+        let input = &tx.input[0];
+        let script = get_script(tx)?;
+
+        // Our builders always produce [signature, tapscript, control block] with SIGHASH_DEFAULT,
+        // which is what binds the signature to every input and output.
+        if input.witness.len() != 3 {
+            return Err(ParserError::InvalidDaRevealSignature);
+        }
+        let signature = input
+            .witness
+            .nth(0)
+            .and_then(|bytes| TaprootSignature::from_slice(bytes).ok())
+            .filter(|signature| signature.sighash_type == TapSighashType::Default)
+            .ok_or(ParserError::InvalidDaRevealSignature)?;
+
+        let tapleaf_hash = TapLeafHash::from_script(script, LeafVersion::TapScript);
+        let signature_hash = SighashCache::new(tx)
+            .taproot_script_spend_signature_hash(
+                0,
+                &Prevouts::All(&[spent_output]),
+                tapleaf_hash,
+                signature.sighash_type,
+            )
+            .map_err(|_| ParserError::InvalidDaRevealSignature)?;
+        let message = Message::from_digest_slice(signature_hash.as_byte_array())
+            .map_err(|_| ParserError::InvalidDaRevealSignature)?;
+        SECP256K1
+            .verify_schnorr(&signature.signature, &message, expected_public_key)
+            .map_err(|_| ParserError::InvalidDaRevealSignature)?;
+
+        let mut instructions = script.instructions().map(|r| r.map_err(ParserError::from));
+        parse_transaction(&mut instructions)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use bitcoin::absolute::LockTime;
+        use bitcoin::hashes::Hash;
+        use bitcoin::key::UntweakedKeypair;
+        use bitcoin::opcodes::all::{OP_CHECKSIGVERIFY, OP_ENDIF, OP_IF, OP_NIP};
+        use bitcoin::opcodes::OP_FALSE;
+        use bitcoin::script::{self, PushBytesBuf};
+        use bitcoin::secp256k1::{Secp256k1, SecretKey};
+        use bitcoin::taproot::TaprootBuilder;
+        use bitcoin::transaction::Version;
+        use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, TxIn, Witness};
+
+        use super::*;
+        use crate::helpers::TransactionKind;
+
+        fn chunk_reveal_script(public_key: &XOnlyPublicKey) -> ScriptBuf {
+            script::Builder::new()
+                .push_x_only_key(public_key)
+                .push_opcode(OP_CHECKSIGVERIFY)
+                .push_slice(PushBytesBuf::from(TransactionKind::Chunks.to_bytes()))
+                .push_opcode(OP_FALSE)
+                .push_opcode(OP_IF)
+                .push_slice([1u8])
+                .push_opcode(OP_ENDIF)
+                .push_slice(16i64.to_le_bytes())
+                .push_opcode(OP_NIP)
+                .into_script()
+        }
+
+        fn taproot_prevout_and_control_block(
+            reveal_script: &ScriptBuf,
+            internal_key: XOnlyPublicKey,
+        ) -> (TxOut, Vec<u8>) {
+            let secp = Secp256k1::new();
+            let spend_info = TaprootBuilder::new()
+                .add_leaf(0, reveal_script.clone())
+                .unwrap()
+                .finalize(&secp, internal_key)
+                .unwrap();
+            let control_block = spend_info
+                .control_block(&(reveal_script.clone(), LeafVersion::TapScript))
+                .unwrap();
+            let spent_output = TxOut {
+                value: Amount::from_sat(10_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, internal_key, spend_info.merkle_root()),
+            };
+
+            (spent_output, control_block.serialize())
+        }
+
+        fn signed_chunk_reveal(private_key: &SecretKey) -> (Transaction, TxOut, XOnlyPublicKey) {
+            let secp = Secp256k1::new();
+            let key_pair = UntweakedKeypair::from_secret_key(&secp, private_key);
+            let public_key = XOnlyPublicKey::from_keypair(&key_pair).0;
+            let reveal_script = chunk_reveal_script(&public_key);
+            let (spent_output, control_block) =
+                taproot_prevout_and_control_block(&reveal_script, public_key);
+            let mut tx = Transaction {
+                version: Version(2),
+                lock_time: LockTime::ZERO,
+                input: vec![TxIn {
+                    previous_output: OutPoint::null(),
+                    script_sig: ScriptBuf::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
+                }],
+                output: vec![TxOut {
+                    value: Amount::ONE_SAT,
+                    script_pubkey: ScriptBuf::new(),
+                }],
+            };
+            let tapleaf_hash = TapLeafHash::from_script(&reveal_script, LeafVersion::TapScript);
+            let signature_hash = SighashCache::new(&tx)
+                .taproot_script_spend_signature_hash(
+                    0,
+                    &Prevouts::All(&[&spent_output]),
+                    tapleaf_hash,
+                    TapSighashType::Default,
+                )
+                .unwrap();
+            let message = Message::from_digest_slice(signature_hash.as_byte_array()).unwrap();
+            let signature = secp.sign_schnorr_no_aux_rand(&message, &key_pair);
+
+            let mut witness = Witness::new();
+            witness.push(signature.as_ref());
+            witness.push(reveal_script);
+            witness.push(control_block);
+            tx.input[0].witness = witness;
+
+            (tx, spent_output, public_key)
+        }
+
+        #[test]
+        fn relevant_transaction_must_be_signed_by_expected_da_key() {
+            let private_key = SecretKey::from_slice(&[1; 32]).unwrap();
+            let (tx, spent_output, expected_public_key) = signed_chunk_reveal(&private_key);
+
+            assert!(
+                parse_relevant_transaction_signed_by(&tx, &spent_output, &expected_public_key)
+                    .is_ok()
+            );
+
+            let secp = Secp256k1::new();
+            let other_private_key = SecretKey::from_slice(&[2; 32]).unwrap();
+            let other_key_pair = UntweakedKeypair::from_secret_key(&secp, &other_private_key);
+            let other_public_key = XOnlyPublicKey::from_keypair(&other_key_pair).0;
+            assert_eq!(
+                parse_relevant_transaction_signed_by(&tx, &spent_output, &other_public_key)
+                    .unwrap_err(),
+                ParserError::InvalidDaRevealSignature
+            );
+
+            let script = tx.input[0].witness.nth(1).unwrap().to_vec();
+            let control_block = tx.input[0].witness.nth(2).unwrap().to_vec();
+            let mut invalid_signature_tx = tx.clone();
+            let mut witness = Witness::new();
+            witness.push([0u8; 64]);
+            witness.push(script);
+            witness.push(control_block);
+            invalid_signature_tx.input[0].witness = witness;
+            assert_eq!(
+                parse_relevant_transaction_signed_by(
+                    &invalid_signature_tx,
+                    &spent_output,
+                    &expected_public_key,
+                )
+                .unwrap_err(),
+                ParserError::InvalidDaRevealSignature
+            );
+
+            let mut tampered_tx = tx.clone();
+            tampered_tx.output[0].value += Amount::ONE_SAT;
+            assert_eq!(
+                parse_relevant_transaction_signed_by(
+                    &tampered_tx,
+                    &spent_output,
+                    &expected_public_key,
+                )
+                .unwrap_err(),
+                ParserError::InvalidDaRevealSignature
+            );
+
+            // The signature also covers the spent output, tying the reveal to the parent the
+            // caller fetched.
+            let other_spent_output = TxOut {
+                value: spent_output.value + Amount::ONE_SAT,
+                script_pubkey: spent_output.script_pubkey.clone(),
+            };
+            assert_eq!(
+                parse_relevant_transaction_signed_by(
+                    &tx,
+                    &other_spent_output,
+                    &expected_public_key,
+                )
+                .unwrap_err(),
+                ParserError::InvalidDaRevealSignature
+            );
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+pub use reveal_auth::parse_relevant_transaction_signed_by;
 
 // Returns the script from the first input of the transaction
 fn get_script(tx: &Transaction) -> Result<&Script, ParserError> {

--- a/crates/bitcoin-da/src/monitoring.rs
+++ b/crates/bitcoin-da/src/monitoring.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::anyhow;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::Hash;
-use bitcoin::{Address, BlockHash, Transaction, Txid};
+use bitcoin::{Address, BlockHash, Transaction, Txid, XOnlyPublicKey};
 use bitcoincore_rpc::json::GetTransactionResult;
 use bitcoincore_rpc::{Client, RpcApi};
 use citrea_common::utils::read_env;
@@ -24,7 +24,7 @@ use tokio::time::{interval, MissedTickBehavior};
 use tracing::{debug, error, info, instrument, trace};
 
 use crate::helpers::builders::TxWithId;
-use crate::helpers::parsers::parse_relevant_transaction;
+use crate::helpers::parsers::parse_relevant_transaction_signed_by;
 use crate::spec::utxo::UTXO;
 
 type BlockHeight = u64;
@@ -223,6 +223,9 @@ pub enum MonitorError {
     /// Already monitored.
     #[error("Transaction already monitored")]
     AlreadyMonitored,
+    /// Restore requires the configured DA key to authenticate wallet-visible transactions.
+    #[error("DA public key is required to restore transaction monitoring")]
+    MissingDaPublicKey,
     /// BlockHash not set.
     #[error("BlockHash not set")]
     BlockHashNotSet,
@@ -346,6 +349,8 @@ pub struct MonitoringService {
     total_size: AtomicUsize,
     finality_depth: u64,
     block_tx: UnboundedSender<u64>,
+    /// DA key which must control every reveal adopted during wallet restore.
+    da_public_key: Option<XOnlyPublicKey>,
 }
 
 impl MonitoringService {
@@ -354,6 +359,7 @@ impl MonitoringService {
         client: Arc<Client>,
         config: Option<MonitoringConfig>,
         finality_depth: u64,
+        da_public_key: Option<XOnlyPublicKey>,
     ) -> (Self, UnboundedReceiver<u64>) {
         let (block_tx, block_rx) = tokio::sync::mpsc::unbounded_channel();
 
@@ -367,6 +373,7 @@ impl MonitoringService {
                 total_size: AtomicUsize::new(0),
                 finality_depth,
                 block_tx,
+                da_public_key,
             },
             block_rx,
         )
@@ -402,54 +409,80 @@ impl MonitoringService {
 
     // Restore TX chain from utxos using list_unspent in range [0..self.finality_depth] confirmations
     async fn restore_from_utxos(&self) -> Result<()> {
+        let da_public_key = self
+            .da_public_key
+            .as_ref()
+            .ok_or(MonitorError::MissingDaPublicKey)?;
+
         let mut unspent = self
             .client
             .list_unspent(None, Some(self.finality_depth as usize), None, None, None)
             .await?;
 
         unspent.sort_unstable_by_key(|utxo| {
-            utxo.ancestor_count.unwrap_or(0) as i64 - utxo.confirmations as i64 - utxo.vout as i64
+            utxo.ancestor_count.unwrap_or(0) as i64 - utxo.confirmations as i64
         });
         tracing::trace!("[restore_from_utxos] {unspent:?}");
 
+        let txids = unspent
+            .iter()
+            .filter(|utxo| utxo.vout == 0 && utxo.spendable && utxo.solvable)
+            .map(|utxo| utxo.txid)
+            .collect::<Vec<_>>();
+
         let mut txs = Vec::new();
-        for tx in &unspent {
-            let reveal_txid = tx.txid;
-            let reveal_tx = self
+        for reveal_txid in txids {
+            let Some(reveal_tx) = self
                 .client
                 .get_transaction(&reveal_txid, None)
-                .await?
-                .transaction()?;
+                .await
+                .ok()
+                .and_then(|result| result.transaction().ok())
+            else {
+                debug!("[restore_from_utxos] skipping unretrievable tx {reveal_txid}");
+                continue;
+            };
 
             let reveal_wtxid = reveal_tx.compute_wtxid();
             let reveal_hash = reveal_wtxid.as_raw_hash().to_byte_array();
 
-            // Assumes that no wallet can hold both txs utxos
-            if reveal_hash.starts_with(REVEAL_TX_PREFIX)
-                && parse_relevant_transaction(&reveal_tx).is_ok()
-            {
-                let commit_txid = reveal_tx.input[0].previous_output.txid;
-                let Some(commit_tx) = self
-                    .client
-                    .get_transaction(&commit_txid, None)
-                    .await
-                    .ok()
-                    .and_then(|result| result.transaction().ok())
-                else {
-                    continue;
-                };
-
-                txs.push([
-                    TxWithId {
-                        id: commit_txid,
-                        tx: commit_tx,
-                    },
-                    TxWithId {
-                        id: reveal_txid,
-                        tx: reveal_tx,
-                    },
-                ]);
+            if !reveal_hash.starts_with(REVEAL_TX_PREFIX) {
+                continue;
             }
+
+            let previous_output = reveal_tx.input[0].previous_output;
+            let commit_txid = previous_output.txid;
+            let Some(commit_tx) = self
+                .client
+                .get_transaction(&commit_txid, None)
+                .await
+                .ok()
+                .and_then(|result| result.transaction().ok())
+            else {
+                debug!(
+                    "[restore_from_utxos] skipping {reveal_txid}: parent {commit_txid} is unretrievable"
+                );
+                continue;
+            };
+
+            let spent_output = &commit_tx.output[previous_output.vout as usize];
+            if let Err(e) =
+                parse_relevant_transaction_signed_by(&reveal_tx, spent_output, da_public_key)
+            {
+                debug!("[restore_from_utxos] skipping {reveal_txid}: {e}");
+                continue;
+            }
+
+            txs.push([
+                TxWithId {
+                    id: commit_txid,
+                    tx: commit_tx,
+                },
+                TxWithId {
+                    id: reveal_txid,
+                    tx: reveal_tx,
+                },
+            ]);
         }
 
         tracing::trace!("[restore_from_utxos] {txs:?}");

--- a/crates/bitcoin-da/src/service.rs
+++ b/crates/bitcoin-da/src/service.rs
@@ -110,6 +110,18 @@ pub struct BitcoinServiceConfig {
     pub rpc_connect_timeout_secs: Option<u64>,
 }
 
+impl BitcoinServiceConfig {
+    /// Parses the configured DA private key. `None` when the node is not configured to publish
+    /// on DA at all.
+    pub fn parse_da_private_key(&self) -> Result<Option<SecretKey>> {
+        self.da_private_key
+            .as_ref()
+            .map(|pk| SecretKey::from_str(pk))
+            .transpose()
+            .map_err(|_| BitcoinServiceError::InvalidPrivateKey)
+    }
+}
+
 impl citrea_common::FromEnv for BitcoinServiceConfig {
     fn from_env() -> anyhow::Result<Self> {
         Ok(Self {
@@ -219,12 +231,7 @@ impl BitcoinService {
                 .map_err(BitcoinServiceError::BackupDirectoryError)?;
         }
 
-        let da_private_key = config
-            .da_private_key
-            .as_ref()
-            .map(|pk| SecretKey::from_str(pk))
-            .transpose()
-            .map_err(|_| BitcoinServiceError::InvalidPrivateKey)?;
+        let da_private_key = config.parse_da_private_key()?;
 
         let tx_queue = Arc::new(Mutex::new(VecDeque::new()));
         let utxo_manager = UtxoManager::new(


### PR DESCRIPTION
# Description

- Verify the reveal's BIP341 signature and filter out TX that follow reveal structure but has an invalid signature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes sequencer/prover Bitcoin DA chain restore, a security-critical path: a bug could either still accept attacker-controlled tips or reject legitimate reveals and stall DA publication.
> 
> **Overview**
> Stops DA monitoring restore from adopting wallet-visible inscriptions that the node did not sign. Anyone can pay dust into a sequencer/prover wallet, so restore now treats `list_unspent` as untrusted.
> 
> Restore only considers spendable, solvable **vout 0** UTXOs, then verifies the reveal’s BIP341 Schnorr signature against the configured DA key (`parse_relevant_transaction_signed_by`) and the fetched parent output. Unsigned or foreign reveals are skipped instead of becoming the chain tip. Honest unconfirmed reveals still restore and remain usable for the next commit.
> 
> Adds an e2e test that publishes hostile commit/reveal pairs (duplicate outputs, later victim outputs, unconfirmed RBF-shaped reveals) and asserts they are not monitored and do not stall publication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 039c3948fefdf3076d9ba02410eb152ab32c70cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->