### PR TITLE
fix: cargo deny

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -2011,7 +2011,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.0",
+ "event-listener 5.4.2",
  "futures-lite",
  "rustix 0.38.44",
  "tracing",
@@ -2343,7 +2343,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.26",
- "h2 0.4.8",
+ "h2 0.4.19",
  "http 0.2.12",
  "http 1.2.0",
  "http-body 0.4.6",
@@ -2731,7 +2731,7 @@ dependencies = [
  "itertools 0.13.0",
  "jsonrpsee",
  "k256",
- "lru 0.16.4",
+ "lru 0.18.4",
  "metrics",
  "metrics-derive",
  "rand 0.8.6",
@@ -3604,7 +3604,7 @@ dependencies = [
  "hex",
  "hyper 1.6.0",
  "jsonrpsee",
- "lru 0.16.4",
+ "lru 0.18.4",
  "metrics",
  "reth-primitives",
  "reth-tasks",
@@ -5078,11 +5078,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -5093,7 +5092,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -5613,9 +5612,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5688,9 +5687,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -6027,7 +6026,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.19",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -7239,11 +7238,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -8777,7 +8776,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.19",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ itertools = { version = "0.13.0", default-features = false }
 jmt = { git = "https://github.com/penumbra-zone/jmt.git", rev = "550a2f2" }
 jsonrpsee = { version = "0.24.8", features = ["jsonrpsee-types"] }
 k256 = { version = "0.13.4" }
-lru = "0.16"
+lru = "0.18"
 hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 log-panics = { version = "2", features = ["with-backtrace"] }
 metrics = "0.24.3"

--- a/deny.toml
+++ b/deny.toml
@@ -74,5 +74,8 @@ ignore = [
   "RUSTSEC-2026-0173", # Ignore unmaintained proc-macro-error2
   "RUSTSEC-2026-0183", # git2: Remote::list() unsoundness. Build-time only (vergen-git2 embedding git info). Fix requires git2 >=0.21, bounded by reth v1.3.7 → vergen-git2. Remove when reth tag is bumped.
   "RUSTSEC-2026-0184", # git2: BlameHunk Signature unsoundness. Build-time only (vergen-git2 embedding git info). Fix requires git2 >=0.21, bounded by reth v1.3.7 → vergen-git2. Remove when reth tag is bumped.
+  "RUSTSEC-2026-0220", # ruint: wrong overflow flag on Uint shifts. Fix needs ruint >=1.20.0, which requires Rust 1.90 (we are on 1.88) and unpinning serde =1.0.218. We never call the affected APIs (checked/overflowing/saturating/strict shifts, to_base_be); revm guards SHL/SHR/SAR with `shift < 256` before using the plain operators.
+  "RUSTSEC-2026-0253", # lru: unsound LruCache::pop() on a panicking key Drop. Our own lru is on 0.18.4; the remaining copies are lru 0.12.5 (discv5 via reth v1.3.7, aws-sdk-s3) and lru 0.13.0 (alloy-provider 1.0.9 via boundless-market =1.0.1). Needs catch_unwind around a pop with a panicking key Drop, which none of them do. Remove when reth and boundless-market are bumped.
+  "RUSTSEC-2026-0258", # h2: unbounded empty DATA frames. No fix on the 0.3 line (patched >=0.4.16); our h2 0.4 is on 0.4.19. h2 0.3.26 is bounded by boundless-market =1.0.1 → aws-sdk-s3/httpmock, i.e. only against the operator-configured S3 endpoint and an in-process mock server. Remove when boundless-market is bumped.
 ]
 unsound = "all"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency and lockfile bumps plus advisory allowlist entries; no runtime behavior changes in Citrea code.
> 
> **Overview**
> Bumps the workspace **`lru`** dependency from **0.16** to **0.18**, refreshing **`Cargo.lock`** with related transitive updates (**`hashbrown`**, **`h2` 0.4.19**, **`event-listener` 5.4.2**).
> 
> Adds three documented **`cargo-deny`** advisory exceptions in **`deny.toml`**: **`RUSTSEC-2026-0220`** (ruint shifts, blocked on Rust/serde pins), **`RUSTSEC-2026-0253`** (older transitive **`lru`** copies via reth/boundless), and **`RUSTSEC-2026-0258`** (remaining **`h2` 0.3** on S3/mock paths). This keeps **`cargo deny`** passing without changing application logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6734942cf8c9628083fe75d184f0b2d9aeee7968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->